### PR TITLE
P5: تحصين التسليم والاستلام المالي — Fail-closed + عزل org + idempotency

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -18,7 +18,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          # Node 18 انتهى دعمه (2025) — موحَّد مع sonarqube.yml على 20 LTS
+          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies

--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -5,7 +5,7 @@
 
 ## 1) قاعدة البيانات — Migrations ✅ مطبَّقة على الإنتاج (10 يوليو 2026)
 
-طُبِّقت 82–86 مباشرةً على مشروع `uutfztmqvajmsxnrqeiv` عبر واجهة الإدارة مع تحقق
+طُبِّقت 82–89 مباشرةً على مشروع `uutfztmqvajmsxnrqeiv` عبر واجهة الإدارة مع تحقق
 بعد كلٍّ. تبقى الملفات مؤرشفةً لإعادة بناء أي بيئة جديدة:
 
 - [x] **82** `82_p4_security_hardening.sql` — إزالة `execute_sql` (كانت غائبة أصلاً)
@@ -13,15 +13,20 @@
   - ⚠️ الملف افترض أسماء سياسات لم تطابق الحيّ فبقيت `"Allow all"` مفتوحة —
     **أُتمّت الإزالة في 86**. تحقُّق نهائي: بمفتاح anon القراءة من products ⇒ 0 صف
 - [x] **84** `84_p4_gr_receipt_event_mapping.sql` — GRNI 210150 + GR_RECEIPT (مدين 131100/دائن 210150)
-- [x] **85** `85_p4_atomic_delivery_note.sql` — دالة التسليم منشورة؛ COGS_DELIVERY
-  زُرعت بالحسابين الفعليين **544000 / 135100** (لا 511100)
-  - ⚠️ **الدالة لا تعمل فعلياً على هذه القاعدة** (تقرأ `items` الفارغ + أعمدة
-    `tenant_id`/`delivery_id` غير موجودة) — راجع `MANIFEST.md` البند 4؛ تحتاج
-    مواءمة `items↔products` قبل تفعيلها
+- [x] **85** `85_p4_atomic_delivery_note.sql` — دالة التسليم (نسخة أولى)
 - [x] **86** `86_p4_close_anon_rls_holes.sql` — إغلاق anon على كل الدفتر المالي
   (gl_entries، sales/purchase/supplier invoices، goods_receipts، delivery_notes
   وأسطرها) بتحويل `"Allow all%"` من public إلى authenticated
   - تحقُّق عملي: بمفتاح anon القراءة من `gl_entries` ⇒ 0 صف (كانت تكشف الكل)
+- [x] **87** `87_p4_fix_delivery_note_schema.sql` — مواءمة دالة التسليم مع المخطط الحيّ
+  (`products`/`org_id` بدل `items`/`tenant_id`)؛ COGS_DELIVERY = **544000 / 135100**.
+  مُختبرة حيّاً بـ rollback (success + total_cogs صحيحة).
+- [x] **88** `88_p5_harden_delivery_note.sql` — **تحصين التسليم**: تحقق عضوية المستخدم
+  + عزل org لكل استعلام + ملكية الفاتورة/السطر/المنتج + منع تسليم زائد +
+  `idempotency_key` + **COGS Fail-closed**. 9 اختبارات rollback حيّة ناجحة.
+- [x] **89** `89_p5_atomic_goods_receipt.sql` — **استلام ذرّي**: رأس+سطور+قيد GRNI في
+  معاملة واحدة Fail-closed (لا مستند بلا قيد) + عزل org + عضوية + idempotency.
+  دفتر المخزون/التقييم يبقى في الواجهة. 5 اختبارات rollback حيّة ناجحة.
 
 ## 2) متغيرات البيئة في Vercel
 
@@ -67,4 +72,5 @@
 | فرض CSP الكامل | Report-Only أولاً لرصد الانتهاكات |
 | Playwright e2e في CI | الإعداد أُصلح (منفذ 5173) — التشغيل الدوري لاحقاً |
 | توحيد مخطط stock-adjustment الثالث | موثَّق في `sql/migrations/MANIFEST.md` |
-| تسلسل DB لأرقام المستندات | مرشح Migration 86 |
+| عزل org_id لجداول الدفتر المالي (بدل authenticated USING(true)) | تجهيز SaaS — Migration 90+ ببيئة staging |
+| strict TypeScript + اختبارات DB حقيقية (تسليم زائد/تزامن) | دفعة جودة لاحقة |

