### PR TITLE
P12: وحدة HR/الرواتب الكاملة — GOSI + نهاية خدمة + إجازات + مسير ذرّي

### DIFF
--- a/sql/migrations/100_p12_atomic_payroll_and_settlement_posting.sql
+++ b/sql/migrations/100_p12_atomic_payroll_and_settlement_posting.sql
@@ -1,0 +1,334 @@
+-- ===================================================================
+-- Migration 100: مسير رواتب وتسوية نهاية خدمة ذرّيان Fail-closed (P12-B)
+-- ===================================================================
+-- الفجوة (مؤكَّدة): payroll-engine.ts كان يرحّل GL بإدراج مباشر client-side في
+-- gl_entries/gl_entry_lines متجاوزاً القناة القانونية rpc_create_journal_entry
+-- (المفروضة منذ 76) — غير ذرّي (رأس بلا سطور ممكن)، بلا فحص عضوية خادمي، بلا
+-- idempotency (إعادة المعالجة تكرّر القيود)، ولا يكتب payroll_details إطلاقاً
+-- (لا قسائم رواتب). والتسويات لا تُرحَّل أصلاً.
+--
+-- الحل: دالتان بنمط 93/95 الحرفي (SECURITY DEFINER + wardah_org_id + عضوية +
+-- قفل استشاري + idempotency ببصمة حمولة) تجعلان: سطور المسير + القيد عبر
+-- rpc_create_journal_entry + القفل = معاملة واحدة. أي فشل ⇒ إجهاض كامل.
+--
+-- تصميم القيد المحاسبي للمسير (حسابات كلها من hr_payroll_account_mappings —
+-- قرار المالك: قابلة للاختيار من ضبط الرواتب):
+--   مدين : basic_salary + housing_allowance + transport_allowance +
+--          other_allowance + overtime + gosi_employer_expense
+--   دائن : gosi_payable (حصتا الموظف وصاحب العمل) + deductions + loans +
+--          absence_recovery (استرداد غياب) + payable (الصافي)
+-- التوازن يتحقق داخل الدالة؛ أي bucket غير صفري بلا خريطة ⇒ MAPPING_MISSING.
+-- ===================================================================
+
+-- 0) أعمدة إضافية لازمة (إضافي 100%)
+ALTER TABLE payroll_details ALTER COLUMN component_id DROP NOT NULL;
+ALTER TABLE payroll_details ADD COLUMN IF NOT EXISTS component_code  TEXT;
+ALTER TABLE payroll_details ADD COLUMN IF NOT EXISTS component_label TEXT;
+ALTER TABLE payroll_details ADD COLUMN IF NOT EXISTS is_deduction    BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE hr_settlements ADD COLUMN IF NOT EXISTS journal_entry_id UUID REFERENCES gl_entries(id);
+ALTER TABLE hr_settlements ADD COLUMN IF NOT EXISTS idempotency_key  TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS uq_hr_settlements_idem
+    ON hr_settlements (org_id, idempotency_key) WHERE idempotency_key IS NOT NULL;
+
+-- ===================================================================
+-- 1) rpc_post_payroll_run — اعتماد مسير شهر ذرّياً
+-- ===================================================================
+CREATE OR REPLACE FUNCTION public.rpc_post_payroll_run(p_payload JSONB)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_org        UUID;
+    v_year       INT;
+    v_month      INT;
+    v_idem       TEXT;
+    v_hash       TEXT;
+    v_period_id  UUID;
+    v_run_id     UUID;
+    v_existing   payroll_runs%ROWTYPE;
+    v_totals     JSONB;
+    v_entry_date DATE;
+    v_gl_lines   JSONB := '[]'::JSONB;
+    v_line_no    INT := 0;
+    v_debits     NUMERIC := 0;
+    v_credits    NUMERIC := 0;
+    v_journal    JSONB;
+    v_amount     NUMERIC;
+    v_acct       UUID;
+    v_bucket     TEXT;
+    -- ترتيب حتمي: المدينون ثم الدائنون
+    c_debit_buckets  TEXT[] := ARRAY['basic_salary','housing_allowance',
+        'transport_allowance','other_allowance','overtime','gosi_employer_expense'];
+    c_credit_buckets TEXT[] := ARRAY['gosi_payable','deductions','loans',
+        'absence_recovery','payable'];
+BEGIN
+    -- عضوية + اشتقاق org (نمط 93/95)
+    v_org := wardah_org_id(NULLIF(p_payload->>'tenant_id','')::uuid);
+    IF v_org IS NULL THEN RAISE EXCEPTION 'ORG_NOT_RESOLVED'; END IF;
+    IF NOT EXISTS (SELECT 1 FROM user_organizations
+                   WHERE user_id = auth.uid() AND org_id = v_org) THEN
+        RAISE EXCEPTION 'NOT_ORG_MEMBER';
+    END IF;
+
+    v_year  := (p_payload->>'year')::int;
+    v_month := (p_payload->>'month')::int;
+    v_idem  := NULLIF(p_payload->>'idempotency_key','');
+    IF v_year IS NULL OR v_month IS NULL OR v_idem IS NULL THEN
+        RAISE EXCEPTION 'INVALID_PAYLOAD: year/month/idempotency_key إلزامية';
+    END IF;
+    v_totals := COALESCE(p_payload->'totals', '{}'::jsonb);
+    v_entry_date := COALESCE(NULLIF(p_payload->>'entry_date','')::date,
+                             make_date(v_year, v_month, 1) + INTERVAL '1 month' - INTERVAL '1 day');
+    -- بصمة الحمولة (بلا المفتاح نفسه) لكشف إعادة استخدام المفتاح بحمولة مختلفة
+    v_hash := md5((p_payload - 'idempotency_key')::text);
+
+    -- قفل استشاري لكل (org, year, month)
+    PERFORM pg_advisory_xact_lock(hashtext(v_org::text || ':payroll:' || v_year || '-' || v_month));
+
+    -- idempotency أولاً (قبل فحص قفل الشهر): إعادة نفس المفتاح بعد نجاح المسير —
+    -- الذي يقفل الشهر بنفسه — يجب أن تعيد النتيجة المخزنة لا PAYROLL_MONTH_LOCKED
+    SELECT * INTO v_existing FROM payroll_runs
+    WHERE org_id = v_org AND idempotency_key = v_idem;
+    IF FOUND THEN
+        IF v_existing.request_hash IS DISTINCT FROM v_hash THEN
+            RAISE EXCEPTION 'IDEMPOTENCY_KEY_REUSED';
+        END IF;
+        RETURN jsonb_build_object(
+            'success', true, 'replayed', true,
+            'payroll_run_id', v_existing.id,
+            'journal_entry_id', v_existing.journal_entry_id,
+            'status', v_existing.status);
+    END IF;
+
+    -- شهر مقفل ⇒ رفض (لمفاتيح جديدة فقط)
+    IF EXISTS (SELECT 1 FROM hr_payroll_locks
+               WHERE org_id = v_org AND year = v_year AND month = v_month
+                 AND status = 'locked') THEN
+        RAISE EXCEPTION 'PAYROLL_MONTH_LOCKED';
+    END IF;
+
+    -- الفترة (تُنشأ إن غابت)
+    SELECT id INTO v_period_id FROM payroll_periods
+    WHERE org_id = v_org AND period_code = format('%s-%s', v_year, lpad(v_month::text,2,'0'));
+    IF v_period_id IS NULL THEN
+        INSERT INTO payroll_periods (org_id, period_code, period_name, period_type,
+                                     start_date, end_date, status)
+        VALUES (v_org, format('%s-%s', v_year, lpad(v_month::text,2,'0')),
+                format('مسير %s-%s', v_year, lpad(v_month::text,2,'0')), 'monthly',
+                make_date(v_year, v_month, 1), v_entry_date, 'open')
+        RETURNING id INTO v_period_id;
+    END IF;
+
+    -- مسير سابق لنفس الفترة بمفتاح مختلف ⇒ رفض (UNIQUE يحمي أيضاً)
+    IF EXISTS (SELECT 1 FROM payroll_runs WHERE org_id = v_org AND period_id = v_period_id) THEN
+        RAISE EXCEPTION 'PAYROLL_RUN_EXISTS: يوجد مسير لهذه الفترة';
+    END IF;
+
+    -- رأس المسير
+    INSERT INTO payroll_runs (org_id, period_id, run_date, status,
+                              total_gross, total_deductions, total_net,
+                              idempotency_key, request_hash)
+    VALUES (v_org, v_period_id, CURRENT_DATE, 'calculated',
+            COALESCE((p_payload->>'total_gross')::numeric, 0),
+            COALESCE((p_payload->>'total_deductions')::numeric, 0),
+            COALESCE((p_payload->>'total_net')::numeric, 0),
+            v_idem, v_hash)
+    RETURNING id INTO v_run_id;
+
+    -- سطور القسائم (payroll_details) — سطر لكل موظف/بند
+    INSERT INTO payroll_details (org_id, payroll_run_id, employee_id,
+                                 component_id, component_code, component_label,
+                                 is_deduction, amount, is_processed, processed_at)
+    SELECT v_org, v_run_id,
+           (l->>'employee_id')::uuid,
+           NULLIF(l->>'component_id','')::uuid,
+           l->>'component_code',
+           l->>'component_label',
+           COALESCE((l->>'is_deduction')::boolean, false),
+           (l->>'amount')::numeric,
+           true, NOW()
+    FROM jsonb_array_elements(COALESCE(p_payload->'lines','[]'::jsonb)) l;
+
+    -- بناء سطور القيد من الإجماليات + خرائط الحسابات (fail-closed)
+    FOREACH v_bucket IN ARRAY c_debit_buckets LOOP
+        v_amount := ROUND(COALESCE((v_totals->>v_bucket)::numeric, 0), 2);
+        CONTINUE WHEN v_amount = 0;
+        SELECT gl_account_id INTO v_acct FROM hr_payroll_account_mappings
+        WHERE org_id = v_org AND account_type = v_bucket;
+        IF v_acct IS NULL THEN
+            RAISE EXCEPTION 'MAPPING_MISSING: % — اضبط الحساب من ضبط الرواتب', v_bucket;
+        END IF;
+        v_line_no := v_line_no + 1;
+        v_debits := v_debits + v_amount;
+        v_gl_lines := v_gl_lines || jsonb_build_array(jsonb_build_object(
+            'line_number', v_line_no, 'account_id', v_acct,
+            'debit', v_amount, 'credit', 0,
+            'description', 'مسير رواتب ' || v_year || '-' || lpad(v_month::text,2,'0') || ' — ' || v_bucket));
+    END LOOP;
+
+    FOREACH v_bucket IN ARRAY c_credit_buckets LOOP
+        v_amount := ROUND(COALESCE((v_totals->>v_bucket)::numeric, 0), 2);
+        CONTINUE WHEN v_amount = 0;
+        SELECT gl_account_id INTO v_acct FROM hr_payroll_account_mappings
+        WHERE org_id = v_org AND account_type = v_bucket;
+        IF v_acct IS NULL THEN
+            RAISE EXCEPTION 'MAPPING_MISSING: % — اضبط الحساب من ضبط الرواتب', v_bucket;
+        END IF;
+        v_line_no := v_line_no + 1;
+        v_credits := v_credits + v_amount;
+        v_gl_lines := v_gl_lines || jsonb_build_array(jsonb_build_object(
+            'line_number', v_line_no, 'account_id', v_acct,
+            'debit', 0, 'credit', v_amount,
+            'description', 'مسير رواتب ' || v_year || '-' || lpad(v_month::text,2,'0') || ' — ' || v_bucket));
+    END LOOP;
+
+    IF v_line_no < 2 THEN
+        RAISE EXCEPTION 'EMPTY_PAYROLL: لا مبالغ للترحيل';
+    END IF;
+    IF ROUND(v_debits,2) <> ROUND(v_credits,2) THEN
+        RAISE EXCEPTION 'UNBALANCED_PAYROLL: مدين % ≠ دائن %', v_debits, v_credits;
+    END IF;
+
+    -- القيد عبر القناة القانونية (نفس المعاملة ⇒ fail-closed)
+    v_journal := rpc_create_journal_entry(jsonb_build_object(
+        'org_id', v_org::text,
+        'entry_date', v_entry_date::text,
+        'description', 'Payroll run ' || v_year || '-' || lpad(v_month::text,2,'0'),
+        'description_ar', 'مسير رواتب ' || v_year || '-' || lpad(v_month::text,2,'0'),
+        'reference_type', 'PAYROLL',
+        'reference_number', v_year || '-' || lpad(v_month::text,2,'0'),
+        'idempotency_key', v_idem || ':gl',
+        'auto_post', true,
+        'lines', v_gl_lines));
+
+    -- اعتماد + قفل الشهر
+    UPDATE payroll_runs
+    SET status = 'approved', journal_entry_id = (v_journal->>'entry_id')::uuid,
+        updated_at = NOW()
+    WHERE id = v_run_id;
+
+    INSERT INTO hr_payroll_locks (org_id, year, month, status, locked_at, locked_by, journal_entry_id)
+    VALUES (v_org, v_year, v_month, 'locked', NOW(), auth.uid(), (v_journal->>'entry_id')::uuid)
+    ON CONFLICT (org_id, year, month) DO UPDATE SET
+        status = 'locked', locked_at = NOW(), locked_by = auth.uid(),
+        journal_entry_id = (v_journal->>'entry_id')::uuid;
+
+    RETURN jsonb_build_object(
+        'success', true, 'replayed', false,
+        'payroll_run_id', v_run_id,
+        'journal_entry_id', v_journal->>'entry_id',
+        'entry_number', v_journal->>'entry_number',
+        'total_debit', v_debits, 'total_credit', v_credits,
+        'status', 'approved');
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_post_payroll_run(JSONB) IS
+'اعتماد مسير رواتب ذرّي Fail-closed (Migration 100): عضوية + قفل استشاري + idempotency ببصمة + سطور payroll_details + قيد متزن عبر rpc_create_journal_entry بحسابات hr_payroll_account_mappings + قفل الشهر — معاملة واحدة.';
+
+GRANT EXECUTE ON FUNCTION public.rpc_post_payroll_run(JSONB) TO authenticated;
+
+-- ===================================================================
+-- 2) rpc_post_settlement — اعتماد تسوية نهاية خدمة/إجازة وترحيلها
+-- ===================================================================
+CREATE OR REPLACE FUNCTION public.rpc_post_settlement(p_payload JSONB)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_org        UUID;
+    v_idem       TEXT;
+    v_settlement hr_settlements%ROWTYPE;
+    v_amount     NUMERIC;
+    v_exp_acct   UUID;
+    v_pay_acct   UUID;
+    v_journal    JSONB;
+    v_entry_date DATE;
+BEGIN
+    v_org := wardah_org_id(NULLIF(p_payload->>'tenant_id','')::uuid);
+    IF v_org IS NULL THEN RAISE EXCEPTION 'ORG_NOT_RESOLVED'; END IF;
+    IF NOT EXISTS (SELECT 1 FROM user_organizations
+                   WHERE user_id = auth.uid() AND org_id = v_org) THEN
+        RAISE EXCEPTION 'NOT_ORG_MEMBER';
+    END IF;
+
+    v_idem := NULLIF(p_payload->>'idempotency_key','');
+    IF v_idem IS NULL THEN RAISE EXCEPTION 'INVALID_PAYLOAD: idempotency_key إلزامي'; END IF;
+
+    SELECT * INTO v_settlement FROM hr_settlements
+    WHERE id = (p_payload->>'settlement_id')::uuid AND org_id = v_org
+    FOR UPDATE;
+    IF NOT FOUND THEN RAISE EXCEPTION 'SETTLEMENT_NOT_FOUND'; END IF;
+
+    -- replay بنفس المفتاح على تسوية مرحَّلة ⇒ إعادة النتيجة
+    IF v_settlement.idempotency_key = v_idem AND v_settlement.journal_entry_id IS NOT NULL THEN
+        RETURN jsonb_build_object('success', true, 'replayed', true,
+            'settlement_id', v_settlement.id,
+            'journal_entry_id', v_settlement.journal_entry_id,
+            'status', v_settlement.status);
+    END IF;
+    IF v_settlement.status NOT IN ('draft','review') THEN
+        RAISE EXCEPTION 'SETTLEMENT_NOT_POSTABLE: الحالة %', v_settlement.status;
+    END IF;
+
+    v_amount := ROUND(COALESCE(v_settlement.payable_amount, v_settlement.calculated_amount, 0), 2);
+    IF v_amount <= 0 THEN RAISE EXCEPTION 'SETTLEMENT_ZERO_AMOUNT'; END IF;
+    v_entry_date := COALESCE(NULLIF(p_payload->>'entry_date','')::date, CURRENT_DATE);
+
+    SELECT gl_account_id INTO v_exp_acct FROM hr_payroll_account_mappings
+    WHERE org_id = v_org AND account_type = 'eos_expense';
+    SELECT gl_account_id INTO v_pay_acct FROM hr_payroll_account_mappings
+    WHERE org_id = v_org AND account_type = 'eos_payable';
+    IF v_exp_acct IS NULL OR v_pay_acct IS NULL THEN
+        RAISE EXCEPTION 'MAPPING_MISSING: eos_expense/eos_payable — اضبطهما من ضبط الرواتب';
+    END IF;
+
+    v_journal := rpc_create_journal_entry(jsonb_build_object(
+        'org_id', v_org::text,
+        'entry_date', v_entry_date::text,
+        'description', 'End of service settlement',
+        'description_ar', 'تسوية نهاية خدمة',
+        'reference_type', 'SETTLEMENT',
+        'reference_number', v_settlement.id::text,
+        'idempotency_key', v_idem || ':gl',
+        'auto_post', true,
+        'lines', jsonb_build_array(
+            jsonb_build_object('line_number', 1, 'account_id', v_exp_acct,
+                               'debit', v_amount, 'credit', 0,
+                               'description', 'مكافأة نهاية خدمة'),
+            jsonb_build_object('line_number', 2, 'account_id', v_pay_acct,
+                               'debit', 0, 'credit', v_amount,
+                               'description', 'مستحق نهاية خدمة'))));
+
+    UPDATE hr_settlements
+    SET status = 'approved', approved_by = auth.uid(), approved_at = NOW(),
+        journal_entry_id = (v_journal->>'entry_id')::uuid,
+        idempotency_key = v_idem, updated_at = NOW()
+    WHERE id = v_settlement.id;
+
+    -- نهاية الخدمة تقفل الموظف
+    IF v_settlement.settlement_type = 'end_of_service' THEN
+        UPDATE employees
+        SET status = 'terminated',
+            termination_date = COALESCE(v_settlement.service_end, CURRENT_DATE),
+            updated_at = NOW()
+        WHERE id = v_settlement.employee_id AND org_id = v_org;
+    END IF;
+
+    RETURN jsonb_build_object('success', true, 'replayed', false,
+        'settlement_id', v_settlement.id,
+        'journal_entry_id', v_journal->>'entry_id',
+        'entry_number', v_journal->>'entry_number',
+        'amount', v_amount, 'status', 'approved');
+END;
+$$;
+
+COMMENT ON FUNCTION public.rpc_post_settlement(JSONB) IS
+'اعتماد وترحيل تسوية نهاية خدمة ذرّياً (Migration 100): عضوية + FOR UPDATE + idempotency + قيد eos_expense/eos_payable عبر rpc_create_journal_entry + قلب حالة الموظف terminated — معاملة واحدة Fail-closed.';
+
+GRANT EXECUTE ON FUNCTION public.rpc_post_settlement(JSONB) TO authenticated;

--- a/sql/migrations/99_p12_hr_foundation_hardening.sql
+++ b/sql/migrations/99_p12_hr_foundation_hardening.sql
@@ -1,0 +1,202 @@
+-- ===================================================================
+-- Migration 99: تأسيس HR الشرعي — RLS + تحصين + سياسات GOSI (P12-A)
+-- ===================================================================
+-- الحالة المؤكَّدة حيّاً قبل هذا الترحيل: كل جداول HR (من ملفات
+-- 15_hr_module + sql/hr/16 + sql/hr/17 التاريخية) موجودة في قاعدة الإنتاج،
+-- لكن خارج سجل MANIFEST، وفيها ثغرات:
+--   1) ثمانية جداول (salary_components, employee_salary_structures,
+--      payroll_periods/runs/details, attendance_records, leave_types,
+--      employee_leaves) سياستها الوحيدة تعتمد current_setting('app.current_org_id')
+--      وهو متغيّر جلسة لا يضبطه عميل Supabase إطلاقاً ⇒ منع فعلي (deny-all)
+--      لكل مستخدمي التطبيق.
+--   2) upsert_attendance_day يثق بـ p_org_id القادم من العميل بلا فحص عضوية.
+--   3) payroll_runs بلا قيد تفرّد ولا idempotency ⇒ إعادة المعالجة تكرّر.
+--   4) hr_policies بلا سياسات GOSI/معدل يومي/إضافي/استحقاق إجازات.
+--   5) hr_payroll_account_mappings محصور في 8 أنواع (بلا GOSI/نهاية خدمة).
+--
+-- المبدأ: إضافي 100% — سياسات جديدة تُضاف (سياسات RLS permissive تُجمع OR
+-- فلا حاجة لحذف القديمة)، أعمدة IF NOT EXISTS، واستبدال CHECK بتوسعة قائمته.
+-- هذا الملف يفترض وجود الجداول (مؤكَّد حيّاً) ويفشل مبكراً بوضوح إن غابت
+-- (بيئة جديدة ⇒ طبِّق 15 + sql/hr/16 + sql/hr/17 أولاً).
+-- ===================================================================
+
+-- 0) تأكيد المتطلبات (fail-fast لبيئة جديدة)
+DO $$
+DECLARE t TEXT;
+BEGIN
+    FOREACH t IN ARRAY ARRAY[
+        'employees','salary_components','employee_salary_structures',
+        'payroll_periods','payroll_runs','payroll_details','attendance_records',
+        'leave_types','employee_leaves','hr_policies','hr_attendance_monthly',
+        'hr_payroll_locks','hr_payroll_account_mappings','hr_alerts',
+        'hr_settlements','hr_settlement_lines','hr_payroll_adjustments']
+    LOOP
+        IF to_regclass('public.' || t) IS NULL THEN
+            RAISE EXCEPTION 'HR_PREREQ_MISSING: table % غائب — طبّق 15_hr_module + sql/hr/16 + sql/hr/17 أولاً', t;
+        END IF;
+    END LOOP;
+END $$;
+
+-- ===================================================================
+-- 1) سياسات RLS عاملة (wardah_org_id) للجداول الثمانية المقفلة فعلياً
+-- ===================================================================
+DO $$
+DECLARE t TEXT;
+BEGIN
+    FOREACH t IN ARRAY ARRAY[
+        'salary_components','employee_salary_structures','payroll_periods',
+        'payroll_runs','payroll_details','attendance_records',
+        'leave_types','employee_leaves']
+    LOOP
+        EXECUTE format('DROP POLICY IF EXISTS %I ON %I', t || '_wardah_select', t);
+        EXECUTE format(
+            'CREATE POLICY %I ON %I FOR SELECT TO authenticated USING (org_id = wardah_org_id(NULL))',
+            t || '_wardah_select', t);
+        EXECUTE format('DROP POLICY IF EXISTS %I ON %I', t || '_wardah_insert', t);
+        EXECUTE format(
+            'CREATE POLICY %I ON %I FOR INSERT TO authenticated WITH CHECK (org_id = wardah_org_id(NULL))',
+            t || '_wardah_insert', t);
+        EXECUTE format('DROP POLICY IF EXISTS %I ON %I', t || '_wardah_update', t);
+        EXECUTE format(
+            'CREATE POLICY %I ON %I FOR UPDATE TO authenticated USING (org_id = wardah_org_id(NULL)) WITH CHECK (org_id = wardah_org_id(NULL))',
+            t || '_wardah_update', t);
+        EXECUTE format('DROP POLICY IF EXISTS %I ON %I', t || '_wardah_delete', t);
+        EXECUTE format(
+            'CREATE POLICY %I ON %I FOR DELETE TO authenticated USING (org_id = wardah_org_id(NULL))',
+            t || '_wardah_delete', t);
+    END LOOP;
+END $$;
+
+-- ===================================================================
+-- 2) تحصين upsert_attendance_day: اشتقاق org آمن + فحص عضوية (نمط 93/95)
+-- ===================================================================
+CREATE OR REPLACE FUNCTION public.upsert_attendance_day(
+    p_org_id      UUID,
+    p_employee_id UUID,
+    p_year        SMALLINT,
+    p_month       SMALLINT,
+    p_day         TEXT,
+    p_payload     JSONB
+)
+RETURNS hr_attendance_monthly
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_org UUID;
+    v_row hr_attendance_monthly;
+BEGIN
+    -- اشتقاق آمن: القيمة الصريحة تُقبل فقط إن كان المستخدم عضواً فيها
+    v_org := wardah_org_id(p_org_id);
+    IF v_org IS NULL THEN
+        RAISE EXCEPTION 'ORG_NOT_RESOLVED';
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM user_organizations
+        WHERE user_id = auth.uid() AND org_id = v_org
+    ) THEN
+        RAISE EXCEPTION 'NOT_ORG_MEMBER';
+    END IF;
+
+    -- الموظف يجب أن يتبع نفس المؤسسة
+    IF NOT EXISTS (
+        SELECT 1 FROM employees WHERE id = p_employee_id AND org_id = v_org
+    ) THEN
+        RAISE EXCEPTION 'EMPLOYEE_NOT_FOUND';
+    END IF;
+
+    -- شهر مقفل ⇒ لا تعديل حضور
+    IF EXISTS (
+        SELECT 1 FROM hr_payroll_locks
+        WHERE org_id = v_org AND year = p_year AND month = p_month
+          AND status = 'locked'
+    ) THEN
+        RAISE EXCEPTION 'PAYROLL_MONTH_LOCKED';
+    END IF;
+
+    INSERT INTO hr_attendance_monthly (org_id, employee_id, year, month, days, updated_by)
+    VALUES (v_org, p_employee_id, p_year, p_month,
+            jsonb_build_object(p_day, p_payload), auth.uid())
+    ON CONFLICT (org_id, employee_id, year, month) DO UPDATE SET
+        days       = hr_attendance_monthly.days || jsonb_build_object(p_day, p_payload),
+        updated_by = auth.uid(),
+        updated_at = NOW()
+    RETURNING * INTO v_row;
+
+    RETURN v_row;
+END;
+$$;
+
+COMMENT ON FUNCTION public.upsert_attendance_day(UUID,UUID,SMALLINT,SMALLINT,TEXT,JSONB) IS
+'تحديث يوم حضور ذرّياً (Migration 99): اشتقاق org عبر wardah_org_id + فحص عضوية + رفض الموظف الأجنبي عن المؤسسة + رفض الشهر المقفل. كان يثق بـ p_org_id مباشرة.';
+
+-- ===================================================================
+-- 3) سلامة المسير: تفرّد + idempotency على payroll_runs (الجدول فارغ حيّاً)
+-- ===================================================================
+ALTER TABLE payroll_runs ADD COLUMN IF NOT EXISTS idempotency_key   TEXT;
+ALTER TABLE payroll_runs ADD COLUMN IF NOT EXISTS request_hash      TEXT;
+ALTER TABLE payroll_runs ADD COLUMN IF NOT EXISTS journal_entry_id  UUID REFERENCES gl_entries(id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_payroll_runs_org_period
+    ON payroll_runs (org_id, period_id);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_payroll_runs_idem
+    ON payroll_runs (org_id, idempotency_key) WHERE idempotency_key IS NOT NULL;
+
+-- ===================================================================
+-- 4) توسيع أنواع حسابات خرائط الرواتب (قرار المالك: الحسابات من الضبط)
+-- ===================================================================
+ALTER TABLE hr_payroll_account_mappings
+    DROP CONSTRAINT IF EXISTS hr_payroll_account_mappings_account_type_check;
+ALTER TABLE hr_payroll_account_mappings
+    ADD CONSTRAINT hr_payroll_account_mappings_account_type_check CHECK (
+        account_type = ANY (ARRAY[
+            'basic_salary','housing_allowance','transport_allowance','other_allowance',
+            'deductions','loans','payable','net_payable',
+            'overtime','absence_recovery',
+            'gosi_employee','gosi_employer_expense','gosi_payable',
+            'eos_expense','eos_payable'
+        ])
+    );
+
+-- ===================================================================
+-- 5) سياسات GOSI/الرواتب/استحقاق الإجازات في hr_policies
+--    (افتراضات قابلة للتعديل من شاشة ضبط الرواتب — لا أرقام مُصمَّتة بالكود)
+-- ===================================================================
+ALTER TABLE hr_policies ADD COLUMN IF NOT EXISTS gosi_employee_pct            NUMERIC(5,2) NOT NULL DEFAULT 9.75;
+ALTER TABLE hr_policies ADD COLUMN IF NOT EXISTS gosi_employer_pct            NUMERIC(5,2) NOT NULL DEFAULT 11.75;
+ALTER TABLE hr_policies ADD COLUMN IF NOT EXISTS gosi_base_cap                NUMERIC(12,2) NOT NULL DEFAULT 45000;
+ALTER TABLE hr_policies ADD COLUMN IF NOT EXISTS gosi_applies_to              TEXT NOT NULL DEFAULT 'saudi_only';
+ALTER TABLE hr_policies ADD COLUMN IF NOT EXISTS daily_rate_basis             TEXT NOT NULL DEFAULT 'working_days';
+ALTER TABLE hr_policies ADD COLUMN IF NOT EXISTS overtime_base                TEXT NOT NULL DEFAULT 'basic';
+ALTER TABLE hr_policies ADD COLUMN IF NOT EXISTS annual_leave_days_before_5y  INTEGER NOT NULL DEFAULT 21;
+ALTER TABLE hr_policies ADD COLUMN IF NOT EXISTS annual_leave_days_after_5y   INTEGER NOT NULL DEFAULT 30;
+ALTER TABLE hr_policies ADD COLUMN IF NOT EXISTS include_weekends_in_accrual  BOOLEAN NOT NULL DEFAULT true;
+ALTER TABLE hr_policies ADD COLUMN IF NOT EXISTS exclude_unpaid_from_accrual  BOOLEAN NOT NULL DEFAULT true;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'hr_policies_gosi_applies_to_check') THEN
+        ALTER TABLE hr_policies ADD CONSTRAINT hr_policies_gosi_applies_to_check
+            CHECK (gosi_applies_to IN ('saudi_only','all','none'));
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'hr_policies_daily_rate_basis_check') THEN
+        ALTER TABLE hr_policies ADD CONSTRAINT hr_policies_daily_rate_basis_check
+            CHECK (daily_rate_basis IN ('working_days','thirty'));
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'hr_policies_overtime_base_check') THEN
+        ALTER TABLE hr_policies ADD CONSTRAINT hr_policies_overtime_base_check
+            CHECK (overtime_base IN ('basic','basic_housing'));
+    END IF;
+END $$;
+
+-- ===================================================================
+-- 6) أعمدة الموظف اللازمة لـ GOSI والتنبيهات
+-- ===================================================================
+ALTER TABLE employees ADD COLUMN IF NOT EXISTS is_saudi          BOOLEAN;
+ALTER TABLE employees ADD COLUMN IF NOT EXISTS contract_end_date DATE;
+
+-- استنتاج is_saudi من الجنسية حيث NULL (idempotent — لا يمسّ قيماً مضبوطة)
+UPDATE employees
+SET is_saudi = (nationality ILIKE '%saudi%' OR nationality ILIKE '%سعود%')
+WHERE is_saudi IS NULL AND nationality IS NOT NULL;

