### PR TITLE
P2: تقرير تكلفة الإنتاج بالوحدات المكافئة + تسوية الدفاتر مع GL + توحيد React Query

### DIFF
--- a/docs/improvements/README.md
+++ b/docs/improvements/README.md
@@ -148,6 +148,24 @@
 | رسائل أخطاء Supabase كانت تصل للمستخدم كـ `[object Object]` — `getErrorMessage` تتعامل الآن مع كائنات PostgREST | `src/services/enhanced-sales-service.ts` |
 | اختبارات `createOrder` محدَّثة للمسار الذرّي (Migration 78) + اختبار `resumeWorkOrder` يحاكي RPC `start_operation` الفعلي | `createOrder.test.ts`، `mesService.test.ts` |
 
+### 🆕 Migration 80 — تقرير تكلفة الإنتاج بالوحدات المكافئة (9 يوليو 2026) — بند 12 (P2)
+
+**⚠️ تتطلب التطبيق على قاعدة البيانات**: نفّذ `sql/migrations/80_cost_of_production_report.sql` في محرّر Supabase SQL.
+
+أول مخرجات المرحلة الثانية: تقرير تكلفة الإنتاج (Cost of Production Report) بالخطوات الخمس القياسية:
+
+1. **جدول الكميات**: WIP أول + بدأ = مكتمل + WIP آخر + تالف طبيعي/غير طبيعي (مع فحص توازن)
+2. **الوحدات المكافئة**: لكل عنصر (مواد/تحويل) — بنفس معادلات `upsert_stage_cost` حرفياً (WA وFIFO)
+3. **التكاليف الواجب حسابها**: WIP أول + محوَّل وارد + مواد + عمالة + أوفرهيد + إعادة طحن − رصيد خردة
+4. **تكلفة الوحدة المكافئة**: لكل عنصر + مقارنة مع `unit_cost` المخزَّن
+5. **التوزيع والتسوية**: مكتمل / WIP نهائي / خسارة تالف غير طبيعي — مع `is_balanced` لكل مرحلة وللأمر كاملاً
+
+المكوّنات (إضافية 100% — قراءة فقط، لا تعديل على أي جدول):
+- `rpc_cost_of_production_report(p_mo_id, p_stage_no?, p_tenant?)` — دالة `STABLE` تُرجع JSONB
+- `src/services/manufacturing/cost-of-production-service.ts` — خدمة بأنواع كاملة + كشف PGRST202 (8 اختبارات)
+- `src/features/manufacturing/cost-of-production-report.tsx` — شاشة RTL قابلة للطباعة (3 اختبارات)
+- مسار جديد `/manufacturing/cost-of-production` + رابط في القائمة الجانبية
+
 ---
 
 ## 📏 معايير القبول العامة (Definition of Done)

--- a/docs/improvements/README.md
+++ b/docs/improvements/README.md
@@ -166,9 +166,9 @@
 - `src/features/manufacturing/cost-of-production-report.tsx` — شاشة RTL قابلة للطباعة (3 اختبارات)
 - مسار جديد `/manufacturing/cost-of-production` + رابط في القائمة الجانبية
 
-### 🆕 Migration 81 — تسوية الدفاتر الفرعية مع GL (9 يوليو 2026) — بند 13 (P2)
+### ✅ تم تطبيق Migration 81 — تسوية الدفاتر الفرعية مع GL (9 يوليو 2026) — بند 13 (P2)
 
-**⚠️ تتطلب التطبيق على قاعدة البيانات**: نفّذ `sql/migrations/81_subledger_gl_reconciliation.sql` في محرّر Supabase SQL.
+نُفِّذ محتوى `sql/migrations/81_subledger_gl_reconciliation.sql` بنجاح. تم التحقق: الدالة `rpc_subledger_gl_reconciliation` موجودة في `pg_proc` ✅
 
 يقارن أرصدة الدفاتر الفرعية مع حسابات الأستاذ العام — أي قيد يدوي شارد أو ترحيل ناقص يظهر فوراً بدلاً من اكتشافه في إقفال نهاية السنة:
 
@@ -181,6 +181,16 @@
 - `rpc_subledger_gl_reconciliation(p_as_of_date?, p_tenant?, p_prefixes?)` — دفاعية: أي جدول غير موجود يُعلَّم قسمه `unavailable` دون فشل الدالة، وبادئات الحسابات قابلة للتخصيص
 - `src/services/accounting/reconciliation-service.ts` (6 اختبارات)
 - شاشة `/accounting/reconciliation` بتاريخ قابل للاختيار + تفصيل حسابات GL + شارات توازن + طباعة (3 اختبارات)
+
+### ✅ بند 11 — توحيد React Query في hooks الجلب اليدوية (9 يوليو 2026) — P2
+
+لا يتطلب أي migration — تحسين واجهة فقط، **بدون تغيير أي واجهة عامة**:
+
+- `useManufacturingOrders` و`useManufacturingProducts` (كانتا `useState + useEffect` يدوياً) تستخدمان الآن React Query داخلياً — الواجهة الخارجية `{ orders, loading, loadOrders }` كما هي حرفياً، لا كسر لأي مستهلك
+- **كاش مشترك**: نفس مفتاح `['manufacturing-orders']` المستخدم في `hooks/use-manufacturing.ts` — أي إنشاء/تغيير حالة عبر mutations يحدّث كل الشاشات تلقائياً
+- المكاسب: إلغاء تكرار الطلبات بين الشاشات، `staleTime` يمنع الجلب الزائد، وإعادة الجلب بعد المسـح invalidation بدل إعادة تحميل يدوية
+- `useAuth`/`usePermissions` بقيتا كما هما عمداً — حالة جلسة وليست بيانات خادم
+- 6 اختبارات جديدة تثبت ثبات الواجهة والسلوك (PGRST205 ⇒ فارغ، خطأ ⇒ toast، loadOrders ⇒ إعادة جلب)
 
 ---
 

--- a/docs/improvements/README.md
+++ b/docs/improvements/README.md
@@ -166,6 +166,22 @@
 - `src/features/manufacturing/cost-of-production-report.tsx` — شاشة RTL قابلة للطباعة (3 اختبارات)
 - مسار جديد `/manufacturing/cost-of-production` + رابط في القائمة الجانبية
 
+### 🆕 Migration 81 — تسوية الدفاتر الفرعية مع GL (9 يوليو 2026) — بند 13 (P2)
+
+**⚠️ تتطلب التطبيق على قاعدة البيانات**: نفّذ `sql/migrations/81_subledger_gl_reconciliation.sql` في محرّر Supabase SQL.
+
+يقارن أرصدة الدفاتر الفرعية مع حسابات الأستاذ العام — أي قيد يدوي شارد أو ترحيل ناقص يظهر فوراً بدلاً من اكتشافه في إقفال نهاية السنة:
+
+| القسم | جانب GL | جانب الدفتر الفرعي |
+|---|---|---|
+| المخزون | حسابات بادئة `131/132/133/135` من القيود المرحَّلة | `inventory_ledger` (AVCO) أو `stock_ledger_entries` — أيهما وُجد |
+| WIP | حسابات بادئة `134` | `stage_costs` للأوامر المفتوحة (غير done/cancelled) |
+
+المكوّنات (إضافية 100% — قراءة فقط):
+- `rpc_subledger_gl_reconciliation(p_as_of_date?, p_tenant?, p_prefixes?)` — دفاعية: أي جدول غير موجود يُعلَّم قسمه `unavailable` دون فشل الدالة، وبادئات الحسابات قابلة للتخصيص
+- `src/services/accounting/reconciliation-service.ts` (6 اختبارات)
+- شاشة `/accounting/reconciliation` بتاريخ قابل للاختيار + تفصيل حسابات GL + شارات توازن + طباعة (3 اختبارات)
+
 ---
 
 ## 📏 معايير القبول العامة (Definition of Done)

--- a/docs/improvements/README.md
+++ b/docs/improvements/README.md
@@ -148,9 +148,9 @@
 | رسائل أخطاء Supabase كانت تصل للمستخدم كـ `[object Object]` — `getErrorMessage` تتعامل الآن مع كائنات PostgREST | `src/services/enhanced-sales-service.ts` |
 | اختبارات `createOrder` محدَّثة للمسار الذرّي (Migration 78) + اختبار `resumeWorkOrder` يحاكي RPC `start_operation` الفعلي | `createOrder.test.ts`، `mesService.test.ts` |
 
-### 🆕 Migration 80 — تقرير تكلفة الإنتاج بالوحدات المكافئة (9 يوليو 2026) — بند 12 (P2)
+### ✅ تم تطبيق Migration 80 — تقرير تكلفة الإنتاج بالوحدات المكافئة (9 يوليو 2026) — بند 12 (P2)
 
-**⚠️ تتطلب التطبيق على قاعدة البيانات**: نفّذ `sql/migrations/80_cost_of_production_report.sql` في محرّر Supabase SQL.
+نُفِّذ محتوى `sql/migrations/80_cost_of_production_report.sql` بنجاح. تم التحقق: الدالة `rpc_cost_of_production_report` موجودة في `pg_proc` ✅
 
 أول مخرجات المرحلة الثانية: تقرير تكلفة الإنتاج (Cost of Production Report) بالخطوات الخمس القياسية:
 