--- a/sql/migrations/88_p5_harden_delivery_note.sql
+++ b/sql/migrations/88_p5_harden_delivery_note.sql
@@ -1,0 +1,267 @@
+-- ===================================================================
+-- Migration 88: تحصين إذن التسليم الذرّي — سلامة أعمال + أمان + Fail-closed
+-- ===================================================================
+-- Migration 87 جعل الدالة تعمل على المخطط الحيّ (products/org_id)، لكنها
+-- بقيت تثق بالمدخلات: تجلب المنتج/الفاتورة/السطر بالـ id دون شرط org_id،
+-- ولا تتحقق من عضوية المستخدم، ولا تمنع التسليم الزائد أو التكرار، وتبتلع
+-- فشل قيد COGS. هذا الملف يعيد تعريف الدالة (CREATE OR REPLACE — إضافي)
+-- بقيود صارمة، ويضيف idempotency، ويجعل فشل القيد المحاسبي يُجهض العملية.
+--
+-- المبدأ: لا مخزون مخصوم بلا قيد مقابل (Fail-closed)، ولا عبور مؤسسات،
+-- ولا تسليم فوق كمية الفاتورة، ولا تكرار عند إعادة الإرسال.
+-- ===================================================================
+
+-- 1) عمود idempotency + فهرس فريد جزئي لكل مؤسسة (إضافي، آمن على البيانات)
+ALTER TABLE delivery_notes ADD COLUMN IF NOT EXISTS idempotency_key TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS ux_delivery_notes_idempotency
+    ON delivery_notes (org_id, idempotency_key)
+    WHERE idempotency_key IS NOT NULL;
+
+-- 2) الدالة المحصَّنة
+CREATE OR REPLACE FUNCTION public.rpc_post_delivery_note(p_payload JSONB)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_org         UUID;
+    v_uid         UUID;
+    v_dn_id       UUID;
+    v_dn_number   TEXT;
+    v_invoice_id  UUID;
+    v_inv_customer UUID;
+    v_payload_customer UUID;
+    v_idem_key    TEXT;
+    v_existing_id UUID;
+    v_existing_no TEXT;
+    v_allow_over  BOOLEAN;
+    v_line        JSONB;
+    v_item        RECORD;
+    v_inv_line    RECORD;
+    v_qty         NUMERIC;
+    v_unit_cost   NUMERIC;
+    v_total_cogs  NUMERIC := 0;
+    v_line_no     INTEGER := 0;
+    v_warnings    JSONB := '[]'::JSONB;
+BEGIN
+    -- ===== هوية المؤسسة + تحقق العضوية (يغلق ثقة القيمة الصريحة من العميل) =====
+    v_org := wardah_org_id(NULLIF(p_payload->>'tenant_id', '')::UUID);
+    IF v_org IS NULL THEN
+        RAISE EXCEPTION 'ORG_NOT_RESOLVED: تعذر تحديد هوية المؤسسة';
+    END IF;
+
+    v_uid := auth.uid();
+    IF v_uid IS NULL OR NOT EXISTS (
+        SELECT 1 FROM user_organizations
+        WHERE user_id = v_uid AND org_id = v_org
+    ) THEN
+        RAISE EXCEPTION 'FORBIDDEN_ORG: المستخدم ليس عضواً في المؤسسة المطلوبة';
+    END IF;
+
+    -- ===== تحقق أساسي من الحمولة =====
+    v_invoice_id := (p_payload->>'sales_invoice_id')::UUID;
+    IF v_invoice_id IS NULL THEN
+        RAISE EXCEPTION 'INVALID_PAYLOAD: sales_invoice_id مطلوب';
+    END IF;
+    IF jsonb_array_length(COALESCE(p_payload->'lines', '[]'::JSONB)) = 0 THEN
+        RAISE EXCEPTION 'INVALID_PAYLOAD: لا سطور في إذن التسليم';
+    END IF;
+    v_allow_over := COALESCE((p_payload->>'allow_over_delivery')::BOOLEAN, FALSE);
+
+    -- ===== Idempotency: إعادة الإرسال بنفس المفتاح تُعيد النتيجة بلا خصم مكرر =====
+    v_idem_key := NULLIF(p_payload->>'idempotency_key', '');
+    IF v_idem_key IS NOT NULL THEN
+        SELECT id, delivery_number INTO v_existing_id, v_existing_no
+        FROM delivery_notes
+        WHERE org_id = v_org AND idempotency_key = v_idem_key;
+        IF v_existing_id IS NOT NULL THEN
+            SELECT COALESCE(SUM(quantity_delivered * unit_cost_at_delivery), 0)
+            INTO v_total_cogs
+            FROM delivery_note_lines WHERE delivery_note_id = v_existing_id;
+            RETURN jsonb_build_object(
+                'success', TRUE, 'delivery_id', v_existing_id,
+                'delivery_number', v_existing_no,
+                'total_cogs', ROUND(v_total_cogs, 6),
+                'idempotent_replay', TRUE, 'warnings', '[]'::JSONB
+            );
+        END IF;
+    END IF;
+
+    -- ===== الفاتورة: يجب أن تخص نفس المؤسسة =====
+    SELECT customer_id INTO v_inv_customer
+    FROM sales_invoices
+    WHERE id = v_invoice_id AND org_id = v_org;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'INVOICE_NOT_FOUND: الفاتورة % ليست ضمن مؤسستك', v_invoice_id;
+    END IF;
+
+    -- تطابق العميل (إن مُرِّر) — الفاتورة هي المرجع
+    v_payload_customer := NULLIF(p_payload->>'customer_id', '')::UUID;
+    IF v_payload_customer IS NOT NULL AND v_payload_customer <> v_inv_customer THEN
+        RAISE EXCEPTION 'CUSTOMER_MISMATCH: العميل لا يطابق عميل الفاتورة';
+    END IF;
+
+    -- ===== فحص الفترة المحاسبية (Migration 79 — إن وُجدت) =====
+    BEGIN
+        PERFORM assert_period_open(
+            v_org, COALESCE((p_payload->>'delivery_date')::DATE, CURRENT_DATE)
+        );
+    EXCEPTION WHEN undefined_function THEN NULL;
+    END;
+
+    -- ===== توليد رقم التسليم داخل المعاملة (قفل استشاري يمنع التصادم) =====
+    PERFORM pg_advisory_xact_lock(hashtext('delivery_notes:' || v_org::TEXT));
+    SELECT 'DN-' || LPAD((
+        COALESCE(MAX(NULLIF(regexp_replace(delivery_number, '\D', '', 'g'), ''))::BIGINT, 0) + 1
+    )::TEXT, 6, '0')
+    INTO v_dn_number
+    FROM delivery_notes
+    WHERE org_id = v_org AND delivery_number ~ '^DN-\d+$';
+    v_dn_number := COALESCE(v_dn_number, 'DN-000001');
+
+    -- ===== رأس إذن التسليم (العميل من الفاتورة، لا من العميل الموثوق) =====
+    INSERT INTO delivery_notes (
+        org_id, delivery_number, sales_invoice_id, customer_id,
+        delivery_date, vehicle_number, driver_name, status, notes, idempotency_key
+    ) VALUES (
+        v_org, v_dn_number, v_invoice_id, v_inv_customer,
+        COALESCE((p_payload->>'delivery_date')::DATE, CURRENT_DATE),
+        NULLIF(p_payload->>'vehicle_number', ''),
+        NULLIF(p_payload->>'driver_name', ''),
+        'delivered',
+        NULLIF(p_payload->>'notes', ''),
+        v_idem_key
+    )
+    RETURNING id INTO v_dn_id;
+
+    -- ===== السطور: تحقق ملكية ← قفل ← منع تسليم زائد ← خصم ← حركة =====
+    FOR v_line IN SELECT * FROM jsonb_array_elements(p_payload->'lines')
+    LOOP
+        v_line_no := v_line_no + 1;
+        v_qty := (v_line->>'delivered_quantity')::NUMERIC;
+        IF v_qty IS NULL OR v_qty <= 0 THEN
+            RAISE EXCEPTION 'INVALID_LINE: كمية غير صالحة في السطر %', v_line_no;
+        END IF;
+
+        -- سطر الفاتورة إلزامي، ويجب أن يخص هذه الفاتورة (تُحسم المؤسسة والمنتج تالياً)
+        IF NULLIF(v_line->>'sales_invoice_line_id', '') IS NULL THEN
+            RAISE EXCEPTION 'LINE_REQUIRED: sales_invoice_line_id مطلوب لكل سطر (السطر %)', v_line_no;
+        END IF;
+
+        SELECT id, product_id, quantity, unit_price, COALESCE(delivered_quantity, 0) AS delivered
+        INTO v_inv_line
+        FROM sales_invoice_lines
+        WHERE id = (v_line->>'sales_invoice_line_id')::UUID
+          AND invoice_id = v_invoice_id
+          AND org_id = v_org
+        FOR UPDATE;
+        IF NOT FOUND THEN
+            RAISE EXCEPTION 'INVALID_LINE: سطر الفاتورة غير موجود ضمن هذه الفاتورة (السطر %)', v_line_no;
+        END IF;
+
+        -- المنتج المُرسل يجب أن يطابق منتج سطر الفاتورة
+        IF (v_line->>'item_id')::UUID <> v_inv_line.product_id THEN
+            RAISE EXCEPTION 'PRODUCT_MISMATCH: المنتج لا يطابق منتج سطر الفاتورة (السطر %)', v_line_no;
+        END IF;
+
+        -- منع التسليم فوق الكمية المتبقّية (ما لم يُسمح صراحةً)
+        IF NOT v_allow_over AND (v_inv_line.delivered + v_qty) > v_inv_line.quantity THEN
+            RAISE EXCEPTION 'OVER_DELIVERY: الكمية % تتجاوز المتبقّي % في السطر %',
+                v_qty, (v_inv_line.quantity - v_inv_line.delivered), v_line_no;
+        END IF;
+
+        -- قفل صف المنتج ضمن المؤسسة — يمنع سباق الخصم المتزامن
+        SELECT id, stock_quantity, cost_price, name, name_ar
+        INTO v_item
+        FROM products
+        WHERE id = v_inv_line.product_id AND org_id = v_org
+        FOR UPDATE;
+        IF NOT FOUND THEN
+            RAISE EXCEPTION 'ITEM_NOT_FOUND: المنتج غير موجود ضمن مؤسستك (السطر %)', v_line_no;
+        END IF;
+
+        IF COALESCE(v_item.stock_quantity, 0) < v_qty THEN
+            RAISE EXCEPTION 'INSUFFICIENT_STOCK: % — المتاح: %، المطلوب: %',
+                COALESCE(v_item.name_ar, v_item.name),
+                COALESCE(v_item.stock_quantity, 0), v_qty;
+        END IF;
+
+        v_unit_cost := COALESCE(v_item.cost_price, 0);
+        v_total_cogs := v_total_cogs + (v_qty * v_unit_cost);
+
+        INSERT INTO delivery_note_lines (
+            org_id, delivery_note_id, sales_invoice_line_id, product_id,
+            invoiced_quantity, delivered_quantity, quantity_delivered,
+            unit_price, unit_cost_at_delivery, notes
+        ) VALUES (
+            v_org, v_dn_id, v_inv_line.id, v_item.id,
+            v_inv_line.quantity, v_qty, v_qty,
+            COALESCE(v_inv_line.unit_price, 0), v_unit_cost,
+            NULLIF(v_line->>'notes', '')
+        );
+
+        UPDATE products
+        SET stock_quantity = stock_quantity - v_qty, updated_at = NOW()
+        WHERE id = v_item.id;
+
+        IF to_regclass('public.stock_moves') IS NOT NULL THEN
+            INSERT INTO stock_moves (
+                org_id, product_id, quantity, move_type, unit_cost_out,
+                reference_type, reference_id, reference_number, status, date_done
+            ) VALUES (
+                v_org, v_item.id, -v_qty, 'sales_delivery', v_unit_cost,
+                'DELIVERY_NOTE', v_dn_id, v_dn_number, 'done', NOW()
+            );
+        END IF;
+
+        UPDATE sales_invoice_lines
+        SET delivered_quantity = v_inv_line.delivered + v_qty,
+            unit_cost_at_sale = v_unit_cost
+        WHERE id = v_inv_line.id;
+    END LOOP;
+
+    -- ===== قيد COGS — Fail-closed: أي فشل يُجهض العملية كلها =====
+    -- (خريطة COGS_DELIVERY مزروعة؛ فشل الترحيل = خطأ حقيقي يجب ألا يمرّ)
+    IF v_total_cogs > 0 THEN
+        PERFORM rpc_post_event_journal(
+            'COGS_DELIVERY', v_total_cogs,
+            'تكلفة بضاعة مباعة - ' || v_dn_number,
+            'DELIVERY_NOTE', v_dn_id, v_org,
+            'COGS_DELIVERY:' || v_dn_id::TEXT, NULL
+        );
+    END IF;
+
+    -- ===== تحديث حالة تسليم الفاتورة =====
+    UPDATE sales_invoices si
+    SET delivery_status = CASE
+        WHEN NOT EXISTS (
+            SELECT 1 FROM sales_invoice_lines l
+            WHERE l.invoice_id = si.id
+              AND COALESCE(l.delivered_quantity, 0) < l.quantity
+        ) THEN 'fully_delivered'
+        ELSE 'partially_delivered'
+    END
+    WHERE si.id = v_invoice_id;
+
+    RETURN jsonb_build_object(
+        'success', TRUE,
+        'delivery_id', v_dn_id,
+        'delivery_number', v_dn_number,
+        'total_cogs', ROUND(v_total_cogs, 6),
+        'lines_processed', v_line_no,
+        'warnings', v_warnings
+    );
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_post_delivery_note(JSONB) IS
+'إذن تسليم ذرّي محصَّن (Migration 88): تحقق عضوية المستخدم + عزل org لكل استعلام + ملكية الفاتورة/السطر/المنتج + منع تسليم زائد + idempotency + خصم تحت قفل + قيد COGS Fail-closed. معاملة واحدة كلها تنجح أو تفشل معاً.';
+
+GRANT EXECUTE ON FUNCTION public.rpc_post_delivery_note(JSONB) TO authenticated;
+
+-- ===================================================================
+-- التحقق: SELECT proname FROM pg_proc WHERE proname='rpc_post_delivery_note';
+--   SELECT 1 FROM information_schema.columns
+--   WHERE table_name='delivery_notes' AND column_name='idempotency_key';
+-- ===================================================================

