### PR TITLE
ci(sonar): تفعيل تحليل SonarCloud الحقيقي بعد ضبط توكن صالح

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -50,14 +50,13 @@ jobs:
         run: npm run test:coverage
         continue-on-error: true
 
-      # تحليل SonarCloud لا يحجب الدمج: لو كان SONAR_TOKEN غير صالح/منتهياً
-      # (مشكلة بنية تحتية لدى المالك) لا يصحّ أن يُبقي CI أحمر على كل PR.
-      # continue-on-error يُبقي الفحص أخضر؛ فرض بوابة الجودة (إن أُريد) يكون
-      # عبر SonarCloud نفسه/حماية الفرع لا عبر رمز خروج هذه الوظيفة.
-      # لتحليل فعلي: جدّد التوكن في SonarCloud وحدّث السرّ SONAR_TOKEN.
+      # SONAR_TOKEN مضبوط الآن → يعمل التحليل فعلاً ويرفع النتائج لـ SonarCloud.
+      # لا continue-on-error: الفحص يُحمِّر فقط عند فشل حقيقي (مصادقة/إعداد).
+      # بوابة الجودة غير حاجزة هنا (sonar.qualitygate.wait غير مضبوط)؛ الماسح
+      # يخرج 0 بعد الرفع، ونتيجة البوابة تظهر في لوحة SonarCloud وتزيين الـ PR.
+      # لجعل البوابة تحجب الدمج: أضِف sonar.qualitygate.wait=true.
       - name: SonarCloud Scan
         if: steps.sonar_cfg.outputs.configured == 'true'
-        continue-on-error: true
         uses: SonarSource/sonarcloud-github-action@ffc3010689be73b8e5ae0c57ce35968afd7909e8 # v5.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
بعد أن جدّد المالك توكن SonarCloud وحدّث سرّ `SONAR_TOKEN` في GitHub، أُزيل `continue-on-error` من خطوة الماسح ليعمل التحليل الحقيقي:

- الماسح يصادق بالتوكن الصالح ويرفع التحليل إلى SonarCloud.
- بوابة الجودة **غير حاجزة** (`sonar.qualitygate.wait` غير مضبوط) — الماسح يخرج 0 بعد الرفع، ونتيجة البوابة تظهر في لوحة SonarCloud وتزيين الـ PR. الفحص يُحمِّر فقط عند فشل حقيقي (مصادقة/إعداد).
- حارس غياب التوكن يبقى (تخطٍّ آمن لو أُزيل السرّ مستقبلاً).

هذا PR تحقّقٌ من أن التوكن الجديد يصادق فعلاً — يجب أن يصير "SonarQube Scan" أخضر بتحليل حقيقي.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSfbLXXPJ76yTumH5Jmg4o)_