--- a/sql/migrations/80_cost_of_production_report.sql
+++ b/sql/migrations/80_cost_of_production_report.sql
@@ -1,0 +1,343 @@
+-- ===================================================================
+-- Migration 80: تقرير تكلفة الإنتاج بالوحدات المكافئة
+-- Cost of Production Report (CPR) — الخطوات الخمس القياسية
+-- ===================================================================
+-- المتطلبات: Migrations 66-69 (WIP/EUP/Scrap/FIFO) + 76 (wardah_org_id)
+-- المبدأ: إضافي 100% — دالة قراءة فقط (READ ONLY)، لا تعديل على أي جدول
+--
+-- التقرير يتبع الشكل المحاسبي القياسي:
+--   الخطوة 1: جدول الكميات (Quantity Schedule)
+--   الخطوة 2: الوحدات المكافئة لكل عنصر تكلفة (EUP)
+--   الخطوة 3: التكاليف الواجب حسابها (Costs to Account For)
+--   الخطوة 4: تكلفة الوحدة المكافئة (Cost per EU)
+--   الخطوة 5: توزيع التكاليف + التسوية (Cost Assignment + Reconciliation)
+--
+-- معادلات EUP مطابقة تماماً لمعادلات upsert_stage_cost (Migration 69):
+--   WA:   EUP = مكتمل + (WIP نهائي × نسبة إتمامه)
+--   FIFO: EUP = مكتمل + (WIP نهائي × نسبته) − (WIP أول × نسبته)
+--   مراحل > 1: EUP_DM = المكتمل فقط (المواد ضمن المحوَّل من المرحلة السابقة)
+-- ===================================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_cost_of_production_report(
+    p_mo_id    UUID,
+    p_stage_no INTEGER DEFAULT NULL,   -- NULL = كل المراحل
+    p_tenant   UUID    DEFAULT NULL    -- NULL = من جلسة المستخدم
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+STABLE                                 -- قراءة فقط — لا كتابة إطلاقاً
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_org        UUID;
+    v_mo         RECORD;
+    v_stage      RECORD;
+    v_stages     JSONB := '[]'::JSONB;
+    v_stage_rpt  JSONB;
+
+    -- أعمدة ديناميكية (org_id/tenant_id على غرار Migrations 67-69)
+    v_tenant_col TEXT;
+    v_mo_col     TEXT;
+    v_stage_col  TEXT;
+    v_sql        TEXT;
+
+    -- الخطوة 1: جدول الكميات
+    v_units_in           NUMERIC;  -- الوحدات الواجب حسابها
+    v_units_out          NUMERIC;  -- الوحدات المحسوبة
+    v_qty_balanced       BOOLEAN;
+
+    -- الخطوة 2: EUP
+    v_eup_dm             NUMERIC;
+    v_eup_cc             NUMERIC;
+
+    -- الخطوة 3: التكاليف الواجب حسابها
+    v_cc_cost            NUMERIC;  -- تكاليف التحويل = عمالة + أوفرهيد
+    v_costs_in           NUMERIC;
+
+    -- الخطوة 4: تكلفة الوحدة المكافئة
+    v_ti_per_eu          NUMERIC := 0;
+    v_dm_per_eu          NUMERIC := 0;
+    v_cc_per_eu          NUMERIC := 0;
+    v_unit_cost_total    NUMERIC := 0;
+    v_ti_eup_base        NUMERIC;
+
+    -- الخطوة 5: توزيع التكاليف
+    v_cost_completed     NUMERIC;
+    v_cost_ending_wip    NUMERIC;
+    v_cost_abnormal      NUMERIC;
+    v_costs_out          NUMERIC;
+    v_reconcile_diff     NUMERIC;
+    v_is_balanced        BOOLEAN;
+
+    -- إجماليات على مستوى الأمر كاملاً
+    v_grand_costs_in     NUMERIC := 0;
+    v_grand_completed    NUMERIC := 0;
+    v_grand_ending_wip   NUMERIC := 0;
+    v_grand_abnormal     NUMERIC := 0;
+    v_all_balanced       BOOLEAN := TRUE;
+BEGIN
+    -- ===== هوية المؤسسة =====
+    v_org := wardah_org_id(p_tenant);
+    IF v_org IS NULL THEN
+        RAISE EXCEPTION 'ORG_NOT_RESOLVED: تعذر تحديد هوية المؤسسة';
+    END IF;
+
+    -- ===== كشف أسماء الأعمدة (نفس نمط Migrations 67-69) =====
+    SELECT column_name INTO v_tenant_col
+    FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'stage_costs'
+      AND column_name IN ('tenant_id', 'org_id')
+    ORDER BY CASE column_name WHEN 'tenant_id' THEN 1 ELSE 2 END
+    LIMIT 1;
+
+    SELECT column_name INTO v_mo_col
+    FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'stage_costs'
+      AND column_name IN ('mo_id', 'manufacturing_order_id')
+    ORDER BY CASE column_name WHEN 'mo_id' THEN 1 ELSE 2 END
+    LIMIT 1;
+
+    SELECT column_name INTO v_stage_col
+    FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'stage_costs'
+      AND column_name IN ('stage_no', 'stage_number')
+    ORDER BY CASE column_name WHEN 'stage_no' THEN 1 ELSE 2 END
+    LIMIT 1;
+
+    IF v_tenant_col IS NULL OR v_mo_col IS NULL OR v_stage_col IS NULL THEN
+        RAISE EXCEPTION 'SCHEMA_MISMATCH: جدول stage_costs لا يحتوي الأعمدة المتوقعة';
+    END IF;
+
+    -- ===== رأس التقرير: بيانات أمر التصنيع =====
+    SELECT * INTO v_mo
+    FROM manufacturing_orders
+    WHERE id = p_mo_id AND org_id = v_org;
+
+    IF v_mo IS NULL THEN
+        RAISE EXCEPTION 'MO_NOT_FOUND: أمر التصنيع غير موجود أو لا يتبع مؤسستك';
+    END IF;
+
+    -- ===== المرور على المراحل =====
+    v_sql := format(
+        'SELECT *,
+                %I  AS k_stage_no
+         FROM stage_costs
+         WHERE %I = $1 AND %I = $2
+           AND ($3::INTEGER IS NULL OR %I = $3)
+         ORDER BY %I',
+        v_stage_col, v_tenant_col, v_mo_col, v_stage_col, v_stage_col
+    );
+
+    FOR v_stage IN EXECUTE v_sql USING v_org, p_mo_id, p_stage_no
+    LOOP
+        -- ============================================================
+        -- الخطوة 1: جدول الكميات
+        -- الوحدات الواجب حسابها = WIP أول المدة + وحدات بدأت
+        -- الوحدات المحسوبة = مكتمل + WIP آخر المدة + تالف طبيعي + تالف غير طبيعي
+        -- ============================================================
+        v_units_in  := COALESCE(v_stage.wip_beginning_qty, 0)
+                     + COALESCE(v_stage.input_qty, 0);
+        v_units_out := COALESCE(v_stage.good_qty, 0)
+                     + COALESCE(v_stage.wip_end_qty, 0)
+                     + COALESCE(v_stage.normal_scrap_qty, 0)
+                     + COALESCE(v_stage.abnormal_scrap_qty, 0)
+                     + COALESCE(v_stage.rework_qty, 0);
+        v_qty_balanced := ABS(v_units_in - v_units_out) < 0.000001;
+
+        -- ============================================================
+        -- الخطوة 2: EUP — نفس معادلات upsert_stage_cost حرفياً
+        -- ============================================================
+        IF COALESCE(v_stage.costing_method, 'weighted_average') = 'fifo' THEN
+            IF v_stage.k_stage_no = 1 THEN
+                v_eup_dm := COALESCE(v_stage.good_qty, 0)
+                          + COALESCE(v_stage.wip_end_qty, 0) * COALESCE(v_stage.wip_end_dm_completion_pct, 0) / 100
+                          - COALESCE(v_stage.wip_beginning_qty, 0) * COALESCE(v_stage.wip_beginning_dm_completion_pct, 0) / 100;
+            ELSE
+                v_eup_dm := COALESCE(v_stage.good_qty, 0);
+            END IF;
+            v_eup_cc := COALESCE(v_stage.good_qty, 0)
+                      + COALESCE(v_stage.wip_end_qty, 0) * COALESCE(v_stage.wip_end_cc_completion_pct, 0) / 100
+                      - COALESCE(v_stage.wip_beginning_qty, 0) * COALESCE(v_stage.wip_beginning_cc_completion_pct, 0) / 100;
+        ELSE
+            -- المتوسط المرجّح
+            IF v_stage.k_stage_no = 1 THEN
+                v_eup_dm := COALESCE(v_stage.good_qty, 0)
+                          + COALESCE(v_stage.wip_end_qty, 0) * COALESCE(v_stage.wip_end_dm_completion_pct, 0) / 100;
+            ELSE
+                v_eup_dm := COALESCE(v_stage.good_qty, 0);
+            END IF;
+            v_eup_cc := COALESCE(v_stage.good_qty, 0)
+                      + COALESCE(v_stage.wip_end_qty, 0) * COALESCE(v_stage.wip_end_cc_completion_pct, 0) / 100;
+        END IF;
+
+        -- ============================================================
+        -- الخطوة 3: التكاليف الواجب حسابها
+        -- WIP أول + محوَّل وارد + مواد + تحويل (عمالة+أوفرهيد) + إعادة طحن − رصيد خردة
+        -- ============================================================
+        v_cc_cost  := COALESCE(v_stage.dl_cost, 0) + COALESCE(v_stage.moh_cost, 0);
+        v_costs_in := COALESCE(v_stage.wip_beginning_cost, 0)
+                    + COALESCE(v_stage.transferred_in, 0)
+                    + COALESCE(v_stage.dm_cost, 0)
+                    + v_cc_cost
+                    + COALESCE(v_stage.regrind_proc_cost, 0)
+                    - COALESCE(v_stage.waste_credit, 0);
+
+        -- ============================================================
+        -- الخطوة 4: تكلفة الوحدة المكافئة لكل عنصر
+        -- المحوَّل الوارد مكتمل 100% دائماً ⇒ قاعدته = مكتمل + WIP نهائي كامل
+        -- ============================================================
+        v_ti_eup_base := COALESCE(v_stage.good_qty, 0) + COALESCE(v_stage.wip_end_qty, 0);
+
+        v_ti_per_eu := CASE WHEN v_ti_eup_base > 0
+                            THEN COALESCE(v_stage.transferred_in, 0) / v_ti_eup_base
+                            ELSE 0 END;
+        v_dm_per_eu := CASE WHEN v_eup_dm > 0
+                            THEN COALESCE(v_stage.dm_cost, 0) / v_eup_dm
+                            ELSE 0 END;
+        -- تكاليف التحويل تشمل تسويات إعادة الطحن ورصيد الخردة (نفس منطق 69)
+        v_cc_per_eu := CASE WHEN v_eup_cc > 0
+                            THEN (v_cc_cost
+                                  + COALESCE(v_stage.regrind_proc_cost, 0)
+                                  - COALESCE(v_stage.waste_credit, 0)
+                                  + COALESCE(v_stage.wip_beginning_cost, 0)) / v_eup_cc
+                            ELSE 0 END;
+        v_unit_cost_total := v_ti_per_eu + v_dm_per_eu + v_cc_per_eu;
+
+        -- ============================================================
+        -- الخطوة 5: توزيع التكاليف
+        -- مكتمل ومحوَّل = بالباقي (يمتص التالف الطبيعي تلقائياً — لا تسريب)
+        -- WIP نهائي = كمية × (TI كامل + DM بنسبته + CC بنسبته)
+        -- تالف غير طبيعي = القيمة المخزنة (احتُسبت وقت الترحيل — خسارة فترة)
+        -- ============================================================
+        v_cost_ending_wip := COALESCE(v_stage.wip_end_qty, 0) * (
+                                 v_ti_per_eu
+                               + v_dm_per_eu * COALESCE(v_stage.wip_end_dm_completion_pct, 0) / 100
+                               + v_cc_per_eu * COALESCE(v_stage.wip_end_cc_completion_pct, 0) / 100
+                             );
+        v_cost_abnormal   := COALESCE(v_stage.abnormal_scrap_cost, 0);
+        v_cost_completed  := v_costs_in - v_cost_ending_wip - v_cost_abnormal;
+
+        v_costs_out      := v_cost_completed + v_cost_ending_wip + v_cost_abnormal;
+        v_reconcile_diff := v_costs_in - v_costs_out;
+        v_is_balanced    := ABS(v_reconcile_diff) < 0.01;
+
+        v_all_balanced     := v_all_balanced AND v_is_balanced AND v_qty_balanced;
+        v_grand_costs_in   := v_grand_costs_in   + v_costs_in;
+        v_grand_completed  := v_grand_completed  + v_cost_completed;
+        v_grand_ending_wip := v_grand_ending_wip + v_cost_ending_wip;
+        v_grand_abnormal   := v_grand_abnormal   + v_cost_abnormal;
+
+        -- ===== بناء JSON المرحلة =====
+        v_stage_rpt := jsonb_build_object(
+            'stage_no',       v_stage.k_stage_no,
+            'work_center_id', v_stage.wc_id,
+            'costing_method', COALESCE(v_stage.costing_method, 'weighted_average'),
+            'mode',           v_stage.mode,
+
+            'quantity_schedule', jsonb_build_object(
+                'wip_beginning_qty',   COALESCE(v_stage.wip_beginning_qty, 0),
+                'units_started',       COALESCE(v_stage.input_qty, 0),
+                'units_to_account',    v_units_in,
+                'units_completed',     COALESCE(v_stage.good_qty, 0),
+                'wip_ending_qty',      COALESCE(v_stage.wip_end_qty, 0),
+                'normal_scrap_qty',    COALESCE(v_stage.normal_scrap_qty, 0),
+                'abnormal_scrap_qty',  COALESCE(v_stage.abnormal_scrap_qty, 0),
+                'rework_qty',          COALESCE(v_stage.rework_qty, 0),
+                'units_accounted',     v_units_out,
+                'qty_difference',      v_units_in - v_units_out,
+                'is_balanced',         v_qty_balanced
+            ),
+
+            'equivalent_units', jsonb_build_object(
+                'eup_dm',                       ROUND(v_eup_dm, 6),
+                'eup_cc',                       ROUND(v_eup_cc, 6),
+                'wip_end_dm_completion_pct',    COALESCE(v_stage.wip_end_dm_completion_pct, 0),
+                'wip_end_cc_completion_pct',    COALESCE(v_stage.wip_end_cc_completion_pct, 0),
+                'wip_beg_dm_completion_pct',    COALESCE(v_stage.wip_beginning_dm_completion_pct, 0),
+                'wip_beg_cc_completion_pct',    COALESCE(v_stage.wip_beginning_cc_completion_pct, 0)
+            ),
+
+            'costs_to_account', jsonb_build_object(
+                'wip_beginning_cost', COALESCE(v_stage.wip_beginning_cost, 0),
+                'transferred_in',     COALESCE(v_stage.transferred_in, 0),
+                'direct_materials',   COALESCE(v_stage.dm_cost, 0),
+                'direct_labor',       COALESCE(v_stage.dl_cost, 0),
+                'overhead_applied',   COALESCE(v_stage.moh_cost, 0),
+                'conversion_costs',   v_cc_cost,
+                'regrind_cost',       COALESCE(v_stage.regrind_proc_cost, 0),
+                'waste_credit',       COALESCE(v_stage.waste_credit, 0),
+                'total_costs_in',     ROUND(v_costs_in, 6)
+            ),
+
+            'cost_per_eu', jsonb_build_object(
+                'transferred_in_per_eu', ROUND(v_ti_per_eu, 6),
+                'dm_per_eu',             ROUND(v_dm_per_eu, 6),
+                'cc_per_eu',             ROUND(v_cc_per_eu, 6),
+                'total_per_eu',          ROUND(v_unit_cost_total, 6),
+                'stored_unit_cost',      COALESCE(v_stage.unit_cost, 0)
+            ),
+
+            'cost_assignment', jsonb_build_object(
+                'completed_and_transferred', ROUND(v_cost_completed, 6),
+                'ending_wip',                ROUND(v_cost_ending_wip, 6),
+                'abnormal_scrap_loss',       ROUND(v_cost_abnormal, 6),
+                'normal_scrap_absorbed',     COALESCE(v_stage.normal_scrap_cost, 0),
+                'total_costs_out',           ROUND(v_costs_out, 6)
+            ),
+
+            'reconciliation', jsonb_build_object(
+                'costs_in',          ROUND(v_costs_in, 6),
+                'costs_out',         ROUND(v_costs_out, 6),
+                'difference',        ROUND(v_reconcile_diff, 6),
+                'is_balanced',       v_is_balanced,
+                'stored_total_cost', COALESCE(v_stage.total_cost, 0),
+                'stored_vs_computed_diff', ROUND(COALESCE(v_stage.total_cost, 0) - v_cost_completed, 6)
+            )
+        );
+
+        v_stages := v_stages || v_stage_rpt;
+    END LOOP;
+
+    IF jsonb_array_length(v_stages) = 0 THEN
+        RAISE EXCEPTION 'NO_STAGE_DATA: لا توجد بيانات مراحل لهذا الأمر%',
+            CASE WHEN p_stage_no IS NOT NULL
+                 THEN format(' (المرحلة %s)', p_stage_no) ELSE '' END;
+    END IF;
+
+    -- ===== التقرير الكامل =====
+    RETURN jsonb_build_object(
+        'success', TRUE,
+        'report_type', 'cost_of_production',
+        'generated_at', now(),
+        'manufacturing_order', jsonb_build_object(
+            'id',             v_mo.id,
+            'order_number',   v_mo.order_number,
+            'product_id',     v_mo.product_id,
+            'status',         v_mo.status,
+            'qty_planned',    v_mo.qty_planned
+        ),
+        'stages', v_stages,
+        'totals', jsonb_build_object(
+            'total_costs_in',            ROUND(v_grand_costs_in, 6),
+            'total_completed',           ROUND(v_grand_completed, 6),
+            'total_ending_wip',          ROUND(v_grand_ending_wip, 6),
+            'total_abnormal_scrap_loss', ROUND(v_grand_abnormal, 6),
+            'all_stages_balanced',       v_all_balanced
+        )
+    );
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_cost_of_production_report(UUID, INTEGER, UUID) IS
+'تقرير تكلفة الإنتاج بالوحدات المكافئة — الخطوات الخمس القياسية: جدول الكميات، EUP، التكاليف الواجب حسابها، تكلفة الوحدة المكافئة، توزيع التكاليف مع التسوية. قراءة فقط (STABLE) — لا يعدّل أي بيانات. Migration 80';
+
+GRANT EXECUTE ON FUNCTION public.rpc_cost_of_production_report(UUID, INTEGER, UUID) TO authenticated;
+
+-- ===================================================================
+-- التحقق بعد التطبيق:
+--   SELECT proname FROM pg_proc WHERE proname = 'rpc_cost_of_production_report';
+-- الاستخدام:
+--   SELECT rpc_cost_of_production_report('<mo-uuid>');            -- كل المراحل
+--   SELECT rpc_cost_of_production_report('<mo-uuid>', 2);         -- مرحلة محددة
+-- ===================================================================

--- a/sql/migrations/81_subledger_gl_reconciliation.sql
+++ b/sql/migrations/81_subledger_gl_reconciliation.sql
@@ -1,0 +1,306 @@
+-- ===================================================================
+-- Migration 81: تسوية الدفاتر الفرعية مع الأستاذ العام
+-- Subledger ↔ GL Reconciliation — بند 13 (P2)
+-- ===================================================================
+-- المتطلبات: Migration 76 (wardah_org_id) — والبقية اختيارية:
+--   الدالة دفاعية 100%: أي جدول غير موجود ⇒ قسمه يُعلَّم unavailable
+--   ولا تفشل الدالة بأكملها
+-- المبدأ: إضافي 100% — دالة قراءة فقط (STABLE)، لا تعديل على أي جدول
+--
+-- الأقسام:
+--   1) المخزون (مواد خام 131* + إنتاج تام 135*) مقابل الدفتر الفرعي
+--      للمخزون (inventory_ledger أو stock_ledger_entries — أيهما وُجد)
+--   2) الإنتاج تحت التشغيل (134*) مقابل stage_costs للأوامر المفتوحة
+--
+-- أي فرق = قيد يدوي شارد أو ترحيل ناقص — يظهر فوراً بدلاً من
+-- اكتشافه في إقفال نهاية السنة
+-- ===================================================================
+
+CREATE OR REPLACE FUNCTION public.rpc_subledger_gl_reconciliation(
+    p_as_of_date DATE  DEFAULT CURRENT_DATE,
+    p_tenant     UUID  DEFAULT NULL,
+    -- بادئات الحسابات قابلة للتخصيص لو اختلفت شجرة الحسابات
+    p_inventory_prefixes TEXT[] DEFAULT ARRAY['131', '132', '133', '135'],
+    p_wip_prefixes       TEXT[] DEFAULT ARRAY['134']
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_org UUID;
+
+    -- كشف أعمدة gl_entry_lines (الأرشيف: debit_amount/account_code — الحي: debit/account_id)
+    v_debit_col   TEXT;
+    v_credit_col  TEXT;
+    v_has_acct_id BOOLEAN;
+    v_sql         TEXT;
+
+    -- أرصدة GL لكل قسم + تفصيل الحسابات
+    v_gl_inventory      NUMERIC := 0;
+    v_gl_wip            NUMERIC := 0;
+    v_inv_accounts      JSONB   := '[]'::JSONB;
+    v_wip_accounts      JSONB   := '[]'::JSONB;
+    v_gl_available      BOOLEAN := FALSE;
+
+    -- الدفاتر الفرعية
+    v_sub_inventory        NUMERIC := NULL;  -- NULL = غير متاح
+    v_sub_inventory_source TEXT    := NULL;
+    v_sub_wip              NUMERIC := NULL;
+    v_sub_wip_source       TEXT    := NULL;
+    v_open_mo_count        INTEGER := 0;
+
+    -- تسوية
+    v_inv_diff      NUMERIC;
+    v_wip_diff      NUMERIC;
+    v_inv_balanced  BOOLEAN;
+    v_wip_balanced  BOOLEAN;
+
+    -- أعمدة stage_costs الديناميكية
+    v_sc_tenant_col TEXT;
+    v_sc_mo_col     TEXT;
+BEGIN
+    -- ===== هوية المؤسسة =====
+    v_org := wardah_org_id(p_tenant);
+    IF v_org IS NULL THEN
+        RAISE EXCEPTION 'ORG_NOT_RESOLVED: تعذر تحديد هوية المؤسسة';
+    END IF;
+
+    -- ================================================================
+    -- جانب GL: أرصدة الحسابات من القيود المرحَّلة حتى التاريخ المطلوب
+    -- ================================================================
+    IF to_regclass('public.gl_entries') IS NOT NULL
+       AND to_regclass('public.gl_entry_lines') IS NOT NULL THEN
+
+        SELECT column_name INTO v_debit_col
+        FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'gl_entry_lines'
+          AND column_name IN ('debit', 'debit_amount')
+        ORDER BY CASE column_name WHEN 'debit' THEN 1 ELSE 2 END
+        LIMIT 1;
+
+        SELECT column_name INTO v_credit_col
+        FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'gl_entry_lines'
+          AND column_name IN ('credit', 'credit_amount')
+        ORDER BY CASE column_name WHEN 'credit' THEN 1 ELSE 2 END
+        LIMIT 1;
+
+        v_has_acct_id := EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_schema = 'public' AND table_name = 'gl_entry_lines'
+              AND column_name = 'account_id'
+        ) AND to_regclass('public.gl_accounts') IS NOT NULL;
+
+        IF v_debit_col IS NOT NULL AND v_credit_col IS NOT NULL THEN
+            v_gl_available := TRUE;
+
+            -- الرصيد المدين الصافي لكل حساب (طبيعة حسابات الأصول)
+            IF v_has_acct_id THEN
+                v_sql := format(
+                    'SELECT COALESCE(a.code, '''') AS code,
+                            COALESCE(a.name, a.name_ar, '''') AS name,
+                            SUM(COALESCE(l.%I,0) - COALESCE(l.%I,0)) AS balance
+                     FROM gl_entry_lines l
+                     JOIN gl_entries e ON e.id = l.entry_id
+                     JOIN gl_accounts a ON a.id = l.account_id
+                     WHERE e.org_id = $1
+                       AND e.status = ''posted''
+                       AND e.entry_date <= $2
+                       AND a.code LIKE ANY (SELECT unnest($3) || ''%%'')
+                     GROUP BY a.code, COALESCE(a.name, a.name_ar, '''')
+                     ORDER BY a.code',
+                    v_debit_col, v_credit_col
+                );
+            ELSE
+                v_sql := format(
+                    'SELECT l.account_code AS code,
+                            COALESCE(MAX(l.account_name), '''') AS name,
+                            SUM(COALESCE(l.%I,0) - COALESCE(l.%I,0)) AS balance
+                     FROM gl_entry_lines l
+                     JOIN gl_entries e ON e.id = l.entry_id
+                     WHERE e.org_id = $1
+                       AND e.status = ''posted''
+                       AND e.entry_date <= $2
+                       AND l.account_code LIKE ANY (SELECT unnest($3) || ''%%'')
+                     GROUP BY l.account_code
+                     ORDER BY l.account_code',
+                    v_debit_col, v_credit_col
+                );
+            END IF;
+
+            -- قسم المخزون
+            EXECUTE format(
+                'SELECT COALESCE(SUM(balance),0),
+                        COALESCE(jsonb_agg(jsonb_build_object(
+                            ''code'', code, ''name'', name,
+                            ''balance'', ROUND(balance,6))), ''[]''::jsonb)
+                 FROM (%s) t', v_sql)
+            INTO v_gl_inventory, v_inv_accounts
+            USING v_org, p_as_of_date, p_inventory_prefixes;
+
+            -- قسم WIP
+            EXECUTE format(
+                'SELECT COALESCE(SUM(balance),0),
+                        COALESCE(jsonb_agg(jsonb_build_object(
+                            ''code'', code, ''name'', name,
+                            ''balance'', ROUND(balance,6))), ''[]''::jsonb)
+                 FROM (%s) t', v_sql)
+            INTO v_gl_wip, v_wip_accounts
+            USING v_org, p_as_of_date, p_wip_prefixes;
+        END IF;
+    END IF;
+
+    -- ================================================================
+    -- الدفتر الفرعي للمخزون: آخر رصيد جارٍ لكل صنف حتى التاريخ
+    -- ================================================================
+    IF to_regclass('public.inventory_ledger') IS NOT NULL THEN
+        BEGIN
+            SELECT COALESCE(SUM(running_value), 0), 'inventory_ledger'
+            INTO v_sub_inventory, v_sub_inventory_source
+            FROM (
+                SELECT DISTINCT ON (item_id) running_value
+                FROM inventory_ledger
+                WHERE tenant_id = v_org
+                  AND moved_at::date <= p_as_of_date
+                ORDER BY item_id, moved_at DESC, created_at DESC
+            ) latest;
+        EXCEPTION WHEN OTHERS THEN
+            v_sub_inventory := NULL;  -- بنية أعمدة مختلفة — نجرّب المصدر الآخر
+        END;
+    END IF;
+
+    IF v_sub_inventory IS NULL
+       AND to_regclass('public.stock_ledger_entries') IS NOT NULL THEN
+        BEGIN
+            SELECT COALESCE(SUM(stock_value), 0), 'stock_ledger_entries'
+            INTO v_sub_inventory, v_sub_inventory_source
+            FROM (
+                SELECT DISTINCT ON (product_id, warehouse_id) stock_value
+                FROM stock_ledger_entries
+                WHERE org_id = v_org
+                  AND posting_date <= p_as_of_date
+                  AND COALESCE(is_cancelled, FALSE) = FALSE
+                ORDER BY product_id, warehouse_id, posting_datetime DESC
+            ) latest;
+        EXCEPTION WHEN OTHERS THEN
+            v_sub_inventory := NULL;
+        END;
+    END IF;
+
+    -- ================================================================
+    -- الدفتر الفرعي لـ WIP: تكاليف مراحل الأوامر المفتوحة
+    -- (أمر مكتمل/ملغى يجب أن يكون WIP الخاص به صفراً — تحوَّل لـ FG)
+    -- ================================================================
+    IF to_regclass('public.stage_costs') IS NOT NULL
+       AND to_regclass('public.manufacturing_orders') IS NOT NULL THEN
+
+        SELECT column_name INTO v_sc_tenant_col
+        FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'stage_costs'
+          AND column_name IN ('tenant_id', 'org_id')
+        ORDER BY CASE column_name WHEN 'tenant_id' THEN 1 ELSE 2 END
+        LIMIT 1;
+
+        SELECT column_name INTO v_sc_mo_col
+        FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'stage_costs'
+          AND column_name IN ('mo_id', 'manufacturing_order_id')
+        ORDER BY CASE column_name WHEN 'mo_id' THEN 1 ELSE 2 END
+        LIMIT 1;
+
+        IF v_sc_tenant_col IS NOT NULL AND v_sc_mo_col IS NOT NULL THEN
+            BEGIN
+                EXECUTE format(
+                    'SELECT COALESCE(SUM(sc.total_cost),0), COUNT(DISTINCT mo.id)
+                     FROM stage_costs sc
+                     JOIN manufacturing_orders mo ON mo.id = sc.%I
+                     WHERE sc.%I = $1
+                       AND mo.org_id = $1
+                       AND lower(replace(mo.status, ''-'', ''_''))
+                           NOT IN (''done'', ''completed'', ''cancelled'', ''closed'')',
+                    v_sc_mo_col, v_sc_tenant_col
+                )
+                INTO v_sub_wip, v_open_mo_count
+                USING v_org;
+                v_sub_wip_source := 'stage_costs (أوامر مفتوحة)';
+            EXCEPTION WHEN OTHERS THEN
+                v_sub_wip := NULL;
+            END;
+        END IF;
+    END IF;
+
+    -- ================================================================
+    -- التسوية
+    -- ================================================================
+    v_inv_diff     := CASE WHEN v_gl_available AND v_sub_inventory IS NOT NULL
+                           THEN v_gl_inventory - v_sub_inventory ELSE NULL END;
+    v_wip_diff     := CASE WHEN v_gl_available AND v_sub_wip IS NOT NULL
+                           THEN v_gl_wip - v_sub_wip ELSE NULL END;
+    v_inv_balanced := v_inv_diff IS NOT NULL AND ABS(v_inv_diff) < 0.01;
+    v_wip_balanced := v_wip_diff IS NOT NULL AND ABS(v_wip_diff) < 0.01;
+
+    RETURN jsonb_build_object(
+        'success', TRUE,
+        'report_type', 'subledger_gl_reconciliation',
+        'as_of_date', p_as_of_date,
+        'generated_at', now(),
+        'gl_available', v_gl_available,
+        'sections', jsonb_build_array(
+            jsonb_build_object(
+                'section', 'inventory',
+                'title_ar', 'المخزون (مواد خام + إنتاج تام)',
+                'gl_prefixes', to_jsonb(p_inventory_prefixes),
+                'gl_balance', CASE WHEN v_gl_available THEN ROUND(v_gl_inventory, 6) END,
+                'gl_accounts', v_inv_accounts,
+                'subledger_balance', CASE WHEN v_sub_inventory IS NOT NULL
+                                          THEN ROUND(v_sub_inventory, 6) END,
+                'subledger_source', v_sub_inventory_source,
+                'difference', CASE WHEN v_inv_diff IS NOT NULL
+                                   THEN ROUND(v_inv_diff, 6) END,
+                'is_balanced', v_inv_balanced,
+                'status', CASE
+                    WHEN NOT v_gl_available          THEN 'gl_unavailable'
+                    WHEN v_sub_inventory IS NULL     THEN 'subledger_unavailable'
+                    WHEN v_inv_balanced              THEN 'balanced'
+                    ELSE 'unbalanced' END
+            ),
+            jsonb_build_object(
+                'section', 'wip',
+                'title_ar', 'الإنتاج تحت التشغيل',
+                'gl_prefixes', to_jsonb(p_wip_prefixes),
+                'gl_balance', CASE WHEN v_gl_available THEN ROUND(v_gl_wip, 6) END,
+                'gl_accounts', v_wip_accounts,
+                'subledger_balance', CASE WHEN v_sub_wip IS NOT NULL
+                                          THEN ROUND(v_sub_wip, 6) END,
+                'subledger_source', v_sub_wip_source,
+                'open_mo_count', v_open_mo_count,
+                'difference', CASE WHEN v_wip_diff IS NOT NULL
+                                   THEN ROUND(v_wip_diff, 6) END,
+                'is_balanced', v_wip_balanced,
+                'status', CASE
+                    WHEN NOT v_gl_available      THEN 'gl_unavailable'
+                    WHEN v_sub_wip IS NULL       THEN 'subledger_unavailable'
+                    WHEN v_wip_balanced          THEN 'balanced'
+                    ELSE 'unbalanced' END
+            )
+        ),
+        'all_balanced', v_inv_balanced AND v_wip_balanced
+    );
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_subledger_gl_reconciliation(DATE, UUID, TEXT[], TEXT[]) IS
+'تسوية الدفاتر الفرعية مع الأستاذ العام: المخزون (131*/135*) مقابل دفتر المخزون الفرعي، وWIP (134*) مقابل stage_costs للأوامر المفتوحة. قراءة فقط (STABLE) — دفاعية: أي جدول غير موجود يُعلَّم قسمه unavailable دون فشل. Migration 81';
+
+GRANT EXECUTE ON FUNCTION public.rpc_subledger_gl_reconciliation(DATE, UUID, TEXT[], TEXT[]) TO authenticated;
+
+-- ===================================================================
+-- التحقق بعد التطبيق:
+--   SELECT proname FROM pg_proc WHERE proname = 'rpc_subledger_gl_reconciliation';
+-- الاستخدام:
+--   SELECT rpc_subledger_gl_reconciliation();                    -- اليوم
+--   SELECT rpc_subledger_gl_reconciliation('2026-06-30');        -- تاريخ محدد
+-- ===================================================================

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -428,7 +428,8 @@ export function Sidebar() {
         { key: 'journal-entries', href: '/accounting/journal-entries', label: isRTL ? 'قيود اليومية' : 'Journal Entries' },
         { key: 'trial-balance', href: '/accounting/trial-balance', label: isRTL ? 'ميزان المراجعة' : 'Trial Balance' },
         { key: 'account-statement', href: '/accounting/account-statement', label: isRTL ? 'كشف حساب' : 'Account Statement' },
-        { key: 'posting', href: '/accounting/posting', label: isRTL ? 'الترحيل' : 'Posting' }
+        { key: 'posting', href: '/accounting/posting', label: isRTL ? 'الترحيل' : 'Posting' },
+        { key: 'reconciliation', href: '/accounting/reconciliation', label: isRTL ? 'تسوية الدفاتر مع GL' : 'Subledger ↔ GL Reconciliation' }
       ]
     },
     {

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -362,6 +362,7 @@ export function Sidebar() {
         { key: 'capacity', href: '/manufacturing/capacity', label: isRTL ? 'تخطيط الطاقة' : 'Capacity Planning' },
         { key: 'efficiency', href: '/manufacturing/efficiency', label: isRTL ? 'الكفاءة والأداء' : 'Efficiency & OEE' },
         { key: 'process-costing', href: '/manufacturing/process-costing', label: t('navigation.process-costing') },
+        { key: 'cost-of-production', href: '/manufacturing/cost-of-production', label: isRTL ? 'تقرير تكلفة الإنتاج' : 'Cost of Production Report' },
         { key: 'stages', href: '/manufacturing/stages', label: t('navigation.stages', { defaultValue: 'مراحل التصنيع' }) },
         { key: 'wip-log', href: '/manufacturing/wip-log', label: t('navigation.wipLog', { defaultValue: 'سجلات WIP' }) },
         { key: 'standard-costs', href: '/manufacturing/standard-costs', label: t('navigation.standardCosts', { defaultValue: 'التكاليف القياسية' }) },

--- a/src/features/accounting/index.tsx
+++ b/src/features/accounting/index.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/button';
 const JournalEntries = lazy(() => import('./journal-entries').then(m => ({ default: m.default })));
 const TrialBalance = lazy(() => import('./trial-balance').then(m => ({ default: m.default })));
 const AccountStatement = lazy(() => import('./account-statement').then(m => ({ default: m.AccountStatement })));
+const ReconciliationPage = lazy(() => import('./reconciliation').then(m => ({ default: m.ReconciliationPage })));
 
 // Loading component
 function LoadingSpinner() {
@@ -156,6 +157,7 @@ export function AccountingModule() {
         <Route path="/trial-balance" element={<TrialBalance />} />
         <Route path="/account-statement" element={<AccountStatement />} />
         <Route path="/posting" element={<PostingPage />} />
+        <Route path="/reconciliation" element={<ReconciliationPage />} />
         <Route path="*" element={<Navigate to="/accounting" replace />} />
       </Routes>
     </Suspense>

--- a/src/features/accounting/reconciliation/__tests__/reconciliation-page.test.tsx
+++ b/src/features/accounting/reconciliation/__tests__/reconciliation-page.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * اختبارات شاشة تسوية الدفاتر الفرعية مع GL
+ */
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '../../../../test/test-utils'
+
+process.env.VITE_SUPABASE_URL = process.env.VITE_SUPABASE_URL || 'http://localhost:54321'
+process.env.VITE_SUPABASE_ANON_KEY = process.env.VITE_SUPABASE_ANON_KEY || 'test-anon-key'
+
+const mockRpc = vi.fn()
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    rpc: (...args: unknown[]) => mockRpc(...args),
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: null }, error: null }),
+    },
+  },
+  getEffectiveTenantId: vi.fn(() => Promise.resolve('test-tenant-id')),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'ar' },
+  }),
+}))
+
+import { ReconciliationPage } from '../index'
+
+const balancedReport = {
+  success: true,
+  report_type: 'subledger_gl_reconciliation',
+  as_of_date: '2026-07-09',
+  generated_at: '2026-07-09T12:00:00Z',
+  gl_available: true,
+  sections: [
+    {
+      section: 'inventory',
+      title_ar: 'المخزون (مواد خام + إنتاج تام)',
+      gl_prefixes: ['131', '135'],
+      gl_balance: 250000,
+      gl_accounts: [{ code: '131100', name: 'مواد خام LDPE', balance: 250000 }],
+      subledger_balance: 250000,
+      subledger_source: 'inventory_ledger',
+      difference: 0,
+      is_balanced: true,
+      status: 'balanced'
+    },
+    {
+      section: 'wip',
+      title_ar: 'الإنتاج تحت التشغيل',
+      gl_prefixes: ['134'],
+      gl_balance: 42000,
+      gl_accounts: [],
+      subledger_balance: 41000,
+      subledger_source: 'stage_costs (أوامر مفتوحة)',
+      open_mo_count: 2,
+      difference: 1000,
+      is_balanced: false,
+      status: 'unbalanced'
+    }
+  ],
+  all_balanced: false
+}
+
+describe('ReconciliationPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRpc.mockResolvedValue({ data: balancedReport, error: null })
+  })
+
+  it('يعرض العنوان وحقل التاريخ وأزرار التحكم', async () => {
+    render(<ReconciliationPage />)
+
+    expect(screen.getByText('تسوية الدفاتر الفرعية مع الأستاذ العام')).toBeInTheDocument()
+    expect(screen.getByTestId('as-of-date')).toBeInTheDocument()
+    expect(screen.getByText('طباعة')).toBeInTheDocument()
+  })
+
+  it('يعرض قسمي المخزون وWIP مع حالة كل قسم', async () => {
+    render(<ReconciliationPage />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reconciliation-report')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('المخزون (مواد خام + إنتاج تام)')).toBeInTheDocument()
+    expect(screen.getByText('الإنتاج تحت التشغيل')).toBeInTheDocument()
+    expect(screen.getByText('متوازن')).toBeInTheDocument()
+    expect(screen.getByText('يوجد فرق!')).toBeInTheDocument()
+    // الشارة الكلية تعكس وجود فرق
+    expect(screen.getByText('توجد فروق تحتاج مراجعة')).toBeInTheDocument()
+  })
+
+  it('يعرض رسالة الخطأ عند غياب Migration 81', async () => {
+    mockRpc.mockResolvedValue({
+      data: null,
+      error: { code: 'PGRST202', message: 'Could not find the function' }
+    })
+
+    render(<ReconciliationPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/Migration 81/)).toBeInTheDocument()
+    })
+  })
+})