--- a/sql/migrations/89_p5_atomic_goods_receipt.sql
+++ b/sql/migrations/89_p5_atomic_goods_receipt.sql
@@ -1,0 +1,179 @@
+-- ===================================================================
+-- Migration 89: استلام بضاعة ذرّي (المستند + القيد) — Fail-closed
+-- ===================================================================
+-- المشكلة (ملاحظة المراجع): receiveGoods يُنشئ سند الاستلام وسطوره ويحدّث
+-- المخزون ثم يرحّل قيد GRNI **منفصلاً ومتسامحاً** (glWarning). فقد ينتهي
+-- الأمر بمستند استلام بلا قيد محاسبي مقابل.
+--
+-- الحل (بلا مساس بمحرّك التقييم الغنيّ bins/FIFO/LIFO في TypeScript):
+-- دالة تُنشئ **الرأس + السطور + قيد GRNI في معاملة واحدة، Fail-closed**.
+-- الواجهة تستدعيها أولاً، ثم تُكمل تحديث دفتر المخزون/الـ bins بالمعرّف
+-- المُعاد. النتيجة: لا مستند استلام مسجَّل بلا قيد GRNI. عزل org + تحقق
+-- عضوية + idempotency. أي فشل في القيد يُجهض المستند كله.
+--
+-- المبدأ: إضافي — دالة جديدة فقط + عمود idempotency. لا يمس بيانات.
+-- ===================================================================
+
+ALTER TABLE goods_receipts ADD COLUMN IF NOT EXISTS idempotency_key TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS ux_goods_receipts_idempotency
+    ON goods_receipts (org_id, idempotency_key)
+    WHERE idempotency_key IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION public.rpc_post_goods_receipt(p_payload JSONB)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_org        UUID;
+    v_uid        UUID;
+    v_gr_id      UUID;
+    v_gr_number  TEXT;
+    v_po_id      UUID;
+    v_vendor_id  UUID;
+    v_idem_key   TEXT;
+    v_existing_id UUID;
+    v_existing_no TEXT;
+    v_line       JSONB;
+    v_line_no    INTEGER := 0;
+    v_prod       UUID;
+    v_recv       NUMERIC;
+    v_cost       NUMERIC;
+    v_quality    TEXT;
+    v_total      NUMERIC := 0;
+BEGIN
+    -- ===== المؤسسة + تحقق العضوية =====
+    v_org := wardah_org_id(NULLIF(p_payload->>'tenant_id', '')::UUID);
+    IF v_org IS NULL THEN
+        RAISE EXCEPTION 'ORG_NOT_RESOLVED: تعذر تحديد هوية المؤسسة';
+    END IF;
+    v_uid := auth.uid();
+    IF v_uid IS NULL OR NOT EXISTS (
+        SELECT 1 FROM user_organizations WHERE user_id = v_uid AND org_id = v_org
+    ) THEN
+        RAISE EXCEPTION 'FORBIDDEN_ORG: المستخدم ليس عضواً في المؤسسة المطلوبة';
+    END IF;
+
+    v_vendor_id := (p_payload->>'vendor_id')::UUID;
+    IF v_vendor_id IS NULL THEN
+        RAISE EXCEPTION 'INVALID_PAYLOAD: vendor_id مطلوب';
+    END IF;
+    IF jsonb_array_length(COALESCE(p_payload->'lines', '[]'::JSONB)) = 0 THEN
+        RAISE EXCEPTION 'INVALID_PAYLOAD: لا سطور في سند الاستلام';
+    END IF;
+
+    -- ===== Idempotency =====
+    v_idem_key := NULLIF(p_payload->>'idempotency_key', '');
+    IF v_idem_key IS NOT NULL THEN
+        SELECT id, receipt_number INTO v_existing_id, v_existing_no
+        FROM goods_receipts WHERE org_id = v_org AND idempotency_key = v_idem_key;
+        IF v_existing_id IS NOT NULL THEN
+            RETURN jsonb_build_object(
+                'success', TRUE, 'goods_receipt_id', v_existing_id,
+                'receipt_number', v_existing_no, 'idempotent_replay', TRUE
+            );
+        END IF;
+    END IF;
+
+    -- ===== أمر الشراء (إن مُرِّر) يجب أن يخص المؤسسة =====
+    v_po_id := NULLIF(p_payload->>'purchase_order_id', '')::UUID;
+    IF v_po_id IS NOT NULL AND NOT EXISTS (
+        SELECT 1 FROM purchase_orders WHERE id = v_po_id AND org_id = v_org
+    ) THEN
+        RAISE EXCEPTION 'PO_NOT_FOUND: أمر الشراء ليس ضمن مؤسستك';
+    END IF;
+
+    -- ===== فحص الفترة (إن وُجد) =====
+    BEGIN
+        PERFORM assert_period_open(
+            v_org, COALESCE((p_payload->>'receipt_date')::DATE, CURRENT_DATE)
+        );
+    EXCEPTION WHEN undefined_function THEN NULL;
+    END;
+
+    -- ===== رقم السند داخل المعاملة (قفل استشاري) =====
+    PERFORM pg_advisory_xact_lock(hashtext('goods_receipts:' || v_org::TEXT));
+    SELECT 'GR-' || LPAD((
+        COALESCE(MAX(NULLIF(regexp_replace(receipt_number, '\D', '', 'g'), ''))::BIGINT, 0) + 1
+    )::TEXT, 6, '0')
+    INTO v_gr_number
+    FROM goods_receipts
+    WHERE org_id = v_org AND receipt_number ~ '^GR-\d+$';
+    v_gr_number := COALESCE(v_gr_number, 'GR-000001');
+
+    -- ===== الرأس =====
+    INSERT INTO goods_receipts (
+        org_id, receipt_number, purchase_order_id, vendor_id, receipt_date,
+        warehouse_id, warehouse_location, receiver_name, status, notes,
+        idempotency_key, created_by
+    ) VALUES (
+        v_org, v_gr_number, v_po_id, v_vendor_id,
+        COALESCE((p_payload->>'receipt_date')::DATE, CURRENT_DATE),
+        NULLIF(p_payload->>'warehouse_id', '')::UUID,
+        NULLIF(p_payload->>'warehouse_location', ''),
+        NULLIF(p_payload->>'receiver_name', ''),
+        'confirmed',
+        NULLIF(p_payload->>'notes', ''),
+        v_idem_key, v_uid
+    )
+    RETURNING id INTO v_gr_id;
+
+    -- ===== السطور (تحقق ملكية المنتج للمؤسسة) =====
+    FOR v_line IN SELECT * FROM jsonb_array_elements(p_payload->'lines')
+    LOOP
+        v_line_no := v_line_no + 1;
+        v_prod := (v_line->>'product_id')::UUID;
+        v_recv := COALESCE((v_line->>'received_quantity')::NUMERIC, 0);
+        v_cost := COALESCE((v_line->>'unit_cost')::NUMERIC, 0);
+        v_quality := COALESCE(NULLIF(v_line->>'quality_status', ''), 'accepted');
+
+        IF NOT EXISTS (SELECT 1 FROM products WHERE id = v_prod AND org_id = v_org) THEN
+            RAISE EXCEPTION 'ITEM_NOT_FOUND: المنتج غير موجود ضمن مؤسستك (السطر %)', v_line_no;
+        END IF;
+
+        INSERT INTO goods_receipt_lines (
+            org_id, goods_receipt_id, purchase_order_line_id, product_id,
+            ordered_quantity, received_quantity, unit_cost, quality_status, notes
+        ) VALUES (
+            v_org, v_gr_id,
+            NULLIF(v_line->>'purchase_order_line_id', '')::UUID, v_prod,
+            COALESCE((v_line->>'ordered_quantity')::NUMERIC, v_recv),
+            v_recv, v_cost, v_quality,
+            NULLIF(v_line->>'notes', '')
+        );
+
+        -- قيمة GRNI تُحتسب على الكميات المقبولة فقط (مطابقة منطق الواجهة)
+        IF v_quality = 'accepted' AND v_recv > 0 THEN
+            v_total := v_total + (v_recv * v_cost);
+        END IF;
+    END LOOP;
+
+    -- ===== قيد GRNI (مدين مخزون / دائن GRNI) — Fail-closed =====
+    IF v_total > 0 THEN
+        PERFORM rpc_post_event_journal(
+            'GR_RECEIPT', v_total,
+            'استلام بضاعة ' || v_gr_number,
+            'GOODS_RECEIPT', v_gr_id, v_org,
+            'GR_RECEIPT:' || v_gr_id::TEXT, NULL
+        );
+    END IF;
+
+    RETURN jsonb_build_object(
+        'success', TRUE,
+        'goods_receipt_id', v_gr_id,
+        'receipt_number', v_gr_number,
+        'total_value', ROUND(v_total, 6),
+        'lines_processed', v_line_no
+    );
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_post_goods_receipt(JSONB) IS
+'استلام بضاعة ذرّي (Migration 89): رأس + سطور + قيد GRNI في معاملة واحدة Fail-closed — لا مستند استلام بلا قيد مقابل. تحقق عضوية + عزل org + ملكية PO/المنتج + idempotency. دفتر المخزون/التقييم (bins/FIFO/LIFO) يبقى في الواجهة ويُنفَّذ بعد نجاح هذه الدالة.';
+
+GRANT EXECUTE ON FUNCTION public.rpc_post_goods_receipt(JSONB) TO authenticated;
+
+-- ===================================================================
+-- التحقق: SELECT proname FROM pg_proc WHERE proname='rpc_post_goods_receipt';
+-- ===================================================================