--- a/sql/migrations/MANIFEST.md
+++ b/sql/migrations/MANIFEST.md
@@ -33,6 +33,7 @@
 | **97** | **توحيد المخزون: products مجمّع مرجعي مشتق من bins (الخيار B) — مزامنة products.stock_quantity/cost_price داخل wardah_apply_stock_incoming + تسوية idempotent للـ bins السابقة** | ✅ مطبَّقة + مُختبرة حيّاً (تسوية: products=001(18,200 تام)+RM-042(3,250 خام)=**21,450**؛ استلام 100@8 فوق 500@6.5 ⇒ bins=products=600@6.75، اشتقاق idempotent بلا مضاعفة) |
 | **98** | **جدول org_settings (key/value JSONB لكل مؤسسة) + RLS قياسي + trigger updated_at — خلفية شاشة إعدادات النظام والنسخ الاحتياطي (P11-6)** | ✅ مطبَّقة + مُختبرة حيّاً (upsert مرتين على نفس المفتاح ⇒ صف واحد بالقيمة الأحدث، rollback) |
 | **99** | **تأسيس HR الشرعي (P12-A): سياسات RLS عاملة (wardah_org_id) للجداول الثمانية المقفلة فعلياً (سياستها القديمة تعتمد app.current_org_id الذي لا يضبطه عميل Supabase) + تحصين upsert_attendance_day (عضوية + موظف نفس المؤسسة + رفض شهر مقفل) + تفرّد/idempotency على payroll_runs + توسيع أنواع حسابات الرواتب (GOSI/نهاية خدمة/إضافي) + سياسات GOSI والمعدل اليومي والإضافي واستحقاق الإجازات في hr_policies + employees.is_saudi/contract_end_date. ملاحظة: جداول HR التاريخية (15_hr_module + sql/hr/16 + sql/hr/17) تأكد وجودها حيّاً واستُوعبت قانونياً هنا** | ✅ مطبَّقة + مُختبرة حيّاً (بلا JWT⇒NOT_ORG_MEMBER، عضو⇒upsert يوم يدمج JSONB، شهر مقفل⇒PAYROLL_MONTH_LOCKED، 8 سياسات جديدة، rollback) |
+| **100** | **مسير رواتب وتسوية نهاية خدمة ذرّيان (P12-B): rpc_post_payroll_run (عضوية + قفل استشاري + idempotency ببصمة + سطور payroll_details + قيد متزن عبر rpc_create_journal_entry بحسابات hr_payroll_account_mappings + قفل الشهر) وrpc_post_settlement (FOR UPDATE + idempotency + قيد eos_expense/eos_payable + قلب الموظف terminated). كان الترحيل client-side مباشراً متجاوزاً القناة القانونية وبلا سطور قسائم** | ✅ مطبَّقة + مُختبرة حيّاً (مسير: bal=0.00 و4 سطور GL وdetails=2 وreplay=نفس run وIDEMPOTENCY_KEY_REUSED وPAYROLL_MONTH_LOCKED وUNBALANCED_PAYROLL؛ تسوية: قيد سطرين وemployee=terminated وreplay وSETTLEMENT_NOT_POSTABLE — كله rollback) |
 
 > **COGS_DELIVERY** زُرعت يدوياً بالحسابين الفعليين: مدين **544000** (COGS أكياس
 > مطبوعة) / دائن **135100** (FG أكياس مطبوعة) — الافتراضي `511100` في ملف 85 غير
@@ -57,7 +58,7 @@
    `rpc_create_journal_entry` فقط منذ P4-B2)، و`journal_entries/journal_entry_lines`
    (يستخدمه stock-adjustment-service فقط — موثَّق، توحيده مؤجل).
 2. **rollback scripts**: تحت `sql/rollback/` — حالياً `83_rollback_org_scoped_rls.sql`.
-3. **أرقام جديدة**: التالي هو **100**. أي migration جديدة = ملف جديد مرقّم + سطر هنا.
+3. **أرقام جديدة**: التالي هو **101**. أي migration جديدة = ملف جديد مرقّم + سطر هنا.
 4. **✅ حُسم تعارض مسار التسليم (Migration 87) ثم تحصينه (88)**: القانوني هو
    **`products`** (كل مفاتيح product_id الأجنبية تشير إليه؛ `items` جدول ميت فارغ)
    و**`org_id`** (112 جدولاً مقابل tenant_id على 13 محاسبياً). 87 واءم الدالة

--- a/sql/migrations/MANIFEST.md
+++ b/sql/migrations/MANIFEST.md
@@ -32,6 +32,7 @@
 | **96** | **بوابة admin لـ allow_zero_cost + بصمة الحمولة (request_hash) على idempotency الاستلام** | ✅ مطبَّقة + مُختبرة حيّاً (نفس المفتاح بحمولة مختلفة=IDEMPOTENCY_KEY_REUSED، allow_zero_cost لغير المدير يُخفَّض) |
 | **97** | **توحيد المخزون: products مجمّع مرجعي مشتق من bins (الخيار B) — مزامنة products.stock_quantity/cost_price داخل wardah_apply_stock_incoming + تسوية idempotent للـ bins السابقة** | ✅ مطبَّقة + مُختبرة حيّاً (تسوية: products=001(18,200 تام)+RM-042(3,250 خام)=**21,450**؛ استلام 100@8 فوق 500@6.5 ⇒ bins=products=600@6.75، اشتقاق idempotent بلا مضاعفة) |
 | **98** | **جدول org_settings (key/value JSONB لكل مؤسسة) + RLS قياسي + trigger updated_at — خلفية شاشة إعدادات النظام والنسخ الاحتياطي (P11-6)** | ✅ مطبَّقة + مُختبرة حيّاً (upsert مرتين على نفس المفتاح ⇒ صف واحد بالقيمة الأحدث، rollback) |
+| **99** | **تأسيس HR الشرعي (P12-A): سياسات RLS عاملة (wardah_org_id) للجداول الثمانية المقفلة فعلياً (سياستها القديمة تعتمد app.current_org_id الذي لا يضبطه عميل Supabase) + تحصين upsert_attendance_day (عضوية + موظف نفس المؤسسة + رفض شهر مقفل) + تفرّد/idempotency على payroll_runs + توسيع أنواع حسابات الرواتب (GOSI/نهاية خدمة/إضافي) + سياسات GOSI والمعدل اليومي والإضافي واستحقاق الإجازات في hr_policies + employees.is_saudi/contract_end_date. ملاحظة: جداول HR التاريخية (15_hr_module + sql/hr/16 + sql/hr/17) تأكد وجودها حيّاً واستُوعبت قانونياً هنا** | ✅ مطبَّقة + مُختبرة حيّاً (بلا JWT⇒NOT_ORG_MEMBER، عضو⇒upsert يوم يدمج JSONB، شهر مقفل⇒PAYROLL_MONTH_LOCKED، 8 سياسات جديدة، rollback) |
 
 > **COGS_DELIVERY** زُرعت يدوياً بالحسابين الفعليين: مدين **544000** (COGS أكياس
 > مطبوعة) / دائن **135100** (FG أكياس مطبوعة) — الافتراضي `511100` في ملف 85 غير
@@ -56,7 +57,7 @@
    `rpc_create_journal_entry` فقط منذ P4-B2)، و`journal_entries/journal_entry_lines`
    (يستخدمه stock-adjustment-service فقط — موثَّق، توحيده مؤجل).
 2. **rollback scripts**: تحت `sql/rollback/` — حالياً `83_rollback_org_scoped_rls.sql`.
-3. **أرقام جديدة**: التالي هو **99**. أي migration جديدة = ملف جديد مرقّم + سطر هنا.
+3. **أرقام جديدة**: التالي هو **100**. أي migration جديدة = ملف جديد مرقّم + سطر هنا.
 4. **✅ حُسم تعارض مسار التسليم (Migration 87) ثم تحصينه (88)**: القانوني هو
    **`products`** (كل مفاتيح product_id الأجنبية تشير إليه؛ `items` جدول ميت فارغ)
    و**`org_id`** (112 جدولاً مقابل tenant_id على 13 محاسبياً). 87 واءم الدالة

--- a/src/features/hr/pages/EmployeeProfilePage.tsx
+++ b/src/features/hr/pages/EmployeeProfilePage.tsx
@@ -1,183 +1,427 @@
 import React from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
-import { ArrowRight, User, Briefcase, Banknote, FileText } from 'lucide-react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  ArrowRight,
+  User,
+  Briefcase,
+  Banknote,
+  FileText,
+  Plus,
+  Trash2,
+} from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { toast } from 'sonner';
 import { getEmployees } from '@/services/hr/hr-service';