--- a/src/features/accounting/reconciliation/index.tsx
+++ b/src/features/accounting/reconciliation/index.tsx
@@ -1,0 +1,248 @@
+/**
+ * شاشة تسوية الدفاتر الفرعية مع الأستاذ العام
+ * المخزون (بادئات 131، 135) وWIP (بادئة 134) مقابل الدفاتر الفرعية — مع كشف الفروق فوراً
+ * تتطلب Migration 81 — تظهر إرشاداً واضحاً إن لم تُطبَّق
+ */
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useQuery } from '@tanstack/react-query'
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Input } from '@/components/ui/input'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import {
+  Table, TableBody, TableCell, TableHead, TableHeader, TableRow
+} from '@/components/ui/table'
+import { RefreshCw, CheckCircle2, AlertTriangle, Scale, Printer } from 'lucide-react'
+import {
+  ReconciliationService,
+  type ReconciliationReport,
+  type ReconciliationSection
+} from '@/services/accounting/reconciliation-service'
+
+const nf = new Intl.NumberFormat('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+function money(v: number | null): string {
+  return v === null || v === undefined ? '—' : nf.format(v)
+}
+
+function StatusBadge({ status, isRTL }: { readonly status: ReconciliationSection['status']; readonly isRTL: boolean }) {
+  switch (status) {
+    case 'balanced':
+      return (
+        <Badge variant="default" className="bg-green-600 hover:bg-green-600 gap-1">
+          <CheckCircle2 className="h-3 w-3" />
+          {isRTL ? 'متوازن' : 'Balanced'}
+        </Badge>
+      )
+    case 'unbalanced':
+      return (
+        <Badge variant="destructive" className="gap-1">
+          <AlertTriangle className="h-3 w-3" />
+          {isRTL ? 'يوجد فرق!' : 'Difference!'}
+        </Badge>
+      )
+    case 'gl_unavailable':
+      return <Badge variant="secondary">{isRTL ? 'GL غير متاح' : 'GL unavailable'}</Badge>
+    default:
+      return <Badge variant="secondary">{isRTL ? 'دفتر فرعي غير متاح' : 'Subledger unavailable'}</Badge>
+  }
+}
+
+function SectionCard({ section, isRTL }: { readonly section: ReconciliationSection; readonly isRTL: boolean }) {
+  return (
+    <Card className={cn(
+      'print:shadow-none print:border-black break-inside-avoid',
+      section.status === 'unbalanced' && 'border-destructive'
+    )}>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between flex-wrap gap-2">
+          <CardTitle className="text-lg">{section.title_ar}</CardTitle>
+          <StatusBadge status={section.status} isRTL={isRTL} />
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* ملخص المقارنة */}
+        <div className="overflow-x-auto">
+          <Table>
+            <TableBody>
+              <TableRow>
+                <TableCell>
+                  {isRTL ? 'رصيد الأستاذ العام' : 'GL balance'}
+                  <span className="text-xs text-muted-foreground mx-1">
+                    ({section.gl_prefixes.join('*, ')}*)
+                  </span>
+                </TableCell>
+                <TableCell className="text-end font-mono">{money(section.gl_balance)}</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>
+                  {isRTL ? 'رصيد الدفتر الفرعي' : 'Subledger balance'}
+                  {section.subledger_source && (
+                    <span className="text-xs text-muted-foreground mx-1">
+                      ({section.subledger_source})
+                    </span>
+                  )}
+                  {typeof section.open_mo_count === 'number' && section.open_mo_count > 0 && (
+                    <span className="text-xs text-muted-foreground mx-1">
+                      · {isRTL ? `${section.open_mo_count} أمر مفتوح` : `${section.open_mo_count} open MOs`}
+                    </span>
+                  )}
+                </TableCell>
+                <TableCell className="text-end font-mono">{money(section.subledger_balance)}</TableCell>
+              </TableRow>
+              <TableRow className={cn(
+                'border-t-2 font-semibold',
+                section.status === 'balanced' && 'text-green-700',
+                section.status === 'unbalanced' && 'text-destructive'
+              )}>
+                <TableCell>{isRTL ? 'الفرق' : 'Difference'}</TableCell>
+                <TableCell className="text-end font-mono">
+                  {money(section.difference)} {section.status === 'balanced' ? '✓' : section.status === 'unbalanced' ? '✗' : ''}
+                </TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </div>
+
+        {/* تفصيل حسابات GL */}
+        {section.gl_accounts.length > 0 && (
+          <div>
+            <h4 className="font-semibold mb-2 text-sm text-muted-foreground">
+              {isRTL ? 'تفصيل حسابات الأستاذ العام' : 'GL account detail'}
+            </h4>
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="text-start">{isRTL ? 'الكود' : 'Code'}</TableHead>
+                    <TableHead className="text-start">{isRTL ? 'الحساب' : 'Account'}</TableHead>
+                    <TableHead className="text-end">{isRTL ? 'الرصيد' : 'Balance'}</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {section.gl_accounts.map((acc) => (
+                    <TableRow key={acc.code}>
+                      <TableCell className="font-mono">{acc.code}</TableCell>
+                      <TableCell>{acc.name}</TableCell>
+                      <TableCell className="text-end font-mono">{money(acc.balance)}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          </div>
+        )}
+
+        {/* إرشاد عند وجود فرق */}
+        {section.status === 'unbalanced' && (
+          <p className="text-sm text-destructive">
+            {isRTL
+              ? 'الفرق يعني قيداً يدوياً شارداً على حسابات هذا القسم أو حركة فرعية لم تُرحَّل — راجع قيود اليومية على هذه الحسابات بنفس التاريخ'
+              : 'A difference means a stray manual entry on these accounts or an unposted subledger movement — review journal entries on these accounts as of this date'}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+export function ReconciliationPage() {
+  const { i18n } = useTranslation()
+  const isRTL = i18n.language === 'ar'
+  const [asOfDate, setAsOfDate] = useState<string>(new Date().toISOString().slice(0, 10))
+
+  const {
+    data: report,
+    isFetching,
+    error,
+    refetch
+  } = useQuery<ReconciliationReport, Error>({
+    queryKey: ['subledger-gl-reconciliation', asOfDate],
+    queryFn: () => ReconciliationService.getReport(asOfDate),
+    retry: false,
+    staleTime: 30_000
+  })
+
+  return (
+    <div className="space-y-6" dir={isRTL ? 'rtl' : 'ltr'}>
+      <div className={cn(isRTL ? 'text-right' : 'text-left', 'print:hidden')}>
+        <h1 className="text-3xl font-bold">
+          {isRTL ? 'تسوية الدفاتر الفرعية مع الأستاذ العام' : 'Subledger ↔ GL Reconciliation'}
+        </h1>
+        <p className="text-muted-foreground mt-2">
+          {isRTL
+            ? 'مقارنة أرصدة المخزون والإنتاج تحت التشغيل الفرعية مع حسابات الأستاذ العام — أي فرق يظهر فوراً'
+            : 'Compare inventory and WIP subledger balances against GL accounts — any difference surfaces immediately'}
+        </p>
+      </div>
+
+      {/* شريط التحكم */}
+      <Card className="print:hidden">
+        <CardContent className="pt-6">
+          <div className="flex flex-wrap items-center gap-3">
+            <div className="flex items-center gap-2">
+              <Scale className="h-4 w-4 text-muted-foreground" />
+              <Input
+                type="date"
+                value={asOfDate}
+                onChange={(e) => setAsOfDate(e.target.value)}
+                className="w-44"
+                data-testid="as-of-date"
+              />
+            </div>
+            <Button
+              variant="outline"
+              onClick={() => refetch()}
+              disabled={isFetching}
+              className="gap-2"
+            >
+              <RefreshCw className={cn('h-4 w-4', isFetching && 'animate-spin')} />
+              {isRTL ? 'تحديث' : 'Refresh'}
+            </Button>
+            <Button onClick={() => window.print()} disabled={!report} className="gap-2">
+              <Printer className="h-4 w-4" />
+              {isRTL ? 'طباعة' : 'Print'}
+            </Button>
+            {report && (
+              <div className="ms-auto">
+                {report.all_balanced ? (
+                  <Badge variant="default" className="bg-green-600 hover:bg-green-600 gap-1">
+                    <CheckCircle2 className="h-3 w-3" />
+                    {isRTL ? 'كل الأقسام متوازنة' : 'All sections balanced'}
+                  </Badge>
+                ) : (
+                  <Badge variant="destructive" className="gap-1">
+                    <AlertTriangle className="h-3 w-3" />
+                    {isRTL ? 'توجد فروق تحتاج مراجعة' : 'Differences need review'}
+                  </Badge>
+                )}
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {error && (
+        <Card className="border-destructive">
+          <CardContent className="pt-6 text-destructive">{error.message}</CardContent>
+        </Card>
+      )}
+
+      {report && (
+        <div className="space-y-6" data-testid="reconciliation-report">
+          {report.sections.map((section) => (
+            <SectionCard key={section.section} section={section} isRTL={isRTL} />
+          ))}
+          <p className="text-xs text-muted-foreground">
+            {isRTL ? 'حتى تاريخ' : 'As of'}: {report.as_of_date}
+            {' · '}
+            {isRTL ? 'أُنشئ في' : 'Generated'}: {new Date(report.generated_at).toLocaleString(isRTL ? 'ar-SA' : 'en-US')}
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default ReconciliationPage

--- a/src/features/manufacturing/__tests__/cost-of-production-report.test.tsx
+++ b/src/features/manufacturing/__tests__/cost-of-production-report.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * اختبارات شاشة تقرير تكلفة الإنتاج
+ */
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '../../../test/test-utils'
+
+process.env.VITE_SUPABASE_URL = process.env.VITE_SUPABASE_URL || 'http://localhost:54321'
+process.env.VITE_SUPABASE_ANON_KEY = process.env.VITE_SUPABASE_ANON_KEY || 'test-anon-key'
+
+const mockRpc = vi.fn()
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    rpc: (...args: unknown[]) => mockRpc(...args),
+    from: vi.fn(() => ({
+      select: vi.fn().mockResolvedValue({ data: [], error: null }),
+    })),
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: null }, error: null }),
+    },
+  },
+  getEffectiveTenantId: vi.fn(() => Promise.resolve('test-tenant-id')),
+}))
+
+// أوامر تصنيع جاهزة للاختيار
+vi.mock('../hooks/useManufacturingOrders', () => ({
+  useManufacturingOrders: () => ({
+    orders: [
+      { id: 'mo-1', order_number: 'MO-2026-0001', product_name: 'منتج تجريبي', status: 'in_progress', quantity: 1000, item_id: 'item-1' },
+    ],
+    loading: false,
+    loadOrders: vi.fn(),
+  }),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'ar' },
+  }),
+}))
+
+import { CostOfProductionReportView } from '../cost-of-production-report'
+
+describe('CostOfProductionReportView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('يعرض الشاشة بدون أخطاء مع رسالة اختيار الأمر', async () => {
+    render(<CostOfProductionReportView />)
+
+    expect(
+      screen.getByText(/اختر أمر تصنيع لعرض تقرير تكلفة الإنتاج/)
+    ).toBeInTheDocument()
+  })
+
+  it('يعرض قائمة اختيار أوامر التصنيع وأزرار التحكم', async () => {
+    render(<CostOfProductionReportView />)
+
+    expect(screen.getByTestId('mo-select')).toBeInTheDocument()
+    expect(screen.getByText('طباعة')).toBeInTheDocument()
+    expect(screen.getByText('تحديث')).toBeInTheDocument()
+  })
+
+  it('زر الطباعة معطَّل قبل توليد التقرير', () => {
+    render(<CostOfProductionReportView />)
+
+    const printBtn = screen.getByText('طباعة').closest('button')
+    expect(printBtn).toBeDisabled()
+  })
+})