--- a/sql/migrations/MANIFEST.md
+++ b/sql/migrations/MANIFEST.md
@@ -21,6 +21,8 @@
 | 85 | إذن التسليم الذرّي `rpc_post_delivery_note` + COGS | ✅ منشورة — ⚠️ راجع «تعارض بنيوي» أدناه |
 | **86** | **أمني: إغلاق ثغرات anon على الدفتر المالي (متمّم لـ 83)** | ✅ مطبَّقة — الملف يعيد إنتاجها |
 | **87** | **مواءمة دالة التسليم الذرّي مع المخطط الحيّ (products/org_id)** | ✅ مطبَّقة + مُختبرة حيّاً |
+| **88** | **تحصين التسليم: عضوية+عزل org+ملكية+منع تسليم زائد+idempotency+COGS fail-closed** | ✅ مطبَّقة + 9 اختبارات rollback |
+| **89** | **استلام بضاعة ذرّي (رأس+سطور+GRNI) fail-closed + idempotency** | ✅ مطبَّقة + 5 اختبارات rollback |
 
 > **COGS_DELIVERY** زُرعت يدوياً بالحسابين الفعليين: مدين **544000** (COGS أكياس
 > مطبوعة) / دائن **135100** (FG أكياس مطبوعة) — الافتراضي `511100` في ملف 85 غير