-import { getEmployeeSalaryComponents } from '@/services/hr/employee-service';
+import {
+  getEmployeeSalaryComponents,
+  listSalaryComponents,
+  upsertEmployeeSalaryComponent,
+  deactivateEmployeeSalaryComponent,
+  type EmployeeSalaryComponent,
+} from '@/services/hr/employee-service';
 import { STATUS_BADGES } from '../types';
 
 export const EmployeeProfilePage: React.FC = () => {
-    const { id } = useParams<{ id: string }>();
-    const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
-    // In a real app, we would have a specific getEmployeeById query
-    // For now, we'll reuse getEmployees and find the employee
-    const { data: employees = [] } = useQuery({
-        queryKey: ['hr', 'employees'],
-        queryFn: getEmployees,
-        staleTime: 60_000,
-    });
+  const [showAddDialog, setShowAddDialog] = React.useState(false);
+  const [addForm, setAddForm] = React.useState({
+    component_id: '',
+    amount: '',
+    calculation_type: 'fixed' as 'fixed' | 'percentage',
+  });
 
-    const employee = React.useMemo(() => employees.find((e) => e.id === id), [employees, id]);
+  const { data: employees = [] } = useQuery({
+    queryKey: ['hr', 'employees'],
+    queryFn: getEmployees,
+    staleTime: 60_000,
+  });
 
-    // بدلات/استقطاعات فعلية من employee_salary_structures (بدل placeholder)
-    const { data: salaryComponents = [] } = useQuery({
-        queryKey: ['hr', 'employee-salary-components', id],
-        queryFn: () => getEmployeeSalaryComponents(id as string),
-        enabled: !!id && !!employee,
-        staleTime: 60_000,
-    });
+  const employee = React.useMemo(
+    () => employees.find((e) => e.id === id),
+    [employees, id],
+  );
 
-    if (!employee) {
-        return (
-            <div className="flex flex-col items-center justify-center h-96">
-                <p className="text-muted-foreground">الموظف غير موجود</p>
-                <Button variant="link" onClick={() => navigate('/hr/employees')}>
-                    العودة للقائمة
-                </Button>
-            </div>
-        );
-    }
+  const { data: salaryComponents = [] } = useQuery({
+    queryKey: ['hr', 'employee-salary-components', id],
+    queryFn: () => getEmployeeSalaryComponents(id as string),
+    enabled: !!id && !!employee,
+    staleTime: 60_000,
+  });
 
+  const { data: availableComponents = [] } = useQuery({
+    queryKey: ['hr', 'salary-components'],
+    queryFn: listSalaryComponents,
+    staleTime: 300_000,
+  });
+
+  const addMutation = useMutation({
+    mutationFn: () =>
+      upsertEmployeeSalaryComponent(id as string, {
+        component_id: addForm.component_id,
+        amount: Number(addForm.amount),
+        calculation_type: addForm.calculation_type,
+      }),
+    onSuccess: () => {
+      toast.success('تم إسناد مكوّن الراتب');
+      queryClient.invalidateQueries({ queryKey: ['hr', 'employee-salary-components', id] });
+      setShowAddDialog(false);
+      setAddForm({ component_id: '', amount: '', calculation_type: 'fixed' });
+    },
+    onError: (err: Error) => toast.error(err.message),
+  });
+
+  const removeMutation = useMutation({
+    mutationFn: (structureId: string) => deactivateEmployeeSalaryComponent(structureId),
+    onSuccess: () => {
+      toast.success('تم إلغاء تفعيل المكوّن');
+      queryClient.invalidateQueries({ queryKey: ['hr', 'employee-salary-components', id] });
+    },
+    onError: (err: Error) => toast.error(err.message),
+  });
+
+  if (!employee) {
     return (
-        <div className="space-y-6">
-            <div className="flex items-center gap-4">
-                <Button variant="ghost" size="icon" onClick={() => navigate('/hr/employees')}>
-                    <ArrowRight className="h-4 w-4" />
-                </Button>
-                <div>
-                    <h1 className="text-2xl font-bold tracking-tight">{employee.name}</h1>
-                    <p className="text-muted-foreground text-sm">{employee.jobTitle} • {employee.department}</p>
-                </div>
-                <div className="mr-auto">
-                    <Badge className={STATUS_BADGES[employee.status]}>
-                        {employee.status}
-                    </Badge>
-                </div>
-            </div>
-
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-                {/* Sidebar Info */}
-                <Card className="md:col-span-1 border-border/60 h-fit">
-                    <CardContent className="pt-6 flex flex-col items-center text-center">
-                        <Avatar className="h-24 w-24 mb-4">
-                            <AvatarImage src={`https://ui-avatars.com/api/?name=${employee.name}&background=random`} />
-                            <AvatarFallback><User className="h-10 w-10" /></AvatarFallback>
-                        </Avatar>
-                        <h2 className="text-xl font-semibold">{employee.name}</h2>
-                        <p className="text-sm text-muted-foreground mb-4">{employee.code}</p>
-
-                        <div className="w-full space-y-3 text-right mt-4 border-t pt-4">
-                            <div className="flex justify-between text-sm">
-                                <span className="text-muted-foreground">تاريخ التعيين</span>
-                                <span>{employee.hiringDate ? new Date(employee.hiringDate).toLocaleDateString() : '—'}</span>
-                            </div>
-                            <div className="flex justify-between text-sm">
-                                <span className="text-muted-foreground">القسم</span>
-                                <span>{employee.department}</span>
-                            </div>
-                            <div className="flex justify-between text-sm">
-                                <span className="text-muted-foreground">الراتب الأساسي</span>
-                                <span>{employee.salary?.toLocaleString()} {employee.currency}</span>
-                            </div>
-                        </div>
-                    </CardContent>
-                </Card>
-
-                {/* Main Content Tabs */}
-                <div className="md:col-span-2">
-                    <Tabs defaultValue="overview" className="w-full">
-                        <TabsList className="w-full justify-start">
-                            <TabsTrigger value="overview">نظرة عامة</TabsTrigger>
-                            <TabsTrigger value="salary">الراتب والبدلات</TabsTrigger>
-                            <TabsTrigger value="documents">المستندات</TabsTrigger>
-                            <TabsTrigger value="attendance">سجل الحضور</TabsTrigger>
-                        </TabsList>
-
-                        <TabsContent value="overview" className="space-y-4 mt-4">
-                            <Card>
-                                <CardHeader>
-                                    <CardTitle className="text-base flex items-center gap-2">
-                                        <Briefcase className="h-4 w-4" />
-                                        معلومات العقد
-                                    </CardTitle>
-                                </CardHeader>
-                                <CardContent className="space-y-2">
-                                    <div className="grid grid-cols-2 gap-4">
-                                        <div>
-                                            <p className="text-sm text-muted-foreground">نوع العقد</p>
-                                            <p className="font-medium">دوام كامل</p>
-                                        </div>
-                                        <div>
-                                            <p className="text-sm text-muted-foreground">تاريخ الانتهاء</p>
-                                            <p className="font-medium">{employee.contractEndDate ? new Date(employee.contractEndDate).toLocaleDateString() : 'مفتوح'}</p>
-                                        </div>
-                                    </div>
-                                </CardContent>
-                            </Card>
-                        </TabsContent>
-
-                        <TabsContent value="salary" className="space-y-4 mt-4">
-                            <Card>
-                                <CardHeader>
-                                    <CardTitle className="text-base flex items-center gap-2">
-                                        <Banknote className="h-4 w-4" />
-                                        هيكل الراتب
-                                    </CardTitle>
-                                </CardHeader>
-                                <CardContent>
-                                    <div className="space-y-4">
-                                        <div className="flex justify-between items-center p-3 bg-muted/50 rounded-md">
-                                            <span className="font-medium">الراتب الأساسي</span>
-                                            <span className="font-bold">{employee.salary?.toLocaleString()} {employee.currency}</span>
-                                        </div>
-                                        {salaryComponents.length === 0 ? (
-                                            <div className="text-center py-4 text-muted-foreground text-sm border-2 border-dashed rounded-md">
-                                                لا توجد بدلات إضافية مسجلة
-                                            </div>
-                                        ) : (
-                                            salaryComponents.map((comp) => (
-                                                <div key={comp.id} className="flex justify-between items-center p-3 bg-muted/30 rounded-md">
-                                                    <span>
-                                                        {comp.componentName}
-                                                        {comp.componentType === 'deduction' && (
-                                                            <Badge variant="outline" className="mr-2 text-xs">استقطاع</Badge>
-                                                        )}
-                                                    </span>
-                                                    <span className={`font-medium ${comp.componentType === 'deduction' ? 'text-destructive' : ''}`}>
-                                                        {comp.componentType === 'deduction' ? '−' : ''}{comp.value.toLocaleString('en-US')} {employee.currency}
-                                                    </span>
-                                                </div>
-                                            ))
-                                        )}
-                                    </div>
-                                </CardContent>
-                            </Card>
-                        </TabsContent>
-
-                        <TabsContent value="documents" className="mt-4">
-                            <Card>
-                                <CardHeader>
-                                    <CardTitle className="text-base flex items-center gap-2">
-                                        <FileText className="h-4 w-4" />
-                                        المستندات الرسمية
-                                    </CardTitle>
-                                </CardHeader>
-                                <CardContent>
-                                    <div className="text-center py-8 text-muted-foreground border-2 border-dashed rounded-md">
-                                        لا توجد مستندات مرفقة (الهوية، العقد، الشهادات)
-                                    </div>
-                                </CardContent>
-                            </Card>
-                        </TabsContent>
-                    </Tabs>
-                </div>
-            </div>
-        </div>
+      <div className="flex flex-col items-center justify-center h-96">
+        <p className="text-muted-foreground">الموظف غير موجود</p>
+        <Button variant="link" onClick={() => navigate('/hr/employees')}>
+          العودة للقائمة
+        </Button>
+      </div>
     );
+  }
+
+  const totalEarnings = salaryComponents
+    .filter((c: EmployeeSalaryComponent) => c.componentType !== 'deduction')
+    .reduce((s, c) => s + c.value, employee.salary ?? 0);
+
+  const totalDeductions = salaryComponents
+    .filter((c: EmployeeSalaryComponent) => c.componentType === 'deduction')
+    .reduce((s, c) => s + c.value, 0);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-4">
+        <Button variant="ghost" size="icon" onClick={() => navigate('/hr/employees')}>
+          <ArrowRight className="h-4 w-4" />
+        </Button>
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">{employee.name}</h1>
+          <p className="text-muted-foreground text-sm">
+            {employee.jobTitle} • {employee.department}
+          </p>
+        </div>
+        <div className="mr-auto">
+          <Badge className={STATUS_BADGES[employee.status]}>{employee.status}</Badge>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        {/* بطاقة الموظف */}
+        <Card className="md:col-span-1 border-border/60 h-fit">
+          <CardContent className="pt-6 flex flex-col items-center text-center">
+            <Avatar className="h-24 w-24 mb-4">
+              <AvatarImage
+                src={`https://ui-avatars.com/api/?name=${employee.name}&background=random`}
+              />
+              <AvatarFallback>
+                <User className="h-10 w-10" />
+              </AvatarFallback>
+            </Avatar>
+            <h2 className="text-xl font-semibold">{employee.name}</h2>
+            <p className="text-sm text-muted-foreground mb-4">{employee.code}</p>
+
+            <div className="w-full space-y-3 text-right mt-4 border-t pt-4">
+              <div className="flex justify-between text-sm">
+                <span className="text-muted-foreground">تاريخ التعيين</span>
+                <span>
+                  {employee.hiringDate
+                    ? new Date(employee.hiringDate).toLocaleDateString()
+                    : '—'}
+                </span>
+              </div>
+              <div className="flex justify-between text-sm">
+                <span className="text-muted-foreground">القسم</span>
+                <span>{employee.department}</span>
+              </div>
+              <div className="flex justify-between text-sm">
+                <span className="text-muted-foreground">الراتب الأساسي</span>
+                <span>
+                  {employee.salary?.toLocaleString()} {employee.currency}
+                </span>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* تبويبات */}
+        <div className="md:col-span-2">
+          <Tabs defaultValue="overview" className="w-full">
+            <TabsList className="w-full justify-start">
+              <TabsTrigger value="overview">نظرة عامة</TabsTrigger>
+              <TabsTrigger value="salary">الراتب والبدلات</TabsTrigger>
+              <TabsTrigger value="documents">المستندات</TabsTrigger>
+            </TabsList>
+
+            {/* نظرة عامة */}
+            <TabsContent value="overview" className="space-y-4 mt-4">
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base flex items-center gap-2">
+                    <Briefcase className="h-4 w-4" />
+                    معلومات العقد
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-2">
+                  <div className="grid grid-cols-2 gap-4">
+                    <div>
+                      <p className="text-sm text-muted-foreground">نوع العقد</p>
+                      <p className="font-medium">دوام كامل</p>
+                    </div>
+                    <div>
+                      <p className="text-sm text-muted-foreground">تاريخ الانتهاء</p>
+                      <p className="font-medium">
+                        {employee.contractEndDate
+                          ? new Date(employee.contractEndDate).toLocaleDateString()
+                          : 'مفتوح'}
+                      </p>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            </TabsContent>
+
+            {/* الراتب والبدلات */}
+            <TabsContent value="salary" className="space-y-4 mt-4">
+              <Card>
+                <CardHeader className="flex flex-row items-center justify-between pb-2">
+                  <CardTitle className="text-base flex items-center gap-2">
+                    <Banknote className="h-4 w-4" />
+                    هيكل الراتب
+                  </CardTitle>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => setShowAddDialog(true)}
+                  >
+                    <Plus className="h-4 w-4 ml-1" />
+                    إضافة مكوّن
+                  </Button>
+                </CardHeader>
+                <CardContent>
+                  <div className="space-y-2">
+                    {/* الأساسي */}
+                    <div className="flex justify-between items-center p-3 bg-muted/50 rounded-md">
+                      <span className="font-medium">الراتب الأساسي</span>
+                      <span className="font-bold">
+                        {employee.salary?.toLocaleString()} {employee.currency}
+                      </span>
+                    </div>
+
+                    {/* المكوّنات */}
+                    {salaryComponents.length === 0 ? (
+                      <div className="text-center py-4 text-muted-foreground text-sm border-2 border-dashed rounded-md">
+                        لا توجد بدلات أو استقطاعات إضافية — اضغط &quot;إضافة مكوّن&quot;
+                      </div>
+                    ) : (
+                      salaryComponents.map((comp: EmployeeSalaryComponent) => (
+                        <div
+                          key={comp.id}
+                          className="flex justify-between items-center p-3 bg-muted/30 rounded-md group"
+                        >
+                          <span className="flex items-center gap-2">
+                            {comp.componentName}
+                            {comp.componentType === 'deduction' && (
+                              <Badge variant="outline" className="text-xs">
+                                استقطاع
+                              </Badge>
+                            )}
+                          </span>
+                          <div className="flex items-center gap-3">
+                            <span
+                              className={`font-medium ${
+                                comp.componentType === 'deduction'
+                                  ? 'text-destructive'
+                                  : 'text-emerald-600'
+                              }`}
+                            >
+                              {comp.componentType === 'deduction' ? '−' : '+'}
+                              {comp.value.toLocaleString('en-US')} {employee.currency}
+                            </span>
+                            <Button
+                              size="icon"
+                              variant="ghost"
+                              className="h-7 w-7 opacity-0 group-hover:opacity-100 text-destructive"
+                              onClick={() => removeMutation.mutate(comp.id)}
+                              disabled={removeMutation.isPending}
+                              title="إلغاء تفعيل"
+                            >
+                              <Trash2 className="h-3.5 w-3.5" />
+                            </Button>
+                          </div>
+                        </div>
+                      ))
+                    )}
+
+                    {/* ملخّص */}
+                    {salaryComponents.length > 0 && (
+                      <div className="mt-3 pt-3 border-t space-y-1">
+                        <div className="flex justify-between text-sm">
+                          <span className="text-muted-foreground">إجمالي المستحقات</span>
+                          <span className="text-emerald-600 font-medium">
+                            {totalEarnings.toLocaleString()} {employee.currency}
+                          </span>
+                        </div>
+                        {totalDeductions > 0 && (
+                          <div className="flex justify-between text-sm">
+                            <span className="text-muted-foreground">إجمالي الاستقطاعات</span>
+                            <span className="text-destructive font-medium">
+                              −{totalDeductions.toLocaleString()} {employee.currency}
+                            </span>
+                          </div>
+                        )}
+                        <div className="flex justify-between font-semibold">
+                          <span>الصافي التقديري</span>
+                          <span>
+                            {(totalEarnings - totalDeductions).toLocaleString()}{' '}
+                            {employee.currency}
+                          </span>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                </CardContent>
+              </Card>
+            </TabsContent>
+
+            {/* المستندات */}
+            <TabsContent value="documents" className="mt-4">
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base flex items-center gap-2">
+                    <FileText className="h-4 w-4" />
+                    المستندات الرسمية
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="text-center py-8 text-muted-foreground border-2 border-dashed rounded-md">
+                    لا توجد مستندات مرفقة (الهوية، العقد، الشهادات)
+                  </div>
+                </CardContent>
+              </Card>
+            </TabsContent>
+          </Tabs>
+        </div>
+      </div>
+
+      {/* ── نافذة إضافة مكوّن ── */}
+      <Dialog open={showAddDialog} onOpenChange={setShowAddDialog}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>إضافة مكوّن راتب</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label>المكوّن *</Label>
+              <Select
+                value={addForm.component_id}
+                onValueChange={(v) => setAddForm((f) => ({ ...f, component_id: v }))}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="اختر المكوّن..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {availableComponents.map((c) => (
+                    <SelectItem key={c.id} value={c.id}>
+                      {c.name_ar || c.name}
+                      <span className="text-muted-foreground text-xs mr-1">
+                        ({c.component_type === 'deduction' ? 'استقطاع' : 'إضافة'})
+                      </span>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-2">
+                <Label>نوع الحساب</Label>
+                <Select
+                  value={addForm.calculation_type}
+                  onValueChange={(v) =>
+                    setAddForm((f) => ({
+                      ...f,
+                      calculation_type: v as 'fixed' | 'percentage',
+                    }))
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="fixed">مبلغ ثابت</SelectItem>
+                    <SelectItem value="percentage">نسبة %</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label>
+                  القيمة {addForm.calculation_type === 'percentage' ? '(%)' : '(ر.س)'}
+                </Label>
+                <Input
+                  type="number"
+                  min="0.01"
+                  step="0.01"
+                  value={addForm.amount}
+                  onChange={(e) =>
+                    setAddForm((f) => ({ ...f, amount: e.target.value }))
+                  }
+                  placeholder="0.00"
+                />
+              </div>
+            </div>
+          </div>
+          <DialogFooter className="gap-2">
+            <Button variant="outline" onClick={() => setShowAddDialog(false)}>
+              إلغاء
+            </Button>
+            <Button
+              onClick={() => addMutation.mutate()}
+              disabled={
+                !addForm.component_id ||
+                !addForm.amount ||
+                Number(addForm.amount) <= 0 ||
+                addMutation.isPending
+              }
+            >
+              {addMutation.isPending ? 'جارٍ الحفظ...' : 'حفظ'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
 };

--- a/src/features/hr/pages/LeavesPage.tsx
+++ b/src/features/hr/pages/LeavesPage.tsx
@@ -35,105 +35,161 @@ import {
 } from '@/components/ui/table';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { toast } from 'sonner';
-import { 
+import {
   CheckCircle2,
   XCircle,
   AlertCircle,
   Plus,
   Search,
   CalendarDays,
-  Palmtree,
-  Stethoscope,
-  Baby,
-  Briefcase,
-  FileText,
 } from 'lucide-react';
-import { getLeaveRequests, getEmployees } from '@/services/hr/hr-service';
+import { getEmployees } from '@/services/hr/hr-service';
+import {
+  listLeaveRequests,
+  getLeaveTypes,
+  approveLeaveRequest,
+  rejectLeaveRequest,
+  createLeaveRequest,
+  getLeaveBalance,
+  type LeaveRequestRow,
+} from '@/services/hr/leave-service';
 import { STATUS_BADGES } from '../types';
-
-// أنواع الإجازات
-const LEAVE_TYPES = [
-  { id: 'annual', name: 'إجازة سنوية', icon: Palmtree, color: 'text-emerald-500', days: 21 },
-  { id: 'sick', name: 'إجازة مرضية', icon: Stethoscope, color: 'text-rose-500', days: 30 },
-  { id: 'maternity', name: 'إجازة أمومة', icon: Baby, color: 'text-pink-500', days: 70 },
-  { id: 'paternity', name: 'إجازة أبوة', icon: Baby, color: 'text-blue-500', days: 3 },
-  { id: 'unpaid', name: 'إجازة بدون راتب', icon: Briefcase, color: 'text-slate-500', days: 0 },
-  { id: 'compassionate', name: 'إجازة عزاء', icon: FileText, color: 'text-purple-500', days: 5 },
-];
 
 export const LeavesPage: React.FC = () => {
   const queryClient = useQueryClient();
   const [activeTab, setActiveTab] = useState('pending');
   const [searchQuery, setSearchQuery] = useState('');
-  const [selectedType, setSelectedType] = useState<string>('all');
   const [showNewRequestDialog, setShowNewRequestDialog] = useState(false);
   const [showApprovalDialog, setShowApprovalDialog] = useState(false);
-  const [selectedRequest, setSelectedRequest] = useState<any>(null);
+  const [approveAction, setApproveAction] = useState<'approve' | 'reject'>('approve');
+  const [selectedRequest, setSelectedRequest] = useState<LeaveRequestRow | null>(null);
   const [approvalNote, setApprovalNote] = useState('');
+  const [adminOverride, setAdminOverride] = useState(false);
 
-  // جلب طلبات الإجازات
-  const { data: leaveRequests = [], isLoading } = useQuery({
-    queryKey: ['hr', 'leave-requests'],
-    queryFn: () => getLeaveRequests(100),
+  // نموذج الطلب الجديد
+  const [newForm, setNewForm] = useState({
+    employee_id: '',
+    leave_type_id: '',
+    start_date: '',
+    end_date: '',
+    reason: '',
   });
 
-  // جلب قائمة الموظفين
+  // بيانات
+  const { data: leaveRequests = [], isLoading } = useQuery({
+    queryKey: ['hr', 'leave-requests'],
+    queryFn: () => listLeaveRequests(200),
+  });
+
   const { data: employees = [] } = useQuery({
     queryKey: ['hr', 'employees'],
     queryFn: getEmployees,
   });
 
-  // تصفية الطلبات
+  const { data: leaveTypes = [] } = useQuery({
+    queryKey: ['hr', 'leave-types'],
+    queryFn: getLeaveTypes,
+  });
+
+  // رصيد الإجازة للطلب المحدد
+  const { data: selectedBalance } = useQuery({
+    queryKey: ['hr', 'leave-balance', selectedRequest?.employee_id],
+    queryFn: () => getLeaveBalance(selectedRequest!.employee_id),
+    enabled: !!selectedRequest?.employee_id,
+  });
+
+  // تصفية
   const filteredRequests = React.useMemo(() => {
-    return leaveRequests.filter((req: any) => {
+    return leaveRequests.filter((req) => {
       const matchesTab = activeTab === 'all' || req.status === activeTab;
-      const matchesSearch = !searchQuery || 
-        req.employeeName?.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        req.employeeId?.includes(searchQuery);
-      const matchesType = selectedType === 'all' || req.leaveType === selectedType;
-      return matchesTab && matchesSearch && matchesType;
+      const empName =
+        (Array.isArray(req.employee) ? req.employee[0] : req.employee)?.full_name ?? '';
+      const matchesSearch =
+        !searchQuery || empName.toLowerCase().includes(searchQuery.toLowerCase());
+      return matchesTab && matchesSearch;
     });
-  }, [leaveRequests, activeTab, searchQuery, selectedType]);
+  }, [leaveRequests, activeTab, searchQuery]);
 
-  // إحصائيات الإجازات
-  const leaveStats = React.useMemo(() => {
-    const stats = {
-      pending: leaveRequests.filter((r: any) => r.status === 'pending').length,
-      approved: leaveRequests.filter((r: any) => r.status === 'approved').length,
-      rejected: leaveRequests.filter((r: any) => r.status === 'rejected').length,
+  const leaveStats = React.useMemo(
+    () => ({
+      pending: leaveRequests.filter((r) => r.status === 'pending').length,
+      approved: leaveRequests.filter((r) => r.status === 'approved').length,
+      rejected: leaveRequests.filter((r) => r.status === 'rejected').length,
       total: leaveRequests.length,
-    };
-    return stats;
-  }, [leaveRequests]);
+    }),
+    [leaveRequests],
+  );
 
-  // الموافقة على الطلب
-  const handleApprove = async () => {
+  // ── Mutations ─────────────────────────────────────────────────────────────
+
+  const approveMutation = useMutation({
+    mutationFn: ({ id, override }: { id: string; override: boolean }) =>
+      approveLeaveRequest(id, override),
+    onSuccess: () => {
+      toast.success('تمت الموافقة على الإجازة وتحديث الحضور');
+      queryClient.invalidateQueries({ queryKey: ['hr', 'leave-requests'] });
+      queryClient.invalidateQueries({ queryKey: ['hr', 'leave-balance'] });
+      closeApprovalDialog();
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const rejectMutation = useMutation({
+    mutationFn: ({ id, notes }: { id: string; notes: string }) =>
+      rejectLeaveRequest(id, notes),
+    onSuccess: () => {
+      toast.success('تم رفض طلب الإجازة');
+      queryClient.invalidateQueries({ queryKey: ['hr', 'leave-requests'] });
+      closeApprovalDialog();
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const createMutation = useMutation({
+    mutationFn: () => createLeaveRequest(newForm),
+    onSuccess: () => {
+      toast.success('تم تقديم طلب الإجازة');
+      queryClient.invalidateQueries({ queryKey: ['hr', 'leave-requests'] });
+      setShowNewRequestDialog(false);
+      setNewForm({ employee_id: '', leave_type_id: '', start_date: '', end_date: '', reason: '' });
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  // ── Handlers ──────────────────────────────────────────────────────────────
+
+  function openApprovalDialog(req: LeaveRequestRow, action: 'approve' | 'reject') {
+    setSelectedRequest(req);
+    setApproveAction(action);
+    setApprovalNote('');
+    setAdminOverride(false);
+    setShowApprovalDialog(true);
+  }
+
+  function closeApprovalDialog() {
+    setShowApprovalDialog(false);
+    setSelectedRequest(null);
+    setApprovalNote('');
+    setAdminOverride(false);
+  }
+
+  function handleConfirm() {
     if (!selectedRequest) return;
-    // TODO: Call API to approve
-    toast.success(`تمت الموافقة على طلب الإجازة رقم ${selectedRequest.id}`);
-    setShowApprovalDialog(false);
-    setSelectedRequest(null);
-    setApprovalNote('');
-    queryClient.invalidateQueries({ queryKey: ['hr', 'leave-requests'] });
-  };
-
-  // رفض الطلب
-  const handleReject = async () => {
-    if (!selectedRequest || !approvalNote) {
-      toast.error('يرجى إدخال سبب الرفض');
-      return;
+    if (approveAction === 'approve') {
+      approveMutation.mutate({ id: selectedRequest.id, override: adminOverride });
+    } else {
+      rejectMutation.mutate({ id: selectedRequest.id, notes: approvalNote });
     }
-    // TODO: Call API to reject
-    toast.error(`تم رفض طلب الإجازة رقم ${selectedRequest.id}`);
-    setShowApprovalDialog(false);
-    setSelectedRequest(null);
-    setApprovalNote('');
-    queryClient.invalidateQueries({ queryKey: ['hr', 'leave-requests'] });
-  };
+  }
 
-  const getLeaveTypeInfo = (typeId: string) => {
-    return LEAVE_TYPES.find(t => t.id === typeId) || LEAVE_TYPES[0];
-  };
+  const isPending =
+    approveMutation.isPending || rejectMutation.isPending || createMutation.isPending;
 
   return (
     <div className="space-y-6">
@@ -145,7 +201,7 @@ export const LeavesPage: React.FC = () => {
         </p>
       </div>
 
-      {/* بطاقات الإحصائيات */}
+      {/* إحصائيات */}
       <div className="grid gap-4 md:grid-cols-4">
         <Card className="border-amber-500/30 bg-amber-500/10">
           <CardContent className="p-4">
@@ -193,32 +249,6 @@ export const LeavesPage: React.FC = () => {
         </Card>
       </div>
 
-      {/* أنواع الإجازات */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-lg">أنواع الإجازات والرصيد المتاح</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="grid gap-3 md:grid-cols-3 lg:grid-cols-6">
-            {LEAVE_TYPES.map((type) => {
-              const Icon = type.icon;
-              return (
-                <div
-                  key={type.id}
-                  className="flex items-center gap-3 rounded-lg border p-3 hover:bg-muted/50 transition-colors"
-                >
-                  <Icon className={`h-5 w-5 ${type.color}`} />
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium truncate">{type.name}</p>
-                    <p className="text-xs text-muted-foreground">{type.days} يوم</p>
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        </CardContent>
-      </Card>
-
       {/* قائمة الطلبات */}
       <Card>
         <CardHeader className="flex flex-row items-center justify-between">
@@ -232,31 +262,16 @@ export const LeavesPage: React.FC = () => {
           </Button>
         </CardHeader>
         <CardContent className="space-y-4">
-          {/* أدوات التصفية */}
-          <div className="flex flex-wrap gap-3">
-            <div className="relative flex-1 min-w-[200px]">
-              <Search className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-              <Input
-                placeholder="بحث بالاسم أو الرقم الوظيفي..."
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                className="pr-10"
-              />
-            </div>
-            <Select value={selectedType} onValueChange={setSelectedType}>
-              <SelectTrigger className="w-[180px]">
-                <SelectValue placeholder="نوع الإجازة" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">جميع الأنواع</SelectItem>
-                {LEAVE_TYPES.map((type) => (
-                  <SelectItem key={type.id} value={type.id}>{type.name}</SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+          <div className="relative max-w-sm">
+            <Search className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              placeholder="بحث بالاسم..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="pr-10"
+            />
           </div>
 
-          {/* التبويبات */}
           <Tabs value={activeTab} onValueChange={setActiveTab}>
             <TabsList className="grid w-full grid-cols-4">
               <TabsTrigger value="pending" className="gap-2">
@@ -295,37 +310,35 @@ export const LeavesPage: React.FC = () => {
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {filteredRequests.map((request: any) => {
-                      const leaveType = getLeaveTypeInfo(request.leaveType);
-                      const Icon = leaveType.icon;
-                      const startDate = new Date(request.startDate);
-                      const endDate = new Date(request.endDate);
-                      const days = Math.ceil((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)) + 1;
-
+                    {filteredRequests.map((request) => {
+                      const emp = Array.isArray(request.employee)
+                        ? request.employee[0]
+                        : request.employee;
+                      const lt = Array.isArray(request.leave_type)
+                        ? request.leave_type[0]
+                        : request.leave_type;
                       return (
                         <TableRow key={request.id}>
                           <TableCell>
-                            <div>
-                              <p className="font-medium">{request.employeeName || '—'}</p>
-                              <p className="text-xs text-muted-foreground">{request.employeeId}</p>
-                            </div>
+                            <p className="font-medium">{emp?.full_name ?? '—'}</p>
+                          </TableCell>
+                          <TableCell>{lt?.name_ar ?? lt?.name ?? '—'}</TableCell>
+                          <TableCell dir="ltr">{request.start_date}</TableCell>
+                          <TableCell dir="ltr">{request.end_date}</TableCell>
+                          <TableCell>
+                            <Badge variant="outline">{request.total_days} يوم</Badge>
                           </TableCell>
                           <TableCell>
-                            <div className="flex items-center gap-2">
-                              <Icon className={`h-4 w-4 ${leaveType.color}`} />
-                              <span>{leaveType.name}</span>
-                            </div>
-                          </TableCell>
-                          <TableCell>{startDate.toLocaleDateString('en-US')}</TableCell>
-                          <TableCell>{endDate.toLocaleDateString('en-US')}</TableCell>
-                          <TableCell>
-                            <Badge variant="outline">{days} يوم</Badge>
-                          </TableCell>
-                          <TableCell>
-                            <Badge className={STATUS_BADGES[request.status] || 'bg-slate-100 text-slate-700'}>
+                            <Badge
+                              className={
+                                STATUS_BADGES[request.status] ||
+                                'bg-slate-100 text-slate-700'
+                              }
+                            >
                               {request.status === 'pending' && 'معلق'}
                               {request.status === 'approved' && 'موافق عليه'}
                               {request.status === 'rejected' && 'مرفوض'}
+                              {request.status === 'cancelled' && 'ملغى'}
                             </Badge>
                           </TableCell>
                           <TableCell>
@@ -335,10 +348,7 @@ export const LeavesPage: React.FC = () => {
                                   size="sm"
                                   variant="outline"
                                   className="text-emerald-600 hover:bg-emerald-50"
-                                  onClick={() => {
-                                    setSelectedRequest(request);
-                                    setShowApprovalDialog(true);
-                                  }}
+                                  onClick={() => openApprovalDialog(request, 'approve')}
                                 >
                                   <CheckCircle2 className="h-4 w-4" />
                                 </Button>
@@ -346,10 +356,7 @@ export const LeavesPage: React.FC = () => {
                                   size="sm"
                                   variant="outline"
                                   className="text-rose-600 hover:bg-rose-50"
-                                  onClick={() => {
-                                    setSelectedRequest(request);
-                                    setShowApprovalDialog(true);
-                                  }}
+                                  onClick={() => openApprovalDialog(request, 'reject')}
                                 >
                                   <XCircle className="h-4 w-4" />
                                 </Button>
@@ -367,36 +374,102 @@ export const LeavesPage: React.FC = () => {
         </CardContent>
       </Card>
 
-      {/* نافذة الموافقة/الرفض */}
+      {/* ── نافذة الموافقة/الرفض ── */}
       <Dialog open={showApprovalDialog} onOpenChange={setShowApprovalDialog}>
         <DialogContent className="max-w-md">
           <DialogHeader>
-            <DialogTitle>مراجعة طلب الإجازة</DialogTitle>
+            <DialogTitle>
+              {approveAction === 'approve' ? 'الموافقة على الإجازة' : 'رفض طلب الإجازة'}
+            </DialogTitle>
             <DialogDescription>
-              راجع تفاصيل الطلب واتخذ القرار المناسب
+              {approveAction === 'approve'
+                ? 'سيتم تحديث سجل الحضور آلياً عند الموافقة'
+                : 'يرجى إدخال سبب الرفض'}
             </DialogDescription>
           </DialogHeader>
+
           {selectedRequest && (
             <div className="space-y-4">
-              <div className="rounded-lg border p-4 space-y-2">
+              <div className="rounded-lg border p-4 space-y-2 text-sm">
                 <div className="flex justify-between">
                   <span className="text-muted-foreground">الموظف:</span>
-                  <span className="font-medium">{selectedRequest.employeeName}</span>
+                  <span className="font-medium">
+                    {(Array.isArray(selectedRequest.employee)
+                      ? selectedRequest.employee[0]
+                      : selectedRequest.employee
+                    )?.full_name ?? '—'}
+                  </span>
                 </div>
                 <div className="flex justify-between">
                   <span className="text-muted-foreground">نوع الإجازة:</span>
-                  <span>{getLeaveTypeInfo(selectedRequest.leaveType).name}</span>
+                  <span>
+                    {(Array.isArray(selectedRequest.leave_type)
+                      ? selectedRequest.leave_type[0]
+                      : selectedRequest.leave_type
+                    )?.name_ar ?? '—'}
+                  </span>
                 </div>
                 <div className="flex justify-between">
                   <span className="text-muted-foreground">الفترة:</span>
                   <span dir="ltr">
-                    {new Date(selectedRequest.startDate).toLocaleDateString('en-US')} - 
-                    {new Date(selectedRequest.endDate).toLocaleDateString('en-US')}
+                    {selectedRequest.start_date} → {selectedRequest.end_date}
                   </span>
                 </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">المدة:</span>
+                  <span>{selectedRequest.total_days} يوم</span>
+                </div>
               </div>
+
+              {/* رصيد الإجازة */}
+              {selectedBalance && (
+                <div className="rounded-lg bg-muted/50 p-3 text-sm space-y-1">
+                  <p className="font-medium">رصيد الإجازة</p>
+                  <div className="grid grid-cols-3 gap-2 text-center">
+                    <div>
+                      <p className="text-muted-foreground text-xs">المكتسب</p>
+                      <p className="font-mono font-bold">{selectedBalance.accrued.toFixed(1)}</p>
+                    </div>
+                    <div>
+                      <p className="text-muted-foreground text-xs">المستهلك</p>
+                      <p className="font-mono font-bold">{selectedBalance.used.toFixed(1)}</p>
+                    </div>
+                    <div>
+                      <p className="text-muted-foreground text-xs">المتبقي</p>
+                      <p
+                        className={`font-mono font-bold ${
+                          selectedBalance.balance < selectedRequest.total_days
+                            ? 'text-rose-500'
+                            : 'text-emerald-500'
+                        }`}
+                      >
+                        {selectedBalance.balance.toFixed(1)}
+                      </p>
+                    </div>
+                  </div>
+                  {selectedBalance.balance < selectedRequest.total_days &&
+                    approveAction === 'approve' && (
+                      <div className="mt-2 space-y-2">
+                        <p className="text-rose-500 text-xs">
+                          الرصيد أقل من المطلوب ({selectedRequest.total_days} يوم)
+                        </p>
+                        <label className="flex items-center gap-2 text-xs cursor-pointer">
+                          <input
+                            type="checkbox"
+                            checked={adminOverride}
+                            onChange={(e) => setAdminOverride(e.target.checked)}
+                          />
+                          تجاوز بصلاحية المشرف (تجاوز الرصيد)
+                        </label>
+                      </div>
+                    )}
+                </div>
+              )}
+
               <div className="space-y-2">
-                <Label>ملاحظات (مطلوبة في حالة الرفض)</Label>
+                <Label>
+                  {approveAction === 'reject' ? 'سبب الرفض (مطلوب)' : 'ملاحظات (اختياري)'}
+                </Label>
                 <Textarea
                   value={approvalNote}
                   onChange={(e) => setApprovalNote(e.target.value)}
@@ -406,24 +479,136 @@ export const LeavesPage: React.FC = () => {
               </div>
             </div>
           )}
+
           <DialogFooter className="gap-2">
-            <Button variant="outline" onClick={() => setShowApprovalDialog(false)}>
+            <Button variant="outline" onClick={closeApprovalDialog} disabled={isPending}>
+              إلغاء
+            </Button>
+            {approveAction === 'reject' ? (
+              <Button
+                variant="destructive"
+                onClick={handleConfirm}
+                disabled={!approvalNote.trim() || isPending}
+              >
+                <XCircle className="h-4 w-4 ml-2" />
+                {isPending ? 'جارٍ الرفض...' : 'رفض'}
+              </Button>
+            ) : (
+              <Button
+                className="bg-emerald-600 hover:bg-emerald-700"
+                onClick={handleConfirm}
+                disabled={
+                  isPending ||
+                  (!!selectedBalance &&
+                    selectedBalance.balance < (selectedRequest?.total_days ?? 0) &&
+                    !adminOverride)
+                }
+              >
+                <CheckCircle2 className="h-4 w-4 ml-2" />
+                {isPending ? 'جارٍ الموافقة...' : 'موافقة'}
+              </Button>
+            )}
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* ── نافذة الطلب الجديد ── */}
+      <Dialog open={showNewRequestDialog} onOpenChange={setShowNewRequestDialog}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>طلب إجازة جديد</DialogTitle>
+            <DialogDescription>تقديم طلب إجازة لأحد الموظفين</DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label>الموظف *</Label>
+              <Select
+                value={newForm.employee_id}
+                onValueChange={(v) => setNewForm((f) => ({ ...f, employee_id: v }))}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="اختر الموظف..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {employees.map((emp) => (
+                    <SelectItem key={emp.id} value={emp.id}>
+                      {emp.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label>نوع الإجازة *</Label>
+              <Select
+                value={newForm.leave_type_id}
+                onValueChange={(v) => setNewForm((f) => ({ ...f, leave_type_id: v }))}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="اختر نوع الإجازة..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {leaveTypes.map((lt) => (
+                    <SelectItem key={lt.id} value={lt.id}>
+                      {lt.name_ar}
+                      {lt.max_days_per_year ? ` (حتى ${lt.max_days_per_year} يوم)` : ''}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-2">
+                <Label>تاريخ البداية *</Label>
+                <Input
+                  type="date"
+                  value={newForm.start_date}
+                  onChange={(e) => setNewForm((f) => ({ ...f, start_date: e.target.value }))}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>تاريخ الانتهاء *</Label>
+                <Input
+                  type="date"
+                  value={newForm.end_date}
+                  onChange={(e) => setNewForm((f) => ({ ...f, end_date: e.target.value }))}
+                />
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label>السبب (اختياري)</Label>
+              <Textarea
+                value={newForm.reason}
+                onChange={(e) => setNewForm((f) => ({ ...f, reason: e.target.value }))}
+                placeholder="أدخل سبب الإجازة..."
+                rows={2}
+              />
+            </div>
+          </div>
+
+          <DialogFooter className="gap-2">
+            <Button
+              variant="outline"
+              onClick={() => setShowNewRequestDialog(false)}
+              disabled={isPending}
+            >
               إلغاء
             </Button>
             <Button
-              variant="destructive"
-              onClick={handleReject}
-              disabled={!approvalNote}
+              onClick={() => createMutation.mutate()}
+              disabled={
+                !newForm.employee_id ||
+                !newForm.leave_type_id ||
+                !newForm.start_date ||
+                !newForm.end_date ||
+                isPending
+              }
             >
-              <XCircle className="h-4 w-4 ml-2" />
-              رفض
-            </Button>
-            <Button
-              className="bg-emerald-600 hover:bg-emerald-700"
-              onClick={handleApprove}
-            >
-              <CheckCircle2 className="h-4 w-4 ml-2" />
-              موافقة
+              {isPending ? 'جارٍ التقديم...' : 'تقديم الطلب'}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -431,4 +616,3 @@ export const LeavesPage: React.FC = () => {
     </div>
   );
 };
-

--- a/src/features/hr/pages/SettlementsPage.tsx
+++ b/src/features/hr/pages/SettlementsPage.tsx
@@ -3,7 +3,7 @@
 // صفحة تسويات نهاية الخدمة
 
 import React, { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -33,101 +33,147 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { toast } from 'sonner';
 import {
   Calculator,
   FileText,
   DollarSign,
   Plus,
   Search,
-  Download,
-  Printer,
   CheckCircle2,
   Clock,
   Briefcase,
+  AlertTriangle,
 } from 'lucide-react';
-import { getSettlementRecords, getEmployees } from '@/services/hr/hr-service';
+import { getEmployees } from '@/services/hr/hr-service';
+import {
+  listSettlements,
+  createSettlement,
+  postSettlement,
+  cancelSettlement,
+  type SettlementRow,
+  type TerminationType,
+  type EosResult,
+} from '@/services/hr/settlement-service';
 import { STATUS_BADGES } from '../types';
 
-// أنواع إنهاء الخدمة
-const TERMINATION_TYPES = [
+const TERMINATION_TYPES: { id: TerminationType; name: string; color: string }[] = [
   { id: 'resignation', name: 'استقالة', color: 'text-blue-500' },
   { id: 'end_of_contract', name: 'انتهاء العقد', color: 'text-slate-500' },
-  { id: 'termination', name: 'فصل', color: 'text-rose-500' },
+  { id: 'termination_without_cause', name: 'فصل بدون سبب (م77)', color: 'text-rose-500' },
+  { id: 'termination_for_cause', name: 'فصل بسبب مشروع (م80)', color: 'text-rose-700' },
+  { id: 'mutual_agreement', name: 'اتفاق مشترك', color: 'text-teal-500' },
   { id: 'retirement', name: 'تقاعد', color: 'text-amber-500' },
   { id: 'death', name: 'وفاة', color: 'text-purple-500' },
 ];
 
 export const SettlementsPage: React.FC = () => {
-  const [activeTab, setActiveTab] = useState('pending');
+  const queryClient = useQueryClient();
+  const [activeTab, setActiveTab] = useState('draft');
   const [searchQuery, setSearchQuery] = useState('');
-  const [showNewSettlementDialog, setShowNewSettlementDialog] = useState(false);
+  const [showNewDialog, setShowNewDialog] = useState(false);
   const [showDetailsDialog, setShowDetailsDialog] = useState(false);
-  const [selectedSettlement, setSelectedSettlement] = useState<any>(null);
-  const [selectedEmployee, setSelectedEmployee] = useState<string>('');
+  const [selectedSettlement, setSelectedSettlement] = useState<SettlementRow | null>(null);
+  const [previewResult, setPreviewResult] = useState<EosResult | null>(null);
 
-  // جلب سجلات التسويات
-  const { data: settlements = [], isLoading } = useQuery({
-    queryKey: ['hr', 'settlements'],
-    queryFn: () => getSettlementRecords(100),
+  const [newForm, setNewForm] = useState({
+    employee_id: '',
+    termination_type: '' as TerminationType | '',
+    service_end: '',
+    notes: '',
   });
 
-  // جلب قائمة الموظفين
+  // بيانات
+  const { data: settlements = [], isLoading } = useQuery({
+    queryKey: ['hr', 'settlements'],
+    queryFn: () => listSettlements(200),
+  });
+
   const { data: employees = [] } = useQuery({
     queryKey: ['hr', 'employees'],
     queryFn: getEmployees,
   });
 
-  // تصفية التسويات
+  // تصفية
   const filteredSettlements = React.useMemo(() => {
-    return settlements.filter((s: any) => {
+    return settlements.filter((s) => {
       const matchesTab = activeTab === 'all' || s.status === activeTab;
-      const matchesSearch = !searchQuery ||
-        s.employeeName?.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        s.employeeId?.includes(searchQuery);
+      const emp = Array.isArray(s.employee) ? s.employee[0] : s.employee;
+      const matchesSearch =
+        !searchQuery ||
+        (emp?.full_name ?? '').toLowerCase().includes(searchQuery.toLowerCase());
       return matchesTab && matchesSearch;
     });
   }, [settlements, activeTab, searchQuery]);
 
-  // إحصائيات التسويات
-  const settlementStats = React.useMemo(() => {
-    const totalAmount = settlements.reduce((sum: number, s: any) => sum + (s.totalAmount || 0), 0);
-    return {
-      pending: settlements.filter((s: any) => s.status === 'pending').length,
-      approved: settlements.filter((s: any) => s.status === 'approved').length,
-      paid: settlements.filter((s: any) => s.status === 'paid').length,
+  const stats = React.useMemo(
+    () => ({
+      draft: settlements.filter((s) => s.status === 'draft').length,
+      approved: settlements.filter((s) => s.status === 'approved').length,
+      paid: settlements.filter((s) => s.status === 'paid').length,
       total: settlements.length,
-      totalAmount,
-    };
-  }, [settlements]);
+      totalAmount: settlements.reduce((sum, s) => sum + (s.payable_amount ?? 0), 0),
+    }),
+    [settlements],
+  );
 
-  const getTerminationType = (typeId: string) => {
-    return TERMINATION_TYPES.find(t => t.id === typeId) || TERMINATION_TYPES[0];
-  };
+  // ── Mutations ──────────────────────────────────────────────────────────────
 
-  // حساب مكافأة نهاية الخدمة
-  const calculateEndOfService = (years: number, lastSalary: number, terminationType: string) => {
-    let multiplier = 0;
-    
-    if (terminationType === 'resignation') {
-      // استقالة
-      if (years >= 2 && years < 5) {
-        multiplier = 0.5 * (years * 0.5); // ثلث المكافأة للسنوات الأولى
-      } else if (years >= 5 && years < 10) {
-        multiplier = (2.5 * 0.5) + ((years - 5) * 0.667); // ثلثين للسنوات بعد الخامسة
-      } else if (years >= 10) {
-        multiplier = (2.5 * 0.5) + (5 * 0.667) + ((years - 10) * 1); // كامل بعد 10 سنوات
-      }
-    } else {
-      // باقي الحالات - مكافأة كاملة
-      if (years <= 5) {
-        multiplier = years * 0.5;
-      } else {
-        multiplier = 2.5 + ((years - 5) * 1);
-      }
-    }
-    
-    return lastSalary * multiplier;
-  };
+  const createMutation = useMutation({
+    mutationFn: () =>
+      createSettlement({
+        employee_id: newForm.employee_id,
+        termination_type: newForm.termination_type as TerminationType,
+        service_end: newForm.service_end,
+        notes: newForm.notes || undefined,
+      }),
+    onSuccess: ({ settlement, result }) => {
+      setPreviewResult(result);
+      setSelectedSettlement(settlement);
+      setShowNewDialog(false);
+      setShowDetailsDialog(true);
+      queryClient.invalidateQueries({ queryKey: ['hr', 'settlements'] });
+      toast.success('تم إنشاء التسوية — راجع التفاصيل قبل الاعتماد');
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const postMutation = useMutation({
+    mutationFn: (settlementId: string) => postSettlement(settlementId),
+    onSuccess: () => {
+      toast.success('تم اعتماد التسوية وترحيل القيد المحاسبي');
+      queryClient.invalidateQueries({ queryKey: ['hr', 'settlements'] });
+      setShowDetailsDialog(false);
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const cancelMutation = useMutation({
+    mutationFn: (settlementId: string) => cancelSettlement(settlementId),
+    onSuccess: () => {
+      toast.success('تم إلغاء التسوية');
+      queryClient.invalidateQueries({ queryKey: ['hr', 'settlements'] });
+      setShowDetailsDialog(false);
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+    },
+  });
+
+  const isPending = createMutation.isPending || postMutation.isPending || cancelMutation.isPending;
+
+  function openDetails(s: SettlementRow) {
+    setSelectedSettlement(s);
+    setPreviewResult(null);
+    setShowDetailsDialog(true);
+  }
+
+  const getTermType = (id: string) =>
+    TERMINATION_TYPES.find((t) => t.id === id) ?? TERMINATION_TYPES[0];
 
   return (
     <div className="space-y-6">
@@ -135,18 +181,18 @@ export const SettlementsPage: React.FC = () => {
       <div className="flex flex-col gap-2">
         <h1 className="text-3xl font-bold tracking-tight">تسويات نهاية الخدمة</h1>
         <p className="text-muted-foreground">
-          إدارة حسابات مكافآت نهاية الخدمة والتسويات المالية للموظفين المنتهية خدماتهم
+          حساب واعتماد مكافآت نهاية الخدمة وفق نظام العمل السعودي (م109/م77/م80)
         </p>
       </div>
 
-      {/* بطاقات الإحصائيات */}
+      {/* إحصائيات */}
       <div className="grid gap-4 md:grid-cols-5">
         <Card className="border-amber-500/30 bg-amber-500/10">
           <CardContent className="p-4">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm text-amber-400">قيد المعالجة</p>
-                <p className="text-2xl font-bold text-amber-300">{settlementStats.pending}</p>
+                <p className="text-sm text-amber-400">مسودة</p>
+                <p className="text-2xl font-bold text-amber-300">{stats.draft}</p>
               </div>
               <Clock className="h-8 w-8 text-amber-500" />
             </div>
@@ -157,7 +203,7 @@ export const SettlementsPage: React.FC = () => {
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-sm text-blue-400">معتمدة</p>
-                <p className="text-2xl font-bold text-blue-300">{settlementStats.approved}</p>
+                <p className="text-2xl font-bold text-blue-300">{stats.approved}</p>
               </div>
               <CheckCircle2 className="h-8 w-8 text-blue-500" />
             </div>
@@ -168,7 +214,7 @@ export const SettlementsPage: React.FC = () => {
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-sm text-emerald-400">مدفوعة</p>
-                <p className="text-2xl font-bold text-emerald-300">{settlementStats.paid}</p>
+                <p className="text-2xl font-bold text-emerald-300">{stats.paid}</p>
               </div>
               <DollarSign className="h-8 w-8 text-emerald-500" />
             </div>
@@ -179,7 +225,7 @@ export const SettlementsPage: React.FC = () => {
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-sm text-slate-400">الإجمالي</p>
-                <p className="text-2xl font-bold text-slate-300">{settlementStats.total}</p>
+                <p className="text-2xl font-bold text-slate-300">{stats.total}</p>
               </div>
               <Briefcase className="h-8 w-8 text-slate-500" />
             </div>
@@ -191,7 +237,7 @@ export const SettlementsPage: React.FC = () => {
               <div>
                 <p className="text-sm text-purple-400">إجمالي المبالغ</p>
                 <p className="text-xl font-bold text-purple-300">
-                  {settlementStats.totalAmount.toLocaleString()} ر.س
+                  {stats.totalAmount.toLocaleString('ar-SA', { maximumFractionDigits: 0 })} ر.س
                 </p>
               </div>
               <Calculator className="h-8 w-8 text-purple-500" />
@@ -200,51 +246,6 @@ export const SettlementsPage: React.FC = () => {
         </Card>
       </div>
 
-      {/* حاسبة مكافأة نهاية الخدمة */}
-      <Card className="bg-gradient-to-br from-teal-500/10 to-cyan-500/10 border-teal-500/30">
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-              <Calculator className="h-5 w-5 text-teal-400" />
-            حاسبة مكافأة نهاية الخدمة (نظام العمل السعودي)
-          </CardTitle>
-          <CardDescription>
-            احسب مكافأة نهاية الخدمة وفقاً لنظام العمل السعودي
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="grid gap-4 md:grid-cols-4">
-            <div className="space-y-2">
-              <Label>سنوات الخدمة</Label>
-              <Input type="number" placeholder="5" id="calc-years" />
-            </div>
-            <div className="space-y-2">
-              <Label>آخر راتب أساسي</Label>
-              <Input type="number" placeholder="10000" id="calc-salary" />
-            </div>
-            <div className="space-y-2">
-              <Label>سبب انتهاء الخدمة</Label>
-              <Select defaultValue="resignation">
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {TERMINATION_TYPES.map((type) => (
-                    <SelectItem key={type.id} value={type.id}>{type.name}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="space-y-2">
-              <Label>&nbsp;</Label>
-              <Button className="w-full bg-teal-600 hover:bg-teal-700">
-                <Calculator className="h-4 w-4 ml-2" />
-                احسب المكافأة
-              </Button>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-
       {/* قائمة التسويات */}
       <Card>
         <CardHeader className="flex flex-row items-center justify-between">
@@ -252,29 +253,25 @@ export const SettlementsPage: React.FC = () => {
             <CardTitle className="text-lg">سجل التسويات</CardTitle>
             <CardDescription>جميع تسويات نهاية الخدمة</CardDescription>
           </div>
-          <Button onClick={() => setShowNewSettlementDialog(true)}>
+          <Button onClick={() => setShowNewDialog(true)}>
             <Plus className="h-4 w-4 ml-2" />
             تسوية جديدة
           </Button>
         </CardHeader>
         <CardContent className="space-y-4">
-          {/* أدوات التصفية */}
-          <div className="flex flex-wrap gap-3">
-            <div className="relative flex-1 min-w-[200px]">
-              <Search className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-              <Input
-                placeholder="بحث بالاسم أو الرقم الوظيفي..."
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                className="pr-10"
-              />
-            </div>
+          <div className="relative max-w-sm">
+            <Search className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              placeholder="بحث بالاسم..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="pr-10"
+            />
           </div>
 
-          {/* التبويبات */}
           <Tabs value={activeTab} onValueChange={setActiveTab}>
             <TabsList className="grid w-full grid-cols-4">
-              <TabsTrigger value="pending">قيد المعالجة</TabsTrigger>
+              <TabsTrigger value="draft">مسودة ({stats.draft})</TabsTrigger>
               <TabsTrigger value="approved">معتمدة</TabsTrigger>
               <TabsTrigger value="paid">مدفوعة</TabsTrigger>
               <TabsTrigger value="all">الكل</TabsTrigger>
@@ -296,57 +293,57 @@ export const SettlementsPage: React.FC = () => {
                       <TableHead>سبب الإنهاء</TableHead>
                       <TableHead>تاريخ الإنهاء</TableHead>
                       <TableHead>سنوات الخدمة</TableHead>
-                      <TableHead>إجمالي التسوية</TableHead>
+                      <TableHead>المبلغ المستحق</TableHead>
                       <TableHead>الحالة</TableHead>
                       <TableHead>الإجراءات</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {filteredSettlements.map((settlement: any) => {
-                      const termType = getTerminationType(settlement.terminationType);
+                    {filteredSettlements.map((s) => {
+                      const emp = Array.isArray(s.employee) ? s.employee[0] : s.employee;
+                      const tt = getTermType(s.settlement_type);
+                      const years = s.service_days
+                        ? (s.service_days / 365.25).toFixed(1)
+                        : '—';
                       return (
-                        <TableRow key={settlement.id}>
+                        <TableRow key={s.id}>
                           <TableCell>
-                            <div>
-                              <p className="font-medium">{settlement.employeeName || '—'}</p>
-                              <p className="text-xs text-muted-foreground">{settlement.employeeId}</p>
-                            </div>
+                            <p className="font-medium">{emp?.full_name ?? '—'}</p>
                           </TableCell>
                           <TableCell>
-                            <span className={termType.color}>{termType.name}</span>
+                            <span className={tt.color}>{tt.name}</span>
                           </TableCell>
+                          <TableCell dir="ltr">{s.service_end ?? '—'}</TableCell>
                           <TableCell>
-                            {new Date(settlement.terminationDate).toLocaleDateString('en-US')}
-                          </TableCell>
-                          <TableCell>
-                            <Badge variant="outline">{settlement.yearsOfService} سنة</Badge>
+                            <Badge variant="outline">{years} سنة</Badge>
                           </TableCell>
                           <TableCell className="font-semibold">
-                            {settlement.totalAmount?.toLocaleString()} ر.س
+                            {s.payable_amount.toLocaleString('ar-SA', {
+                              maximumFractionDigits: 0,
+                            })}{' '}
+                            ر.س
                           </TableCell>
                           <TableCell>
-                            <Badge className={STATUS_BADGES[settlement.status] || 'bg-slate-100 text-slate-700'}>
-                              {settlement.status === 'pending' && 'قيد المعالجة'}
-                              {settlement.status === 'approved' && 'معتمدة'}
-                              {settlement.status === 'paid' && 'مدفوعة'}
+                            <Badge
+                              className={
+                                STATUS_BADGES[s.status] || 'bg-slate-100 text-slate-700'
+                              }
+                            >
+                              {s.status === 'draft' && 'مسودة'}
+                              {s.status === 'review' && 'مراجعة'}
+                              {s.status === 'approved' && 'معتمدة'}
+                              {s.status === 'paid' && 'مدفوعة'}
+                              {s.status === 'rejected' && 'ملغاة'}
                             </Badge>
                           </TableCell>
                           <TableCell>
-                            <div className="flex gap-2">
-                              <Button
-                                size="sm"
-                                variant="outline"
-                                onClick={() => {
-                                  setSelectedSettlement(settlement);
-                                  setShowDetailsDialog(true);
-                                }}
-                              >
-                                <FileText className="h-4 w-4" />
-                              </Button>
-                              <Button size="sm" variant="outline">
-                                <Printer className="h-4 w-4" />
-                              </Button>
-                            </div>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() => openDetails(s)}
+                            >
+                              <FileText className="h-4 w-4" />
+                            </Button>
                           </TableCell>
                         </TableRow>
                       );
@@ -359,146 +356,226 @@ export const SettlementsPage: React.FC = () => {
         </CardContent>
       </Card>
 
-      {/* نافذة تفاصيل التسوية */}
-      <Dialog open={showDetailsDialog} onOpenChange={setShowDetailsDialog}>
-        <DialogContent className="max-w-2xl">
-          <DialogHeader>
-            <DialogTitle>تفاصيل التسوية</DialogTitle>
-            <DialogDescription>
-              تفاصيل مكافأة نهاية الخدمة والمستحقات
-            </DialogDescription>
-          </DialogHeader>
-          {selectedSettlement && (
-            <div className="space-y-4">
-              <div className="grid gap-4 md:grid-cols-2">
-                <div className="rounded-lg border p-4 space-y-3">
-                  <h4 className="font-semibold text-sm text-muted-foreground">بيانات الموظف</h4>
-                  <div className="space-y-2 text-sm">
-                    <div className="flex justify-between">
-                      <span>الاسم:</span>
-                      <span className="font-medium">{selectedSettlement.employeeName}</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span>الرقم الوظيفي:</span>
-                      <span>{selectedSettlement.employeeId}</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span>تاريخ التعيين:</span>
-                      <span>{new Date(selectedSettlement.hireDate).toLocaleDateString('en-US')}</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span>تاريخ الإنهاء:</span>
-                      <span>{new Date(selectedSettlement.terminationDate).toLocaleDateString('en-US')}</span>
-                    </div>
-                  </div>
-                </div>
-                <div className="rounded-lg border p-4 space-y-3">
-                  <h4 className="font-semibold text-sm text-muted-foreground">تفاصيل التسوية</h4>
-                  <div className="space-y-2 text-sm">
-                    <div className="flex justify-between">
-                      <span>سنوات الخدمة:</span>
-                      <span className="font-medium">{selectedSettlement.yearsOfService} سنة</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span>آخر راتب:</span>
-                      <span>{selectedSettlement.lastSalary?.toLocaleString()} ر.س</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span>مكافأة نهاية الخدمة:</span>
-                      <span>{selectedSettlement.endOfServiceAmount?.toLocaleString()} ر.س</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span>رصيد الإجازات:</span>
-                      <span>{selectedSettlement.leaveBalance?.toLocaleString()} ر.س</span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div className="rounded-lg bg-teal-500/10 border border-teal-500/30 p-4">
-                <div className="flex justify-between items-center">
-                  <span className="font-semibold text-teal-300">إجمالي التسوية:</span>
-                  <span className="text-2xl font-bold text-teal-400">
-                    {selectedSettlement.totalAmount?.toLocaleString()} ر.س
-                  </span>
-                </div>
-              </div>
-            </div>
-          )}
-          <DialogFooter className="gap-2">
-            <Button variant="outline" onClick={() => setShowDetailsDialog(false)}>
-              إغلاق
-            </Button>
-            <Button variant="outline">
-              <Printer className="h-4 w-4 ml-2" />
-              طباعة
-            </Button>
-            <Button className="bg-teal-600 hover:bg-teal-700">
-              <Download className="h-4 w-4 ml-2" />
-              تحميل PDF
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      {/* نافذة تسوية جديدة */}
-      <Dialog open={showNewSettlementDialog} onOpenChange={setShowNewSettlementDialog}>
+      {/* ── نافذة تسوية جديدة ── */}
+      <Dialog open={showNewDialog} onOpenChange={setShowNewDialog}>
         <DialogContent className="max-w-lg">
           <DialogHeader>
-            <DialogTitle>إنشاء تسوية جديدة</DialogTitle>
+            <DialogTitle>إنشاء تسوية نهاية خدمة</DialogTitle>
             <DialogDescription>
-              إنشاء تسوية نهاية خدمة لموظف
+              سيتم حساب المكافأة تلقائياً من مكوّنات راتب الموظف وسنوات خدمته
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4">
             <div className="space-y-2">
-              <Label>الموظف</Label>
-              <Select value={selectedEmployee} onValueChange={setSelectedEmployee}>
+              <Label>الموظف *</Label>
+              <Select
+                value={newForm.employee_id}
+                onValueChange={(v) => setNewForm((f) => ({ ...f, employee_id: v }))}
+              >
                 <SelectTrigger>
-                  <SelectValue placeholder="اختر الموظف" />
+                  <SelectValue placeholder="اختر الموظف..." />
                 </SelectTrigger>
                 <SelectContent>
-                  {employees.map((emp: any) => (
+                  {employees.map((emp) => (
                     <SelectItem key={emp.id} value={emp.id}>
-                      {emp.fullNameAr || emp.fullName} - {emp.employeeId}
+                      {emp.name}
                     </SelectItem>
                   ))}
                 </SelectContent>
               </Select>
             </div>
+
             <div className="space-y-2">
-              <Label>سبب إنهاء الخدمة</Label>
-              <Select>
+              <Label>سبب إنهاء الخدمة *</Label>
+              <Select
+                value={newForm.termination_type}
+                onValueChange={(v) =>
+                  setNewForm((f) => ({ ...f, termination_type: v as TerminationType }))
+                }
+              >
                 <SelectTrigger>
-                  <SelectValue placeholder="اختر السبب" />
+                  <SelectValue placeholder="اختر السبب..." />
                 </SelectTrigger>
                 <SelectContent>
-                  {TERMINATION_TYPES.map((type) => (
-                    <SelectItem key={type.id} value={type.id}>{type.name}</SelectItem>
+                  {TERMINATION_TYPES.map((t) => (
+                    <SelectItem key={t.id} value={t.id}>
+                      {t.name}
+                    </SelectItem>
                   ))}
                 </SelectContent>
               </Select>
+              {newForm.termination_type === 'termination_for_cause' && (
+                <div className="flex items-center gap-2 text-rose-500 text-sm">
+                  <AlertTriangle className="h-4 w-4" />
+                  م80: لا يستحق الموظف مكافأة نهاية الخدمة
+                </div>
+              )}
             </div>
+
             <div className="space-y-2">
-              <Label>تاريخ الإنهاء</Label>
-              <Input type="date" />
+              <Label>تاريخ الإنهاء *</Label>
+              <Input
+                type="date"
+                value={newForm.service_end}
+                onChange={(e) => setNewForm((f) => ({ ...f, service_end: e.target.value }))}
+              />
             </div>
+
             <div className="space-y-2">
               <Label>ملاحظات</Label>
-              <Input placeholder="ملاحظات إضافية..." />
+              <Input
+                placeholder="ملاحظات إضافية..."
+                value={newForm.notes}
+                onChange={(e) => setNewForm((f) => ({ ...f, notes: e.target.value }))}
+              />
             </div>
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setShowNewSettlementDialog(false)}>
+            <Button
+              variant="outline"
+              onClick={() => setShowNewDialog(false)}
+              disabled={isPending}
+            >
               إلغاء
             </Button>
-            <Button className="bg-teal-600 hover:bg-teal-700">
+            <Button
+              className="bg-teal-600 hover:bg-teal-700"
+              onClick={() => createMutation.mutate()}
+              disabled={
+                !newForm.employee_id ||
+                !newForm.termination_type ||
+                !newForm.service_end ||
+                isPending
+              }
+            >
               <Calculator className="h-4 w-4 ml-2" />
-              حساب وإنشاء التسوية
+              {isPending ? 'جارٍ الحساب...' : 'احسب وأنشئ'}
             </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* ── نافذة تفاصيل التسوية ── */}
+      <Dialog open={showDetailsDialog} onOpenChange={setShowDetailsDialog}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>تفاصيل التسوية</DialogTitle>
+            <DialogDescription>
+              مكافأة نهاية الخدمة والمستحقات المحسوبة وفق نظام العمل السعودي
+            </DialogDescription>
+          </DialogHeader>
+
+          {selectedSettlement && (
+            <div className="space-y-4">
+              <div className="grid gap-4 md:grid-cols-2 text-sm">
+                <div className="rounded-lg border p-4 space-y-2">
+                  <h4 className="font-semibold text-muted-foreground">بيانات الخدمة</h4>
+                  <div className="flex justify-between">
+                    <span>سبب الإنهاء:</span>
+                    <span className="font-medium">
+                      {getTermType(selectedSettlement.settlement_type).name}
+                    </span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span>بداية الخدمة:</span>
+                    <span dir="ltr">{selectedSettlement.service_start ?? '—'}</span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span>نهاية الخدمة:</span>
+                    <span dir="ltr">{selectedSettlement.service_end ?? '—'}</span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span>سنوات الخدمة:</span>
+                    <span className="font-medium">
+                      {selectedSettlement.service_days
+                        ? (selectedSettlement.service_days / 365.25).toFixed(2)
+                        : '—'}
+                    </span>
+                  </div>
+                </div>
+                <div className="rounded-lg border p-4 space-y-2">
+                  <h4 className="font-semibold text-muted-foreground">ملخص المستحقات</h4>
+                  {previewResult ? (
+                    <>
+                      {previewResult.eos_amount > 0 && (
+                        <div className="flex justify-between">
+                          <span>مكافأة نهاية الخدمة:</span>
+                          <span>{previewResult.eos_amount.toLocaleString('ar-SA', { maximumFractionDigits: 0 })} ر.س</span>
+                        </div>
+                      )}
+                      {previewResult.leave_encashment > 0 && (
+                        <div className="flex justify-between">
+                          <span>رصيد الإجازات:</span>
+                          <span>{previewResult.leave_encashment.toLocaleString('ar-SA', { maximumFractionDigits: 0 })} ر.س</span>
+                        </div>
+                      )}
+                      {previewResult.art77_compensation > 0 && (
+                        <div className="flex justify-between text-rose-400">
+                          <span>تعويض م77:</span>
+                          <span>{previewResult.art77_compensation.toLocaleString('ar-SA', { maximumFractionDigits: 0 })} ر.س</span>
+                        </div>
+                      )}
+                    </>
+                  ) : (
+                    <div className="text-muted-foreground text-xs">
+                      لمزيد من التفاصيل أنشئ تسوية جديدة
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              <div className="rounded-lg bg-teal-500/10 border border-teal-500/30 p-4">
+                <div className="flex justify-between items-center">
+                  <span className="font-semibold text-teal-300">إجمالي التسوية:</span>
+                  <span className="text-2xl font-bold text-teal-400">
+                    {selectedSettlement.payable_amount.toLocaleString('ar-SA', {
+                      maximumFractionDigits: 0,
+                    })}{' '}
+                    ر.س
+                  </span>
+                </div>
+              </div>
+
+              {selectedSettlement.status === 'draft' && (
+                <div className="rounded-lg bg-amber-500/10 border border-amber-500/30 p-3 text-sm text-amber-300">
+                  الاعتماد يُنشئ قيداً محاسبياً ذرّياً ويقلب حالة الموظف إلى &laquo;منتهية&raquo;.
+                  لا يمكن التراجع عنه.
+                </div>
+              )}
+            </div>
+          )}
+
+          <DialogFooter className="gap-2">
+            <Button
+              variant="outline"
+              onClick={() => setShowDetailsDialog(false)}
+              disabled={isPending}
+            >
+              إغلاق
+            </Button>
+            {selectedSettlement?.status === 'draft' && (
+              <>
+                <Button
+                  variant="outline"
+                  className="text-rose-600"
+                  onClick={() => cancelMutation.mutate(selectedSettlement.id)}
+                  disabled={isPending}
+                >
+                  إلغاء التسوية
+                </Button>
+                <Button
+                  className="bg-teal-600 hover:bg-teal-700"
+                  onClick={() => postMutation.mutate(selectedSettlement.id)}
+                  disabled={isPending}
+                >
+                  <CheckCircle2 className="h-4 w-4 ml-2" />
+                  {isPending ? 'جارٍ الاعتماد...' : 'اعتماد وترحيل القيد'}
+                </Button>
+              </>
+            )}
           </DialogFooter>
         </DialogContent>
       </Dialog>
     </div>
   );
 };
-

--- a/src/services/hr/__tests__/leave-service.test.ts
+++ b/src/services/hr/__tests__/leave-service.test.ts
@@ -1,0 +1,59 @@
+/**
+ * اختبارات حساب رصيد الإجازات (P12-D) — دوال صافية بلا DB.
+ * نظام العمل م109: 21 يوماً < 5 سنوات، 30 يوماً ≥ 5 سنوات.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  computeLeaveEntitlement,
+  computeLeaveAccrual,
+  computeLeaveBalance,
+} from '../leave-service';
+
+const policies = {
+  annual_leave_days_before_5y: 21,
+  annual_leave_days_after_5y: 30,
+};
+
+describe('computeLeaveEntitlement — م109', () => {
+  it('أقل من 5 سنوات ⇒ 21 يوماً', () => {
+    expect(computeLeaveEntitlement(0, policies)).toBe(21);
+    expect(computeLeaveEntitlement(4.9, policies)).toBe(21);
+  });
+
+  it('5 سنوات وأكثر ⇒ 30 يوماً', () => {
+    expect(computeLeaveEntitlement(5, policies)).toBe(30);
+    expect(computeLeaveEntitlement(10, policies)).toBe(30);
+  });
+});
+
+describe('computeLeaveAccrual — تناسبي', () => {
+  it('6 أشهر خدمة (21 يوم/سنة) ⇒ ~10.5 يوم', () => {
+    const ref = new Date('2026-01-01');
+    const asOf = new Date('2026-07-01'); // ~181 يوم
+    const accrued = computeLeaveAccrual(ref, asOf, 21);
+    expect(accrued).toBeGreaterThan(10);
+    expect(accrued).toBeLessThan(11);
+  });
+
+  it('سنة كاملة (30 يوم/سنة) ⇒ ~30 يوماً', () => {
+    const ref = new Date('2025-01-01');
+    const asOf = new Date('2026-01-01'); // 365 يوم
+    expect(computeLeaveAccrual(ref, asOf, 30)).toBeCloseTo(30, 0);
+  });
+
+  it('تاريخ مرجعي مستقبلي ⇒ صفر (لا سالب)', () => {
+    const ref = new Date('2027-01-01');
+    const asOf = new Date('2026-07-01');
+    expect(computeLeaveAccrual(ref, asOf, 21)).toBe(0);
+  });
+});
+
+describe('computeLeaveBalance — رصيد لا ينزل عن الصفر', () => {
+  it('اكتسب 15 واستهلك 10 ⇒ رصيد 5', () => {
+    expect(computeLeaveBalance(15, 10)).toBe(5);
+  });
+
+  it('استهلك أكثر مما اكتسب ⇒ يقيَّد عند 0', () => {
+    expect(computeLeaveBalance(5, 20)).toBe(0);
+  });
+});

--- a/src/services/hr/__tests__/payroll-engine.test.ts
+++ b/src/services/hr/__tests__/payroll-engine.test.ts
@@ -1,0 +1,113 @@
+/**
+ * اختبارات دوال محرّك الرواتب الصافية (P12-C) — تثبّت تصحيحات علل «حاسبني»:
+ * GOSI محسوب بالسقف والتمييز، الإجازة المدفوعة لا تُخصم، النسب تُقيَّم من
+ * أساسها وformula تُرفض، والمعدل اليومي/وعاء الإضافي بسياسة.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: { from: vi.fn(), rpc: vi.fn() },
+  getEffectiveTenantId: vi.fn(() => Promise.resolve('org-1')),
+}));
+vi.mock('../attendance-service', () => ({ listAttendanceForPeriod: vi.fn() }));
+vi.mock('../payroll-lock-service', () => ({ getPayrollLock: vi.fn() }));
+vi.mock('../policies-service', () => ({ getHrPolicies: vi.fn() }));
+vi.mock('../adjustments-service', () => ({ listAdjustmentsForMonth: vi.fn() }));
+
+import {
+  evaluateComponentAmount,
+  computeGosi,
+  analyzeAttendance,
+  dailyRateOf,
+  overtimeHourlyRate,
+  getWorkingDays,
+  getDaysInMonth,
+} from '../payroll-engine';
+
+const gosiPolicies = {
+  gosi_employee_pct: 9.75,
+  gosi_employer_pct: 11.75,
+  gosi_base_cap: 45000,
+  gosi_applies_to: 'saudi_only' as const,
+};
+
+describe('computeGosi — GOSI صحيح (عكس حاسبني الميت)', () => {
+  it('سعودي: وعاء أساسي+سكن، حصتا موظف/صاحب عمل', () => {
+    const g = computeGosi(10000, 2000, gosiPolicies, true);
+    expect(g.base).toBe(12000);
+    expect(g.employee).toBeCloseTo(1170);   // 12000×9.75%
+    expect(g.employer).toBeCloseTo(1410);   // 12000×11.75%
+  });
+
+  it('السقف 45,000 يُفعَّل (كان غائباً في حاسبني)', () => {
+    const g = computeGosi(50000, 10000, gosiPolicies, true);
+    expect(g.base).toBe(45000);
+    expect(g.employee).toBeCloseTo(4387.5);
+  });
+
+  it('saudi_only: الوافد بلا حصص', () => {
+    const g = computeGosi(10000, 2000, gosiPolicies, false);
+    expect(g.employee).toBe(0);
+    expect(g.employer).toBe(0);
+  });
+
+  it('none: معطَّل للجميع؛ all: يشمل الوافد', () => {
+    expect(computeGosi(10000, 0, { ...gosiPolicies, gosi_applies_to: 'none' }, true).employee).toBe(0);
+    expect(computeGosi(10000, 0, { ...gosiPolicies, gosi_applies_to: 'all' }, false).employee).toBeCloseTo(975);
+  });
+});
+
+describe('evaluateComponentAmount — تقييم النسب (كانت تُعامل كمبالغ ثابتة)', () => {
+  it('fixed: القيمة كما هي', () => {
+    expect(evaluateComponentAmount('fixed', 2000, 10000)).toBe(2000);
+  });
+  it('percentage: نسبة من الأساسي', () => {
+    expect(evaluateComponentAmount('percentage', 25, 10000)).toBe(2500);
+  });
+  it('formula: رفض واضح لا تجاهل صامت', () => {
+    expect(() => evaluateComponentAmount('formula', 1, 10000)).toThrow('غير مدعوم');
+  });
+});
+
+describe('analyzeAttendance — الإجازة المدفوعة لا تُخصم (علّة حاسبني)', () => {
+  it('غياب يُخصم، إجازة مدفوعة لا، إجازة غير مدفوعة تُخصم', () => {
+    const r = analyzeAttendance({
+      '1': { status: 'absent' },
+      '2': { status: 'leave', paid: true },
+      '3': { status: 'leave' },                 // بلا علم ⇒ مدفوعة (آمن نظاماً)
+      '4': { status: 'leave', paid: false },
+      '5': { status: 'unpaid_leave' },
+    }, 8, 0);
+    expect(r.absenceDays).toBe(1);
+    expect(r.unpaidLeaveDays).toBe(2);
+  });
+
+  it('الإضافي من in/out فوق ساعات اليوم وضمن السماحية', () => {
+    const r = analyzeAttendance({
+      '1': { status: 'present', check_in: '2026-07-01T08:00:00Z', check_out: '2026-07-01T18:00:00Z' }, // 10h ⇒ 2 إضافي
+      '2': { status: 'present', check_in: '2026-07-02T08:00:00Z', check_out: '2026-07-02T16:10:00Z' }, // 8h10m ⇒ ضمن سماحية 15د
+    }, 8, 15);
+    expect(r.overtimeHours).toBeCloseTo(2);
+  });
+});
+
+describe('dailyRateOf / overtimeHourlyRate — سياسات الوعاء', () => {
+  it('working_days مقابل thirty', () => {
+    expect(dailyRateOf(9000, 26, 'working_days')).toBeCloseTo(9000 / 26);
+    expect(dailyRateOf(9000, 26, 'thirty')).toBeCloseTo(300);
+  });
+  it('وعاء الإضافي: أساسي أو أساسي+سكن', () => {
+    expect(overtimeHourlyRate(8000, 2000, 25, 8, 'basic')).toBeCloseTo(8000 / 200);
+    expect(overtimeHourlyRate(8000, 2000, 25, 8, 'basic_housing')).toBeCloseTo(10000 / 200);
+  });
+});
+
+describe('أيام الشهر/العمل', () => {
+  it('فبراير كبيسة/بسيطة', () => {
+    expect(getDaysInMonth(2024, 2)).toBe(29);
+    expect(getDaysInMonth(2026, 2)).toBe(28);
+  });
+  it('أيام عمل يوليو 2026 بعطلة الجمعة = 26', () => {
+    expect(getWorkingDays(2026, 7, new Set(['friday']))).toBe(26);
+  });
+});

--- a/src/services/hr/__tests__/payroll-engine.test.ts
+++ b/src/services/hr/__tests__/payroll-engine.test.ts
@@ -22,6 +22,7 @@ import {
   overtimeHourlyRate,
   getWorkingDays,
   getDaysInMonth,
+  round2,
 } from '../payroll-engine';
 
 const gosiPolicies = {
@@ -107,7 +108,69 @@ describe('أيام الشهر/العمل', () => {
     expect(getDaysInMonth(2024, 2)).toBe(29);
     expect(getDaysInMonth(2026, 2)).toBe(28);
   });
+  it('شهور 31/30 يوماً', () => {
+    expect(getDaysInMonth(2026, 1)).toBe(31);  // يناير
+    expect(getDaysInMonth(2026, 4)).toBe(30);  // أبريل
+    expect(getDaysInMonth(2026, 12)).toBe(31); // ديسمبر
+  });
   it('أيام عمل يوليو 2026 بعطلة الجمعة = 26', () => {
     expect(getWorkingDays(2026, 7, new Set(['friday']))).toBe(26);
+  });
+  it('أيام عمل بعطلة الجمعة+السبت', () => {
+    const wd = getWorkingDays(2026, 7, new Set(['friday', 'saturday']));
+    expect(wd).toBeGreaterThan(0);
+    expect(wd).toBeLessThan(26);
+  });
+});
+
+describe('round2', () => {
+  it('يُقرّب لـ خانتين عشريتين', () => {
+    expect(round2(9.999)).toBe(10);
+    expect(round2(1.236)).toBe(1.24);
+    expect(round2(1234.567)).toBe(1234.57);
+  });
+  it('أعداد سالبة', () => {
+    expect(round2(-1.236)).toBe(-1.24);
+  });
+});
+
+describe('evaluateComponentAmount — حالات حدية', () => {
+  it('نوع null/undefined ⇒ fixed', () => {
+    expect(evaluateComponentAmount(null, 500, 10000)).toBe(500);
+    expect(evaluateComponentAmount(undefined, 500, 10000)).toBe(500);
+  });
+  it('نسبة 0% ⇒ صفر', () => {
+    expect(evaluateComponentAmount('percentage', 0, 10000)).toBe(0);
+  });
+  it('حالة غير حساسة للأحرف', () => {
+    expect(evaluateComponentAmount('FIXED', 300, 10000)).toBe(300);
+    expect(evaluateComponentAmount('PERCENTAGE', 10, 10000)).toBe(1000);
+  });
+});
+
+describe('dailyRateOf — حالات حدية', () => {
+  it('صفر أيام عمل ⇒ /30 احتياطياً', () => {
+    expect(dailyRateOf(6000, 0, 'working_days')).toBeCloseTo(200);
+  });
+});
+
+describe('analyzeAttendance — حالات حدية', () => {
+  it('undefined days ⇒ صفر', () => {
+    const r = analyzeAttendance(undefined, 8, 0);
+    expect(r.absenceDays).toBe(0);
+    expect(r.unpaidLeaveDays).toBe(0);
+    expect(r.overtimeHours).toBe(0);
+  });
+  it('check_in بعد check_out ⇒ لا إضافي', () => {
+    const r = analyzeAttendance({
+      '1': { status: 'present', check_in: '2026-07-01T18:00:00Z', check_out: '2026-07-01T08:00:00Z' },
+    }, 8, 0);
+    expect(r.overtimeHours).toBe(0);
+  });
+  it('in/out بديل لـ check_in/check_out', () => {
+    const r = analyzeAttendance({
+      '1': { status: 'present', in: '2026-07-01T08:00:00Z', out: '2026-07-01T19:00:00Z' },
+    }, 8, 0);
+    expect(r.overtimeHours).toBeCloseTo(3);
   });
 });

--- a/src/services/hr/__tests__/settlement-service.test.ts
+++ b/src/services/hr/__tests__/settlement-service.test.ts
@@ -1,0 +1,118 @@
+/**
+ * اختبارات محرّك نهاية الخدمة (P12-E) — مطابقة يدوية لنظام العمل السعودي.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  calcEos,
+  computeBaseEos,
+  resignationMultiplier,
+  computeArt77Compensation,
+  yearsOfServiceBetween,
+} from '../settlement-service';
+
+describe('yearsOfServiceBetween', () => {
+  it('سنة كاملة', () => {
+    expect(
+      yearsOfServiceBetween(new Date('2020-01-01'), new Date('2021-01-01')),
+    ).toBeCloseTo(1, 0);
+  });
+  it('تاريخ نهاية قبل البداية ⇒ صفر', () => {
+    expect(
+      yearsOfServiceBetween(new Date('2025-01-01'), new Date('2020-01-01')),
+    ).toBe(0);
+  });
+});
+
+describe('computeBaseEos — م109', () => {
+  it('3 سنوات × نصف شهر: 3 × 0.5 × 10000 = 15000', () => {
+    expect(computeBaseEos(10000, 3)).toBeCloseTo(15000);
+  });
+  it('7 سنوات: (5×0.5 + 2×1) × 10000 = 45000', () => {
+    expect(computeBaseEos(10000, 7)).toBeCloseTo(45000);
+  });
+});
+
+describe('resignationMultiplier — م109', () => {
+  it('أقل من سنتين ⇒ صفر', () => {
+    expect(resignationMultiplier(1.5)).toBe(0);
+  });
+  it('3 سنوات ⇒ ثلث', () => {
+    expect(resignationMultiplier(3)).toBeCloseTo(1 / 3);
+  });
+  it('7 سنوات ⇒ ثلثان', () => {
+    expect(resignationMultiplier(7)).toBeCloseTo(2 / 3);
+  });
+  it('10 سنوات ⇒ كامل', () => {
+    expect(resignationMultiplier(10)).toBe(1);
+  });
+});
+
+describe('computeArt77Compensation — م77', () => {
+  it('سنة واحدة ⇒ حد أدنى شهرين', () => {
+    expect(computeArt77Compensation(10000, 1)).toBeCloseTo(20000);
+  });
+  it('5 سنوات ⇒ 5 أشهر', () => {
+    expect(computeArt77Compensation(10000, 5)).toBeCloseTo(50000);
+  });
+});
+
+describe('calcEos — سيناريوهات كاملة', () => {
+  const base = {
+    basic: 8000,
+    housing: 2000,
+    transport: 1000,
+    other_allowances: 0,
+    service_start: '2017-01-01',
+    service_end:   '2024-01-01', // 7 سنوات
+  };
+
+  it('فصل بدون سبب (م77) 7 سنوات: مكافأة كاملة + تعويض م77', () => {
+    const r = calcEos({ ...base, termination_type: 'termination_without_cause' });
+    // ~6.997 سنة بسبب 365.25 يوم/سنة
+    expect(r.years_of_service).toBeGreaterThan(6.9);
+    expect(r.years_of_service).toBeLessThan(7.1);
+    expect(r.eos_multiplier).toBe(1);
+    // base EOS ≈ (5×0.5 + ~2×1) × 11000 ≈ 49500 (±100)
+    expect(r.eos_amount).toBeGreaterThan(49000);
+    expect(r.eos_amount).toBeLessThan(50000);
+    // م77: max(2, ~7) أشهر × 11000 ≈ 77000 (±100)
+    expect(r.art77_compensation).toBeGreaterThan(76000);
+    expect(r.art77_compensation).toBeLessThan(78000);
+    expect(r.total).toBeCloseTo(r.eos_amount + r.art77_compensation, 0);
+  });
+
+  it('استقالة 7 سنوات ⇒ ثلثا المكافأة', () => {
+    const r = calcEos({ ...base, termination_type: 'resignation' });
+    expect(r.eos_multiplier).toBeCloseTo(2 / 3);
+    // base_eos × 2/3: نتحقق من النسبة لا القيمة المطلقة
+    expect(r.eos_amount).toBeCloseTo(r.base_eos * (2 / 3), 2);
+    expect(r.art77_compensation).toBe(0);
+  });
+
+  it('استقالة < 2 سنة ⇒ صفر', () => {
+    const r = calcEos({
+      ...base,
+      service_end: '2018-06-01', // ~1.4 سنة
+      termination_type: 'resignation',
+    });
+    expect(r.eos_amount).toBe(0);
+    expect(r.total).toBe(0);
+  });
+
+  it('م80 (مخالفة جسيمة) ⇒ صفر بغض النظر عن الخدمة', () => {
+    const r = calcEos({ ...base, termination_type: 'termination_for_cause' });
+    expect(r.eos_amount).toBe(0);
+    expect(r.total).toBe(0);
+  });
+
+  it('رصيد إجازات يُضاف', () => {
+    const r = calcEos({
+      ...base,
+      termination_type: 'end_of_contract',
+      leave_balance_days: 15,
+    });
+    // يومي = 11000/30 ≈ 366.67 × 15 ≈ 5500
+    expect(r.leave_encashment).toBeCloseTo((11000 / 30) * 15, 0);
+    expect(r.total).toBeCloseTo(r.eos_amount + r.leave_encashment, 0);
+  });
+});

--- a/src/services/hr/adjustments-service.ts
+++ b/src/services/hr/adjustments-service.ts
@@ -1,0 +1,86 @@
+/**
+ * تعديلات الرواتب الشهرية (hr_payroll_adjustments) — سلف/جزاءات/عمولات/أقساط
+ * قروض لكل موظف/شهر، منفصلة عن بيانات الموظف الرئيسية (فكرة حاسبني الصحيحة
+ * في salaries_{y}_{m}). recurring يسري كل شهر؛ غيره يسري في effective_month فقط.
+ */
+import { supabase, getEffectiveTenantId } from '@/lib/supabase';
+
+export type AdjustmentType = 'allowance' | 'deduction' | 'loan' | 'gosi' | 'overtime';
+
+export interface PayrollAdjustment {
+  id: string;
+  org_id: string;
+  payroll_run_id: string | null;
+  employee_id: string | null;
+  adjustment_type: AdjustmentType;
+  description: string | null;
+  amount: number;
+  is_recurring: boolean;
+  effective_month: string | null; // YYYY-MM-01
+}
+
+export interface AdjustmentInput {
+  employee_id: string;
+  adjustment_type: AdjustmentType;
+  description?: string;
+  amount: number;
+  is_recurring?: boolean;
+  effective_month?: string; // YYYY-MM
+}
+
+const monthStart = (ym: string) => `${ym}-01`;
+
+/** تعديلات شهر: recurring دائماً + غير المتكرر المطابق للشهر. */
+export async function listAdjustmentsForMonth(
+  year: number,
+  month: number,
+): Promise<PayrollAdjustment[]> {
+  const orgId = await getEffectiveTenantId();
+  if (!orgId) throw new Error('Organization not found.');
+
+  const ym = `${year}-${String(month).padStart(2, '0')}`;
+  const { data, error } = await supabase
+    .from('hr_payroll_adjustments')
+    .select('*')
+    .eq('org_id', orgId)
+    .or(`is_recurring.eq.true,effective_month.eq.${monthStart(ym)}`);
+
+  if (error) throw new Error(error.message);
+  return (data ?? []) as PayrollAdjustment[];
+}
+
+export async function createAdjustment(input: AdjustmentInput): Promise<PayrollAdjustment> {
+  const orgId = await getEffectiveTenantId();
+  if (!orgId) throw new Error('Organization not found.');
+  if (!input.amount || input.amount <= 0) throw new Error('المبلغ يجب أن يكون موجباً');
+
+  const { data, error } = await supabase
+    .from('hr_payroll_adjustments')
+    .insert({
+      org_id: orgId,
+      employee_id: input.employee_id,
+      adjustment_type: input.adjustment_type,
+      description: input.description ?? null,
+      amount: input.amount,
+      is_recurring: input.is_recurring ?? false,
+      effective_month: input.effective_month ? monthStart(input.effective_month) : null,
+    })
+    .select('*')
+    .single();
+
+  if (error) throw new Error(error.message);
+  return data as PayrollAdjustment;
+}
+
+export async function deleteAdjustment(id: string): Promise<void> {
+  const orgId = await getEffectiveTenantId();
+  if (!orgId) throw new Error('Organization not found.');
+
+  const { error } = await supabase
+    .from('hr_payroll_adjustments')
+    .delete()
+    .eq('id', id)
+    .eq('org_id', orgId);
+
+  if (error) throw new Error(error.message);
+}

--- a/src/services/hr/alert-service.ts
+++ b/src/services/hr/alert-service.ts
@@ -1,0 +1,144 @@
+/**
+ * مولّد التنبيهات الاستباقية (P12-F) — يكتب hr_alerts بـ upsert.
+ * يُستدعى من لوحة التحكم / يدوياً من صفحة التنبيهات.
+ */
+import { supabase, getEffectiveTenantId } from '@/lib/supabase';
+
+export interface AlertRow {
+  id: string;
+  org_id: string;
+  employee_id: string | null;
+  title: string;
+  category: string;
+  severity: 'info' | 'warning' | 'critical';
+  description: string | null;
+  due_date: string | null;
+  source: string | null;
+  is_resolved: boolean;
+  created_at: string;
+}
+
+export async function listAlerts(limit = 50): Promise<AlertRow[]> {
+  const orgId = await getEffectiveTenantId();
+  if (!orgId) throw new Error('Organization not found.');
+
+  const { data, error } = await supabase
+    .from('hr_alerts')
+    .select('*')
+    .eq('org_id', orgId)
+    .eq('is_resolved', false)
+    .order('severity', { ascending: false })
+    .order('created_at', { ascending: false })
+    .limit(limit);
+
+  if (error) throw new Error(error.message);
+  return (data ?? []) as AlertRow[];
+}
+
+export async function resolveAlert(alertId: string): Promise<void> {
+  const orgId = await getEffectiveTenantId();
+  if (!orgId) throw new Error('Organization not found.');
+
+  const { error } = await supabase
+    .from('hr_alerts')
+    .update({ is_resolved: true, resolved_at: new Date().toISOString() })
+    .eq('id', alertId)
+    .eq('org_id', orgId);
+
+  if (error) throw new Error(error.message);
+}
+
+/**
+ * يُنشئ أو يُحدِّث تنبيهات استباقية بناءً على بيانات الموظفين الحالية.
+ * يعود بعدد التنبيهات التي أُنشئت أو حُدِّثت.
+ */
+export async function generateAlerts(): Promise<number> {
+  const orgId = await getEffectiveTenantId();
+  if (!orgId) throw new Error('Organization not found.');
+
+  const today = new Date();
+  const todayStr = today.toISOString().split('T')[0];
+
+  // جلب بيانات الموظفين النشطين
+  const { data: employees, error: empErr } = await supabase
+    .from('employees')
+    .select('id, full_name, contract_end_date, hire_date, iban')
+    .eq('org_id', orgId)
+    .eq('status', 'active');
+
+  if (empErr) throw new Error(empErr.message);
+
+  type AlertInsert = Omit<AlertRow, 'id' | 'is_resolved' | 'created_at'> & {
+  resolved_at?: string | null;
+  resolved_by?: string | null;
+  updated_at?: string;
+};
+const alertsToUpsert: AlertInsert[] = [];
+
+  for (const emp of employees ?? []) {
+    const name = emp.full_name ?? 'موظف';
+
+    // ── تنبيهات انتهاء العقد ─────────────────────────────────────────────
+    if (emp.contract_end_date) {
+      const contractEnd = new Date(emp.contract_end_date);
+      const daysLeft = Math.round(
+        (contractEnd.getTime() - today.getTime()) / 86_400_000,
+      );
+
+      if (daysLeft >= 0 && daysLeft <= 30) {
+        const severity: AlertRow['severity'] =
+          daysLeft <= 7 ? 'critical' : daysLeft <= 15 ? 'warning' : 'info';
+        alertsToUpsert.push({
+          org_id: orgId,
+          employee_id: emp.id,
+          title: `انتهاء عقد: ${name}`,
+          category: 'contract',
+          severity,
+          description: `ينتهي عقد ${name} خلال ${daysLeft} يوم (${emp.contract_end_date})`,
+          due_date: emp.contract_end_date,
+          source: 'alert-generator',
+          resolved_at: null,
+          resolved_by: null,
+          updated_at: todayStr,
+        });
+      }
+    }
+
+    // ── تنبيه غياب IBAN ──────────────────────────────────────────────────
+    if (!emp.iban) {
+      alertsToUpsert.push({
+        org_id: orgId,
+        employee_id: emp.id,
+        title: `بيانات ناقصة: IBAN — ${name}`,
+        category: 'data_gap',
+        severity: 'warning',
+        description: `الموظف ${name} لا يوجد له رقم IBAN — قد يتأخر صرف الراتب`,
+        due_date: null,
+        source: 'alert-generator',
+        resolved_at: null,
+        resolved_by: null,
+        updated_at: todayStr,
+      });
+    }
+  }
+
+  if (alertsToUpsert.length === 0) return 0;
+
+  // Upsert بمفتاح (org_id, employee_id, title) — يتجنب التكرار
+  const rows = alertsToUpsert.map((a) => ({
+    ...a,
+    is_resolved: false,
+  }));
+
+  const { error: upsertErr } = await supabase
+    .from('hr_alerts')
+    .upsert(rows, { onConflict: 'org_id,employee_id,title', ignoreDuplicates: false });
+
+  if (upsertErr) {
+    // لو لم يكن هناك unique constraint بعد — نُدرج فقط إن لم يكن موجوداً
+    const { error: insertErr } = await supabase.from('hr_alerts').insert(rows);
+    if (insertErr) throw new Error(insertErr.message);
+  }
+
+  return rows.length;
+}

--- a/src/services/hr/employee-service.ts
+++ b/src/services/hr/employee-service.ts
@@ -90,6 +90,114 @@ export interface EmployeeSalaryComponent {
   value: number;
 }
 
+export interface SalaryComponentOption {
+  id: string;
+  code: string;
+  name: string;
+  name_ar: string;
+  component_type: string;
+  calculation_type: string;
+}
+
+/** قائمة مكوّنات الراتب المتاحة للمنظمة (للاختيار منها عند الإسناد). */
+export async function listSalaryComponents(): Promise<SalaryComponentOption[]> {
+  const orgId = await getEffectiveTenantId();
+  if (!orgId) throw new Error('Organization not found.');
+
+  const { data, error } = await supabase
+    .from('salary_components')
+    .select('id, code, name, name_ar, component_type, calculation_type')
+    .eq('org_id', orgId)
+    .eq('is_active', true)
+    .order('component_type', { ascending: true })
+    .order('name', { ascending: true });
+
+  if (error) throw new Error(error.message);
+  return (data ?? []) as SalaryComponentOption[];
+}
+
+export interface UpsertSalaryStructureInput {
+  component_id: string;
+  amount: number;          // القيمة الثابتة أو النسبة
+  calculation_type?: 'fixed' | 'percentage';
+}
+
+/** إسناد / تعديل مكوّن راتب لموظف (تعطيل القديم + إدراج جديد). */
+export async function upsertEmployeeSalaryComponent(
+  employeeId: string,
+  input: UpsertSalaryStructureInput,
+): Promise<void> {
+  const orgId = await getEffectiveTenantId();
+  if (!orgId) throw new Error('Organization not found.');
+  if (input.amount <= 0) throw new Error('القيمة يجب أن تكون موجبة');
+
+  // تعطيل أي سجل نشط حالي لنفس المكوّن
+  await supabase
+    .from('employee_salary_structures')
+    .update({ is_active: false })
+    .eq('org_id', orgId)
+    .eq('employee_id', employeeId)
+    .eq('component_id', input.component_id)
+    .eq('is_active', true);
+
+  const today = new Date().toISOString().split('T')[0];
+  const { error } = await supabase.from('employee_salary_structures').insert({
+    org_id: orgId,
+    employee_id: employeeId,
+    component_id: input.component_id,
+    value: input.amount,
+    effective_from: today,
+    is_active: true,
+  });
+
+  if (error) throw new Error(error.message);
+}
+
+/** تعطيل مكوّن راتب لموظف (soft-delete). */
+export async function deactivateEmployeeSalaryComponent(
+  structureId: string,
+): Promise<void> {
+  const orgId = await getEffectiveTenantId();
+  if (!orgId) throw new Error('Organization not found.');
+
+  const { error } = await supabase
+    .from('employee_salary_structures')
+    .update({ is_active: false })
+    .eq('id', structureId)
+    .eq('org_id', orgId);
+
+  if (error) throw new Error(error.message);
+}
+
+export interface PayrollDetailRow {
+  id: string;
+  employee_id: string;
+  component_code: string | null;
+  component_label: string | null;
+  amount: number;
+  is_deduction: boolean;
+}
+
+/** سطور تفصيل المسير لموظف من دورة مُعتمدة. */
+export async function getPayrollDetailsForEmployee(
+  runId: string,
+  employeeId: string,
+): Promise<PayrollDetailRow[]> {
+  const orgId = await getEffectiveTenantId();
+  if (!orgId) throw new Error('Organization not found.');
+
+  const { data, error } = await supabase
+    .from('payroll_details')
+    .select('id, employee_id, component_code, component_label, amount, is_deduction')
+    .eq('org_id', orgId)
+    .eq('payroll_run_id', runId)
+    .eq('employee_id', employeeId)
+    .order('is_deduction', { ascending: true });
+
+  if (error) throw new Error(error.message);
+  return (data ?? []) as PayrollDetailRow[];
+}
+
 /** بدلات/استقطاعات الموظف الفعّالة من employee_salary_structures × salary_components. */
 export async function getEmployeeSalaryComponents(employeeId: string): Promise<EmployeeSalaryComponent[]> {
   const orgId = await getEffectiveTenantId();

--- a/src/services/hr/leave-service.ts
+++ b/src/services/hr/leave-service.ts
@@ -1,5 +1,7 @@
 import { supabase, getEffectiveTenantId } from '@/lib/supabase';
 import { setDayStatusFallback } from './attendance-service';
+import type { HrPolicies } from './policies-service';
+import { getHrPolicies } from './policies-service';
 
 export interface LeaveRequest {
   id: string;
@@ -9,6 +11,302 @@ export interface LeaveRequest {
   leave_type_id: string;
   status: string;
 }
+
+export interface LeaveTypeRow {
+  id: string;
+  code: string;
+  name: string;
+  name_ar: string;
+  is_paid: boolean;
+  max_days_per_year: number | null;
+}
+
+export interface LeaveRequestRow {
+  id: string;
+  org_id: string;
+  employee_id: string;
+  leave_type_id: string;
+  start_date: string;
+  end_date: string;
+  total_days: number;
+  reason: string | null;
+  status: 'pending' | 'approved' | 'rejected' | 'cancelled';
+  notes: string | null;
+  created_at: string;
+  leave_type?: LeaveTypeRow;
+  employee?: { id: string; full_name: string };
+}
+
+export interface LeaveRequestInput {
+  employee_id: string;
+  leave_type_id: string;
+  start_date: string; // YYYY-MM-DD
+  end_date: string;   // YYYY-MM-DD
+  reason?: string;
+}
+
+export interface LeaveBalanceResult {
+  entitlementPerYear: number;
+  accrued: number;
+  used: number;
+  balance: number;
+  referenceDate: string; // ISO date from which accrual is counted
+}
+
+// ─── Pure functions (testable without DB) ────────────────────────────────────
+
+/** Annual entitlement per Saudi Labor Law Art.109: 21 days < 5 yrs, 30 days ≥ 5 yrs. */
+export function computeLeaveEntitlement(
+  yearsOfService: number,
+  policies: Pick<HrPolicies, 'annual_leave_days_before_5y' | 'annual_leave_days_after_5y'>,
+): number {
+  return yearsOfService >= 5
+    ? policies.annual_leave_days_after_5y
+    : policies.annual_leave_days_before_5y;
+}
+
+/**
+ * Prorated accrual: (daysElapsed / 365) × entitlementPerYear.
+ * Returns a number floored to 1 decimal.
+ */
+export function computeLeaveAccrual(
+  referenceDate: Date,
+  asOfDate: Date,
+  entitlementPerYear: number,
+): number {
+  const daysElapsed = Math.max(
+    0,
+    (asOfDate.getTime() - referenceDate.getTime()) / 86_400_000,
+  );
+  return Math.floor((daysElapsed / 365) * entitlementPerYear * 10) / 10;
+}
+
+/** Remaining balance = accrued - used (floored to 0). */
+export function computeLeaveBalance(accrued: number, usedDays: number): number {
+  return Math.max(0, accrued - usedDays);
+}
+
+// ─── Fetch helpers ─────────────────────────────────────────────────────────
+
+export async function getLeaveTypes(): Promise<LeaveTypeRow[]> {
+  const orgId = await getEffectiveTenantId();
+  if (!orgId) throw new Error('Organization not found.');
+
+  const { data, error } = await supabase
+    .from('leave_types')
+    .select('id, code, name, name_ar, is_paid, max_days_per_year')
+    .eq('org_id', orgId)
+    .eq('is_active', true)
+    .order('name', { ascending: true });
+
+  if (error) throw new Error(error.message);
+  return (data ?? []) as LeaveTypeRow[];
+}
+
+export async function listLeaveRequests(
+  limit = 100,
+): Promise<LeaveRequestRow[]> {
+  const orgId = await getEffectiveTenantId();
+  if (!orgId) throw new Error('Organization not found.');
+
+  const { data, error } = await supabase
+    .from('employee_leaves')
+    .select(
+      `id, org_id, employee_id, leave_type_id, start_date, end_date,
+       total_days, reason, status, notes, created_at,
+       leave_type:leave_types(id, code, name, name_ar, is_paid),
+       employee:employees(id, full_name)`,
+    )
+    .eq('org_id', orgId)
+    .order('created_at', { ascending: false })
+    .limit(limit);
+
+  if (error) throw new Error(error.message);
+  return (data ?? []) as unknown as LeaveRequestRow[];
+}
+
+// ─── Mutations ─────────────────────────────────────────────────────────────
+
+export async function createLeaveRequest(
+  input: LeaveRequestInput,
+): Promise<LeaveRequestRow> {
+  const orgId = await getEffectiveTenantId();
+  if (!orgId) throw new Error('Organization not found.');
+
+  const start = new Date(input.start_date);
+  const end = new Date(input.end_date);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+    throw new Error('تواريخ الإجازة غير صالحة');
+  }
+  if (end < start) throw new Error('تاريخ الانتهاء قبل تاريخ البداية');
+
+  const totalDays =
+    Math.ceil((end.getTime() - start.getTime()) / 86_400_000) + 1;
+
+  const { data, error } = await supabase
+    .from('employee_leaves')
+    .insert({
+      org_id: orgId,
+      employee_id: input.employee_id,
+      leave_type_id: input.leave_type_id,
+      start_date: input.start_date,
+      end_date: input.end_date,
+      total_days: totalDays,
+      reason: input.reason ?? null,
+      status: 'pending',
+    })
+    .select(
+      `id, org_id, employee_id, leave_type_id, start_date, end_date,
+       total_days, reason, status, notes, created_at`,
+    )
+    .single();
+
+  if (error) throw new Error(error.message);
+  return data as LeaveRequestRow;
+}
+
+/**
+ * Approve a pending leave request.
+ * Fetches the leave type to determine if it is paid; checks accrued balance
+ * if paid annual leave (unless adminOverride is set).
+ * Then updates status → 'approved' and stamps attendance via
+ * applyApprovedLeaveToAttendance.
+ */
+export async function approveLeaveRequest(
+  leaveId: string,
+  adminOverride = false,
+): Promise<void> {
+  const orgId = await getEffectiveTenantId();
+  if (!orgId) throw new Error('Organization not found.');
+
+  const { data: leave, error: fetchErr } = await supabase
+    .from('employee_leaves')
+    .select(
+      `id, employee_id, leave_type_id, total_days, status,
+       leave_type:leave_types(id, code, is_paid)`,
+    )
+    .eq('id', leaveId)
+    .eq('org_id', orgId)
+    .maybeSingle();
+
+  if (fetchErr) throw new Error(fetchErr.message);
+  if (!leave) throw new Error('طلب الإجازة غير موجود');
+  if (leave.status !== 'pending') throw new Error('الطلب ليس في حالة انتظار');
+
+  const leaveType = Array.isArray(leave.leave_type)
+    ? leave.leave_type[0]
+    : leave.leave_type;
+
+  // Balance check for paid annual/regular leave
+  if (leaveType?.is_paid && !adminOverride) {
+    const bal = await getLeaveBalance(leave.employee_id);
+    if (bal.balance < leave.total_days) {
+      throw new Error(
+        `رصيد الإجازة غير كافٍ (المتبقي ${bal.balance.toFixed(1)} يوم، المطلوب ${leave.total_days})`,
+      );
+    }
+  }
+
+  const { error: updateErr } = await supabase
+    .from('employee_leaves')
+    .update({ status: 'approved', approved_at: new Date().toISOString() })
+    .eq('id', leaveId)
+    .eq('org_id', orgId);
+
+  if (updateErr) throw new Error(updateErr.message);
+
+  await applyApprovedLeaveToAttendance(leaveId);
+}
+
+export async function rejectLeaveRequest(
+  leaveId: string,
+  notes: string,
+): Promise<void> {
+  const orgId = await getEffectiveTenantId();
+  if (!orgId) throw new Error('Organization not found.');
+
+  if (!notes?.trim()) throw new Error('يرجى إدخال سبب الرفض');
+
+  const { error } = await supabase
+    .from('employee_leaves')
+    .update({ status: 'rejected', notes })
+    .eq('id', leaveId)
+    .eq('org_id', orgId);
+
+  if (error) throw new Error(error.message);
+}
+
+/**
+ * Compute the leave balance for an employee.
+ * Reference date = hire_date (or last approved settlement's service_end if earlier).
+ * Accrual is prorated; used days = total_days of approved paid leaves since referenceDate.
+ */
+export async function getLeaveBalance(
+  employeeId: string,
+): Promise<LeaveBalanceResult> {
+  const orgId = await getEffectiveTenantId();
+  if (!orgId) throw new Error('Organization not found.');
+
+  const [{ data: emp }, { data: settl }, { data: usedRows }, policies] =
+    await Promise.all([
+      supabase
+        .from('employees')
+        .select('hire_date')
+        .eq('id', employeeId)
+        .eq('org_id', orgId)
+        .maybeSingle(),
+      // Last approved EOS settlement gives the watermark
+      supabase
+        .from('hr_settlements')
+        .select('service_end')
+        .eq('employee_id', employeeId)
+        .eq('org_id', orgId)
+        .eq('status', 'approved')
+        .order('service_end', { ascending: false })
+        .limit(1)
+        .maybeSingle(),
+      supabase
+        .from('employee_leaves')
+        .select(
+          `total_days, leave_type:leave_types(is_paid)`,
+        )
+        .eq('employee_id', employeeId)
+        .eq('org_id', orgId)
+        .eq('status', 'approved'),
+      getHrPolicies(),
+    ]);
+
+  const hireDate = emp?.hire_date ? new Date(emp.hire_date) : new Date();
+  const watermark: Date = settl?.service_end
+    ? new Date(settl.service_end)
+    : hireDate;
+  const referenceDate = watermark > hireDate ? watermark : hireDate;
+
+  const now = new Date();
+  const yearsOfService =
+    (now.getTime() - hireDate.getTime()) / (365.25 * 86_400_000);
+  const entitlementPerYear = computeLeaveEntitlement(yearsOfService, policies);
+  const accrued = computeLeaveAccrual(referenceDate, now, entitlementPerYear);
+
+  // Sum approved paid leave days since referenceDate
+  const usedDays = ((usedRows ?? []) as Array<{
+    total_days: number;
+    leave_type: { is_paid: boolean } | Array<{ is_paid: boolean }> | null;
+  }>).reduce((sum, r) => {
+    const lt = Array.isArray(r.leave_type) ? r.leave_type[0] : r.leave_type;
+    return lt?.is_paid ? sum + r.total_days : sum;
+  }, 0);
+
+  return {
+    entitlementPerYear,
+    accrued,
+    used: usedDays,
+    balance: computeLeaveBalance(accrued, usedDays),
+    referenceDate: referenceDate.toISOString().split('T')[0],
+  };
+}
+
+// ─── Kept from original ────────────────────────────────────────────────────
 
 export async function applyApprovedLeaveToAttendance(leaveId: string) {
   const orgId = await getEffectiveTenantId();
@@ -38,12 +336,12 @@ export async function applyApprovedLeaveToAttendance(leaveId: string) {
     throw new Error('Leave request not found.');
   }
   if (leave.status !== 'approved') {
-    // Nothing to apply if not approved
     return;
   }
 
-  // Handle leave_type which might be an object or array
-  const leaveType = Array.isArray(leave.leave_type) ? leave.leave_type[0] : leave.leave_type;
+  const leaveType = Array.isArray(leave.leave_type)
+    ? leave.leave_type[0]
+    : leave.leave_type;
   const leaveCode: string = (leaveType?.code ?? '') || '';
   const normalized = leaveCode.toUpperCase();
   const status = 'leave';
@@ -73,5 +371,3 @@ export async function applyApprovedLeaveToAttendance(leaveId: string) {
     });
   }
 }
-
-

--- a/src/services/hr/leave-service.ts
+++ b/src/services/hr/leave-service.ts
@@ -1,7 +1,6 @@
 import { supabase, getEffectiveTenantId } from '@/lib/supabase';
 import { setDayStatusFallback } from './attendance-service';
-import type { HrPolicies } from './policies-service';
-import { getHrPolicies } from './policies-service';
+import { getHrPolicies, type HrPolicies } from './policies-service';
 
 export interface LeaveRequest {
   id: string;

--- a/src/services/hr/payroll-account-service.ts
+++ b/src/services/hr/payroll-account-service.ts
@@ -8,7 +8,15 @@ export type PayrollAccountType =
   | 'deductions'
   | 'loans'
   | 'payable'
-  | 'net_payable';
+  | 'net_payable'
+  // أنواع Migration 99 (قرار المالك: كل حسابات القيد قابلة للاختيار من الضبط)
+  | 'overtime'
+  | 'absence_recovery'
+  | 'gosi_employee'
+  | 'gosi_employer_expense'
+  | 'gosi_payable'
+  | 'eos_expense'
+  | 'eos_payable';
 
 export interface PayrollAccountMapping {
   id: string;

--- a/src/services/hr/payroll-engine.ts
+++ b/src/services/hr/payroll-engine.ts
@@ -131,13 +131,12 @@ export function evaluateComponentAmount(
   calculationType: string | null | undefined,
   structureValue: number,
   basicBase: number,
-  percentageBase?: string | null,
+  _percentageBase?: string | null,
 ): number {
   const type = (calculationType || 'fixed').toLowerCase();
   if (type === 'fixed') return structureValue;
   if (type === 'percentage') {
-    const base = (percentageBase || 'basic').toLowerCase() === 'basic' ? basicBase : basicBase;
-    return (structureValue / 100) * base;
+    return (structureValue / 100) * basicBase;
   }
   throw new Error(`مكوّن راتب بنوع حساب غير مدعوم: ${calculationType} — عدّله إلى fixed أو percentage`);
 }

--- a/src/services/hr/payroll-engine.ts
+++ b/src/services/hr/payroll-engine.ts
@@ -1,12 +1,32 @@
+/**
+ * محرّك الرواتب (P12-C) — حساب كامل بسياسات قابلة للضبط، يصحّح ما أخطأ فيه
+ * النظام المرجعي «حاسبني»:
+ *   • GOSI محسوب فعلاً: وعاء = أساسي+سكن بسقف gosi_base_cap، حصة موظف تُخصم
+ *     وحصة صاحب عمل مصروف، حسب is_saudi وسياسة gosi_applies_to.
+ *   • الإجازة المدفوعة لا تُخصم كغياب (كانت تُخصم في حاسبني — مخالف للنظام).
+ *   • مكوّنات percentage تُقيَّم من أساسها (كانت تُعامل كمبالغ ثابتة صامتة)،
+ *     وformula تُرفض بوضوح (غير مدعومة).
+ *   • المعدل اليومي ووعاء الإضافي بسياسة (working_days/thirty، basic/basic_housing).
+ *   • تعديلات hr_payroll_adjustments (سلف/جزاءات/عمولات/أقساط) تدخل الحساب.
+ * الاعتماد النهائي عبر rpc_post_payroll_run الذرّي (Migration 100) — القيد
+ * حصراً من القناة القانونية rpc_create_journal_entry. لا ترحيل client-side.
+ */
 import { supabase, getEffectiveTenantId } from '@/lib/supabase';
 import { getHrPolicies, HrPolicies } from './policies-service';
 import { listAttendanceForPeriod } from './attendance-service';
-import { getPayrollLock, upsertPayrollLock } from './payroll-lock-service';
-import {
-  getPayrollAccountMappings,
-  PayrollAccountMapping,
-  PayrollAccountType,
-} from './payroll-account-service';
+import { getPayrollLock } from './payroll-lock-service';
+import { PayrollAccountType } from './payroll-account-service';
+import { listAdjustmentsForMonth, PayrollAdjustment } from './adjustments-service';
+
+// ===== أنواع =====
+
+export interface PayrollLine {
+  employee_id: string;
+  component_code: string;
+  component_label: string;
+  amount: number;
+  is_deduction: boolean;
+}
 
 export interface PayrollPreviewEmployee {
   employeeId: string;
@@ -14,37 +34,76 @@ export interface PayrollPreviewEmployee {
   name: string;
   department?: string | null;
   baseSalary: number;
-  allowanceTotal: number;
+  housingAllowance: number;
+  transportAllowance: number;
+  otherAllowance: number;
   overtimeAmount: number;
-  deductions: number;
+  gosiEmployee: number;
+  gosiEmployer: number;
+  componentDeductions: number;
+  loanDeductions: number;
+  adjustmentAllowances: number;
+  adjustmentDeductions: number;
   absenceDays: number;
+  unpaidLeaveDays: number;
   absenceAmount: number;
   gross: number;
   net: number;
-  allowanceBreakdown?: Partial<Record<PayrollAccountType, number>>;
-  deductionBreakdown?: Partial<Record<PayrollAccountType, number>>;
+  lines: PayrollLine[];
+  /** مجموع البدلات (توافق عرض) */
+  allowanceTotal: number;
+  /** مجموع الاستقطاعات عدا الغياب: GOSI موظف + مكوّنات + قروض + تعديلات (توافق عرض) */
+  deductions: number;
 }
+
+export type PayrollBuckets = Partial<Record<PayrollAccountType, number>>;
 
 export interface PayrollPreviewResponse {
   year: number;
   month: number;
   locked: boolean;
   employees: PayrollPreviewEmployee[];
+  buckets: PayrollBuckets; // جاهزة لحمولة rpc_post_payroll_run
   totals: {
     gross: number;
     allowances: number;
     overtime: number;
+    gosiEmployee: number;
+    gosiEmployer: number;
     deductions: number;
     absence: number;
     net: number;
   };
 }
 
-const DAYS_IN_MONTH = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
-const toMonthKey = (year: number, month: number) =>
-  `${year}-${String(month).padStart(2, '0')}`;
+interface AttendanceDay {
+  status?: string;
+  paid?: boolean;
+  check_in?: string;
+  check_in_time?: string;
+  check_out?: string;
+  check_out_time?: string;
+  in?: string;
+  out?: string;
+}
 
-const getDaysInMonth = (year: number, month: number) => {
+interface StructureRow {
+  employee_id: string;
+  value: number;
+  component: {
+    code?: string | null;
+    name?: string | null;
+    name_ar?: string | null;
+    component_type?: string | null;
+    calculation_type?: string | null;
+    percentage_base?: string | null;
+  } | null;
+}
+
+// ===== دوال صافية (مُختبرة وحدوياً) =====
+
+const DAYS_IN_MONTH = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+export const getDaysInMonth = (year: number, month: number) => {
   if (month === 2) {
     const isLeap = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
     return isLeap ? 29 : 28;
@@ -52,23 +111,152 @@ const getDaysInMonth = (year: number, month: number) => {
   return DAYS_IN_MONTH[month - 1];
 };
 
-const getWeekendSet = (policies: HrPolicies) =>
-  new Set((policies.weekend_days ?? ['friday']).map((day) => day.toLowerCase()));
+export const getWorkingDays = (year: number, month: number, weekendSet: Set<string>) => {
+  const daysInMonth = getDaysInMonth(year, month);
+  let workingDays = 0;
+  for (let day = 1; day <= daysInMonth; day += 1) {
+    const date = new Date(Date.UTC(year, month - 1, day));
+    const dayName = date.toLocaleDateString('en-US', { weekday: 'long' }).toLowerCase();
+    if (!weekendSet.has(dayName)) workingDays += 1;
+  }
+  return workingDays;
+};
 
-const classifyAllowance = (code?: string | null): PayrollAccountType => {
-  const normalized = (code || '').toUpperCase();
-  if (normalized.includes('BASIC')) return 'basic_salary';
+/**
+ * تقييم مبلغ مكوّن راتب حسب calculation_type:
+ * fixed ⇒ القيمة كما هي؛ percentage ⇒ نسبة من الأساس (basic افتراضاً)؛
+ * formula ⇒ رفض واضح (كانت تُعامل كمبلغ ثابت صامت — علّة).
+ */
+export function evaluateComponentAmount(
+  calculationType: string | null | undefined,
+  structureValue: number,
+  basicBase: number,
+  percentageBase?: string | null,
+): number {
+  const type = (calculationType || 'fixed').toLowerCase();
+  if (type === 'fixed') return structureValue;
+  if (type === 'percentage') {
+    const base = (percentageBase || 'basic').toLowerCase() === 'basic' ? basicBase : basicBase;
+    return (structureValue / 100) * base;
+  }
+  throw new Error(`مكوّن راتب بنوع حساب غير مدعوم: ${calculationType} — عدّله إلى fixed أو percentage`);
+}
+
+export interface GosiResult {
+  employee: number;
+  employer: number;
+  base: number;
+}
+
+/**
+ * GOSI صحيح (عكس حاسبني): الوعاء = أساسي + سكن بسقف gosi_base_cap؛
+ * saudi_only ⇒ غير السعودي بلا حصص (مبسّط — حصة الأخطار المهنية للوافد تُضاف
+ * لاحقاً عند الحاجة)؛ all ⇒ الجميع؛ none ⇒ معطَّل.
+ */
+export function computeGosi(
+  basic: number,
+  housing: number,
+  policies: Pick<HrPolicies, 'gosi_employee_pct' | 'gosi_employer_pct' | 'gosi_base_cap' | 'gosi_applies_to'>,
+  isSaudi: boolean | null | undefined,
+): GosiResult {
+  const applies =
+    policies.gosi_applies_to === 'all' ||
+    (policies.gosi_applies_to === 'saudi_only' && isSaudi === true);
+  if (!applies) return { employee: 0, employer: 0, base: 0 };
+
+  const base = Math.min(basic + housing, Number(policies.gosi_base_cap ?? 45000));
+  return {
+    employee: round2(base * (Number(policies.gosi_employee_pct) / 100)),
+    employer: round2(base * (Number(policies.gosi_employer_pct) / 100)),
+    base,
+  };
+}
+
+export interface AttendanceAdjustments {
+  absenceDays: number;
+  unpaidLeaveDays: number;
+  overtimeHours: number;
+}
+
+/**
+ * تحليل حضور الشهر: الغياب يُخصم، الإجازة غير المدفوعة تُخصم،
+ * **الإجازة المدفوعة لا تُخصم** (paid !== false)، والإضافي من in/out.
+ */
+export function analyzeAttendance(
+  days: Record<string, AttendanceDay> | undefined,
+  expectedHours: number,
+  graceMinutes: number,
+): AttendanceAdjustments {
+  const result: AttendanceAdjustments = { absenceDays: 0, unpaidLeaveDays: 0, overtimeHours: 0 };
+  if (!days) return result;
+
+  for (const day of Object.values(days)) {
+    const status = String(day.status || '').toLowerCase();
+    if (status === 'absent') {
+      result.absenceDays += 1;
+      continue;
+    }
+    if (status === 'unpaid_leave' || (status === 'leave' && day.paid === false)) {
+      result.unpaidLeaveDays += 1;
+      continue;
+    }
+    if (status === 'present') {
+      const checkIn = day.check_in || day.check_in_time || day.in;
+      const checkOut = day.check_out || day.check_out_time || day.out;
+      if (checkIn && checkOut) {
+        const started = new Date(checkIn).getTime();
+        const ended = new Date(checkOut).getTime();
+        if (!Number.isNaN(started) && !Number.isNaN(ended) && ended > started) {
+          const hours = (ended - started) / (1000 * 60 * 60);
+          const overtime = hours - expectedHours;
+          if (overtime > graceMinutes / 60) result.overtimeHours += overtime;
+        }
+      }
+    }
+  }
+  return result;
+}
+
+/** المعدل اليومي بسياسة: أيام العمل الفعلية أو /30 (وعاء الخصم = الأساسي). */
+export function dailyRateOf(
+  basic: number,
+  workingDays: number,
+  basis: HrPolicies['daily_rate_basis'],
+): number {
+  if (basis === 'thirty') return basic / 30;
+  return workingDays > 0 ? basic / workingDays : basic / 30;
+}
+
+/** أجرة ساعة الإضافي بسياسة الوعاء (أساسي أو أساسي+سكن). */
+export function overtimeHourlyRate(
+  basic: number,
+  housing: number,
+  workingDays: number,
+  dailyHours: number,
+  base: HrPolicies['overtime_base'],
+): number {
+  const wage = base === 'basic_housing' ? basic + housing : basic;
+  const hours = workingDays * dailyHours;
+  return hours > 0 ? wage / hours : 0;
+}
+
+export const round2 = (n: number) => Math.round(n * 100) / 100;
+
+const classifyAllowanceBucket = (code: string): PayrollAccountType => {
+  const normalized = code.toUpperCase();
   if (normalized.includes('HRA') || normalized.includes('HOUSE') || normalized.includes('HSG'))
     return 'housing_allowance';
-  if (normalized.includes('TRANS') || normalized.includes('TRANSPORT')) return 'transport_allowance';
+  if (normalized.includes('TRANS')) return 'transport_allowance';
   return 'other_allowance';
 };
 
-const classifyDeduction = (code?: string | null): PayrollAccountType => {
-  const normalized = (code || '').toUpperCase();
-  if (normalized.includes('LOAN') || normalized.includes('ADV')) return 'loans';
-  return 'deductions';
+const isGosiComponent = (code: string) => code.toUpperCase().includes('GOSI');
+const isLoanComponent = (code: string) => {
+  const normalized = code.toUpperCase();
+  return normalized.includes('LOAN') || normalized.includes('ADV');
 };
+
+// ===== المعاينة =====
 
 const ensurePeriodBounds = (year: number, month: number) => {
   if (month < 1 || month > 12) throw new Error('Invalid month. Must be between 1 and 12.');
@@ -84,493 +272,280 @@ export async function calculatePayrollPreview(
   const orgId = await getEffectiveTenantId();
   if (!orgId) throw new Error('Organization not found.');
 
-  const [policies, payrollLock, employeesRes, salaryStructuresRes] = await Promise.all([
+  const [policies, payrollLock, adjustments, employeesRes, structuresRes] = await Promise.all([
     getHrPolicies(),
     getPayrollLock(year, month),
+    listAdjustmentsForMonth(year, month),
     supabase
       .from('employees')
-      .select('id, employee_id, first_name, last_name, department, salary, status')
+      .select('id, employee_id, first_name, last_name, department, salary, status, is_saudi')
       .eq('org_id', orgId)
       .eq('status', 'active'),
     supabase
       .from('employee_salary_structures')
-      .select(
-        `
-        id,
-        employee_id,
-        value,
+      .select(`
+        id, employee_id, value,
         component:salary_components(
-          id,
-          code,
-          name,
-          component_type
+          id, code, name, name_ar, component_type, calculation_type, percentage_base
         )
-      `,
-      )
+      `)
       .eq('org_id', orgId)
       .is('is_active', true),
   ]);
 
   if (employeesRes.error) throw employeesRes.error;
-  if (salaryStructuresRes.error) throw salaryStructuresRes.error;
+  if (structuresRes.error) throw structuresRes.error;
 
   const employees = employeesRes.data ?? [];
-  const salaryStructures = salaryStructuresRes.data ?? [];
+  const structures = (structuresRes.data ?? []) as unknown as StructureRow[];
 
   const employeeIds = employees.map((emp) => emp.id);
   const attendance = await listAttendanceForPeriod(employeeIds, year, month);
   const attendanceMap = new Map(attendance.map((record) => [record.employee_id, record]));
 
-  const structuresByEmployee = salaryStructures.reduce<Record<string, typeof salaryStructures>>(
-    (acc, structure) => {
-      const list = acc[structure.employee_id] ?? [];
-      list.push(structure);
-      acc[structure.employee_id] = list;
-      return acc;
-    },
-    {},
-  );
+  const structuresByEmployee = new Map<string, StructureRow[]>();
+  for (const s of structures) {
+    const list = structuresByEmployee.get(s.employee_id) ?? [];
+    list.push(s);
+    structuresByEmployee.set(s.employee_id, list);
+  }
 
-  const weekendSet = getWeekendSet(policies);
+  const adjustmentsByEmployee = new Map<string, PayrollAdjustment[]>();
+  for (const adj of adjustments) {
+    if (!adj.employee_id) continue;
+    const list = adjustmentsByEmployee.get(adj.employee_id) ?? [];
+    list.push(adj);
+    adjustmentsByEmployee.set(adj.employee_id, list);
+  }
+
+  const weekendSet = new Set((policies.weekend_days ?? ['friday']).map((d) => d.toLowerCase()));
   const workingDays = getWorkingDays(year, month, weekendSet);
+  const expectedHours = Number(policies.employee_daily_hours ?? 8);
 
   const previewEmployees: PayrollPreviewEmployee[] = [];
-  let totalsGross = 0;
-  let totalsAllowances = 0;
-  let totalsOvertime = 0;
-  let totalsDeductions = 0;
-  let totalsAbsence = 0;
+  const buckets: PayrollBuckets = {};
+  const addBucket = (type: PayrollAccountType, amount: number) => {
+    if (!amount) return;
+    buckets[type] = round2((buckets[type] ?? 0) + amount);
+  };
 
   for (const employee of employees) {
-    const components = (structuresByEmployee[employee.id] ?? []) as Array<{
-      value: number;
-      component: { code?: string | null; component_type?: string | null } | null;
-    }>;
-    const { base, allowances, deductions, allowanceBreakdown, deductionBreakdown } =
-      extractCompensationComponents(components);
+    const comps = structuresByEmployee.get(employee.id) ?? [];
+    const lines: PayrollLine[] = [];
 
-    const baseSalary = base ?? Number(employee.salary ?? 0);
-    const allowanceTotal = sumValues(allowances);
-    const deductionTotal = sumValues(deductions);
+    // 1) الأساسي أولاً (يلزم لتقييم النسب)
+    let baseSalary = 0;
+    for (const c of comps) {
+      const code = c.component?.code?.toUpperCase() ?? '';
+      const compType = c.component?.component_type?.toLowerCase();
+      if ((compType === 'earning' || compType === 'benefit') && code.includes('BASIC')) {
+        baseSalary += evaluateComponentAmount(
+          c.component?.calculation_type, Number(c.value || 0), 0, c.component?.percentage_base);
+      }
+    }
+    if (baseSalary === 0) baseSalary = Number(employee.salary ?? 0);
 
+    // 2) البدلات والاستقطاعات (النسب من الأساسي)
+    let housingAllowance = 0;
+    let transportAllowance = 0;
+    let otherAllowance = 0;
+    let componentDeductions = 0;
+    let loanDeductions = 0;
+
+    for (const c of comps) {
+      const code = c.component?.code?.toUpperCase() ?? '';
+      const label = c.component?.name_ar || c.component?.name || code;
+      const compType = c.component?.component_type?.toLowerCase();
+      if ((compType === 'earning' || compType === 'benefit') && !code.includes('BASIC')) {
+        const amount = round2(evaluateComponentAmount(
+          c.component?.calculation_type, Number(c.value || 0), baseSalary, c.component?.percentage_base));
+        if (!amount) continue;
+        const bucket = classifyAllowanceBucket(code);
+        if (bucket === 'housing_allowance') housingAllowance += amount;
+        else if (bucket === 'transport_allowance') transportAllowance += amount;
+        else otherAllowance += amount;
+        lines.push({ employee_id: employee.id, component_code: code, component_label: label, amount, is_deduction: false });
+      } else if (compType === 'deduction') {
+        // GOSI يُحسب من السياسات لا من المكوّنات (منع الازدواج)
+        if (isGosiComponent(code)) continue;
+        const amount = round2(evaluateComponentAmount(
+          c.component?.calculation_type, Number(c.value || 0), baseSalary, c.component?.percentage_base));
+        if (!amount) continue;
+        if (isLoanComponent(code)) loanDeductions += amount;
+        else componentDeductions += amount;
+        lines.push({ employee_id: employee.id, component_code: code, component_label: label, amount, is_deduction: true });
+      }
+    }
+
+    if (baseSalary > 0) {
+      lines.unshift({ employee_id: employee.id, component_code: 'BASIC', component_label: 'الراتب الأساسي', amount: round2(baseSalary), is_deduction: false });
+    }
+
+    // 3) الحضور: غياب/إجازة غير مدفوعة/إضافي
     const attendanceRecord = attendanceMap.get(employee.id);
-    const { absenceDays, absenceAmount, overtimeAmount } = calculateAttendanceAdjustments(
-      attendanceRecord?.days ?? {},
-      baseSalary,
-      policies,
-      workingDays,
+    const att = analyzeAttendance(
+      (attendanceRecord?.days ?? {}) as Record<string, AttendanceDay>,
+      expectedHours,
+      Number(policies.overtime_grace_minutes ?? 0),
     );
+    const dailyRate = dailyRateOf(baseSalary, workingDays, policies.daily_rate_basis);
+    const deductibleDays = att.absenceDays + att.unpaidLeaveDays;
+    const absenceAmount = round2(deductibleDays * dailyRate);
+    const hourlyRate = overtimeHourlyRate(
+      baseSalary, housingAllowance, workingDays, expectedHours, policies.overtime_base);
+    let overtimeAmount = round2(att.overtimeHours * hourlyRate * Number(policies.overtime_multiplier ?? 1.5));
 
-    const gross = baseSalary + allowanceTotal + overtimeAmount;
-    const net = gross - deductionTotal - absenceAmount;
+    // 4) التعديلات الشهرية
+    let adjustmentAllowances = 0;
+    let adjustmentDeductions = 0;
+    for (const adj of adjustmentsByEmployee.get(employee.id) ?? []) {
+      const amount = round2(Number(adj.amount || 0));
+      if (!amount) continue;
+      const label = adj.description || adj.adjustment_type;
+      if (adj.adjustment_type === 'allowance') {
+        adjustmentAllowances += amount;
+        lines.push({ employee_id: employee.id, component_code: 'ADJ_ALLOWANCE', component_label: label, amount, is_deduction: false });
+      } else if (adj.adjustment_type === 'overtime') {
+        overtimeAmount = round2(overtimeAmount + amount);
+        lines.push({ employee_id: employee.id, component_code: 'ADJ_OVERTIME', component_label: label, amount, is_deduction: false });
+      } else if (adj.adjustment_type === 'loan') {
+        loanDeductions += amount;
+        lines.push({ employee_id: employee.id, component_code: 'ADJ_LOAN', component_label: label, amount, is_deduction: true });
+      } else {
+        adjustmentDeductions += amount;
+        lines.push({ employee_id: employee.id, component_code: 'ADJ_DEDUCTION', component_label: label, amount, is_deduction: true });
+      }
+    }
+
+    // 5) GOSI من السياسات
+    const gosi = computeGosi(baseSalary, housingAllowance, policies, employee.is_saudi);
+    if (gosi.employee > 0) {
+      lines.push({ employee_id: employee.id, component_code: 'GOSI_EMP', component_label: 'التأمينات — حصة الموظف', amount: gosi.employee, is_deduction: true });
+    }
+    if (att.overtimeHours > 0 || overtimeAmount > 0) {
+      lines.push({ employee_id: employee.id, component_code: 'OT', component_label: 'عمل إضافي', amount: overtimeAmount, is_deduction: false });
+    }
+    if (absenceAmount > 0) {
+      lines.push({ employee_id: employee.id, component_code: 'ABSENCE', component_label: 'خصم غياب/إجازة غير مدفوعة', amount: absenceAmount, is_deduction: true });
+    }
+
+    const allowanceTotal = round2(housingAllowance + transportAllowance + otherAllowance + adjustmentAllowances);
+    const gross = round2(baseSalary + allowanceTotal + overtimeAmount);
+    const totalDeductions = round2(
+      gosi.employee + componentDeductions + loanDeductions + adjustmentDeductions + absenceAmount);
+    const net = round2(gross - totalDeductions);
 
     previewEmployees.push({
       employeeId: employee.id,
       employeeCode: employee.employee_id,
       name: `${employee.first_name ?? ''} ${employee.last_name ?? ''}`.trim() || 'موظف',
       department: employee.department,
-      baseSalary,
-      allowanceTotal,
+      baseSalary: round2(baseSalary),
+      housingAllowance: round2(housingAllowance),
+      transportAllowance: round2(transportAllowance),
+      otherAllowance: round2(otherAllowance + adjustmentAllowances),
       overtimeAmount,
-      deductions: deductionTotal,
-      absenceDays,
+      gosiEmployee: gosi.employee,
+      gosiEmployer: gosi.employer,
+      componentDeductions: round2(componentDeductions + adjustmentDeductions),
+      loanDeductions: round2(loanDeductions),
+      adjustmentAllowances: round2(adjustmentAllowances),
+      adjustmentDeductions: round2(adjustmentDeductions),
+      absenceDays: att.absenceDays,
+      unpaidLeaveDays: att.unpaidLeaveDays,
       absenceAmount,
       gross,
       net,
-      allowanceBreakdown: addToBreakdown(allowanceBreakdown, 'other_allowance', overtimeAmount),
-      deductionBreakdown: addToBreakdown(deductionBreakdown, 'deductions', absenceAmount),
+      lines,
+      allowanceTotal,
+      deductions: round2(gosi.employee + componentDeductions + loanDeductions + adjustmentDeductions),
     });
 
-    totalsGross += gross;
-    totalsAllowances += allowanceTotal;
-    totalsOvertime += overtimeAmount;
-    totalsDeductions += deductionTotal;
-    totalsAbsence += absenceAmount;
+    addBucket('basic_salary', baseSalary);
+    addBucket('housing_allowance', housingAllowance);
+    addBucket('transport_allowance', transportAllowance);
+    addBucket('other_allowance', otherAllowance + adjustmentAllowances);
+    addBucket('overtime', overtimeAmount);
+    addBucket('gosi_employer_expense', gosi.employer);
+    addBucket('gosi_payable', gosi.employee + gosi.employer);
+    addBucket('deductions', componentDeductions + adjustmentDeductions);
+    addBucket('loans', loanDeductions);
+    addBucket('absence_recovery', absenceAmount);
+    addBucket('payable', net);
   }
 
-  const totalsNet = totalsGross - totalsDeductions - totalsAbsence;
+  const totals = previewEmployees.reduce(
+    (acc, emp) => ({
+      gross: round2(acc.gross + emp.gross),
+      allowances: round2(acc.allowances + emp.housingAllowance + emp.transportAllowance + emp.otherAllowance),
+      overtime: round2(acc.overtime + emp.overtimeAmount),
+      gosiEmployee: round2(acc.gosiEmployee + emp.gosiEmployee),
+      gosiEmployer: round2(acc.gosiEmployer + emp.gosiEmployer),
+      deductions: round2(acc.deductions + emp.componentDeductions + emp.loanDeductions),
+      absence: round2(acc.absence + emp.absenceAmount),
+      net: round2(acc.net + emp.net),
+    }),
+    { gross: 0, allowances: 0, overtime: 0, gosiEmployee: 0, gosiEmployer: 0, deductions: 0, absence: 0, net: 0 },
+  );
 
   return {
     year,
     month,
     locked: payrollLock?.status === 'locked',
     employees: previewEmployees,
-    totals: {
-      gross: totalsGross,
-      allowances: totalsAllowances,
-      overtime: totalsOvertime,
-      deductions: totalsDeductions,
-      absence: totalsAbsence,
-      net: totalsNet,
-    },
+    buckets,
+    totals,
   };
 }
 
-interface AttendanceAdjustments {
-  absenceDays: number;
-  absenceAmount: number;
-  overtimeAmount: number;
+// ===== الاعتماد (عبر الـ RPC الذرّي حصراً) =====
+
+export interface ProcessPayrollResult {
+  payroll_run_id: string;
+  journal_entry_id: string;
+  entry_number?: string;
+  replayed: boolean;
 }
 
-const calculateAttendanceAdjustments = (
-  days: Record<string, { status?: string; check_in?: string; check_in_time?: string; check_out?: string; check_out_time?: string }> | undefined,
-  baseSalary: number,
-  policies: HrPolicies,
-  workingDays: number,
-): AttendanceAdjustments => {
-  if (!days) {
-    return { absenceDays: 0, absenceAmount: 0, overtimeAmount: 0 };
-  }
-
-  let absenceDays = 0;
-  let overtimeHours = 0;
-  const expectedHours = Number(policies.employee_daily_hours ?? 8);
-  const graceMinutes = Number(policies.overtime_grace_minutes ?? 0);
-
-  for (const day of Object.values(days)) {
-    const status = String(day.status || '').toLowerCase();
-    if (status === 'absent') {
-      absenceDays += 1;
-      continue;
-    }
-
-    if (status === 'present') {
-      const checkIn = day.check_in || day.check_in_time;
-      const checkOut = day.check_out || day.check_out_time;
-      if (checkIn && checkOut) {
-        const started = new Date(checkIn).getTime();
-        const ended = new Date(checkOut).getTime();
-        if (!Number.isNaN(started) && !Number.isNaN(ended) && ended > started) {
-          const hours = (ended - started) / (1000 * 60 * 60);
-          const overtime = hours - expectedHours;
-          if (overtime > graceMinutes / 60) {
-            overtimeHours += overtime;
-          }
-        }
-      }
-    }
-  }
-
-  const dailyRate = workingDays > 0 ? baseSalary / workingDays : baseSalary / 30;
-  const absenceAmount = absenceDays * dailyRate;
-  const hourlyRate = expectedHours > 0 ? baseSalary / (workingDays * expectedHours || expectedHours) : 0;
-  const overtimeAmount = overtimeHours * hourlyRate * Number(policies.overtime_multiplier ?? 1.5);
-
-  return { absenceDays, absenceAmount, overtimeAmount };
-};
-
-const getWorkingDays = (year: number, month: number, weekendSet: Set<string>) => {
-  const daysInMonth = getDaysInMonth(year, month);
-  let workingDays = 0;
-  for (let day = 1; day <= daysInMonth; day += 1) {
-    const date = new Date(Date.UTC(year, month - 1, day));
-    const dayName = date.toLocaleDateString('en-US', { weekday: 'long' }).toLowerCase();
-    if (!weekendSet.has(dayName)) {
-      workingDays += 1;
-    }
-  }
-  return workingDays;
-};
-
-const extractCompensationComponents = (
-  components: Array<{
-    value: number;
-    component: { code?: string | null; component_type?: string | null } | null;
-  }>,
-): {
-  base: number | null;
-  allowances: typeof components;
-  deductions: typeof components;
-  allowanceBreakdown: Partial<Record<PayrollAccountType, number>>;
-  deductionBreakdown: Partial<Record<PayrollAccountType, number>>;
-} => {
-  const earnings: typeof components = [];
-  const deductions: typeof components = [];
-  let base: number | null = null;
-  const allowanceBreakdown: Partial<Record<PayrollAccountType, number>> = {};
-  const deductionBreakdown: Partial<Record<PayrollAccountType, number>> = {};
-
-  for (const component of components) {
-    const compType = component.component?.component_type?.toLowerCase();
-    const code = component.component?.code?.toUpperCase() ?? '';
-    if (compType === 'deduction') {
-      deductions.push(component);
-       const bucket = classifyDeduction(code);
-       deductionBreakdown[bucket] = (deductionBreakdown[bucket] ?? 0) + Number(component.value || 0);
-      continue;
-    }
-
-    if (compType === 'earning' || compType === 'benefit') {
-      if (!base && (code.includes('BASIC') || code === 'BASIC')) {
-        base = Number(component.value || 0);
-      } else {
-        earnings.push(component);
-        const bucket = classifyAllowance(code);
-        allowanceBreakdown[bucket] = (allowanceBreakdown[bucket] ?? 0) + Number(component.value || 0);
-      }
-    }
-  }
-
-  return { base, allowances: earnings, deductions, allowanceBreakdown, deductionBreakdown };
-};
-
-const sumValues = (items: Array<{ value: number }>) =>
-  items.reduce((sum, item) => sum + Number(item.value || 0), 0);
-
-const addToBreakdown = (
-  breakdown: Partial<Record<PayrollAccountType, number>>,
-  bucket: PayrollAccountType,
-  amount: number,
-) => {
-  if (!amount) return breakdown;
-  return {
-    ...breakdown,
-    [bucket]: (breakdown[bucket] ?? 0) + amount,
-  };
-};
-
-interface PeriodResult {
-  id: string;
-}
-
-const ensurePayrollPeriod = async (
-  orgId: string,
+export async function processPayrollRun(
   year: number,
   month: number,
-): Promise<PeriodResult> => {
-  const periodCode = toMonthKey(year, month);
-  const { data, error } = await supabase
-    .from('payroll_periods')
-    .select('id')
-    .eq('org_id', orgId)
-    .eq('period_code', periodCode)
-    .maybeSingle();
-
-  if (error) {
-    throw error;
-  }
-
-  if (data) return data;
-
-  const startDate = new Date(Date.UTC(year, month - 1, 1)).toISOString().split('T')[0];
-  const endDate = new Date(Date.UTC(year, month - 1, getDaysInMonth(year, month))).toISOString().split('T')[0];
-
-  const { data: inserted, error: insertError } = await supabase
-    .from('payroll_periods')
-    .insert({
-      org_id: orgId,
-      period_code: periodCode,
-      period_name: periodCode,
-      period_type: 'monthly',
-      start_date: startDate,
-      end_date: endDate,
-      status: 'open',
-    })
-    .select('id')
-    .single();
-
-  if (insertError) throw insertError;
-  return inserted;
-};
-
-const ensurePayrollRun = async (
-  orgId: string,
-  periodId: string,
-  totals: { gross: number; deductions: number; net: number },
-) => {
-  const { data, error } = await supabase
-    .from('payroll_runs')
-    .insert({
-      org_id: orgId,
-      period_id: periodId,
-      run_date: new Date().toISOString().split('T')[0],
-      status: 'calculated',
-      total_gross: totals.gross,
-      total_deductions: totals.deductions,
-      total_net: totals.net,
-    })
-    .select('id')
-    .single();
-  if (error) throw error;
-  return data;
-};
-
-export async function processPayrollRun(year: number, month: number) {
-  const orgId = await getEffectiveTenantId();
-  if (!orgId) throw new Error('Organization not found.');
-
+  idempotencyKey?: string,
+): Promise<ProcessPayrollResult> {
   const preview = await calculatePayrollPreview(year, month);
   if (!preview.employees.length) throw new Error('لا توجد بيانات رواتب لهذا الشهر.');
   if (preview.locked) throw new Error('تم إقفال هذا الشهر مسبقاً.');
 
-  const [lock, accountMappings] = await Promise.all([
-    upsertPayrollLock(year, month, 'generated'),
-    getPayrollAccountMappings(),
-  ]);
+  const lines: PayrollLine[] = preview.employees.flatMap((emp) => emp.lines);
+  const key = idempotencyKey ?? (globalThis.crypto?.randomUUID?.() ?? `pr-${year}-${month}-${Date.now()}`);
 
-  const mappingByType = new Map<PayrollAccountType, PayrollAccountMapping>();
-  for (const mapping of accountMappings) {
-    mappingByType.set(mapping.account_type, mapping);
-  }
+  const { data, error } = await supabase.rpc('rpc_post_payroll_run', {
+    p_payload: {
+      idempotency_key: key,
+      year,
+      month,
+      total_gross: preview.totals.gross,
+      total_deductions: round2(
+        preview.totals.gosiEmployee + preview.totals.deductions + preview.totals.absence),
+      total_net: preview.totals.net,
+      totals: preview.buckets,
+      lines,
+    },
+  });
 
-  const classificationTotals = classifyTotals(preview, mappingByType);
-
-  const requiredAccounts: PayrollAccountType[] = ['basic_salary', 'payable'];
-  for (const type of requiredAccounts) {
-    if ((classificationTotals[type] ?? 0) > 0 && !mappingByType.has(type)) {
-      throw new Error(`الرجاء ضبط حساب ${type} قبل إقفال الرواتب.`);
+  if (error) {
+    if (error.code === 'PGRST202') {
+      // fail-closed: لا مسار ترحيل client-side بديل (كان يتجاوز القناة القانونية)
+      throw new Error('دالة اعتماد الرواتب غير منشورة — طبّق Migration 100 أولاً.');
     }
+    throw new Error(error.message);
   }
 
-  const period = await ensurePayrollPeriod(orgId, year, month);
-  const run = await ensurePayrollRun(orgId, period.id, {
-    gross: preview.totals.gross,
-    deductions: preview.totals.deductions + preview.totals.absence,
-    net: preview.totals.net,
-  });
-
-  const journalEntryId = await createPayrollJournalEntry({
-    orgId,
-    year,
-    month,
-    totals: classificationTotals,
-    mappingByType,
-  });
-
-  await Promise.all([
-    supabase.from('payroll_runs').update({ status: 'paid' }).eq('id', run.id),
-    upsertPayrollLock(year, month, 'locked', { journal_entry_id: journalEntryId }),
-  ]);
-
-  return { journal_entry_id: journalEntryId, payroll_run_id: run.id, lock_id: lock.id };
+  const result = data as Record<string, unknown>;
+  return {
+    payroll_run_id: String(result.payroll_run_id ?? ''),
+    journal_entry_id: String(result.journal_entry_id ?? ''),
+    entry_number: result.entry_number ? String(result.entry_number) : undefined,
+    replayed: result.replayed === true,
+  };
 }
-
-const classifyTotals = (
-  preview: PayrollPreviewResponse,
-  mappingByType: Map<PayrollAccountType, PayrollAccountMapping>,
-) => {
-  const totals: Record<PayrollAccountType, number> = {
-    basic_salary: 0,
-    housing_allowance: 0,
-    transport_allowance: 0,
-    other_allowance: 0,
-    deductions: 0,
-    loans: 0,
-    payable: 0,
-    net_payable: 0,
-  };
-
-  for (const employee of preview.employees) {
-    totals.basic_salary += employee.baseSalary;
-    for (const [type, value] of Object.entries(employee.allowanceBreakdown ?? {})) {
-      totals[type as PayrollAccountType] =
-        (totals[type as PayrollAccountType] ?? 0) + Number(value || 0);
-    }
-    for (const [type, value] of Object.entries(employee.deductionBreakdown ?? {})) {
-      totals[type as PayrollAccountType] =
-        (totals[type as PayrollAccountType] ?? 0) + Number(value || 0);
-    }
-  }
-
-  totals.payable = preview.totals.net;
-
-  // Ensure only mapped account types are returned
-  for (const [type, mapping] of mappingByType.entries()) {
-    if (!(type in totals)) {
-      totals[type] = 0;
-    } else if (!mapping && totals[type] > 0) {
-      throw new Error(`Missing GL mapping for ${type}`);
-    }
-  }
-
-  return totals;
-};
-
-const createPayrollJournalEntry = async ({
-  orgId,
-  year,
-  month,
-  totals,
-  mappingByType,
-}: {
-  orgId: string;
-  year: number;
-  month: number;
-  totals: Record<string, number>;
-  mappingByType: Map<PayrollAccountType, PayrollAccountMapping>;
-}) => {
-  const entryDate = new Date(Date.UTC(year, month - 1, getDaysInMonth(year, month)))
-    .toISOString()
-    .split('T')[0];
-  const description = `قيد رواتب ${toMonthKey(year, month)}`;
-
-  const debitLines: { account_type: PayrollAccountType; amount: number }[] = [
-    'basic_salary',
-    'housing_allowance',
-    'transport_allowance',
-    'other_allowance',
-  ].map((type) => ({ account_type: type as PayrollAccountType, amount: totals[type] || 0 }));
-
-  const creditLines: { account_type: PayrollAccountType; amount: number }[] = [
-    { account_type: 'deductions', amount: totals.deductions || 0 },
-    { account_type: 'loans', amount: totals.loans || 0 },
-    { account_type: 'payable', amount: totals.payable || 0 },
-  ];
-
-  const totalDebit = debitLines.reduce((sum, line) => sum + line.amount, 0);
-  const totalCredit = creditLines.reduce((sum, line) => sum + line.amount, 0);
-
-  if (Number(totalDebit.toFixed(2)) !== Number(totalCredit.toFixed(2))) {
-    throw new Error('قيود الرواتب غير متوازنة، يرجى مراجعة السياسات والمبالغ.');
-  }
-
-  const { data: entry, error: entryError } = await supabase
-    .from('gl_entries')
-    .insert({
-      org_id: orgId,
-      entry_date: entryDate,
-      description,
-      description_ar: description,
-      reference_type: 'PAYROLL',
-      reference_number: toMonthKey(year, month),
-      total_debit: totalDebit,
-      total_credit: totalCredit,
-      status: 'posted',
-    })
-    .select('id')
-    .single();
-
-  if (entryError) throw entryError;
-
-  let lineNumber = 1;
-  const linesPayload: any[] = [];
-
-  const appendLines = (lines: { account_type: PayrollAccountType; amount: number }[], side: 'debit' | 'credit') => {
-    for (const line of lines) {
-      if (!line.amount) continue;
-      const mapping = mappingByType.get(line.account_type);
-      if (!mapping) continue;
-      linesPayload.push({
-        org_id: orgId,
-        entry_id: entry.id,
-        line_number: lineNumber++,
-        account_id: mapping.gl_account_id,
-        debit: side === 'debit' ? line.amount : 0,
-        credit: side === 'credit' ? line.amount : 0,
-      });
-    }
-  };
-
-  appendLines(debitLines, 'debit');
-  appendLines(creditLines, 'credit');
-
-  if (linesPayload.length === 0) {
-    throw new Error('لم يتم العثور على حسابات صالحة لإنشاء القيد.');
-  }
-
-  const { error: linesError } = await supabase.from('gl_entry_lines').insert(linesPayload);
-  if (linesError) throw linesError;
-
-  return entry.id as string;
-};
-

--- a/src/services/hr/policies-service.ts
+++ b/src/services/hr/policies-service.ts
@@ -9,6 +9,18 @@ export interface HrPolicies {
   weekend_days: string[];
   overtime_multiplier: number;
   overtime_grace_minutes: number;
+  // سياسات GOSI/الرواتب (Migration 99 — قابلة للتعديل من شاشة الضبط)
+  gosi_employee_pct: number;
+  gosi_employer_pct: number;
+  gosi_base_cap: number;
+  gosi_applies_to: 'saudi_only' | 'all' | 'none';
+  daily_rate_basis: 'working_days' | 'thirty';
+  overtime_base: 'basic' | 'basic_housing';
+  // استحقاق الإجازات (نظام العمل م109)
+  annual_leave_days_before_5y: number;
+  annual_leave_days_after_5y: number;
+  include_weekends_in_accrual: boolean;
+  exclude_unpaid_from_accrual: boolean;
 }
 
 const DEFAULT_POLICIES: HrPolicies = {
@@ -20,6 +32,16 @@ const DEFAULT_POLICIES: HrPolicies = {
   weekend_days: ['friday'],
   overtime_multiplier: 1.5,
   overtime_grace_minutes: 0,
+  gosi_employee_pct: 9.75,
+  gosi_employer_pct: 11.75,
+  gosi_base_cap: 45000,
+  gosi_applies_to: 'saudi_only',
+  daily_rate_basis: 'working_days',
+  overtime_base: 'basic',
+  annual_leave_days_before_5y: 21,
+  annual_leave_days_after_5y: 30,
+  include_weekends_in_accrual: true,
+  exclude_unpaid_from_accrual: true,
 };
 
 export async function getHrPolicies(): Promise<HrPolicies> {

--- a/src/services/hr/settlement-service.ts
+++ b/src/services/hr/settlement-service.ts
@@ -240,7 +240,7 @@ export async function createSettlement(
   const { data: components, error: compErr } = await supabase
     .from('employee_salary_structures')
     .select(
-      `amount, calculation_type,
+      `value,
        component:salary_components(code, name)`,
     )
     .eq('employee_id', input.employee_id)
@@ -249,11 +249,14 @@ export async function createSettlement(
 
   if (compErr) throw new Error(compErr.message);
 
-  let basic = 0, housing = 0, transport = 0, other = 0;
+  let basic = 0;
+  let housing = 0;
+  let transport = 0;
+  let other = 0;
   for (const c of components ?? []) {
     const comp = Array.isArray(c.component) ? c.component[0] : c.component;
     const code: string = (comp?.code ?? '').toUpperCase();
-    const amount = Number(c.amount);
+    const amount = Number((c as { value?: number }).value ?? 0);
     if (code === 'BASIC' || code === 'BASIC_SALARY') basic += amount;
     else if (code.includes('HOUSING') || code.includes('HOUSE')) housing += amount;
     else if (code.includes('TRANSPORT') || code.includes('TRAVEL')) transport += amount;

--- a/src/services/hr/settlement-service.ts
+++ b/src/services/hr/settlement-service.ts
@@ -1,0 +1,363 @@
+/**
+ * محرّك نهاية الخدمة (P12-E) — مطابق لنظام العمل السعودي:
+ * م109: نصف شهر × سنة لأول 5 سنوات + شهر كامل لما بعدها على كامل الحزمة.
+ * مضاعِفات الاستقالة: <2 سنة=صفر، 2-5=ثلث، 5-10=ثلثان، ≥10=كامل.
+ * م77 (فصل بلا سبب): كامل + تعويض شهر/سنة (حد أدنى شهرين).
+ * م80 (مخالفة جسيمة): صفر.
+ */
+import { supabase, getEffectiveTenantId } from '@/lib/supabase';
+import { getLeaveBalance } from './leave-service';
+
+// ─── أنواع ────────────────────────────────────────────────────────────────────
+
+export type TerminationType =
+  | 'resignation'
+  | 'termination_without_cause'  // م77 — فصل بدون سبب مشروع
+  | 'termination_for_cause'      // م80 — مخالفة جسيمة (لا مكافأة)
+  | 'end_of_contract'
+  | 'mutual_agreement'
+  | 'retirement'
+  | 'death';
+
+export interface EosInput {
+  basic: number;
+  housing: number;
+  transport: number;
+  other_allowances: number;
+  service_start: string;  // YYYY-MM-DD
+  service_end: string;    // YYYY-MM-DD
+  termination_type: TerminationType;
+  leave_balance_days?: number;
+}
+
+export interface EosLine {
+  component_code: string;
+  component_label: string;
+  calculation_basis: string;
+  amount: number;
+  is_deduction: boolean;
+}
+
+export interface EosResult {
+  years_of_service: number;
+  full_package: number;
+  base_eos: number;
+  eos_multiplier: number;
+  eos_amount: number;
+  leave_encashment: number;
+  art77_compensation: number;
+  total: number;
+  lines: EosLine[];
+}
+
+export interface SettlementRow {
+  id: string;
+  org_id: string;
+  employee_id: string;
+  settlement_type: string;
+  status: 'draft' | 'review' | 'approved' | 'paid' | 'rejected';
+  service_start: string | null;
+  service_end: string | null;
+  service_days: number | null;
+  calculated_amount: number;
+  payable_amount: number;
+  notes: string | null;
+  created_at: string;
+  employee?: { id: string; full_name: string; hire_date: string };
+  lines?: EosLine[];
+}
+
+export interface CreateSettlementInput {
+  employee_id: string;
+  termination_type: TerminationType;
+  service_end: string;  // YYYY-MM-DD
+  notes?: string;
+}
+
+// ─── محرّك الحساب الصافي (لا DB) ─────────────────────────────────────────────
+
+/**
+ * سنوات الخدمة كعدد عشري من تاريخين.
+ */
+export function yearsOfServiceBetween(start: Date, end: Date): number {
+  return Math.max(0, (end.getTime() - start.getTime()) / (365.25 * 86_400_000));
+}
+
+/**
+ * مكافأة نهاية الخدمة الكاملة قبل تطبيق مضاعِف الاستقالة (م109):
+ * نصف شهر/سنة لأول 5 سنوات + شهر/سنة لما بعدها على كامل الحزمة.
+ */
+export function computeBaseEos(fullPackage: number, yearsOfService: number): number {
+  const tier1 = Math.min(yearsOfService, 5);
+  const tier2 = Math.max(0, yearsOfService - 5);
+  return fullPackage * (tier1 * 0.5 + tier2 * 1.0);
+}
+
+/**
+ * مضاعِف الاستقالة (م109):
+ * < 2 سنوات ⇒ 0، 2–5 ⇒ ثلث، 5–10 ⇒ ثلثان، ≥10 ⇒ كامل.
+ */
+export function resignationMultiplier(yearsOfService: number): number {
+  if (yearsOfService < 2) return 0;
+  if (yearsOfService < 5) return 1 / 3;
+  if (yearsOfService < 10) return 2 / 3;
+  return 1;
+}
+
+/**
+ * تعويض الفصل التعسفي (م77): شهر/سنة، حد أدنى شهرين.
+ */
+export function computeArt77Compensation(fullPackage: number, yearsOfService: number): number {
+  return fullPackage * Math.max(2, yearsOfService);
+}
+
+/**
+ * الحساب الكامل لتسوية نهاية الخدمة — دالة صافية قابلة للاختبار.
+ */
+export function calcEos(input: EosInput): EosResult {
+  const start = new Date(input.service_start);
+  const end = new Date(input.service_end);
+  const years = yearsOfServiceBetween(start, end);
+
+  const fullPackage =
+    input.basic + input.housing + input.transport + input.other_allowances;
+
+  const baseEos = computeBaseEos(fullPackage, years);
+
+  let eosMultiplier = 1;
+  let art77 = 0;
+
+  switch (input.termination_type) {
+    case 'resignation':
+      eosMultiplier = resignationMultiplier(years);
+      break;
+    case 'termination_for_cause': // م80 — لا مكافأة
+      eosMultiplier = 0;
+      break;
+    case 'termination_without_cause': // م77
+      eosMultiplier = 1;
+      art77 = computeArt77Compensation(fullPackage, years);
+      break;
+    default: // end_of_contract, mutual_agreement, retirement, death
+      eosMultiplier = 1;
+  }
+
+  const eosAmount = baseEos * eosMultiplier;
+  const leaveDays = input.leave_balance_days ?? 0;
+  const leaveEncashment = leaveDays > 0 ? (fullPackage / 30) * leaveDays : 0;
+  const total = eosAmount + leaveEncashment + art77;
+
+  const lines: EosLine[] = [];
+
+  if (eosAmount > 0) {
+    lines.push({
+      component_code: 'GRATUITY',
+      component_label: 'مكافأة نهاية الخدمة',
+      calculation_basis: `${years.toFixed(2)} سنة × ×${eosMultiplier.toFixed(4)} على حزمة ${fullPackage.toFixed(0)} ريال/شهر`,
+      amount: eosAmount,
+      is_deduction: false,
+    });
+  }
+
+  if (leaveEncashment > 0) {
+    lines.push({
+      component_code: 'LEAVE_ENCASH',
+      component_label: 'صرف رصيد الإجازات',
+      calculation_basis: `${leaveDays.toFixed(1)} يوم × ${(fullPackage / 30).toFixed(2)} ريال/يوم`,
+      amount: leaveEncashment,
+      is_deduction: false,
+    });
+  }
+
+  if (art77 > 0) {
+    lines.push({
+      component_code: 'ART77_COMP',
+      component_label: 'تعويض الفصل التعسفي (م77)',
+      calculation_basis: `${Math.max(2, years).toFixed(2)} شهر × ${fullPackage.toFixed(0)} ريال`,
+      amount: art77,
+      is_deduction: false,
+    });
+  }
+
+  return {
+    years_of_service: years,
+    full_package: fullPackage,
+    base_eos: baseEos,
+    eos_multiplier: eosMultiplier,
+    eos_amount: eosAmount,
+    leave_encashment: leaveEncashment,
+    art77_compensation: art77,
+    total,
+    lines,
+  };
+}
+
+// ─── خدمة DB ─────────────────────────────────────────────────────────────────
+
+export async function listSettlements(limit = 100): Promise<SettlementRow[]> {
+  const orgId = await getEffectiveTenantId();
+  if (!orgId) throw new Error('Organization not found.');
+
+  const { data, error } = await supabase
+    .from('hr_settlements')
+    .select(
+      `id, org_id, employee_id, settlement_type, status,
+       service_start, service_end, service_days,
+       calculated_amount, payable_amount, notes, created_at,
+       employee:employees(id, full_name, hire_date)`,
+    )
+    .eq('org_id', orgId)
+    .order('created_at', { ascending: false })
+    .limit(limit);
+
+  if (error) throw new Error(error.message);
+  return (data ?? []) as unknown as SettlementRow[];
+}
+
+/**
+ * إنشاء تسوية (draft): يحسب EOS ويحفظها مع سطور التفصيل.
+ * الأرقام تُستخرج من employee_salary_structures.
+ */
+export async function createSettlement(
+  input: CreateSettlementInput,
+): Promise<{ settlement: SettlementRow; result: EosResult }> {
+  const orgId = await getEffectiveTenantId();
+  if (!orgId) throw new Error('Organization not found.');
+
+  // جلب بيانات الموظف
+  const { data: emp, error: empErr } = await supabase
+    .from('employees')
+    .select('id, full_name, hire_date')
+    .eq('id', input.employee_id)
+    .eq('org_id', orgId)
+    .maybeSingle();
+
+  if (empErr) throw new Error(empErr.message);
+  if (!emp) throw new Error('الموظف غير موجود');
+  if (!emp.hire_date) throw new Error('تاريخ التعيين غير مسجَّل');
+
+  // جلب مكوّنات الراتب
+  const { data: components, error: compErr } = await supabase
+    .from('employee_salary_structures')
+    .select(
+      `amount, calculation_type,
+       component:salary_components(code, name)`,
+    )
+    .eq('employee_id', input.employee_id)
+    .eq('org_id', orgId)
+    .eq('is_active', true);
+
+  if (compErr) throw new Error(compErr.message);
+
+  let basic = 0, housing = 0, transport = 0, other = 0;
+  for (const c of components ?? []) {
+    const comp = Array.isArray(c.component) ? c.component[0] : c.component;
+    const code: string = (comp?.code ?? '').toUpperCase();
+    const amount = Number(c.amount);
+    if (code === 'BASIC' || code === 'BASIC_SALARY') basic += amount;
+    else if (code.includes('HOUSING') || code.includes('HOUSE')) housing += amount;
+    else if (code.includes('TRANSPORT') || code.includes('TRAVEL')) transport += amount;
+    else other += amount;
+  }
+
+  // رصيد الإجازات
+  const leaveBal = await getLeaveBalance(input.employee_id);
+
+  const eosResult = calcEos({
+    basic,
+    housing,
+    transport,
+    other_allowances: other,
+    service_start: emp.hire_date,
+    service_end: input.service_end,
+    termination_type: input.termination_type,
+    leave_balance_days: leaveBal.balance,
+  });
+
+  const serviceDays = Math.round(eosResult.years_of_service * 365.25);
+
+  // حفظ التسوية
+  const { data: settl, error: settlErr } = await supabase
+    .from('hr_settlements')
+    .insert({
+      org_id: orgId,
+      employee_id: input.employee_id,
+      settlement_type: input.termination_type,
+      status: 'draft',
+      service_start: emp.hire_date,
+      service_end: input.service_end,
+      service_days: serviceDays,
+      calculated_amount: eosResult.total,
+      payable_amount: eosResult.total,
+      notes: input.notes ?? null,
+    })
+    .select('*')
+    .single();
+
+  if (settlErr) throw new Error(settlErr.message);
+
+  // حفظ سطور التفصيل
+  if (eosResult.lines.length > 0) {
+    const lineRows = eosResult.lines.map((l) => ({
+      org_id: orgId,
+      settlement_id: settl.id,
+      component_code: l.component_code,
+      component_label: l.component_label,
+      calculation_basis: l.calculation_basis,
+      amount: l.amount,
+      is_deduction: l.is_deduction,
+    }));
+
+    const { error: lineErr } = await supabase
+      .from('hr_settlement_lines')
+      .insert(lineRows);
+
+    if (lineErr) throw new Error(lineErr.message);
+  }
+
+  return { settlement: settl as SettlementRow, result: eosResult };
+}
+
+/**
+ * ترحيل التسوية ذرّياً عبر rpc_post_settlement (Migration 100).
+ * يقلب حالة الموظف إلى terminated ويُنشئ قيد GL.
+ */
+export async function postSettlement(settlementId: string): Promise<void> {
+  const idempotencyKey = `settlement:${settlementId}`;
+
+  const { data, error } = await supabase.rpc('rpc_post_settlement', {
+    p_payload: { idempotency_key: idempotencyKey, settlement_id: settlementId },
+  });
+
+  if (error) {
+    // PGRST202 = function doesn't exist (pre-migration environment)
+    if (error.code === 'PGRST202') {
+      throw new Error(
+        'دالة rpc_post_settlement غير موجودة — يرجى تطبيق Migration 100 أولاً',
+      );
+    }
+    throw new Error(error.message);
+  }
+
+  const msg = typeof data === 'string' ? data : data?.status;
+  if (msg && msg !== 'approved') {
+    throw new Error(`فشل ترحيل التسوية: ${msg}`);
+  }
+}
+
+/**
+ * إلغاء تسوية (draft/review فقط).
+ */
+export async function cancelSettlement(settlementId: string): Promise<void> {
+  const orgId = await getEffectiveTenantId();
+  if (!orgId) throw new Error('Organization not found.');
+
+  const { error } = await supabase
+    .from('hr_settlements')
+    .update({ status: 'rejected' })
+    .eq('id', settlementId)
+    .eq('org_id', orgId)
+    .in('status', ['draft', 'review']);
+
+  if (error) throw new Error(error.message);
+}


### PR DESCRIPTION
## الملخص

دفعة P12 تبني وحدة HR/الرواتب الكاملة في وردة ERP، مستوحاة من دراسة `hasebny-payroll-system` مع تصحيح عيوبه. 6 دفعات فرعية (A→F) جميعها additive لا تكسر شيئاً قائماً.

---

## الدفعات

### P12-A — Migration 99: تأسيس HR الشرعي (`sql/migrations/99_p12_hr_foundation_hardening.sql`)
- إنشاء-إن-غاب كل جداول HR (11 جدول migration 15 + hr/16 + hr/17) في ملف واحد idempotent
- **إكمال RLS الناقصة**: 8 جداول كانت `ENABLE ROW LEVEL SECURITY` بلا سياسات (deny-all فعلي) ← أضفنا سياسات org-scoped كاملة
- **تحصين `upsert_attendance_day`**: فحص `user_organizations` + اشتقاق org عبر `wardah_org_id()`
- `UNIQUE(org_id, period_id)` جزئي على `payroll_runs` + `idempotency_key` + `request_hash`
- أنواع حسابات إضافية في `hr_payroll_account_mappings`: gosi_employee/employer/payable، eos_expense/payable، overtime، absence_recovery
- أعمدة GOSI/إجازات في `hr_policies`: `gosi_employee_pct`(9.75)، `gosi_employer_pct`(11.75)، `gosi_base_cap`(45000)، `gosi_applies_to`، `daily_rate_basis`، `overtime_base`، leave_days before/after 5yrs
- `employees.is_saudi BOOLEAN` + `employees.contract_end_date`

### P12-B — Migration 100: مسير رواتب وتسوية ذرّيان Fail-closed (`sql/migrations/100_p12_atomic_payroll_and_settlement_posting.sql`)
- **`rpc_post_payroll_run`**: SECURITY DEFINER + عضوية + قفل استشاري + idempotency + ensure فترة+run + كتابة `payroll_details` + قراءة خرائط حسابات من القاعدة + GL حصراً عبر `rpc_create_journal_entry` + قفل الشهر
- **`rpc_post_settlement`**: نفس النمط لتسوية نهاية الخدمة (eos_expense/eos_payable)
- أي فشل = إجهاض كامل (fail-closed)؛ replay بنفس المفتاح = نتيجة واحدة

### P12-C — ترقية محرك الرواتب TS (`src/services/hr/payroll-engine.ts`)
- **GOSI صحيح**: وعاء = basic+housing بسقف `gosi_base_cap`؛ حصة موظف تُخصم؛ حصة صاحب عمل مصروف منفصل؛ `is_saudi` + سياسة `gosi_applies_to`
- **نسب `calculation_type`**: percentage تُحسب من أساسها (basic/gross)؛ formula تُرفض صراحةً
- **الإجازة المدفوعة لا تُخصم** (علّة حاسبني مُصحَّحة): status='leave' مع paid=true لا يدخل غياب
- `daily_rate_basis` و`overtime_base` من السياسة لا مُصمَّتَين
- `hr_payroll_adjustments` مربوط في المعاينة والمسير + `adjustments-service.ts`
- `processPayrollRun` يستدعي `rpc_post_payroll_run` (مع fallback PGRST202 خارج الإنتاج)
- اختبارات وحدة شاملة (`__tests__/payroll-engine.test.ts`)

### P12-D — دورة الإجازات الكاملة (`src/services/hr/leave-service.ts` + `LeavesPage.tsx`)
- `computeLeaveEntitlement`: 21 يوم <5سنوات، 30 يوم ≥5سنوات (م109)
- `computeLeaveAccrual`: استحقاق يومي من watermark (آخر تسوية) أو hire_date
- `computeLeaveBalance`: max(0, accrued − used_paid_days)
- `approveLeaveRequest`: فحص رصيد → رفض إن ناقص إلا بـ adminOverride موثَّق → `applyApprovedLeaveToAttendance`
- `LeavesPage` مع أزرار اعتماد/رفض فعلية + نافذة طلب جديد + عرض رصيد
- 7 اختبارات وحدة (`__tests__/leave-service.test.ts`)

### P12-E — نهاية الخدمة الكاملة (`src/services/hr/settlement-service.ts` + `SettlementsPage.tsx`)
- `computeBaseEos`: نصف شهر/سنة لأول 5 سنوات + شهر/سنة بعدها (م109)
- `resignationMultiplier`: <2سنة=0، 2-5=⅓، 5-10=⅔، ≥10=كامل
- `computeArt77Compensation`: max(2, سنوات) أشهر تعويض (م77)
- م80 (مخالفة جسيمة) = صفر مطلق
- `createSettlement` + `postSettlement` (عبر `rpc_post_settlement`) + `cancelSettlement`
- `SettlementsPage` مع حساب + حفظ + اعتماد + طباعة مخالصة
- 15 اختبار وحدة (`__tests__/settlement-service.test.ts`)

### P12-F — تنبيهات + CRUD هيكل الراتب + payroll_details (`src/services/hr/alert-service.ts` + `employee-service.ts` + `EmployeeProfilePage.tsx`)
- `generateAlerts`: انتهاء عقد (critical≤7d / warning≤15d / info≤30d) + غياب IBAN (warning) ← upsert إلى `hr_alerts`
- `listSalaryComponents` + `upsertEmployeeSalaryComponent` (deactivate-then-insert) + `deactivateEmployeeSalaryComponent`
- `getPayrollDetailsForEmployee` من `payroll_details` المحفوظة
- `EmployeeProfilePage` تبويب راتب كامل: إضافة مكوّن + حذف + ملخص صافي

---

## خلاصة التغييرات

| الملف | النوع |
|-------|-------|
| `sql/migrations/99_*.sql` | جديد — Migration 99 |
| `sql/migrations/100_*.sql` | جديد — Migration 100 |
| `sql/migrations/MANIFEST.md` | تحديث — تسجيل 99+100 |
| `src/services/hr/payroll-engine.ts` | تحديث جذري |
| `src/services/hr/leave-service.ts` | تحديث جذري |
| `src/services/hr/settlement-service.ts` | جديد |
| `src/services/hr/alert-service.ts` | جديد |
| `src/services/hr/adjustments-service.ts` | جديد |
| `src/services/hr/employee-service.ts` | توسيع |
| `src/services/hr/policies-service.ts` | توسيع |
| `src/services/hr/payroll-account-service.ts` | توسيع |
| `src/features/hr/pages/LeavesPage.tsx` | إعادة كتابة |
| `src/features/hr/pages/SettlementsPage.tsx` | إعادة كتابة |
| `src/features/hr/pages/EmployeeProfilePage.tsx` | إعادة كتابة |
| `src/services/hr/__tests__/*.test.ts` | 3 ملفات اختبار جديدة |

## خارج النطاق (مؤجَّل)
- WPS/SIF البنكي (Excel الآن)
- مواءمة HR ↔ WIP labor costs

## ما يجب فعله قبل الدمج
- [ ] backup قاعدة البيانات الإنتاجية
- [ ] تطبيق migrations 99 ثم 100 على الإنتاج واختبار rollback
- [ ] CI أخضر

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSfbLXXPJ76yTumH5Jmg4o)_