--- a/src/features/manufacturing/cost-of-production-report.tsx
+++ b/src/features/manufacturing/cost-of-production-report.tsx
@@ -1,0 +1,442 @@
+/**
+ * تقرير تكلفة الإنتاج بالوحدات المكافئة — Cost of Production Report
+ * الشكل المحاسبي القياسي بخطواته الخمس + تسوية + طباعة
+ * يتطلب Migration 80 (rpc_cost_of_production_report) — يظهر إرشاد واضح إن لم تُطبَّق
+ */
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useQuery } from '@tanstack/react-query'
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import {
+  Table, TableBody, TableCell, TableHead, TableHeader, TableRow
+} from '@/components/ui/table'
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue
+} from '@/components/ui/select'
+import { Printer, RefreshCw, CheckCircle2, AlertTriangle, FileBarChart } from 'lucide-react'
+import { useManufacturingOrders } from './hooks/useManufacturingOrders'
+import {
+  CostOfProductionService,
+  type CostOfProductionReport as CPReport,
+  type StageReport
+} from '@/services/manufacturing/cost-of-production-service'
+
+const nf = new Intl.NumberFormat('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+const qf = new Intl.NumberFormat('en-US', { maximumFractionDigits: 3 })
+
+function money(v: number): string { return nf.format(v ?? 0) }
+function qty(v: number): string { return qf.format(v ?? 0) }
+
+function BalanceBadge({ balanced, isRTL }: { readonly balanced: boolean; readonly isRTL: boolean }) {
+  return balanced ? (
+    <Badge variant="default" className="bg-green-600 hover:bg-green-600 gap-1">
+      <CheckCircle2 className="h-3 w-3" />
+      {isRTL ? 'متوازن' : 'Balanced'}
+    </Badge>
+  ) : (
+    <Badge variant="destructive" className="gap-1">
+      <AlertTriangle className="h-3 w-3" />
+      {isRTL ? 'غير متوازن' : 'Unbalanced'}
+    </Badge>
+  )
+}
+
+function StageSection({ stage, isRTL }: { readonly stage: StageReport; readonly isRTL: boolean }) {
+  const qs = stage.quantity_schedule
+  const eu = stage.equivalent_units
+  const ca = stage.costs_to_account
+  const pe = stage.cost_per_eu
+  const asg = stage.cost_assignment
+  const rec = stage.reconciliation
+  const methodLabel = stage.costing_method === 'fifo'
+    ? (isRTL ? 'الوارد أولاً صادر أولاً (FIFO)' : 'FIFO')
+    : (isRTL ? 'المتوسط المرجّح' : 'Weighted Average')
+
+  return (
+    <Card className="print:shadow-none print:border-black break-inside-avoid">
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between flex-wrap gap-2">
+          <CardTitle className="text-lg">
+            {isRTL ? `المرحلة ${stage.stage_no}` : `Stage ${stage.stage_no}`}
+            <span className="text-sm font-normal text-muted-foreground mx-2">({methodLabel})</span>
+          </CardTitle>
+          <BalanceBadge balanced={rec.is_balanced && qs.is_balanced} isRTL={isRTL} />
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-6">
+
+        {/* ===== الخطوة 1: جدول الكميات ===== */}
+        <section>
+          <h4 className="font-semibold mb-2 text-sm">
+            {isRTL ? '١) جدول الكميات' : '1) Quantity Schedule'}
+          </h4>
+          <div className="overflow-x-auto">
+            <Table>
+              <TableBody>
+                <TableRow>
+                  <TableCell>{isRTL ? 'وحدات تحت التشغيل أول المدة' : 'Beginning WIP'}</TableCell>
+                  <TableCell className="text-end font-mono">{qty(qs.wip_beginning_qty)}</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>{isRTL ? 'وحدات بدأ تشغيلها' : 'Units started'}</TableCell>
+                  <TableCell className="text-end font-mono">{qty(qs.units_started)}</TableCell>
+                </TableRow>
+                <TableRow className="border-t-2 font-semibold bg-muted/50">
+                  <TableCell>{isRTL ? 'الوحدات الواجب حسابها' : 'Units to account for'}</TableCell>
+                  <TableCell className="text-end font-mono">{qty(qs.units_to_account)}</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>{isRTL ? 'وحدات مكتملة ومحوَّلة' : 'Completed & transferred'}</TableCell>
+                  <TableCell className="text-end font-mono">{qty(qs.units_completed)}</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>{isRTL ? 'وحدات تحت التشغيل آخر المدة' : 'Ending WIP'}</TableCell>
+                  <TableCell className="text-end font-mono">{qty(qs.wip_ending_qty)}</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>{isRTL ? 'تالف طبيعي' : 'Normal scrap'}</TableCell>
+                  <TableCell className="text-end font-mono">{qty(qs.normal_scrap_qty)}</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>{isRTL ? 'تالف غير طبيعي' : 'Abnormal scrap'}</TableCell>
+                  <TableCell className="text-end font-mono">{qty(qs.abnormal_scrap_qty)}</TableCell>
+                </TableRow>
+                {qs.rework_qty > 0 && (
+                  <TableRow>
+                    <TableCell>{isRTL ? 'إعادة تشغيل' : 'Rework'}</TableCell>
+                    <TableCell className="text-end font-mono">{qty(qs.rework_qty)}</TableCell>
+                  </TableRow>
+                )}
+                <TableRow className="border-t-2 font-semibold bg-muted/50">
+                  <TableCell>{isRTL ? 'الوحدات المحسوبة' : 'Units accounted for'}</TableCell>
+                  <TableCell className="text-end font-mono">{qty(qs.units_accounted)}</TableCell>
+                </TableRow>
+                {!qs.is_balanced && (
+                  <TableRow className="text-destructive font-semibold">
+                    <TableCell>{isRTL ? '⚠ فرق كميات' : '⚠ Quantity difference'}</TableCell>
+                    <TableCell className="text-end font-mono">{qty(qs.qty_difference)}</TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </section>
+
+        {/* ===== الخطوة 2: الوحدات المكافئة ===== */}
+        <section>
+          <h4 className="font-semibold mb-2 text-sm">
+            {isRTL ? '٢) الوحدات المكافئة (EUP)' : '2) Equivalent Units (EUP)'}
+          </h4>
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="text-start">{isRTL ? 'عنصر التكلفة' : 'Cost element'}</TableHead>
+                  <TableHead className="text-end">{isRTL ? 'نسبة إتمام WIP النهائي' : 'Ending WIP %'}</TableHead>
+                  <TableHead className="text-end">{isRTL ? 'الوحدات المكافئة' : 'EUP'}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                <TableRow>
+                  <TableCell>{isRTL ? 'مواد مباشرة' : 'Direct materials'}</TableCell>
+                  <TableCell className="text-end font-mono">{eu.wip_end_dm_completion_pct}%</TableCell>
+                  <TableCell className="text-end font-mono">{qty(eu.eup_dm)}</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>{isRTL ? 'تكاليف تحويل (عمالة + أوفرهيد)' : 'Conversion costs'}</TableCell>
+                  <TableCell className="text-end font-mono">{eu.wip_end_cc_completion_pct}%</TableCell>
+                  <TableCell className="text-end font-mono">{qty(eu.eup_cc)}</TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </div>
+        </section>
+
+        {/* ===== الخطوة 3: التكاليف الواجب حسابها ===== */}
+        <section>
+          <h4 className="font-semibold mb-2 text-sm">
+            {isRTL ? '٣) التكاليف الواجب حسابها' : '3) Costs to Account For'}
+          </h4>
+          <div className="overflow-x-auto">
+            <Table>
+              <TableBody>
+                {ca.wip_beginning_cost > 0 && (
+                  <TableRow>
+                    <TableCell>{isRTL ? 'تكلفة WIP أول المدة' : 'Beginning WIP cost'}</TableCell>
+                    <TableCell className="text-end font-mono">{money(ca.wip_beginning_cost)}</TableCell>
+                  </TableRow>
+                )}
+                {ca.transferred_in > 0 && (
+                  <TableRow>
+                    <TableCell>{isRTL ? 'محوَّل وارد من المرحلة السابقة' : 'Transferred in'}</TableCell>
+                    <TableCell className="text-end font-mono">{money(ca.transferred_in)}</TableCell>
+                  </TableRow>
+                )}
+                <TableRow>
+                  <TableCell>{isRTL ? 'مواد مباشرة' : 'Direct materials'}</TableCell>
+                  <TableCell className="text-end font-mono">{money(ca.direct_materials)}</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>{isRTL ? 'عمالة مباشرة' : 'Direct labor'}</TableCell>
+                  <TableCell className="text-end font-mono">{money(ca.direct_labor)}</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>{isRTL ? 'أوفرهيد محمَّل' : 'Overhead applied'}</TableCell>
+                  <TableCell className="text-end font-mono">{money(ca.overhead_applied)}</TableCell>
+                </TableRow>
+                {ca.regrind_cost > 0 && (
+                  <TableRow>
+                    <TableCell>{isRTL ? 'تكلفة إعادة طحن' : 'Regrind cost'}</TableCell>
+                    <TableCell className="text-end font-mono">{money(ca.regrind_cost)}</TableCell>
+                  </TableRow>
+                )}
+                {ca.waste_credit > 0 && (
+                  <TableRow>
+                    <TableCell>{isRTL ? '(−) رصيد بيع خردة' : '(−) Waste credit'}</TableCell>
+                    <TableCell className="text-end font-mono">({money(ca.waste_credit)})</TableCell>
+                  </TableRow>
+                )}
+                <TableRow className="border-t-2 font-semibold bg-muted/50">
+                  <TableCell>{isRTL ? 'إجمالي التكاليف الواجب حسابها' : 'Total costs to account for'}</TableCell>
+                  <TableCell className="text-end font-mono">{money(ca.total_costs_in)}</TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </div>
+        </section>
+
+        {/* ===== الخطوة 4: تكلفة الوحدة المكافئة ===== */}
+        <section>
+          <h4 className="font-semibold mb-2 text-sm">
+            {isRTL ? '٤) تكلفة الوحدة المكافئة' : '4) Cost per Equivalent Unit'}
+          </h4>
+          <div className="overflow-x-auto">
+            <Table>
+              <TableBody>
+                {pe.transferred_in_per_eu > 0 && (
+                  <TableRow>
+                    <TableCell>{isRTL ? 'محوَّل وارد / وحدة' : 'Transferred-in per EU'}</TableCell>
+                    <TableCell className="text-end font-mono">{money(pe.transferred_in_per_eu)}</TableCell>
+                  </TableRow>
+                )}
+                <TableRow>
+                  <TableCell>{isRTL ? 'مواد / وحدة مكافئة' : 'DM per EU'}</TableCell>
+                  <TableCell className="text-end font-mono">{money(pe.dm_per_eu)}</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>{isRTL ? 'تحويل / وحدة مكافئة' : 'CC per EU'}</TableCell>
+                  <TableCell className="text-end font-mono">{money(pe.cc_per_eu)}</TableCell>
+                </TableRow>
+                <TableRow className="border-t-2 font-semibold bg-muted/50">
+                  <TableCell>{isRTL ? 'إجمالي تكلفة الوحدة' : 'Total per EU'}</TableCell>
+                  <TableCell className="text-end font-mono">{money(pe.total_per_eu)}</TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </div>
+        </section>
+
+        {/* ===== الخطوة 5: توزيع التكاليف + التسوية ===== */}
+        <section>
+          <h4 className="font-semibold mb-2 text-sm">
+            {isRTL ? '٥) توزيع التكاليف والتسوية' : '5) Cost Assignment & Reconciliation'}
+          </h4>
+          <div className="overflow-x-auto">
+            <Table>
+              <TableBody>
+                <TableRow>
+                  <TableCell>{isRTL ? 'مكتمل ومحوَّل للمرحلة التالية / مخزون تام' : 'Completed & transferred out'}</TableCell>
+                  <TableCell className="text-end font-mono">{money(asg.completed_and_transferred)}</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>{isRTL ? 'تحت التشغيل آخر المدة' : 'Ending WIP'}</TableCell>
+                  <TableCell className="text-end font-mono">{money(asg.ending_wip)}</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>
+                    {isRTL ? 'خسارة تالف غير طبيعي (مصروف فترة)' : 'Abnormal scrap loss (period expense)'}
+                  </TableCell>
+                  <TableCell className="text-end font-mono">{money(asg.abnormal_scrap_loss)}</TableCell>
+                </TableRow>
+                {asg.normal_scrap_absorbed > 0 && (
+                  <TableRow className="text-muted-foreground text-sm">
+                    <TableCell>
+                      {isRTL ? '(للعلم: تالف طبيعي مُمتص في تكلفة الوحدات الجيدة)' : '(Memo: normal scrap absorbed by good units)'}
+                    </TableCell>
+                    <TableCell className="text-end font-mono">{money(asg.normal_scrap_absorbed)}</TableCell>
+                  </TableRow>
+                )}
+                <TableRow className="border-t-2 font-semibold bg-muted/50">
+                  <TableCell>{isRTL ? 'إجمالي التكاليف الموزَّعة' : 'Total costs accounted for'}</TableCell>
+                  <TableCell className="text-end font-mono">{money(asg.total_costs_out)}</TableCell>
+                </TableRow>
+                <TableRow className={cn('font-semibold', rec.is_balanced ? 'text-green-700' : 'text-destructive')}>
+                  <TableCell>
+                    {isRTL ? 'التسوية: داخل − خارج' : 'Reconciliation: in − out'}
+                  </TableCell>
+                  <TableCell className="text-end font-mono">
+                    {money(rec.difference)} {rec.is_balanced ? '✓' : '✗'}
+                  </TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </div>
+        </section>
+      </CardContent>
+    </Card>
+  )
+}
+
+export function CostOfProductionReportView() {
+  const { i18n } = useTranslation()
+  const isRTL = i18n.language === 'ar'
+  const { orders, loading: ordersLoading } = useManufacturingOrders()
+  const [selectedMoId, setSelectedMoId] = useState<string>('')
+
+  const {
+    data: report,
+    isFetching,
+    error,
+    refetch
+  } = useQuery<CPReport, Error>({
+    queryKey: ['cost-of-production-report', selectedMoId],
+    queryFn: () => CostOfProductionService.getReport(selectedMoId),
+    enabled: !!selectedMoId,
+    retry: false,
+    staleTime: 30_000
+  })
+
+  return (
+    <div className="space-y-6">
+      {/* شريط التحكم — يختفي عند الطباعة */}
+      <Card className="print:hidden">
+        <CardContent className="pt-6">
+          <div className="flex flex-wrap items-center gap-3">
+            <div className="min-w-64">
+              <Select value={selectedMoId} onValueChange={setSelectedMoId} disabled={ordersLoading}>
+                <SelectTrigger data-testid="mo-select">
+                  <SelectValue placeholder={isRTL ? 'اختر أمر التصنيع…' : 'Select MO…'} />
+                </SelectTrigger>
+                <SelectContent>
+                  {orders.map((mo) => (
+                    <SelectItem key={mo.id} value={mo.id}>
+                      {mo.order_number || mo.id} {mo.product_name ? `— ${mo.product_name}` : ''}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <Button
+              variant="outline"
+              onClick={() => refetch()}
+              disabled={!selectedMoId || isFetching}
+              className="gap-2"
+            >
+              <RefreshCw className={cn('h-4 w-4', isFetching && 'animate-spin')} />
+              {isRTL ? 'تحديث' : 'Refresh'}
+            </Button>
+            <Button
+              onClick={() => window.print()}
+              disabled={!report}
+              className="gap-2"
+            >
+              <Printer className="h-4 w-4" />
+              {isRTL ? 'طباعة' : 'Print'}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* حالات: خطأ / فارغ / التقرير */}
+      {error && (
+        <Card className="border-destructive">
+          <CardContent className="pt-6 text-destructive">
+            {error.message}
+          </CardContent>
+        </Card>
+      )}
+
+      {!selectedMoId && !error && (
+        <Card>
+          <CardContent className="pt-6 text-center text-muted-foreground py-16">
+            <FileBarChart className="h-12 w-12 mx-auto mb-4 opacity-40" />
+            {isRTL
+              ? 'اختر أمر تصنيع لعرض تقرير تكلفة الإنتاج بالوحدات المكافئة'
+              : 'Select a manufacturing order to view the Cost of Production Report'}
+          </CardContent>
+        </Card>
+      )}
+
+      {report && (
+        <div className="space-y-6" data-testid="cpr-report">
+          {/* رأس التقرير */}
+          <Card className="print:shadow-none print:border-black">
+            <CardContent className="pt-6">
+              <div className="flex items-start justify-between flex-wrap gap-3">
+                <div>
+                  <h2 className="text-2xl font-bold">
+                    {isRTL ? 'تقرير تكلفة الإنتاج' : 'Cost of Production Report'}
+                  </h2>
+                  <p className="text-muted-foreground mt-1">
+                    {isRTL ? 'أمر التصنيع' : 'MO'}: <span className="font-mono font-semibold">{report.manufacturing_order.order_number}</span>
+                    {' · '}
+                    {isRTL ? 'الحالة' : 'Status'}: {report.manufacturing_order.status}
+                    {' · '}
+                    {isRTL ? 'الكمية المخططة' : 'Planned qty'}: {qty(report.manufacturing_order.qty_planned)}
+                  </p>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    {isRTL ? 'أُنشئ في' : 'Generated'}: {new Date(report.generated_at).toLocaleString(isRTL ? 'ar-SA' : 'en-US')}
+                  </p>
+                </div>
+                <BalanceBadge balanced={report.totals.all_stages_balanced} isRTL={isRTL} />
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* المراحل */}
+          {report.stages.map((stage) => (
+            <StageSection key={stage.stage_no} stage={stage} isRTL={isRTL} />
+          ))}
+
+          {/* الإجماليات */}
+          <Card className="print:shadow-none print:border-black break-inside-avoid">
+            <CardHeader className="pb-3">
+              <CardTitle className="text-lg">
+                {isRTL ? 'إجمالي أمر التصنيع (كل المراحل)' : 'Grand Totals (all stages)'}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableBody>
+                    <TableRow>
+                      <TableCell>{isRTL ? 'إجمالي التكاليف الداخلة' : 'Total costs in'}</TableCell>
+                      <TableCell className="text-end font-mono">{money(report.totals.total_costs_in)}</TableCell>
+                    </TableRow>
+                    <TableRow>
+                      <TableCell>{isRTL ? 'مكتمل ومحوَّل' : 'Completed & transferred'}</TableCell>
+                      <TableCell className="text-end font-mono">{money(report.totals.total_completed)}</TableCell>
+                    </TableRow>
+                    <TableRow>
+                      <TableCell>{isRTL ? 'تحت التشغيل آخر المدة' : 'Ending WIP'}</TableCell>
+                      <TableCell className="text-end font-mono">{money(report.totals.total_ending_wip)}</TableCell>
+                    </TableRow>
+                    <TableRow>
+                      <TableCell>{isRTL ? 'خسائر تالف غير طبيعي' : 'Abnormal scrap losses'}</TableCell>
+                      <TableCell className="text-end font-mono">{money(report.totals.total_abnormal_scrap_loss)}</TableCell>
+                    </TableRow>
+                  </TableBody>
+                </Table>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default CostOfProductionReportView

--- a/src/features/manufacturing/hooks/__tests__/useManufacturingOrders.test.tsx
+++ b/src/features/manufacturing/hooks/__tests__/useManufacturingOrders.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * اختبارات useManufacturingOrders الموحَّد على React Query (بند 11)
+ * تثبت أن الواجهة { orders, loading, loadOrders } لم تتغير
+ */
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const mockGetAll = vi.fn()
+
+vi.mock('@/services/supabase-service', () => ({
+  manufacturingService: { getAll: (...args: unknown[]) => mockGetAll(...args) },
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'ar' } }),
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {},
+  getEffectiveTenantId: vi.fn(() => Promise.resolve(null)),
+}))
+
+import { useManufacturingOrders, MANUFACTURING_ORDERS_QUERY_KEY } from '../useManufacturingOrders'
+import { useManufacturingProducts } from '../useManufacturingProducts'
+
+function wrapper({ children }: { readonly children: React.ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+}
+
+describe('useManufacturingOrders (React Query — بند 11)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('يحمّل الأوامر ويرجعها بنفس الواجهة القديمة { orders, loading, loadOrders }', async () => {
+    const orders = [{ id: 'mo-1', order_number: 'MO-001', status: 'draft' }]
+    mockGetAll.mockResolvedValue(orders)
+
+    const { result } = renderHook(() => useManufacturingOrders(), { wrapper })
+
+    expect(result.current.loading).toBe(true)
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.orders).toEqual(orders)
+    expect(typeof result.current.loadOrders).toBe('function')
+  })
+
+  it('يستخدم نفس مفتاح الكاش المشترك مع hooks/use-manufacturing', () => {
+    expect(MANUFACTURING_ORDERS_QUERY_KEY).toEqual(['manufacturing-orders'])
+  })
+
+  it('جدول غير موجود (PGRST205) ⇒ قائمة فارغة بدون كسر', async () => {
+    mockGetAll.mockRejectedValue({ code: 'PGRST205', message: 'Could not find the table' })
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const { result } = renderHook(() => useManufacturingOrders(), { wrapper })
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.orders).toEqual([])
+    warnSpy.mockRestore()
+  })
+
+  it('خطأ حقيقي ⇒ toast + قائمة فارغة (نفس السلوك القديم)', async () => {
+    mockGetAll.mockRejectedValue(new Error('network down'))
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { toast } = await import('sonner')
+
+    const { result } = renderHook(() => useManufacturingOrders(), { wrapper })
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.orders).toEqual([])
+    expect(toast.error).toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
+
+  it('loadOrders يعيد الجلب (invalidate) — بيانات جديدة تظهر', async () => {
+    mockGetAll.mockResolvedValueOnce([{ id: 'mo-1' }])
+
+    const { result } = renderHook(() => useManufacturingOrders(), { wrapper })
+    await waitFor(() => expect(result.current.orders).toHaveLength(1))
+
+    mockGetAll.mockResolvedValueOnce([{ id: 'mo-1' }, { id: 'mo-2' }])
+    await result.current.loadOrders()
+
+    await waitFor(() => expect(result.current.orders).toHaveLength(2))
+    expect(mockGetAll).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('useManufacturingProducts (React Query — بند 11)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('يرجع نفس الواجهة القديمة { products, loading, loadProducts } — وفشل الجلب لا يكسر النموذج', async () => {
+    // supabase mock فارغ ⇒ fetchProducts يلتقط الخطأ ويرجع []
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const { result } = renderHook(() => useManufacturingProducts(), { wrapper })
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.products).toEqual([])
+    expect(typeof result.current.loadProducts).toBe('function')
+    warnSpy.mockRestore()
+  })
+})

--- a/src/features/manufacturing/hooks/useManufacturingOrders.ts
+++ b/src/features/manufacturing/hooks/useManufacturingOrders.ts
@@ -1,41 +1,54 @@
-import { useState, useEffect } from 'react';
+import { useCallback } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { manufacturingService } from '@/services/supabase-service';
 import { toast } from 'sonner';
 import { useTranslation } from 'react-i18next';
 import type { ManufacturingOrder } from '@/lib/supabase';
 
+/**
+ * نفس مفتاح hooks/use-manufacturing.ts — كاش واحد مشترك عبر التطبيق:
+ * أي invalidation من useCreateManufacturingOrder/useUpdateOrderStatus
+ * يحدّث هذه الشاشات تلقائياً، والعكس صحيح
+ */
+export const MANUFACTURING_ORDERS_QUERY_KEY = ['manufacturing-orders'] as const;
+
+/**
+ * بند 11: موحَّد على React Query داخلياً — الواجهة الخارجية
+ * { orders, loading, loadOrders } كما كانت تماماً، لا كسر لأي مستهلك.
+ * المكاسب: كاش مشترك + إلغاء تكرار الطلبات + refetch تلقائي
+ */
 export function useManufacturingOrders() {
   const { t } = useTranslation();
-  const [orders, setOrders] = useState<ManufacturingOrder[]>([]);
-  const [loading, setLoading] = useState(true);
+  const queryClient = useQueryClient();
 
-  const loadOrders = async () => {
-    try {
-      const data = await manufacturingService.getAll();
-      // Convert OrderWithItem[] to ManufacturingOrder[]
-      const orders = (data || []) as unknown as ManufacturingOrder[];
-      setOrders(orders);
-    } catch (error: any) {
-      if (error.code === 'PGRST205' || error.message?.includes('Could not find the table')) {
-        console.warn('manufacturing_orders table not found, using empty array');
-        setOrders([]);
-      } else {
+  const { data, isLoading } = useQuery<ManufacturingOrder[]>({
+    queryKey: MANUFACTURING_ORDERS_QUERY_KEY,
+    queryFn: async () => {
+      try {
+        const data = await manufacturingService.getAll();
+        return (data || []) as unknown as ManufacturingOrder[];
+      } catch (error: unknown) {
+        const err = error as { code?: string; message?: string };
+        if (err.code === 'PGRST205' || err.message?.includes('Could not find the table')) {
+          console.warn('manufacturing_orders table not found, using empty array');
+          return [];
+        }
         console.error('Error loading orders:', error);
         toast.error(t('manufacturing.ordersPage.loadError'));
+        return [];
       }
-    } finally {
-      setLoading(false);
-    }
-  };
+    },
+    staleTime: 30_000,
+  });
 
-  useEffect(() => {
-    loadOrders();
-  }, []);
+  // نفس التوقيع القديم: تُستدعى بعد الإنشاء/تغيير الحالة لإعادة التحميل
+  const loadOrders = useCallback(async () => {
+    await queryClient.invalidateQueries({ queryKey: MANUFACTURING_ORDERS_QUERY_KEY });
+  }, [queryClient]);
 
   return {
-    orders,
-    loading,
+    orders: data ?? [],
+    loading: isLoading,
     loadOrders
   };
 }
-

--- a/src/features/manufacturing/hooks/useManufacturingProducts.ts
+++ b/src/features/manufacturing/hooks/useManufacturingProducts.ts
@@ -1,4 +1,5 @@
-import { useState, useEffect } from 'react';
+import { useCallback } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { supabase, getEffectiveTenantId } from '@/lib/supabase';
 
 interface Product {
@@ -7,94 +8,85 @@ interface Product {
   code?: string;
 }
 
-export function useManufacturingProducts() {
-  const [products, setProducts] = useState<Product[]>([]);
-  const [loading, setLoading] = useState(false);
+export const MANUFACTURING_PRODUCTS_QUERY_KEY = ['manufacturing-products'] as const;
 
-  const loadProducts = async () => {
+interface ProductRow {
+  id: string;
+  name?: string | null;
+  code?: string | null;
+}
+
+const mapProducts = (data: ProductRow[] | null | undefined): Product[] =>
+  (data || []).map((item) => ({
+    id: item.id,
+    name: item.name || item.code || 'Unnamed product',
+    code: item.code ?? undefined
+  }));
+
+async function fetchProducts(): Promise<Product[]> {
+  try {
+    const orgId = await getEffectiveTenantId();
+
+    const buildQuery = (table: 'products' | 'items') => {
+      let query = supabase
+        .from(table)
+        .select('id, name, code, org_id')
+        .order('name', { ascending: true })
+        .limit(100);
+      if (orgId) query = query.eq('org_id', orgId);
+      return query;
+    };
+
+    let productData: ProductRow[] | null = null;
+
     try {
-      setLoading(true);
-      const orgId = await getEffectiveTenantId();
-
-      const mapProducts = (data: any[] | null | undefined): Product[] =>
-        (data || []).map((item) => ({
-          id: item.id,
-          name: item.name || item.code || 'Unnamed product',
-          code: item.code
-        }));
-
-      const buildProductQuery = () => {
-        let query = supabase
-          .from('products')
-          .select('id, name, code, org_id')
-          .order('name', { ascending: true })
-          .limit(100);
-
-        if (orgId) {
-          query = query.eq('org_id', orgId);
-        }
-
-        return query;
-      };
-
-      const buildItemsQuery = () => {
-        let query = supabase
-          .from('items')
-          .select('id, name, code, org_id')
-          .order('name', { ascending: true })
-          .limit(100);
-
-        if (orgId) {
-          query = query.eq('org_id', orgId);
-        }
-
-        return query;
-      };
-
-      let productData: any[] | null = null;
-
-      try {
-        const { data, error } = await buildProductQuery();
-        if (error && (error.code === 'PGRST205' || error.message?.includes('relation'))) {
-          // Table doesn't exist, try items table - productData already null, no assignment needed
-        } else if (error) {
-          throw error;
-        } else {
-          productData = data || null;
-        }
-      } catch (error: unknown) {
-        const err = error as { code?: string }
-        if (err.code !== 'PGRST205') {
-          throw error;
-        }
-        // Table doesn't exist, try items table - productData already null, no assignment needed
+      const { data, error } = await buildQuery('products');
+      if (error && (error.code === 'PGRST205' || error.message?.includes('relation'))) {
+        // الجدول غير موجود — نجرّب items
+      } else if (error) {
+        throw error;
+      } else {
+        productData = data || null;
       }
-
-      if (!productData || productData.length === 0) {
-        const { data: itemsData, error: itemsError } = await buildItemsQuery();
-        if (itemsError && itemsError.code !== 'PGRST205') {
-          throw itemsError;
-        }
-        productData = itemsData || null;
-      }
-
-      setProducts(mapProducts(productData));
-    } catch (error) {
-      console.warn('Could not load products for manufacturing orders form', error);
-      setProducts([]);
-      } finally {
-      setLoading(false);
+    } catch (error: unknown) {
+      const err = error as { code?: string };
+      if (err.code !== 'PGRST205') throw error;
     }
-  };
 
-  useEffect(() => {
-    loadProducts();
-  }, []);
+    if (!productData || productData.length === 0) {
+      const { data: itemsData, error: itemsError } = await buildQuery('items');
+      if (itemsError && itemsError.code !== 'PGRST205') throw itemsError;
+      productData = itemsData || null;
+    }
+
+    return mapProducts(productData);
+  } catch (error) {
+    // نفس السلوك القديم: تحذير + قائمة فارغة — لا نكسر نموذج إنشاء الأوامر
+    console.warn('Could not load products for manufacturing orders form', error);
+    return [];
+  }
+}
+
+/**
+ * بند 11: موحَّد على React Query داخلياً — الواجهة الخارجية
+ * { products, loading, loadProducts } كما كانت تماماً، لا كسر لأي مستهلك
+ */
+export function useManufacturingProducts() {
+  const queryClient = useQueryClient();
+
+  const { data, isLoading } = useQuery<Product[]>({
+    queryKey: MANUFACTURING_PRODUCTS_QUERY_KEY,
+    queryFn: fetchProducts,
+    staleTime: 60_000,
+  });
+
+  const loadProducts = useCallback(async () => {
+    await queryClient.invalidateQueries({ queryKey: MANUFACTURING_PRODUCTS_QUERY_KEY });
+  }, [queryClient]);
 
   return {
-    products,
-    loading,
+    products: data ?? [],
+    loading: isLoading,
     loadProducts
   };
 }
-

--- a/src/features/manufacturing/index.tsx
+++ b/src/features/manufacturing/index.tsx
@@ -49,6 +49,7 @@ import {
 } from '@/utils/manufacturing-order-status'
 import StageCostingPanel from './stage-costing-panel.tsx'
 import { EquivalentUnitsDashboard } from './equivalent-units-dashboard'
+import { CostOfProductionReportView } from './cost-of-production-report'
 import { VarianceAlerts } from './variance-alerts'
 import { BOMManagement, BOMBuilder } from './bom'
 import { ManufacturingStagesList } from './manufacturing-stages-list'
@@ -97,6 +98,7 @@ export function ManufacturingModule() {
       <Route path="efficiency" element={<EfficiencyDashboard />} />
       <Route path="process-costing" element={<ProcessCostingPage />} />
       <Route path="equivalent-units" element={<EquivalentUnitsPage />} />
+      <Route path="cost-of-production" element={<CostOfProductionPage />} />
       <Route path="variance-alerts" element={<VarianceAlertsPage />} />
       <Route path="workcenters" element={<WorkCentersManagement />} />
       <Route path="stages" element={<ManufacturingStagesPage />} />
@@ -143,6 +145,28 @@ function EquivalentUnitsPage() {
       </div>
 
       <EquivalentUnitsDashboard />
+    </div>
+  )
+}
+
+function CostOfProductionPage() {
+  const { i18n } = useTranslation()
+  const isRTL = i18n.language === 'ar'
+
+  return (
+    <div className="space-y-6">
+      <div className={cn(isRTL ? "text-right" : "text-left", "print:hidden")}>
+        <h1 className="text-3xl font-bold">
+          {isRTL ? 'تقرير تكلفة الإنتاج' : 'Cost of Production Report'}
+        </h1>
+        <p className="text-muted-foreground mt-2">
+          {isRTL
+            ? 'الخطوات الخمس القياسية: الكميات، الوحدات المكافئة، التكاليف، تكلفة الوحدة، التوزيع والتسوية'
+            : 'The five standard steps: quantities, EUP, costs, cost per EU, assignment & reconciliation'}
+        </p>
+      </div>
+
+      <CostOfProductionReportView />
     </div>
   )
 }

--- a/src/services/accounting/__tests__/reconciliation-service.test.ts
+++ b/src/services/accounting/__tests__/reconciliation-service.test.ts
@@ -1,0 +1,123 @@
+/**
+ * اختبارات خدمة تسوية الدفاتر الفرعية مع GL (Migration 81)
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockRpc = vi.fn()
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: { rpc: (...args: unknown[]) => mockRpc(...args) },
+  getEffectiveTenantId: vi.fn(() => Promise.resolve(null)),
+}))
+
+import { ReconciliationService } from '../reconciliation-service'
+import type { ReconciliationReport } from '../reconciliation-service'
+
+function sampleReport(overrides?: Partial<ReconciliationReport>): ReconciliationReport {
+  return {
+    success: true,
+    report_type: 'subledger_gl_reconciliation',
+    as_of_date: '2026-07-09',
+    generated_at: '2026-07-09T12:00:00Z',
+    gl_available: true,
+    sections: [
+      {
+        section: 'inventory',
+        title_ar: 'المخزون (مواد خام + إنتاج تام)',
+        gl_prefixes: ['131', '132', '133', '135'],
+        gl_balance: 250000,
+        gl_accounts: [
+          { code: '131100', name: 'مواد خام LDPE', balance: 150000 },
+          { code: '135100', name: 'FG أكياس مطبوعة', balance: 100000 }
+        ],
+        subledger_balance: 250000,
+        subledger_source: 'inventory_ledger',
+        difference: 0,
+        is_balanced: true,
+        status: 'balanced'
+      },
+      {
+        section: 'wip',
+        title_ar: 'الإنتاج تحت التشغيل',
+        gl_prefixes: ['134'],
+        gl_balance: 42000,
+        gl_accounts: [{ code: '134100', name: 'WIP الخلط', balance: 42000 }],
+        subledger_balance: 42000,
+        subledger_source: 'stage_costs (أوامر مفتوحة)',
+        open_mo_count: 3,
+        difference: 0,
+        is_balanced: true,
+        status: 'balanced'
+      }
+    ],
+    all_balanced: true,
+    ...overrides
+  }
+}
+
+describe('ReconciliationService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('يستدعي rpc_subledger_gl_reconciliation بتاريخ اليوم افتراضياً', async () => {
+    mockRpc.mockResolvedValue({ data: sampleReport(), error: null })
+
+    await ReconciliationService.getReport()
+
+    const today = new Date().toISOString().slice(0, 10)
+    expect(mockRpc).toHaveBeenCalledWith('rpc_subledger_gl_reconciliation', {
+      p_as_of_date: today,
+      p_tenant: null
+    })
+  })
+
+  it('يمرّر التاريخ وهوية المؤسسة عند تحديدهما', async () => {
+    mockRpc.mockResolvedValue({ data: sampleReport(), error: null })
+
+    await ReconciliationService.getReport('2026-06-30', 'org-7')
+
+    expect(mockRpc).toHaveBeenCalledWith('rpc_subledger_gl_reconciliation', {
+      p_as_of_date: '2026-06-30',
+      p_tenant: 'org-7'
+    })
+  })
+
+  it('يرجع التقرير ببنيته الكاملة', async () => {
+    mockRpc.mockResolvedValue({ data: sampleReport(), error: null })
+
+    const report = await ReconciliationService.getReport()
+
+    expect(report.sections).toHaveLength(2)
+    expect(report.sections[0].section).toBe('inventory')
+    expect(report.sections[1].open_mo_count).toBe(3)
+    expect(report.all_balanced).toBe(true)
+  })
+
+  it('يرمي رسالة Migration 81 عند PGRST202', async () => {
+    mockRpc.mockResolvedValue({
+      data: null,
+      error: { code: 'PGRST202', message: 'Could not find the function' }
+    })
+
+    await expect(ReconciliationService.getReport()).rejects.toThrow('Migration 81')
+  })
+
+  it('يمرّر أخطاء قاعدة البيانات الحقيقية كما هي', async () => {
+    mockRpc.mockResolvedValue({
+      data: null,
+      error: { code: 'P0001', message: 'ORG_NOT_RESOLVED: تعذر تحديد هوية المؤسسة' }
+    })
+
+    await expect(ReconciliationService.getReport()).rejects.toThrow('ORG_NOT_RESOLVED')
+  })
+
+  it('isBalanced يرجع false عند وجود فرق', async () => {
+    mockRpc.mockResolvedValue({
+      data: sampleReport({ all_balanced: false }),
+      error: null
+    })
+
+    await expect(ReconciliationService.isBalanced()).resolves.toBe(false)
+  })
+})

--- a/src/services/accounting/reconciliation-service.ts
+++ b/src/services/accounting/reconciliation-service.ts
@@ -1,0 +1,84 @@
+import { supabase } from '@/lib/supabase'
+
+/**
+ * تسوية الدفاتر الفرعية مع الأستاذ العام — الأنواع كما تُرجعها
+ * rpc_subledger_gl_reconciliation (Migration 81)
+ */
+
+export interface GLAccountBalance {
+  code: string
+  name: string
+  balance: number
+}
+
+export type SectionStatus = 'balanced' | 'unbalanced' | 'gl_unavailable' | 'subledger_unavailable'
+
+export interface ReconciliationSection {
+  section: 'inventory' | 'wip'
+  title_ar: string
+  gl_prefixes: string[]
+  gl_balance: number | null
+  gl_accounts: GLAccountBalance[]
+  subledger_balance: number | null
+  subledger_source: string | null
+  open_mo_count?: number
+  difference: number | null
+  is_balanced: boolean
+  status: SectionStatus
+}
+
+export interface ReconciliationReport {
+  success: boolean
+  report_type: 'subledger_gl_reconciliation'
+  as_of_date: string
+  generated_at: string
+  gl_available: boolean
+  sections: ReconciliationSection[]
+  all_balanced: boolean
+}
+
+function isMissingFunctionError(error: { code?: string; message?: string } | null | undefined): boolean {
+  if (!error) return false
+  return error.code === 'PGRST202' || error.message?.includes('Could not find the function') || false
+}
+
+const MIGRATION_81_HINT =
+  'دالة التسوية غير متاحة — طبّق Migration 81 (sql/migrations/81_subledger_gl_reconciliation.sql) أولاً'
+
+/**
+ * خدمة تسوية الدفاتر الفرعية مع GL
+ * قراءة فقط: تقارن أرصدة المخزون وWIP الفرعية مع حسابات الأستاذ العام
+ * وتكشف أي قيد يدوي شارد أو ترحيل ناقص فوراً بدلاً من نهاية السنة
+ */
+export class ReconciliationService {
+  /**
+   * توليد تقرير التسوية حتى تاريخ معيّن (افتراضياً: اليوم)
+   */
+  static async getReport(asOfDate?: string, tenantId?: string): Promise<ReconciliationReport> {
+    if (!supabase) throw new Error('Supabase client not initialized')
+
+    const { data, error } = await supabase.rpc('rpc_subledger_gl_reconciliation', {
+      p_as_of_date: asOfDate ?? new Date().toISOString().slice(0, 10),
+      p_tenant: tenantId ?? null
+    })
+
+    if (error) {
+      if (isMissingFunctionError(error)) throw new Error(MIGRATION_81_HINT)
+      throw new Error(error.message)
+    }
+    if (!data) {
+      throw new Error('لم تُرجع قاعدة البيانات تقرير تسوية')
+    }
+    return data as ReconciliationReport
+  }
+
+  /**
+   * فحص سريع للوحات التحكم: هل كل الأقسام متوازنة؟
+   */
+  static async isBalanced(asOfDate?: string, tenantId?: string): Promise<boolean> {
+    const report = await ReconciliationService.getReport(asOfDate, tenantId)
+    return report.all_balanced
+  }
+}
+
+export const reconciliationService = ReconciliationService

--- a/src/services/manufacturing/__tests__/cost-of-production-service.test.ts
+++ b/src/services/manufacturing/__tests__/cost-of-production-service.test.ts
@@ -1,0 +1,195 @@
+/**
+ * اختبارات خدمة تقرير تكلفة الإنتاج (Migration 80)
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockRpc = vi.fn()
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: { rpc: (...args: unknown[]) => mockRpc(...args) },
+  getEffectiveTenantId: vi.fn(() => Promise.resolve(null)),
+}))
+
+import { CostOfProductionService } from '../cost-of-production-service'
+import type { CostOfProductionReport } from '../cost-of-production-service'
+
+/** تقرير نموذجي متوازن — مرحلة واحدة بالمتوسط المرجّح */
+function sampleReport(overrides?: Partial<CostOfProductionReport>): CostOfProductionReport {
+  return {
+    success: true,
+    report_type: 'cost_of_production',
+    generated_at: '2026-07-09T12:00:00Z',
+    manufacturing_order: {
+      id: 'mo-1',
+      order_number: 'MO-2026-0001',
+      product_id: 'prod-1',
+      status: 'in_progress',
+      qty_planned: 1000
+    },
+    stages: [
+      {
+        stage_no: 1,
+        work_center_id: 'wc-1',
+        costing_method: 'weighted_average',
+        mode: 'actual',
+        quantity_schedule: {
+          wip_beginning_qty: 100,
+          units_started: 900,
+          units_to_account: 1000,
+          units_completed: 800,
+          wip_ending_qty: 150,
+          normal_scrap_qty: 40,
+          abnormal_scrap_qty: 10,
+          rework_qty: 0,
+          units_accounted: 1000,
+          qty_difference: 0,
+          is_balanced: true
+        },
+        equivalent_units: {
+          eup_dm: 950, // 800 + 150×100%
+          eup_cc: 875, // 800 + 150×50%
+          wip_end_dm_completion_pct: 100,
+          wip_end_cc_completion_pct: 50,
+          wip_beg_dm_completion_pct: 0,
+          wip_beg_cc_completion_pct: 0
+        },
+        costs_to_account: {
+          wip_beginning_cost: 500,
+          transferred_in: 0,
+          direct_materials: 9500,
+          direct_labor: 5000,
+          overhead_applied: 3750,
+          conversion_costs: 8750,
+          regrind_cost: 0,
+          waste_credit: 0,
+          total_costs_in: 18750
+        },
+        cost_per_eu: {
+          transferred_in_per_eu: 0,
+          dm_per_eu: 10,
+          cc_per_eu: 10.571429,
+          total_per_eu: 20.571429,
+          stored_unit_cost: 20.57
+        },
+        cost_assignment: {
+          completed_and_transferred: 16371.43,
+          ending_wip: 2292.86,
+          abnormal_scrap_loss: 85.71,
+          normal_scrap_absorbed: 342.86,
+          total_costs_out: 18750
+        },
+        reconciliation: {
+          costs_in: 18750,
+          costs_out: 18750,
+          difference: 0,
+          is_balanced: true,
+          stored_total_cost: 18750,
+          stored_vs_computed_diff: 0
+        }
+      }
+    ],
+    totals: {
+      total_costs_in: 18750,
+      total_completed: 16371.43,
+      total_ending_wip: 2292.86,
+      total_abnormal_scrap_loss: 85.71,
+      all_stages_balanced: true
+    },
+    ...overrides
+  }
+}
+
+describe('CostOfProductionService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('getReport', () => {
+    it('يستدعي rpc_cost_of_production_report بالمعاملات الصحيحة', async () => {
+      mockRpc.mockResolvedValue({ data: sampleReport(), error: null })
+
+      await CostOfProductionService.getReport('mo-1')
+
+      expect(mockRpc).toHaveBeenCalledWith('rpc_cost_of_production_report', {
+        p_mo_id: 'mo-1',
+        p_stage_no: null,
+        p_tenant: null
+      })
+    })
+
+    it('يمرّر رقم المرحلة وهوية المؤسسة عند تحديدهما', async () => {
+      mockRpc.mockResolvedValue({ data: sampleReport(), error: null })
+
+      await CostOfProductionService.getReport('mo-1', 2, 'org-9')
+
+      expect(mockRpc).toHaveBeenCalledWith('rpc_cost_of_production_report', {
+        p_mo_id: 'mo-1',
+        p_stage_no: 2,
+        p_tenant: 'org-9'
+      })
+    })
+
+    it('يرجع التقرير كاملاً ببنيته الصحيحة', async () => {
+      mockRpc.mockResolvedValue({ data: sampleReport(), error: null })
+
+      const report = await CostOfProductionService.getReport('mo-1')
+
+      expect(report.manufacturing_order.order_number).toBe('MO-2026-0001')
+      expect(report.stages).toHaveLength(1)
+      expect(report.stages[0].quantity_schedule.units_to_account).toBe(1000)
+      expect(report.stages[0].equivalent_units.eup_dm).toBe(950)
+      expect(report.stages[0].reconciliation.is_balanced).toBe(true)
+      expect(report.totals.all_stages_balanced).toBe(true)
+    })
+
+    it('يرمي رسالة Migration 80 عند PGRST202', async () => {
+      mockRpc.mockResolvedValue({
+        data: null,
+        error: { code: 'PGRST202', message: 'Could not find the function' }
+      })
+
+      await expect(CostOfProductionService.getReport('mo-1'))
+        .rejects.toThrow('Migration 80')
+    })
+
+    it('يمرّر أخطاء قاعدة البيانات الحقيقية كما هي', async () => {
+      mockRpc.mockResolvedValue({
+        data: null,
+        error: { code: 'P0001', message: 'MO_NOT_FOUND: أمر التصنيع غير موجود' }
+      })
+
+      await expect(CostOfProductionService.getReport('mo-x'))
+        .rejects.toThrow('MO_NOT_FOUND')
+    })
+
+    it('يرمي خطأً واضحاً إذا رجعت البيانات فارغة بلا خطأ', async () => {
+      mockRpc.mockResolvedValue({ data: null, error: null })
+
+      await expect(CostOfProductionService.getReport('mo-1'))
+        .rejects.toThrow('لم تُرجع قاعدة البيانات تقريراً')
+    })
+  })
+
+  describe('isFullyReconciled', () => {
+    it('يرجع true عندما تكون كل المراحل متوازنة', async () => {
+      mockRpc.mockResolvedValue({ data: sampleReport(), error: null })
+
+      await expect(CostOfProductionService.isFullyReconciled('mo-1')).resolves.toBe(true)
+    })
+
+    it('يرجع false عند وجود اختلال في أي مرحلة', async () => {
+      const unbalanced = sampleReport({
+        totals: {
+          total_costs_in: 18750,
+          total_completed: 16000,
+          total_ending_wip: 2292.86,
+          total_abnormal_scrap_loss: 85.71,
+          all_stages_balanced: false
+        }
+      })
+      mockRpc.mockResolvedValue({ data: unbalanced, error: null })
+
+      await expect(CostOfProductionService.isFullyReconciled('mo-1')).resolves.toBe(false)
+    })
+  })
+})

--- a/src/services/manufacturing/cost-of-production-service.ts
+++ b/src/services/manufacturing/cost-of-production-service.ts
@@ -1,0 +1,158 @@
+import { supabase } from '@/lib/supabase'
+
+/**
+ * تقرير تكلفة الإنتاج بالوحدات المكافئة — الأنواع كما تُرجعها
+ * rpc_cost_of_production_report (Migration 80)
+ */
+
+/** الخطوة 1: جدول الكميات */
+export interface QuantitySchedule {
+  wip_beginning_qty: number
+  units_started: number
+  units_to_account: number
+  units_completed: number
+  wip_ending_qty: number
+  normal_scrap_qty: number
+  abnormal_scrap_qty: number
+  rework_qty: number
+  units_accounted: number
+  qty_difference: number
+  is_balanced: boolean
+}
+
+/** الخطوة 2: الوحدات المكافئة */
+export interface EquivalentUnits {
+  eup_dm: number
+  eup_cc: number
+  wip_end_dm_completion_pct: number
+  wip_end_cc_completion_pct: number
+  wip_beg_dm_completion_pct: number
+  wip_beg_cc_completion_pct: number
+}
+
+/** الخطوة 3: التكاليف الواجب حسابها */
+export interface CostsToAccount {
+  wip_beginning_cost: number
+  transferred_in: number
+  direct_materials: number
+  direct_labor: number
+  overhead_applied: number
+  conversion_costs: number
+  regrind_cost: number
+  waste_credit: number
+  total_costs_in: number
+}
+
+/** الخطوة 4: تكلفة الوحدة المكافئة */
+export interface CostPerEU {
+  transferred_in_per_eu: number
+  dm_per_eu: number
+  cc_per_eu: number
+  total_per_eu: number
+  stored_unit_cost: number
+}
+
+/** الخطوة 5أ: توزيع التكاليف */
+export interface CostAssignment {
+  completed_and_transferred: number
+  ending_wip: number
+  abnormal_scrap_loss: number
+  normal_scrap_absorbed: number
+  total_costs_out: number
+}
+
+/** الخطوة 5ب: التسوية */
+export interface Reconciliation {
+  costs_in: number
+  costs_out: number
+  difference: number
+  is_balanced: boolean
+  stored_total_cost: number
+  stored_vs_computed_diff: number
+}
+
+export interface StageReport {
+  stage_no: number
+  work_center_id: string
+  costing_method: 'weighted_average' | 'fifo'
+  mode: string
+  quantity_schedule: QuantitySchedule
+  equivalent_units: EquivalentUnits
+  costs_to_account: CostsToAccount
+  cost_per_eu: CostPerEU
+  cost_assignment: CostAssignment
+  reconciliation: Reconciliation
+}
+
+export interface CostOfProductionReport {
+  success: boolean
+  report_type: 'cost_of_production'
+  generated_at: string
+  manufacturing_order: {
+    id: string
+    order_number: string
+    product_id: string
+    status: string
+    qty_planned: number
+  }
+  stages: StageReport[]
+  totals: {
+    total_costs_in: number
+    total_completed: number
+    total_ending_wip: number
+    total_abnormal_scrap_loss: number
+    all_stages_balanced: boolean
+  }
+}
+
+function isMissingFunctionError(error: { code?: string; message?: string } | null | undefined): boolean {
+  if (!error) return false
+  return error.code === 'PGRST202' || error.message?.includes('Could not find the function') || false
+}
+
+const MIGRATION_80_HINT =
+  'دالة تقرير تكلفة الإنتاج غير متاحة — طبّق Migration 80 (sql/migrations/80_cost_of_production_report.sql) أولاً'
+
+/**
+ * خدمة تقرير تكلفة الإنتاج — Cost of Production Report
+ * قراءة فقط: لا تعدّل أي بيانات. تتطلب Migration 80 على قاعدة البيانات؛
+ * ترجع رسالة عربية واضحة إن لم تكن مطبَّقة.
+ */
+export class CostOfProductionService {
+  /**
+   * توليد التقرير الكامل لأمر تصنيع (كل المراحل أو مرحلة محددة)
+   */
+  static async getReport(
+    moId: string,
+    stageNo?: number,
+    tenantId?: string
+  ): Promise<CostOfProductionReport> {
+    if (!supabase) throw new Error('Supabase client not initialized')
+
+    const { data, error } = await supabase.rpc('rpc_cost_of_production_report', {
+      p_mo_id: moId,
+      p_stage_no: stageNo ?? null,
+      p_tenant: tenantId ?? null
+    })
+
+    if (error) {
+      if (isMissingFunctionError(error)) throw new Error(MIGRATION_80_HINT)
+      throw new Error(error.message)
+    }
+    if (!data) {
+      throw new Error('لم تُرجع قاعدة البيانات تقريراً — تحقق من بيانات أمر التصنيع')
+    }
+    return data as CostOfProductionReport
+  }
+
+  /**
+   * فحص سريع: هل كل مراحل الأمر متوازنة (كميات + تكاليف)؟
+   * مفيد للتنبيهات قبل الإقفال
+   */
+  static async isFullyReconciled(moId: string, tenantId?: string): Promise<boolean> {
+    const report = await CostOfProductionService.getReport(moId, undefined, tenantId)
+    return report.totals.all_stages_balanced
+  }
+}
+
+export const costOfProductionService = CostOfProductionService


### PR DESCRIPTION
# المرحلة الثانية (P2) — التقارير المحاسبية المتقدمة

## المبدأ الحاكم
**كل التغييرات إضافية 100% — لا حذف، لا كسر.** الـ Migrations كلها دوال قراءة فقط (`STABLE`) لا تعدّل أي بيانات.

## بند 12 — تقرير تكلفة الإنتاج (Migration 80 ✅ مطبَّقة على قاعدة البيانات)
- `rpc_cost_of_production_report`: الخطوات الخمس القياسية — جدول الكميات، EUP لكل عنصر (بنفس معادلات `upsert_stage_cost` حرفياً للمتوسط المرجّح وFIFO)، التكاليف الواجب حسابها، تكلفة الوحدة المكافئة، التوزيع والتسوية
- فحص توازن لكل مرحلة (كميات وتكاليف) + مقارنة المحسوب مع المخزَّن لكشف خلل البيانات مبكراً
- شاشة RTL قابلة للطباعة: `/manufacturing/cost-of-production` (11 اختباراً)

## بند 13 — تسوية الدفاتر الفرعية مع GL (Migration 81 ✅ مطبَّقة)
- `rpc_subledger_gl_reconciliation`: المخزون (131*/135*) مقابل `inventory_ledger`/`stock_ledger_entries`، وWIP (134*) مقابل `stage_costs` للأوامر المفتوحة
- دفاعية بالكامل: أي جدول غير موجود يُعلَّم قسمه unavailable دون فشل — وبادئات الحسابات معامِلات قابلة للتخصيص
- شاشة `/accounting/reconciliation` بتاريخ قابل للاختيار + تفصيل حسابات GL (9 اختبارات)

## بند 11 — توحيد React Query
- `useManufacturingOrders` + `useManufacturingProducts` تحولتا من الجلب اليدوي إلى React Query **بدون تغيير أي واجهة عامة** — كاش مشترك بنفس مفتاح `['manufacturing-orders']` فتتحدث كل الشاشات تلقائياً بعد أي mutation (6 اختبارات)

## الحالة
- ✅ 152 ملف اختبار — 3492 اختباراً كلها ناجحة
- ✅ `tsc --noEmit` نظيف + `npm run build` ناجح
- ✅ Migrations 80-81 مطبَّقة ومتحقَّق منها على قاعدة البيانات الحية
- ✅ فرع نسخة احتياطية قبل الدمج: `backup/main-before-p2-merge-2026-07-09`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSfbLXXPJ76yTumH5Jmg4o

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSfbLXXPJ76yTumH5Jmg4o)_