@@ -45,16 +47,15 @@
    `rpc_create_journal_entry` فقط منذ P4-B2)، و`journal_entries/journal_entry_lines`
    (يستخدمه stock-adjustment-service فقط — موثَّق، توحيده مؤجل).
 2. **rollback scripts**: تحت `sql/rollback/` — حالياً `83_rollback_org_scoped_rls.sql`.
-3. **أرقام جديدة**: التالي هو **88**. أي migration جديدة = ملف جديد مرقّم + سطر هنا.
-4. **✅ حُسم تعارض مسار التسليم (Migration 87)**: القانوني هو **`products`** (كل
-   مفاتيح product_id الأجنبية تشير إليه، 118 صفاً؛ `items` جدول ميت فارغ) و**`org_id`**
-   (موجود على 112 جدولاً مقابل tenant_id على 13 محاسبياً فقط). Migration 87 أعاد
-   تعريف `rpc_post_delivery_note` بالأسماء الحيّة (products/org_id/delivery_note_id/
-   sales_invoice_line_id + أعمدة NOT NULL: invoiced_quantity/delivered_quantity/
-   unit_price)، و`enhanced-sales-service.ts` وُوئم بالكامل (items→products،
-   tenant_id→org_id، sales_invoice_id→invoice_id على السطور والتحصيل). **اختبار حيّ
-   (rollback) أثبت نجاح الدالة**: success + total_cogs صحيحة + قيد COGS مُرحَّل، صفر
-   تغيير للبيانات.
+3. **أرقام جديدة**: التالي هو **90**. أي migration جديدة = ملف جديد مرقّم + سطر هنا.
+4. **✅ حُسم تعارض مسار التسليم (Migration 87) ثم تحصينه (88)**: القانوني هو
+   **`products`** (كل مفاتيح product_id الأجنبية تشير إليه؛ `items` جدول ميت فارغ)
+   و**`org_id`** (112 جدولاً مقابل tenant_id على 13 محاسبياً). 87 واءم الدالة
+   والخدمة بالكامل؛ **88 حصّنها** (تحقق عضوية + عزل org لكل استعلام + ملكية
+   الفاتورة/السطر/المنتج + منع تسليم زائد + idempotency + COGS **fail-closed**).
+   **89** يوفّر استلاماً ذرّياً مماثلاً (رأس+سطور+GRNI fail-closed). كلاهما مُختبَر
+   بـ rollback حيّ. دفتر المخزون/التقييم (bins/FIFO/LIFO) يبقى في الواجهة عمداً
+   (بورت SQL له خارج نطاق هذه الدفعة).
 5. **مؤجَّل (دفعة مواءمة تالية)**: خدمات أخرى ما زالت تشير إلى `items` القديم للقراءة
    فقط (financial-dashboard, sales-reports, gemini-financial, بعض manufacturing/*).
    لوحات/تقارير غير حرجة — تُواءم على حدة مع تشغيل التطبيق.

--- a/src/services/__tests__/delivery-note-atomic.test.ts
+++ b/src/services/__tests__/delivery-note-atomic.test.ts
@@ -77,6 +77,19 @@ describe('createDeliveryNote — المسار الذرّي (Migration 85)', () =
     })
   })
 
+  it('يمرّر idempotency_key في حمولة الـ RPC (منع تكرار الخصم عند إعادة الإرسال)', async () => {
+    mockRpc.mockResolvedValue({
+      data: { success: true, delivery_id: 'dn-idem', delivery_number: 'DN-000011', total_cogs: 0, warnings: [] },
+      error: null
+    })
+
+    await createDeliveryNote(deliveryInput)
+
+    const payload = mockRpc.mock.calls[0][1].p_payload as { idempotency_key?: string }
+    expect(typeof payload.idempotency_key).toBe('string')
+    expect(payload.idempotency_key && payload.idempotency_key.length > 0).toBe(true)
+  })
+
   it('خطأ حقيقي (رصيد غير كافٍ) يصل للمستخدم — لا fallback صامت', async () => {
     mockRpc.mockResolvedValue({
       data: null,

--- a/src/services/__tests__/goods-receipt-atomic.test.ts
+++ b/src/services/__tests__/goods-receipt-atomic.test.ts
@@ -1,0 +1,113 @@
+/**
+ * اختبارات المسار الذرّي لاستلام البضاعة (Migration 89 — P5)
+ * يتحقق من: RPC أولاً، Fail-closed عند فشل حقيقي (لا دفتر مخزون بلا مستند+قيد)،
+ * وتمرير idempotency_key.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockRpc = vi.fn()
+const mockFrom = vi.fn()
+const mockCreateSLE = vi.fn()
+const mockGetBin = vi.fn()
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    rpc: (...a: unknown[]) => mockRpc(...a),
+    from: (...a: unknown[]) => mockFrom(...a),
+  },
+  resolveOrgIdWithFallback: vi.fn(() => Promise.resolve('org-gr-test')),
+}))
+
+vi.mock('@/services/stock-ledger-service', () => ({
+  createStockLedgerEntry: (...a: unknown[]) => mockCreateSLE(...a),
+  getBin: (...a: unknown[]) => mockGetBin(...a),
+}))
+
+import { receiveGoods } from '../purchasing-service'
+
+const receipt = {
+  purchase_order_id: 'po-1',
+  vendor_id: 'vendor-1',
+  receipt_date: '2026-07-10',
+  warehouse_id: 'wh-1',
+  warehouse_location: 'A1',
+  receiver_name: 'Tester',
+} as Parameters<typeof receiveGoods>[0]
+
+const lines = [
+  { product_id: 'prod-1', purchase_order_line_id: 'pol-1', ordered_quantity: 100,
+    received_quantity: 100, unit_cost: 5, quality_status: 'accepted' },
+] as Parameters<typeof receiveGoods>[1]
+
+describe('receiveGoods — المسار الذرّي (Migration 89)', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('يستدعي rpc_post_goods_receipt أولاً ويمرّر idempotency_key + vendor + lines', async () => {
+    mockRpc.mockResolvedValue({
+      data: { success: true, goods_receipt_id: 'gr-1', receipt_number: 'GR-000001' },
+      error: null,
+    })
+    mockGetBin.mockResolvedValue({ data: null })
+    mockCreateSLE.mockResolvedValue({ success: true })
+    mockFrom.mockImplementation(() => {
+      const c: Record<string, unknown> = {}
+      c.select = vi.fn().mockReturnValue(c)
+      c.eq = vi.fn().mockReturnValue(c)
+      c.single = vi.fn().mockResolvedValue({ data: { received_quantity: 0, quantity: 100 } })
+      c.update = vi.fn().mockReturnValue(c)
+      c.upsert = vi.fn().mockResolvedValue({ error: null })
+      return c
+    })
+
+    await receiveGoods(receipt, lines)
+
+    // الأهم: الـ RPC الذرّي استُدعي أولاً بحمولة صحيحة (بغضّ النظر عن دفتر المخزون)
+    expect(mockRpc).toHaveBeenCalledWith('rpc_post_goods_receipt', expect.anything())
+    const payload = mockRpc.mock.calls[0][1].p_payload as {
+      idempotency_key?: string; vendor_id?: string; lines?: unknown[]
+    }
+    expect(typeof payload.idempotency_key).toBe('string')
+    expect(payload.vendor_id).toBe('vendor-1')
+    expect(payload.lines).toHaveLength(1)
+  })
+
+  it('Fail-closed: خطأ حقيقي من الـ RPC (فشل GRNI) يوقف العملية — لا دفتر مخزون', async () => {
+    mockRpc.mockResolvedValue({
+      data: null,
+      error: { code: 'P0001', message: 'EVENT_MAPPING_NOT_FOUND: GR_RECEIPT' },
+    })
+
+    const res = await receiveGoods(receipt, lines)
+
+    expect(res.success).toBe(false)
+    // لم يصل إلى دفتر المخزون إطلاقاً
+    expect(mockCreateSLE).not.toHaveBeenCalled()
+  })
+
+  it('Fallback: غياب الدالة (PGRST202) يسقط للمسار القديم (إدراج يدوي)', async () => {
+    mockRpc.mockResolvedValue({
+      data: null,
+      error: { code: 'PGRST202', message: 'Could not find the function' },
+    })
+    mockGetBin.mockResolvedValue({ data: null })
+    mockCreateSLE.mockResolvedValue({ success: true })
+    const insertSpy = vi.fn().mockReturnValue({
+      select: () => ({ single: () => Promise.resolve({ data: { id: 'gr-legacy' }, error: null }) }),
+    })
+    mockFrom.mockImplementation(() => {
+      const c: Record<string, unknown> = {}
+      c.insert = insertSpy
+      c.select = vi.fn().mockReturnValue(c)
+      c.eq = vi.fn().mockReturnValue(c)
+      c.single = vi.fn().mockResolvedValue({ data: { received_quantity: 0, quantity: 100 } })
+      c.update = vi.fn().mockReturnValue(c)
+      c.upsert = vi.fn().mockResolvedValue({ error: null })
+      return c
+    })
+
+    await receiveGoods(receipt, lines)
+
+    // المسار القديم أدرج الرأس يدوياً (fallback عند غياب الدالة الذرّية)
+    expect(insertSpy).toHaveBeenCalled()
+  })
+})

--- a/src/services/enhanced-sales-service.ts
+++ b/src/services/enhanced-sales-service.ts
@@ -918,8 +918,7 @@ export async function createDeliveryNote(delivery: Omit<DeliveryNote, 'id' | 'de
     // رأس + سطور + قفل صف الصنف + خصم + حركة + COGS في معاملة واحدة، مع تحقق
     // عضوية/ملكية/منع تسليم زائد وidempotency (88). PGRST202 ⇒ المسار القديم كما هو.
     // idempotency_key يمنع تكرار الخصم عند إعادة إرسال نفس الطلب (شبكة/عميل).
-    const idempotencyKey =
-      (globalThis.crypto?.randomUUID?.() ?? `dn-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    const idempotencyKey = globalThis.crypto.randomUUID();
     const { data: rpcResult, error: rpcError } = await supabase.rpc('rpc_post_delivery_note', {
       p_payload: {
         tenant_id: tenantId,

--- a/src/services/enhanced-sales-service.ts
+++ b/src/services/enhanced-sales-service.ts
@@ -914,12 +914,16 @@ export async function createDeliveryNote(delivery: Omit<DeliveryNote, 'id' | 'de
     validateDeliveryLines(delivery.lines);
     await validateInvoiceExists(delivery.sales_invoice_id);
 
-    // ===== P4-B5: المسار الذرّي أولاً (Migration 85) =====
-    // رأس + سطور + قفل صف الصنف + خصم + حركة + COGS في معاملة واحدة —
-    // يحل سباق الخصم المتزامن. PGRST202 ⇒ المسار القديم كما هو
+    // ===== P4-B5 + P5: المسار الذرّي المحصَّن أولاً (Migrations 85/87/88) =====
+    // رأس + سطور + قفل صف الصنف + خصم + حركة + COGS في معاملة واحدة، مع تحقق
+    // عضوية/ملكية/منع تسليم زائد وidempotency (88). PGRST202 ⇒ المسار القديم كما هو.
+    // idempotency_key يمنع تكرار الخصم عند إعادة إرسال نفس الطلب (شبكة/عميل).
+    const idempotencyKey =
+      (globalThis.crypto?.randomUUID?.() ?? `dn-${Date.now()}-${Math.random().toString(36).slice(2)}`);
     const { data: rpcResult, error: rpcError } = await supabase.rpc('rpc_post_delivery_note', {
       p_payload: {
         tenant_id: tenantId,
+        idempotency_key: idempotencyKey,
         sales_invoice_id: delivery.sales_invoice_id,
         customer_id: delivery.customer_id,
         delivery_date: delivery.delivery_date,

--- a/src/services/purchasing-service.ts
+++ b/src/services/purchasing-service.ts
@@ -248,44 +248,91 @@ export async function receiveGoods(
     // P4-A4: جلسة المستخدم أولاً، والافتراضية التاريخية كـ Fallback بتحذير
     const org_id = await resolveOrgIdWithFallback();
 
-    // 1. إنشاء سند الاستلام
-    const { data: grData, error: grError } = await supabase
-      .from('goods_receipts')
-      .insert({
-        org_id,  // ⭐ Required for RLS
-        purchase_order_id: receipt.purchase_order_id,
+    // 1. إنشاء سند الاستلام — P5: المسار الذرّي أولاً (Migration 89):
+    //    رأس + سطور + قيد GRNI في معاملة واحدة Fail-closed، فلا يُسجَّل استلام
+    //    بلا قيد مقابل. idempotency يمنع التكرار. PGRST202 ⇒ المسار القديم حرفياً.
+    const grIdempotencyKey =
+      (globalThis.crypto?.randomUUID?.() ?? `gr-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    let grData: { id: string; receipt_number?: string; [k: string]: unknown };
+    let linesAlreadyCreated = false;
+
+    const { data: grRpc, error: grRpcError } = await supabase.rpc('rpc_post_goods_receipt', {
+      p_payload: {
+        tenant_id: org_id,
+        idempotency_key: grIdempotencyKey,
         vendor_id: receipt.vendor_id,
+        purchase_order_id: receipt.purchase_order_id ?? null,
         receipt_date: receipt.receipt_date,
-        warehouse_id: receipt.warehouse_id,  // ⭐ Required
-        warehouse_location: receipt.warehouse_location,
-        receiver_name: receipt.receiver_name,
-        notes: receipt.notes,
-      })
-      .select()
-      .single();
+        warehouse_id: receipt.warehouse_id,
+        warehouse_location: receipt.warehouse_location ?? null,
+        receiver_name: receipt.receiver_name ?? null,
+        notes: receipt.notes ?? null,
+        lines: lines.map((l) => ({
+          product_id: l.product_id,
+          purchase_order_line_id: l.purchase_order_line_id ?? null,
+          ordered_quantity: l.ordered_quantity,
+          received_quantity: l.received_quantity,
+          unit_cost: l.unit_cost,
+          quality_status: l.quality_status,
+          notes: l.notes ?? null,
+        })),
+      },
+    });
 
-    if (grError) throw grError;
+    const grRpcMissing =
+      grRpcError != null &&
+      ((grRpcError as { code?: string }).code === 'PGRST202' ||
+        /Could not find the function/i.test((grRpcError as { message?: string }).message ?? ''));
 
-    console.log('✅ Goods Receipt created:', grData.id);
-
-    // 2. إنشاء سطور الاستلام وStock Ledger Entries
-    for (const line of lines) {
-      // إدراج سطر الاستلام
-      const { error: lineError } = await supabase
-        .from('goods_receipt_lines')
+    if (!grRpcError && (grRpc as { success?: boolean } | null)?.success) {
+      const res = grRpc as { goods_receipt_id: string; receipt_number?: string };
+      grData = { id: res.goods_receipt_id, receipt_number: res.receipt_number };
+      linesAlreadyCreated = true;
+      console.log('✅ Goods Receipt + GRNI posted atomically:', grData.id);
+    } else if (grRpcError && !grRpcMissing) {
+      // خطأ حقيقي (فشل قيد GRNI / عزل / عضوية) — Fail-closed: لا استلام ناقص
+      throw new Error((grRpcError as { message?: string }).message ?? 'فشل ترحيل الاستلام الذرّي');
+    } else {
+      // Fallback: Migration 89 غير مطبَّقة — إدراج الرأس يدوياً كالسابق
+      const { data: grLegacy, error: grError } = await supabase
+        .from('goods_receipts')
         .insert({
-          org_id,  // ⭐ Required for RLS
-          goods_receipt_id: grData.id,
-          purchase_order_line_id: line.purchase_order_line_id,
-          product_id: line.product_id,
-          ordered_quantity: line.ordered_quantity,
-          received_quantity: line.received_quantity,
-          unit_cost: line.unit_cost,
-          quality_status: line.quality_status,
-          notes: line.notes,
-        });
+          org_id,
+          purchase_order_id: receipt.purchase_order_id,
+          vendor_id: receipt.vendor_id,
+          receipt_date: receipt.receipt_date,
+          warehouse_id: receipt.warehouse_id,
+          warehouse_location: receipt.warehouse_location,
+          receiver_name: receipt.receiver_name,
+          notes: receipt.notes,
+        })
+        .select()
+        .single();
+      if (grError) throw grError;
+      grData = grLegacy;
+      console.log('✅ Goods Receipt created (legacy path):', grData.id);
+    }
 
-      if (lineError) throw lineError;
+    // 2. سطور الاستلام (أُنشئت ذرّياً في الـ RPC) + Stock Ledger Entries
+    for (const line of lines) {
+      // إدراج سطر الاستلام — فقط في مسار الـ fallback (المسار الذرّي أنشأها)
+      if (!linesAlreadyCreated) {
+        const { error: lineError } = await supabase
+          .from('goods_receipt_lines')
+          .insert({
+            org_id,  // ⭐ Required for RLS
+            goods_receipt_id: grData.id,
+            purchase_order_line_id: line.purchase_order_line_id,
+            product_id: line.product_id,
+            ordered_quantity: line.ordered_quantity,
+            received_quantity: line.received_quantity,
+            unit_cost: line.unit_cost,
+            quality_status: line.quality_status,
+            notes: line.notes,
+          });
+
+        if (lineError) throw lineError;
+      }
 
       // ⭐ إنشاء Stock Ledger Entry (فقط للكميات المقبولة)
       if (line.quality_status === 'accepted' && line.received_quantity > 0) {
@@ -440,30 +487,33 @@ export async function receiveGoods(
     const newStatus = allReceived ? 'fully_received' : (anyReceived ? 'partially_received' : 'approved');
     await updatePurchaseOrderStatus(receipt.purchase_order_id, newStatus);
 
-    // 5. قيد GL: مدين مخزون / دائن GRNI (Migration 84) — متسامح:
-    //    غياب الـ RPC أو الخريطة لا يُفشل الاستلام أبداً، لكنه يُبلَّغ كتحذير
+    // 5. قيد GRNI (مدين مخزون / دائن GRNI): يُرحَّل **ذرّياً** داخل
+    //    rpc_post_goods_receipt (Migration 89) في المسار الأساسي — Fail-closed.
+    //    هنا نرحّله فقط في مسار الـ fallback (متسامح تاريخياً بتحذير).
     let glWarning: string | undefined;
-    const totalValue = lines.reduce(
-      (sum, l) => sum + (l.received_quantity || 0) * (l.unit_cost || 0), 0
-    );
-    if (totalValue > 0) {
-      try {
-        const { PostingService } = await import('./accounting/posting-service');
-        await PostingService.postEventJournal({
-          event: 'GR_RECEIPT',
-          amount: totalValue,
-          memo: `استلام بضاعة ${grData.receipt_number || grData.id}`,
-          refType: 'GOODS_RECEIPT',
-          refId: grData.id,
-          idempotencyKey: `GR_RECEIPT:${grData.id}`
-        });
-        console.log('✅ GL entry posted for goods receipt (Dr Inventory / Cr GRNI)');
-      } catch (glError: unknown) {
-        const msg = glError instanceof Error ? glError.message : String(glError);
-        glWarning =
-          'الاستلام تم لكن قيد GL لم يُرحَّل: ' + msg +
-          ' — تأكد من تطبيق Migration 84 (GR_RECEIPT) ثم أنشئ القيد يدوياً لهذا السند';
-        console.warn('⚠️ ' + glWarning);
+    if (!linesAlreadyCreated) {
+      const totalValue = lines.reduce(
+        (sum, l) => sum + (l.received_quantity || 0) * (l.unit_cost || 0), 0
+      );
+      if (totalValue > 0) {
+        try {
+          const { PostingService } = await import('./accounting/posting-service');
+          await PostingService.postEventJournal({
+            event: 'GR_RECEIPT',
+            amount: totalValue,
+            memo: `استلام بضاعة ${grData.receipt_number || grData.id}`,
+            refType: 'GOODS_RECEIPT',
+            refId: grData.id,
+            idempotencyKey: `GR_RECEIPT:${grData.id}`
+          });
+          console.log('✅ GL entry posted for goods receipt (Dr Inventory / Cr GRNI)');
+        } catch (glError: unknown) {
+          const msg = glError instanceof Error ? glError.message : String(glError);
+          glWarning =
+            'الاستلام تم لكن قيد GL لم يُرحَّل: ' + msg +
+            ' — تأكد من تطبيق Migration 84 (GR_RECEIPT) ثم أنشئ القيد يدوياً لهذا السند';
+          console.warn('⚠️ ' + glWarning);
+        }
       }
     }
 

--- a/src/services/purchasing-service.ts
+++ b/src/services/purchasing-service.ts
@@ -251,8 +251,7 @@ export async function receiveGoods(
     // 1. إنشاء سند الاستلام — P5: المسار الذرّي أولاً (Migration 89):
     //    رأس + سطور + قيد GRNI في معاملة واحدة Fail-closed، فلا يُسجَّل استلام
     //    بلا قيد مقابل. idempotency يمنع التكرار. PGRST202 ⇒ المسار القديم حرفياً.
-    const grIdempotencyKey =
-      (globalThis.crypto?.randomUUID?.() ?? `gr-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    const grIdempotencyKey = globalThis.crypto.randomUUID();
     let grData: { id: string; receipt_number?: string; [k: string]: unknown };
     let linesAlreadyCreated = false;
 


### PR DESCRIPTION
معالجة الملاحظات الجوهرية من المراجعة الخارجية على السلامة المالية والأمان (كلها إضافية، Migrations مطبَّقة ومُتحقَّقة على الإنتاج بـ rollback حيّ).

## Migration 88 — تحصين `rpc_post_delivery_note`
- **تحقق عضوية المستخدم** (`auth.uid()` في `user_organizations`) — يغلق ثقة `org_id` القادم من العميل عبر `wardah_org_id`.
- **عزل كل استعلام بـ `org_id`** + التحقق من ملكية الفاتورة/سطر الفاتورة/المنتج وتطابقها.
- **منع التسليم الزائد** (`delivered + qty > invoice qty`) — قابل للاسترخاء بعلم `allow_over_delivery`.
- `sales_invoice_line_id` **إلزامي** + تطابق العميل مع الفاتورة.
- **`idempotency_key`** (عمود + فهرس فريد) يمنع تكرار الخصم عند إعادة الإرسال.
- **COGS Fail-closed**: إزالة ابتلاع الخطأ — فشل القيد يُجهض العملية كلها (لا مخزون مخصوم بلا قيد).
- **9 اختبارات rollback حيّة** ناجحة (نجاح/عضوية/فاتورة/سطر/منتج/تسليم زائد/سطر إلزامي/COGS fail-closed/idempotency) — صفر تغيير بيانات.

## Migration 89 — استلام بضاعة ذرّي `rpc_post_goods_receipt`
- رأس + سطور + **قيد GRNI في معاملة واحدة Fail-closed** (لا مستند استلام بلا قيد مقابل).
- عزل org + عضوية + ملكية PO/المنتج + idempotency.
- دفتر المخزون/التقييم (`bins`/FIFO/LIFO) يبقى في الواجهة **عمداً** (بورت محرّك التقييم إلى SQL خارج نطاق هذه الدفعة). الواجهة تستدعي الـ RPC أولاً ثم تُكمل دفتر المخزون بالمعرّف المُعاد.
- **5 اختبارات rollback حيّة** ناجحة.

## الواجهة
- `enhanced-sales-service.ts`: تمرير `idempotency_key`.
- `purchasing-service.ts` (`receiveGoods`): RPC أولاً Fail-closed + fallback عند PGRST202.

## مكاسب سريعة
- **مزامنة التوثيق**: إزالة ملاحظة «Migration 85 لا تعمل» القديمة، إضافة 87/88/89، تصحيح الإشارات القديمة.
- **ترقية CI**: Node 18 (منتهي الدعم) ← 20 LTS، موحَّد مع `sonarqube.yml`.

## خارج النطاق (موثَّق — تجهيز SaaS)
عزل org_id لجداول الدفتر المالي، strict TypeScript، اختبارات DB حقيقية للتزامن، بورت محرّك التقييم إلى SQL.

## التحقق
`npx tsc --noEmit` نظيف · **3523 اختباراً أخضر** (159 ملفاً، +4 جديدة) · `npm run build` ناجح · Migrations 88/89 مطبَّقة ومُتحقَّقة حيّاً. نسخة احتياطية: `backup-main-pre-p5-merge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSfbLXXPJ76yTumH5Jmg4o)_