### PR TITLE
fix(P1): atomic inventory integrity, production drift guards, and documentation

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -11,10 +11,10 @@ jobs:
     name: Test & Build
     runs-on: ubuntu-latest
 
-    # T3: خدمة PostgreSQL للـfresh-DB chain test (تُشغَّل دائماً، تُستخدم عند وجود baseline)
+    # Fresh DB uses the same PostgreSQL major version as Supabase Production.
     services:
       postgres:
-        image: postgres:16
+        image: postgres:17
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -34,26 +34,19 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          # Node 18/20 انتهى دعمهما — موحَّد مع sonarqube.yml على 24 LTS
           node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
 
-      # i18n gate: يمنع عودة النصوص المشفَّرة (isRTL ? 'عربي' : 'إنجليزي') بعد T6 م3
       - name: i18n hardcoded-text gate
         run: node scripts/i18n/count-hardcoded.mjs --ci
 
-      # تقرير إعلامي للأنماط الأشمل (placeholder/aria-label + نصوص JSX مباشرة)
-      # غير حاجز — يُظهر العداد الحالي لتتبع التقدم نحو صفر عبر مهام i18n المستقبلية
       - name: i18n extended report (informational)
         run: node scripts/i18n/count-hardcoded.mjs --extended
         continue-on-error: true
 
-      # P5: التحقق من أن ملف الأنواع المولَّدة محدَّث مع المخطط المُودَع
-      # (يكشف تناقضاً بين database.generated.ts المُودَع والأنواع التي سيولّدها CLI
-      #  عبر مقارنة بسيطة لحجم الملف — تحديث كامل يتطلب بيانات اعتماد Supabase)
       - name: Check generated types are committed
         run: |
           if [ ! -f "src/types/database.generated.ts" ]; then
@@ -75,21 +68,15 @@ jobs:
         run: npm run lint
         continue-on-error: false
 
-      # P4-C1: الاختبارات حاجز حقيقي — أي فشل يمنع الدمج والنشر
-      # (coverage معطَّل هنا للسرعة — SonarQube يتولى قياس التغطية)
       - name: Unit & integration tests
         run: npm run test -- --run --coverage.enabled=false
         continue-on-error: false
 
-      # فحص صياغة migrations بمحلل PostgreSQL الحقيقي (libpg_query) —
-      # يمسك RAISE العارية وصياغة SQL Server المتسللة وأي SQL مرفوض
       - name: Migration SQL syntax check (pglast)
         run: |
           pip install --quiet pglast
           python3 scripts/ci/check_migration_syntax.py
 
-      # P2: التحقق من اتساق ترقيم الـ migrations (لا ثغرات في الأرقام، كل فجوة موثَّقة)
-      # يقرأ sql/migrations/skipped_migration_numbers.yml (مقارنة دقيقة بالأرقام لا grep)
       - name: Validate migration numbering
         run: |
           pip install --quiet pyyaml
@@ -130,42 +117,32 @@ jobs:
           print(f"✅ ترقيم migrations سليم (1–{max_num})، {len(skipped)} رقم موثَّق كمتجاوز")
           PYEOF
 
-      # T1 CI guard: منع دوال SECURITY DEFINER جديدة بلا حارس عضوية مؤسسة
       - name: DEFINER guard check (no new unguarded DEFINER functions)
         run: python3 scripts/ci/check_definer_guards.py
 
-      # T3: اختبار بناء القاعدة من الصفر (يُشغَّل فقط عند وجود baseline)
-      # يتطلب T2 — يُفعَّل تلقائياً حين يُودَع sql/baseline/000_schema_baseline_*.sql
-      # لتوليد الـbaseline: شغّل .github/workflows/generate-baseline.yml يدوياً
       - name: Fresh DB chain test
         run: |
+          set -Eeuo pipefail
           BASELINE=$(ls sql/baseline/000_schema_baseline_*.sql 2>/dev/null | sort | tail -1)
           if [ -z "$BASELINE" ]; then
-            echo "⏭ لا baseline بعد (T2 معلق) — تجاوز اختبار البناء من الصفر"
-            echo "   لتفعيله: شغّل generate-baseline.yml بعد إضافة SUPABASE_DB_URL للـsecrets"
+            echo "⏭ لا baseline بعد — تجاوز اختبار البناء من الصفر"
             exit 0
           fi
 
           echo "✅ Baseline موجود: $BASELINE"
-
-          # استخرج migration_cutoff من أول سطر الـbaseline
           CUTOFF=$(grep -oE '^-- migration_cutoff: ([0-9]+)' "$BASELINE" \
                    | grep -oE '[0-9]+$' | head -1)
           CUTOFF=${CUTOFF:-0}
           echo "   migration_cutoff = $CUTOFF"
+          echo "   PostgreSQL client: $(psql --version)"
 
-          # أنشئ قاعدة فارغة
           createdb wardah_fresh
 
-          # طبّق shim (roles + auth + storage) — أوقف عند أي خطأ SQL
           psql -v ON_ERROR_STOP=1 -d wardah_fresh \
             -f scripts/ci/fresh-db/supabase_shim.sql -q
-
-          # طبّق baseline — أوقف عند أي خطأ SQL
           psql -v ON_ERROR_STOP=1 -d wardah_fresh \
             -f "$BASELINE" -q
 
-          # تحقق من أعداد الكائنات بعد التطبيق
           TABLES=$(psql -d wardah_fresh -tAc \
             "SELECT count(*) FROM pg_tables WHERE schemaname='public'")
           SEQS=$(psql -d wardah_fresh -tAc \
@@ -178,17 +155,12 @@ jobs:
             "SELECT count(*) FROM pg_policies WHERE schemaname='public'")
 
           echo "   Schema counts after baseline: tables=$TABLES seqs=$SEQS funcs=$FUNCS policies=$POLICIES"
-
-          # الحدود الدنيا المتوقعة (تتسامح مع ±10 للتكيف مع تغييرات مستقبلية)
           if [ "$TABLES" -lt 120 ] || [ "$SEQS" -lt 10 ] || \
              [ "$FUNCS" -lt 150 ] || [ "$POLICIES" -lt 300 ]; then
             echo "❌ عدد كائنات ما بعد الـbaseline أقل من الحد الأدنى المتوقع"
             exit 1
           fi
-          echo "✅ Schema counts سليمة"
 
-          # تحقق من الأعمدة المحسوبة (GENERATED ALWAYS AS STORED)
-          # يفشل إذا كان أي عمود محسوب معروف قد تحول إلى عمود عادي
           GENERATED=$(psql -d wardah_fresh -tAc \
             "SELECT count(*) FROM pg_attribute a
              JOIN pg_class c ON a.attrelid = c.oid
@@ -196,7 +168,7 @@ jobs:
              WHERE n.nspname = 'public' AND a.attgenerated = 's' AND NOT a.attisdropped")
           echo "   Generated columns: $GENERATED (expected ≥22)"
           if [ "$GENERATED" -lt 22 ]; then
-            echo "❌ الأعمدة المحسوبة (GENERATED ALWAYS AS STORED) أقل من المتوقع — تحقق من الـbaseline"
+            echo "❌ الأعمدة المحسوبة أقل من المتوقع"
             psql -d wardah_fresh -c \
               "SELECT c.relname, a.attname FROM pg_attribute a
                JOIN pg_class c ON a.attrelid = c.oid
@@ -205,9 +177,7 @@ jobs:
                ORDER BY c.relname, a.attname"
             exit 1
           fi
-          echo "✅ Generated columns سليمة ($GENERATED)"
 
-          # ابنِ قائمة المهاجرات الأحدث من الـbaseline فقط
           python3 scripts/ci/fresh-db/build_apply_order.py sql/migrations "$CUTOFF" \
             > /tmp/chain_order.txt
 
@@ -221,17 +191,14 @@ jobs:
           REPORT=/tmp/chain_report.txt PGDATABASE=wardah_fresh \
             bash scripts/ci/fresh-db/run_chain.sh sql/migrations /tmp/chain_order.txt
           STATUS=$?
-
-          # اطبع ملخص التقرير
           tail -5 /tmp/chain_report.txt
 
-          # فشل إن وجد FAIL أو NOT_RUN
           if [ $STATUS -ne 0 ]; then
             echo "❌ fresh-db chain test فشل"
             grep -E '^(FAIL|NOT_RUN) ' /tmp/chain_report.txt || true
             exit 1
           fi
-          echo "✅ fresh-db chain test اجتاز بنجاح"
+          echo "✅ fresh-db chain test اجتاز بنجاح على PostgreSQL 17"
         env:
           PGHOST: localhost
           PGUSER: postgres
@@ -263,7 +230,7 @@ jobs:
           name: dist
           path: dist/
 
-      # TODO: replace with real deploy (Vercel CLI, rsync, AWS S3, etc.)
-      # Until then this step is a placeholder — the job still gates on `test`.
+      # External Vercel/Netlify integrations currently perform deployment.
+      # This job remains an explicit placeholder and does not mutate production.
       - name: Deploy to Server (placeholder)
-        run: echo "⚠️ Deploy step is a placeholder — wire up a real deployment target."
+        run: echo "⚠️ Deploy step is a placeholder — deployment is handled externally."

--- a/.github/workflows/generate-baseline.yml
+++ b/.github/workflows/generate-baseline.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       reason:
-        description: 'سبب التوليد (مثال: "بعد migration 121")'
+        description: 'سبب التوليد (مثال: "بعد تطبيق migration 123 على الإنتاج")'
         required: false
         default: 'توليد baseline يدوي'
 
@@ -17,11 +17,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          # نحتاج push لاحقاً — استخدم token كامل الصلاحيات
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install pg_dump (PostgreSQL 17 client)
+      - name: Install PostgreSQL 17 client
         run: |
+          set -Eeuo pipefail
           sudo apt-get install -y gnupg curl lsb-release
           curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
             | sudo gpg --dearmor -o /usr/share/keyrings/postgresql.gpg
@@ -29,33 +29,85 @@ jobs:
             https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
             | sudo tee /etc/apt/sources.list.d/pgdg.list
           sudo apt-get update -q
-          # نثبّت نفس إصدار الخادم (Supabase يعمل على PG17)
           sudo apt-get install -y postgresql-client-17
           pg_dump --version
 
-      - name: Determine migration cutoff
-        id: cutoff
+      - name: Validate database secret
+        env:
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
         run: |
-          MAX=$(ls sql/migrations/ | grep -oE '^[0-9]+' | sort -n | uniq | tail -1)
-          echo "max_migration=$MAX" >> "$GITHUB_OUTPUT"
-          echo "✅ أعلى migration: $MAX"
+          set -Eeuo pipefail
+          if [ -z "${SUPABASE_DB_URL:-}" ]; then
+            echo "❌ SUPABASE_DB_URL غير مضبوط في GitHub Actions secrets"
+            exit 1
+          fi
+
+      - name: Determine production migration cutoff
+        id: cutoff
+        env:
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+        run: |
+          set -Eeuo pipefail
+
+          REPO_MAX=$(find sql/migrations -maxdepth 1 -type f -printf '%f\n' \
+            | grep -oE '^[0-9]+' | sort -n | uniq | tail -1)
+          if [ -z "${REPO_MAX:-}" ]; then
+            echo "❌ لم أجد migrations مرقمة في المستودع"
+            exit 1
+          fi
+
+          LIVE_NAME=$(psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 -tAc \
+            "SELECT name FROM supabase_migrations.schema_migrations ORDER BY version DESC LIMIT 1")
+          LIVE_NAME=$(echo "$LIVE_NAME" | xargs)
+          if [ -z "${LIVE_NAME:-}" ]; then
+            echo "❌ تعذر قراءة آخر migration مطبقة من production"
+            exit 1
+          fi
+
+          LIVE_FILE=$(find sql/migrations -maxdepth 1 -type f \
+            -name "*_${LIVE_NAME}.sql" -printf '%f\n' | sort | tail -1)
+          if [ -z "${LIVE_FILE:-}" ]; then
+            echo "❌ آخر migration في production (${LIVE_NAME}) لا تطابق ملفًا في sql/migrations/"
+            echo "   أوقف التوليد حتى تُوثَّق المطابقة؛ لن نكتب cutoff تخمينيًا."
+            exit 1
+          fi
+
+          LIVE_CUTOFF=$(echo "$LIVE_FILE" | grep -oE '^[0-9]+')
+          if [ "$LIVE_CUTOFF" -gt "$REPO_MAX" ]; then
+            echo "❌ production متقدمة على المستودع: live=$LIVE_CUTOFF repo=$REPO_MAX"
+            exit 1
+          fi
+
+          if [ "$REPO_MAX" -gt "$LIVE_CUTOFF" ]; then
+            echo "⚠️ توجد migrations في المستودع لم تُطبق بعد على production:"
+            find sql/migrations -maxdepth 1 -type f -printf '%f\n' | sort -V \
+              | awk -F_ -v cutoff="$LIVE_CUTOFF" '$1 ~ /^[0-9]+$/ && $1 > cutoff {print "   - " $0}'
+            echo "   سيُستخدم cutoff الحي $LIVE_CUTOFF ولن تُعتبر الملفات المعلقة مشمولة."
+          fi
+
+          echo "live_cutoff=$LIVE_CUTOFF" >> "$GITHUB_OUTPUT"
+          echo "live_name=$LIVE_NAME" >> "$GITHUB_OUTPUT"
+          echo "repo_max=$REPO_MAX" >> "$GITHUB_OUTPUT"
+          echo "✅ production cutoff=$LIVE_CUTOFF (${LIVE_NAME}); repo max=$REPO_MAX"
 
       - name: Generate baseline from production
         env:
           SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
         run: |
-          DATE=$(date +%Y%m%d)
-          BASELINE="sql/baseline/000_schema_baseline_${DATE}.sql"
-          MAX="${{ steps.cutoff.outputs.max_migration }}"
+          set -Eeuo pipefail
+          STAMP=$(date -u +%Y%m%d_%H%M%S)
+          BASELINE="sql/baseline/000_schema_baseline_${STAMP}.sql"
+          CUTOFF="${{ steps.cutoff.outputs.live_cutoff }}"
+          LIVE_NAME="${{ steps.cutoff.outputs.live_name }}"
 
           mkdir -p sql/baseline
 
           {
-            echo "-- migration_cutoff: $MAX"
+            echo "-- migration_cutoff: $CUTOFF"
             echo "-- ============================================================"
             echo "-- Schema Baseline — generated $(date -u +%Y-%m-%dT%H:%M:%SZ)"
             echo "-- Project: uutfztmqvajmsxnrqeiv"
-            echo "-- Migrations covered: 1–$MAX"
+            echo "-- Production migration: $CUTOFF ($LIVE_NAME)"
             echo "-- Generated by: .github/workflows/generate-baseline.yml"
             echo "-- Apply with: psql -f supabase_shim.sql && psql -f this_file"
             echo "-- ============================================================"
@@ -69,40 +121,47 @@ jobs:
               --no-tablespaces
           } > "$BASELINE"
 
+          echo "baseline_path=$BASELINE" >> "$GITHUB_ENV"
           LINES=$(wc -l < "$BASELINE")
           echo "✅ Baseline generated: $BASELINE ($LINES سطر)"
 
-      - name: Verify baseline (smoke test)
+      - name: Verify baseline
         run: |
-          BASELINE=$(ls sql/baseline/000_schema_baseline_*.sql | sort | tail -1)
-          # التحقق من وجود migration_cutoff
-          if ! grep -q '^-- migration_cutoff:' "$BASELINE"; then
-            echo "❌ migration_cutoff مفقود من أول سطر"
+          set -Eeuo pipefail
+          BASELINE="$baseline_path"
+          CUTOFF="${{ steps.cutoff.outputs.live_cutoff }}"
+
+          FIRST_LINE=$(head -1 "$BASELINE")
+          if [ "$FIRST_LINE" != "-- migration_cutoff: $CUTOFF" ]; then
+            echo "❌ migration_cutoff في الملف لا يطابق production: $FIRST_LINE"
             exit 1
           fi
-          # التحقق من حجم معقول (> 500 سطر)
+
           LINES=$(wc -l < "$BASELINE")
           if [ "$LINES" -lt 500 ]; then
-            echo "❌ الـbaseline يبدو قصيراً جداً ($LINES سطر) — تحقق من SUPABASE_DB_URL"
+            echo "❌ الـbaseline يبدو قصيراً جداً ($LINES سطر) — تحقق من الاتصال والصلاحيات"
             exit 1
           fi
-          echo "✅ Baseline سليم ($LINES سطر)"
+
+          grep -q '^CREATE TABLE' "$BASELINE" || { echo "❌ لا توجد CREATE TABLE في baseline"; exit 1; }
+          grep -q 'CREATE.*FUNCTION' "$BASELINE" || { echo "❌ لا توجد functions في baseline"; exit 1; }
+          echo "✅ Baseline سليم وموسوم بآخر migration حية ($CUTOFF)"
 
       - name: Commit and push baseline
         run: |
+          set -Eeuo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          BASELINE=$(ls sql/baseline/000_schema_baseline_*.sql | sort | tail -1)
-          MAX="${{ steps.cutoff.outputs.max_migration }}"
-
-          git add sql/baseline/
+          CUTOFF="${{ steps.cutoff.outputs.live_cutoff }}"
+          LIVE_NAME="${{ steps.cutoff.outputs.live_name }}"
+          git add "$baseline_path"
           git diff --cached --quiet && echo "لا تغييرات" && exit 0
 
           git commit \
-            -m "sql(baseline): schema baseline $(date +%Y%m%d) — migration_cutoff ${MAX}" \
-            -m "Generated from production (uutfztmqvajmsxnrqeiv) after migration ${MAX}." \
+            -m "sql(baseline): production schema cutoff ${CUTOFF}" \
+            -m "Generated from production after ${LIVE_NAME}; repository migrations newer than ${CUTOFF} are intentionally excluded." \
             -m "Reason: ${{ github.event.inputs.reason }}"
 
           git push origin HEAD
-          echo "✅ Baseline مُودَع ومُرفوع"
+          echo "✅ Baseline جديد أُضيف دون حذف اللقطات السابقة"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,56 +6,51 @@
 
 ## القاعدة الذهبية
 
-لا تحذف جدولًا أو عمودًا أو migration أو Baseline أو بيانات تاريخية لمعالجة مشكلة. فضّل:
+لا تحذف جدولًا أو عمودًا أو migration أو Baseline أو بيانات تاريخية لمعالجة مشكلة. فضّل دائمًا:
 
 - additive migrations.
 - `CREATE OR REPLACE FUNCTION`.
-- أعمدة جديدة nullable عند الحاجة للمواءمة.
+- أعمدة nullable للمواءمة.
 - RPC ذرية وFail-closed.
-- عكس قانوني موثق بدل تعديل/حذف التاريخ.
+- عكس قانوني موثق بدل تعديل أو حذف التاريخ.
 
 أي تغيير Production يمر عبر PR وCI وrunbook واختبارات قبل/بعد التطبيق.
 
 ## Stack
 
-| Layer | Technology |
-|---|---|
-| Frontend | React 18, TypeScript, Vite |
-| UI | shadcn/ui, Tailwind CSS, RTL |
-| Backend | Supabase, PostgreSQL 17, PostgREST, Auth, Storage |
-| State | Zustand, TanStack Query |
-| Forms | React Hook Form, Zod |
-| Tests | Vitest + Playwright |
-| CI | GitHub Actions |
-| Deployment | Vercel/Netlify integrations outside the placeholder deploy job |
+React 18 + TypeScript + Vite، shadcn/ui + Tailwind، Zustand + TanStack Query، Supabase/PostgreSQL 17، Vitest + Playwright، GitHub Actions، ونشر خارجي عبر Vercel/Netlify.
 
-## حالة قاعدة البيانات
+## افصل حالات قاعدة البيانات
 
-افصل دائمًا بين ثلاث حالات:
+1. **Repository latest migration:** أعلى ملف مرقم في `sql/migrations/`.
+2. **Fresh DB:** Baseline + migrations الأحدث من cutoff.
+3. **Production:** سجل `supabase_migrations.schema_migrations`.
 
-1. **Repository latest migration**: أعلى ملف مرقم في `sql/migrations/`.
-2. **Fresh DB state**: Baseline + migrations الأحدث من cutoff.
-3. **Production applied state**: سجل `supabase_migrations.schema_migrations`.
+عند بداية PR #32:
 
-عند كتابة هذا الملف:
+- Baseline: `000_schema_baseline_20260717.sql`, cutoff 121.
+- Production: مطبقة حتى 121.
+- Repository: يحتوي 122، وPR #32 يضيف 123–127.
+- لا تعتبر أي migration مطبقة حيًا لمجرد نجاح Fresh DB.
 
-- Baseline الحالي: `000_schema_baseline_20260717.sql`, cutoff 121.
-- Production كانت مطبقة حتى 121 عند بداية PR #32.
-- Migration 122 موجودة في المستودع وتحتاج تطبيقًا قبل 123 و124.
-- PR #32 يضيف 123 و124؛ لا تعتبرهما مطبقتين حيًا لمجرد وجودهما في GitHub.
+الترتيب القانوني المقترح بعد الدمج:
 
-مرجع التطبيق والتحقق:
+```text
+122 → 123 → 124 → 125 → 126 → 127
+```
 
+المراجع:
+
+- `sql/migrations/STATUS_122_124.md` — اسم تاريخي، والمحتوى ممتد حتى 127.
 - `docs/db/INTEGRITY_HARDENING_122_124_RUNBOOK.md`
+- `docs/db/INTEGRITY_HARDENING_125_127_ADDENDUM.md`
 - `docs/db/BASELINE_PRODUCTION_CUTOFF_POLICY.md`
 
 ## Baseline
 
-`.github/workflows/generate-baseline.yml` يجب أن يقرأ cutoff من Production، ثم يطابق اسم migration بملف المستودع. لا تستخدم أعلى رقم ملف بوصفه cutoff.
+`.github/workflows/generate-baseline.yml` يقرأ cutoff من Production ويطابق اسم migration بملف المستودع. لا يستخدم أعلى رقم ملف بوصفه cutoff. اللقطات الجديدة تحمل timestamp وتُضاف دون حذف القديمة.
 
-اللقطات الجديدة تُضاف باسم timestamp ولا تستبدل اللقطات القديمة.
-
-## PostgreSQL Generated Columns
+## Generated Columns
 
 المخطط يحتوي 22 عمودًا `GENERATED ALWAYS AS ... STORED` وقت Baseline 121، منها:
 
@@ -67,19 +62,19 @@
 - `sales_invoice_lines.line_total`
 - `purchase_order_lines.line_total`
 
-القاعدة: لا ترسل أي Generated Column في `INSERT` أو `UPDATE`. لا تستخدم `SELECT *` ثم spread كاملًا لإعادة الإدخال.
+لا ترسل Generated Columns في `INSERT` أو `UPDATE`. لا تستخدم `SELECT *` ثم spread كاملًا لإعادة الإدخال.
 
 ## Inventory architecture
 
-- `stock_ledger_entries`: سجل الحركات القانوني.
+- `stock_ledger_entries`: سجل الحركة القانوني.
 - `bins`: الرصيد والتقييم حسب المنتج والمخزن.
 - `products.stock_quantity`: مجمع مرجعي مشتق من bins للمنتجات ذات bins.
 - `gl_entries/gl_entry_lines`: الدفتر المحاسبي القانوني.
-- `journal_entries/journal_lines`: تاريخي؛ لا تنشئ مسارًا جديدًا عليه.
+- `journal_entries/journal_lines`: تاريخي، لا تنشئ مسارًا جديدًا عليه.
 
-الكتابة التشغيلية يجب أن تكون داخل RPC ذرية واحدة. لا تفصل SLE وbin وproduct وGL إلى طلبات شبكة مستقلة.
+الكتابة التشغيلية يجب أن تكون داخل RPC ذرية واحدة. لا تفصل SLE وbin وproduct وGL إلى طلبات مستقلة.
 
-PR #32 يضيف:
+PR #32 يضيف أو يحسن:
 
 - `rpc_create_stock_adjustment`
 - `rpc_submit_stock_adjustment`
@@ -88,75 +83,65 @@ PR #32 يضيف:
 - `rpc_consume_reserved_materials`
 - helper داخلي `wardah_apply_stock_outgoing`
 
+قيمة GL لتسوية المخزون تُشتق من `stock_ledger_entries.stock_value_difference` الفعلية، لا من تقدير الواجهة. الحسابات القانونية:
+
+- زيادة: مدين مخزون، دائن مكسب/فائض.
+- نقص: مدين مصروف/خسارة، دائن مخزون.
+
 ## Security model
 
 - RLS على جداول المؤسسات.
-- `wardah_assert_org_member` و`wardah_assert_org_admin` للحراسة الداخلية.
-- العضوية النشطة تعني `is_active IS TRUE`، لا `COALESCE(is_active, TRUE)`.
-- دوال `SECURITY DEFINER` الجديدة تحتاج حارسًا معروفًا أو سحب EXECUTE من `PUBLIC` والعملاء.
+- `wardah_assert_org_member` و`wardah_assert_org_admin` للحراسة.
+- العضوية النشطة تعني `is_active IS TRUE`.
+- دوال `SECURITY DEFINER` الجديدة تحتاج حارسًا معروفًا أو سحب EXECUTE من PUBLIC والعملاء.
 - helpers الداخلية لا تُمنح لـ`anon` أو `authenticated`.
 
-`scripts/ci/check_definer_guards.py` يفحص migrations الأحدث من Baseline cutoff بحثًا عن مرجع حارس معروف أو سحب PUBLIC. لا تدّع أنه يثبت ترتيب أول statement أو صحة المنطق كاملة؛ المراجعة البشرية والاختبارات السلبية لازمة.
+`scripts/ci/check_definer_guards.py` يفحص migrations الأحدث من cutoff بحثًا عن مرجع حارس معروف أو سحب PUBLIC. لا يثبت ترتيب أول statement أو صحة المنطق كاملة؛ المراجعة البشرية والاختبارات السلبية لازمة.
 
 ## i18n
 
-البوابة الحاجزة الحالية تمنع عودة نمط legacy:
+البوابة الحاجزة تمنع نمط legacy:
 
 ```text
 isRTL ? 'نص عربي' : 'English text'
 ```
 
-الفحص الموسع للنصوص العربية المباشرة في JSX وattributes إعلامي حاليًا، وليس صفرًا مضمونًا ولا بوابة حاجزة بعد.
+الفحص الموسع للنصوص العربية المباشرة في JSX وattributes إعلامي وليس بوابة صفر شاملة بعد.
 
 ## CI gates
 
-الـPR يجب أن يمر عبر:
-
 1. i18n legacy gate.
-2. generated types presence check.
+2. generated types presence.
 3. TypeScript.
 4. ESLint.
 5. unit/integration tests.
-6. PostgreSQL migration syntax via pglast.
+6. pglast migration syntax.
 7. migration numbering.
-8. SECURITY DEFINER guard scan.
-9. Fresh DB chain.
-10. application build.
+8. SECURITY DEFINER guard.
+9. Fresh DB على PostgreSQL 17.
+10. build.
 11. SonarCloud Quality Gate عند توفر `SONAR_TOKEN`.
-
-Fresh DB يجب أن يستخدم PostgreSQL 17 لمطابقة Production.
 
 ## E2E
 
-Playwright workflow يحتاج staging URL وحسابات اختبار منفصلة للأدوار والمؤسستين. لا تعتبر T4 مثبتة دون تشغيل فعلي وتقرير artifact ناجح. لا تستخدم حسابات Production الحقيقية.
+Playwright يحتاج staging URL وحسابات اختبار منفصلة للأدوار والمؤسستين. لا تعتبر T4 مثبتة دون تشغيل فعلي وArtifact ناجح. لا تستخدم حسابات Production الحقيقية.
 
 ## Migration workflow
 
 1. ابدأ من أحدث `main`.
-2. استخدم رقم migration التالي.
-3. لا تعدّل migration مطبقة حيًا لتغيير السلوك؛ أضف migration جديدة.
-4. حدّث runbook/manifest.
-5. شغّل CI وFresh DB.
-6. راجع SQL أمنيًا ووظيفيًا.
-7. ادمج PR.
-8. طبّق على Production بالترتيب.
-9. نفذ استعلامات التحقق.
-10. حدث Baseline فقط بعد ظهور migration في سجل Production.
+2. أضف migration جديدة؛ لا تغيّر migration مطبقة حيًا.
+3. حدث runbook/status.
+4. شغّل CI وFresh DB.
+5. راجع SQL أمنيًا ووظيفيًا.
+6. ادمج PR.
+7. طبّق على Production بالترتيب.
+8. نفذ استعلامات التحقق.
+9. حدّث Baseline بعد ظهور migration في سجل Production فقط.
 
 ## Secrets
 
-- `SUPABASE_DB_URL`: baseline workflow فقط؛ يبقى في GitHub Actions Secrets.
+- `SUPABASE_DB_URL`: baseline workflow فقط.
 - `SONAR_TOKEN`: SonarCloud.
-- E2E: staging URL وحسابات الاختبار.
+- E2E: staging URL وحسابات اختبار.
 
-لا تطبع كلمات المرور أو تحفظها في الوثائق أو commits.
-
-## ملفات مرجعية
-
-- `.github/workflows/ci-cd.yml`
-- `.github/workflows/generate-baseline.yml`
-- `sql/migrations/MANIFEST.md`
-- `sql/migrations/skipped_migration_numbers.yml`
-- `sql/baseline/README.md`
-- `docs/db/INTEGRITY_HARDENING_122_124_RUNBOOK.md`
-- `docs/security/SECURITY_DEFINER_AUDIT.md`
+لا تطبع أو تحفظ كلمات المرور في الوثائق أو commits.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,162 @@
+# Wardah Process Costing — Project Manifest
+
+**آخر تحديث موثق:** 2026-07-18  
+**Repository:** `6thd/wardah-process-costing`  
+**Supabase project:** `uutfztmqvajmsxnrqeiv`
+
+## القاعدة الذهبية
+
+لا تحذف جدولًا أو عمودًا أو migration أو Baseline أو بيانات تاريخية لمعالجة مشكلة. فضّل:
+
+- additive migrations.
+- `CREATE OR REPLACE FUNCTION`.
+- أعمدة جديدة nullable عند الحاجة للمواءمة.
+- RPC ذرية وFail-closed.
+- عكس قانوني موثق بدل تعديل/حذف التاريخ.
+
+أي تغيير Production يمر عبر PR وCI وrunbook واختبارات قبل/بعد التطبيق.
+
+## Stack
+
+| Layer | Technology |
+|---|---|
+| Frontend | React 18, TypeScript, Vite |
+| UI | shadcn/ui, Tailwind CSS, RTL |
+| Backend | Supabase, PostgreSQL 17, PostgREST, Auth, Storage |
+| State | Zustand, TanStack Query |
+| Forms | React Hook Form, Zod |
+| Tests | Vitest + Playwright |
+| CI | GitHub Actions |
+| Deployment | Vercel/Netlify integrations outside the placeholder deploy job |
+
+## حالة قاعدة البيانات
+
+افصل دائمًا بين ثلاث حالات:
+
+1. **Repository latest migration**: أعلى ملف مرقم في `sql/migrations/`.
+2. **Fresh DB state**: Baseline + migrations الأحدث من cutoff.
+3. **Production applied state**: سجل `supabase_migrations.schema_migrations`.
+
+عند كتابة هذا الملف:
+
+- Baseline الحالي: `000_schema_baseline_20260717.sql`, cutoff 121.
+- Production كانت مطبقة حتى 121 عند بداية PR #32.
+- Migration 122 موجودة في المستودع وتحتاج تطبيقًا قبل 123 و124.
+- PR #32 يضيف 123 و124؛ لا تعتبرهما مطبقتين حيًا لمجرد وجودهما في GitHub.
+
+مرجع التطبيق والتحقق:
+
+- `docs/db/INTEGRITY_HARDENING_122_124_RUNBOOK.md`
+- `docs/db/BASELINE_PRODUCTION_CUTOFF_POLICY.md`
+
+## Baseline
+
+`.github/workflows/generate-baseline.yml` يجب أن يقرأ cutoff من Production، ثم يطابق اسم migration بملف المستودع. لا تستخدم أعلى رقم ملف بوصفه cutoff.
+
+اللقطات الجديدة تُضاف باسم timestamp ولا تستبدل اللقطات القديمة.
+
+## PostgreSQL Generated Columns
+
+المخطط يحتوي 22 عمودًا `GENERATED ALWAYS AS ... STORED` وقت Baseline 121، منها:
+
+- `bins.projected_qty`
+- `stage_wip_log.cost_total`
+- `stock_ledger_entries.posting_datetime`
+- `sales_invoices.balance`
+- `supplier_invoices.balance`
+- `sales_invoice_lines.line_total`
+- `purchase_order_lines.line_total`
+
+القاعدة: لا ترسل أي Generated Column في `INSERT` أو `UPDATE`. لا تستخدم `SELECT *` ثم spread كاملًا لإعادة الإدخال.
+
+## Inventory architecture
+
+- `stock_ledger_entries`: سجل الحركات القانوني.
+- `bins`: الرصيد والتقييم حسب المنتج والمخزن.
+- `products.stock_quantity`: مجمع مرجعي مشتق من bins للمنتجات ذات bins.
+- `gl_entries/gl_entry_lines`: الدفتر المحاسبي القانوني.
+- `journal_entries/journal_lines`: تاريخي؛ لا تنشئ مسارًا جديدًا عليه.
+
+الكتابة التشغيلية يجب أن تكون داخل RPC ذرية واحدة. لا تفصل SLE وbin وproduct وGL إلى طلبات شبكة مستقلة.
+
+PR #32 يضيف:
+
+- `rpc_create_stock_adjustment`
+- `rpc_submit_stock_adjustment`
+- `rpc_cancel_stock_adjustment`
+- `rpc_manual_stock_movement`
+- `rpc_consume_reserved_materials`
+- helper داخلي `wardah_apply_stock_outgoing`
+
+## Security model
+
+- RLS على جداول المؤسسات.
+- `wardah_assert_org_member` و`wardah_assert_org_admin` للحراسة الداخلية.
+- العضوية النشطة تعني `is_active IS TRUE`، لا `COALESCE(is_active, TRUE)`.
+- دوال `SECURITY DEFINER` الجديدة تحتاج حارسًا معروفًا أو سحب EXECUTE من `PUBLIC` والعملاء.
+- helpers الداخلية لا تُمنح لـ`anon` أو `authenticated`.
+
+`scripts/ci/check_definer_guards.py` يفحص migrations الأحدث من Baseline cutoff بحثًا عن مرجع حارس معروف أو سحب PUBLIC. لا تدّع أنه يثبت ترتيب أول statement أو صحة المنطق كاملة؛ المراجعة البشرية والاختبارات السلبية لازمة.
+
+## i18n
+
+البوابة الحاجزة الحالية تمنع عودة نمط legacy:
+
+```text
+isRTL ? 'نص عربي' : 'English text'
+```
+
+الفحص الموسع للنصوص العربية المباشرة في JSX وattributes إعلامي حاليًا، وليس صفرًا مضمونًا ولا بوابة حاجزة بعد.
+
+## CI gates
+
+الـPR يجب أن يمر عبر:
+
+1. i18n legacy gate.
+2. generated types presence check.
+3. TypeScript.
+4. ESLint.
+5. unit/integration tests.
+6. PostgreSQL migration syntax via pglast.
+7. migration numbering.
+8. SECURITY DEFINER guard scan.
+9. Fresh DB chain.
+10. application build.
+11. SonarCloud Quality Gate عند توفر `SONAR_TOKEN`.
+
+Fresh DB يجب أن يستخدم PostgreSQL 17 لمطابقة Production.
+
+## E2E
+
+Playwright workflow يحتاج staging URL وحسابات اختبار منفصلة للأدوار والمؤسستين. لا تعتبر T4 مثبتة دون تشغيل فعلي وتقرير artifact ناجح. لا تستخدم حسابات Production الحقيقية.
+
+## Migration workflow
+
+1. ابدأ من أحدث `main`.
+2. استخدم رقم migration التالي.
+3. لا تعدّل migration مطبقة حيًا لتغيير السلوك؛ أضف migration جديدة.
+4. حدّث runbook/manifest.
+5. شغّل CI وFresh DB.
+6. راجع SQL أمنيًا ووظيفيًا.
+7. ادمج PR.
+8. طبّق على Production بالترتيب.
+9. نفذ استعلامات التحقق.
+10. حدث Baseline فقط بعد ظهور migration في سجل Production.
+
+## Secrets
+
+- `SUPABASE_DB_URL`: baseline workflow فقط؛ يبقى في GitHub Actions Secrets.
+- `SONAR_TOKEN`: SonarCloud.
+- E2E: staging URL وحسابات الاختبار.
+
+لا تطبع كلمات المرور أو تحفظها في الوثائق أو commits.
+
+## ملفات مرجعية
+
+- `.github/workflows/ci-cd.yml`
+- `.github/workflows/generate-baseline.yml`
+- `sql/migrations/MANIFEST.md`
+- `sql/migrations/skipped_migration_numbers.yml`
+- `sql/baseline/README.md`
+- `docs/db/INTEGRITY_HARDENING_122_124_RUNBOOK.md`
+- `docs/security/SECURITY_DEFINER_AUDIT.md`

--- a/docs/db/BASELINE_PRODUCTION_CUTOFF_POLICY.md
+++ b/docs/db/BASELINE_PRODUCTION_CUTOFF_POLICY.md
@@ -1,0 +1,65 @@
+# سياسة توليد Schema Baseline من Production
+
+**الحالة:** قانونية للمستودع ابتداءً من Migration 123  
+**المبدأ:** لا تُحذف اللقطات القديمة، ولا يُكتب cutoff تخميني.
+
+## مصدر الحقيقة
+
+`migration_cutoff` يساوي آخر migration مطبقة فعليًا في Production وفق جدول:
+
+```sql
+SELECT name
+FROM supabase_migrations.schema_migrations
+ORDER BY version DESC
+LIMIT 1;
+```
+
+بعد قراءة الاسم، يجب مطابقته بملف داخل `sql/migrations/` واستخراج الرقم من مقدمة اسم الملف. أعلى رقم موجود في GitHub ليس دليلًا على أنه مطبق في Production.
+
+## حماية الـworkflow
+
+`.github/workflows/generate-baseline.yml` ينفذ الآتي:
+
+1. يتحقق من وجود بيانات الاتصال في GitHub Actions Secrets.
+2. يقرأ اسم آخر migration مطبقة من Production.
+3. يطابق الاسم مع ملف المستودع.
+4. يتوقف إذا لم يجد تطابقًا بدل وضع cutoff تخميني.
+5. يعرض migrations الموجودة في GitHub وغير المطبقة بعد.
+6. ينشئ لقطة جديدة باسم يحتوي التاريخ والوقت حتى لا يستبدل ملفًا سابقًا.
+7. يتحقق من أول سطر، الحجم، ووجود جداول ودوال قبل الإيداع.
+
+## الاتصال
+
+في GitHub-hosted runners استخدم رابط Session Pooler الداعم لـIPv4 والمنسوخ مباشرة من زر **Connect** في لوحة Supabase، مع SSL مطلوب. لا تضع كلمة المرور في المستودع أو الوثائق.
+
+Direct Connection قد يعتمد IPv6 فقط ويعطي `Network is unreachable` من بعض runners.
+
+## الترتيب الصحيح
+
+1. دمج migration بعد نجاح CI.
+2. تطبيقها على Production بالطريقة المعتمدة.
+3. التحقق من ظهورها في `supabase_migrations.schema_migrations`.
+4. تشغيل Generate Schema Baseline.
+5. التأكد أن رأس الملف يحمل رقم migration الحية نفسها.
+
+## التحقق بعد التوليد
+
+```sql
+SELECT count(*) FROM pg_tables WHERE schemaname = 'public';
+SELECT count(*) FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = 'public' AND c.relkind = 'S';
+SELECT count(*) FROM pg_attribute a
+JOIN pg_class c ON c.oid = a.attrelid
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = 'public' AND a.attgenerated = 's' AND NOT a.attisdropped;
+SELECT count(*) FROM pg_policies WHERE schemaname = 'public';
+```
+
+## قواعد عدم الكسر
+
+- لا تحذف Baseline قديمة عند إنشاء لقطة جديدة.
+- لا تعدّل بيانات Production أثناء عملية `pg_dump`.
+- لا تعتبر migrations المعلقة مشمولة في اللقطة.
+- لا تُرسل الأعمدة `GENERATED ALWAYS` ضمن payload للكتابة.
+- لا تستخدم الرابط المباشر إذا كان runner لا يدعم مسار IPv6.

--- a/docs/db/INTEGRITY_HARDENING_122_124_RUNBOOK.md
+++ b/docs/db/INTEGRITY_HARDENING_122_124_RUNBOOK.md
@@ -1,0 +1,202 @@
+# Runbook — Integrity Hardening Migrations 122–124
+
+**التاريخ:** 2026-07-18  
+**النطاق:** Supabase project `uutfztmqvajmsxnrqeiv`  
+**قاعدة السلامة:** لا حذف جداول أو أعمدة أو بيانات. التطبيق متسلسل، والتحقق بعد كل migration.
+
+## الحالة قبل التطبيق
+
+وقت إعداد هذا الدليل:
+
+- Production مطبقة حتى Migration 121.
+- المستودع يحتوي Migration 122 لكنها غير مطبقة حيًا.
+- `handle_new_user()` الحية تكتب إلى جدول النسخة التاريخية بدل `user_profiles`.
+- `wardah_assert_org_member()` تعامل `is_active IS NULL` كعضوية نشطة.
+- تسويات المخزون تُنفذ عبر عدة طلبات منفصلة ويمكن أن تترك Ledger/Products/GL غير متطابقة عند فشل جزئي.
+
+## التغييرات
+
+### Migration 122
+
+تنظف fallback المؤسسة الافتراضية داخل `check_entry_approval_required()`، دون تغيير جداول أو بيانات.
+
+### Migration 123
+
+- تستبدل جسم `handle_new_user()` ليكتب إلى `public.user_profiles`.
+- تبقي trigger `on_auth_user_created` كما هو.
+- تستخدم upsert للحفاظ على الملف الحالي وتحديث الاسم والبريد فقط عند توفرهما.
+- تجعل العضوية والإدارة مشروطتين بـ`is_active IS TRUE`.
+- لا تحذف الجدول التاريخي ولا بياناته.
+
+### Migration 124
+
+- تضيف عمودين اختياريين على `stock_adjustments` لربط القيود القانونية في `gl_entries`، مع إبقاء حقول `journal_entries` التاريخية.
+- تضيف outgoing stock helper مع FIFO/LIFO/Weighted Average.
+- تضيف RPC ذري لإنشاء تسوية المخزون ورأسها وسطروها.
+- تضيف RPC ذري لترحيل التسوية: Ledger + bins + products + GL + status.
+- تضيف RPC ذري للإلغاء الدقيق.
+- ترفض الإلغاء عند وجود حركة لاحقة على نفس المنتج/المخزن، بدل تنفيذ عكس غير موثوق.
+- تضيف حركة مخزون يدوية قانونية عبر Ledger.
+- تضيف استهلاك مواد محجوزة ذريًا مع تحديث الحجز والمخزون والـLedger.
+
+## اختبارات ما قبل التطبيق
+
+نفذ للقراءة فقط:
+
+```sql
+SELECT version, name
+FROM supabase_migrations.schema_migrations
+ORDER BY version DESC
+LIMIT 10;
+
+SELECT pg_get_functiondef('public.handle_new_user()'::regprocedure);
+SELECT pg_get_functiondef('public.check_entry_approval_required(uuid)'::regprocedure);
+SELECT pg_get_functiondef('public.wardah_assert_org_member(uuid)'::regprocedure);
+SELECT pg_get_functiondef('public.wardah_is_org_admin(uuid)'::regprocedure);
+
+SELECT count(*) FILTER (WHERE qual = 'true') AS using_true,
+       count(*) FILTER (WHERE with_check = 'true') AS check_true
+FROM pg_policies
+WHERE schemaname = 'public';
+```
+
+سجل النتائج في تذكرة النشر أو تعليق PR.
+
+## ترتيب التطبيق
+
+التطبيق يجب أن يكون بالترتيب التالي فقط:
+
+1. `122_fix_check_entry_approval_dead_code.sql`
+2. `123_fix_user_profile_trigger_and_active_guards.sql`
+3. `124_atomic_stock_adjustments_and_material_consumption.sql`
+
+لا تشغل 124 قبل 123، لأن RPCs الجديدة تعتمد الحارس المشدد.
+
+## اختبارات بعد Migration 122
+
+```sql
+SELECT pg_get_functiondef('public.check_entry_approval_required(uuid)'::regprocedure);
+```
+
+معيار النجاح: لا وجود لـ`app.current_org_id` ولا للمؤسسة الافتراضية داخل الدالة.
+
+## اختبارات بعد Migration 123
+
+```sql
+SELECT pg_get_functiondef('public.handle_new_user()'::regprocedure);
+SELECT pg_get_functiondef('public.wardah_assert_org_member(uuid)'::regprocedure);
+SELECT pg_get_functiondef('public.wardah_is_org_admin(uuid)'::regprocedure);
+
+SELECT tgname, pg_get_triggerdef(oid)
+FROM pg_trigger
+WHERE tgrelid = 'auth.users'::regclass AND NOT tgisinternal;
+```
+
+معايير النجاح:
+
+- `handle_new_user` تحتوي `public.user_profiles`.
+- الحارسان يحتويان `is_active IS TRUE`.
+- trigger `on_auth_user_created` ما زال موجودًا.
+
+اختبار المستخدم الجديد يُنفذ بحساب اختبار فقط، ثم التأكد من وجود صف في `user_profiles`. لا تحذف مستخدمًا حقيقيًا.
+
+## اختبارات بعد Migration 124
+
+### وجود الكائنات
+
+```sql
+SELECT to_regprocedure('public.rpc_create_stock_adjustment(jsonb)');
+SELECT to_regprocedure('public.rpc_submit_stock_adjustment(uuid)');
+SELECT to_regprocedure('public.rpc_cancel_stock_adjustment(uuid,text)');
+SELECT to_regprocedure('public.rpc_manual_stock_movement(uuid,numeric,text,uuid,text)');
+SELECT to_regprocedure('public.rpc_consume_reserved_materials(uuid,jsonb)');
+SELECT to_regprocedure('public.wardah_apply_stock_outgoing(uuid,uuid,uuid,numeric,text,uuid,text,date)');
+```
+
+### الصلاحيات
+
+```sql
+SELECT p.proname,
+       has_function_privilege('anon', p.oid, 'EXECUTE') AS anon_exec,
+       has_function_privilege('authenticated', p.oid, 'EXECUTE') AS authenticated_exec,
+       has_function_privilege('PUBLIC', p.oid, 'EXECUTE') AS public_exec
+FROM pg_proc p
+JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname = 'public'
+  AND p.proname IN (
+    'rpc_create_stock_adjustment',
+    'rpc_submit_stock_adjustment',
+    'rpc_cancel_stock_adjustment',
+    'rpc_manual_stock_movement',
+    'rpc_consume_reserved_materials',
+    'wardah_apply_stock_outgoing'
+  )
+ORDER BY p.proname;
+```
+
+المعيار:
+
+- RPCs العامة: `authenticated=true`, `anon=false`, `PUBLIC=false`.
+- helper الخارجي: غير متاح للعملاء.
+
+### اختبار وظيفي آمن
+
+نفذ داخل transaction مع بيانات اختبار موجودة ثم `ROLLBACK`:
+
+```sql
+BEGIN;
+-- set_config/request.jwt.claims أو جلسة مستخدم اختبار حسب أسلوب الاختبارات الحالي.
+-- أنشئ تسوية صغيرة عبر rpc_create_stock_adjustment.
+-- رحّلها وتحقق من SLE/bin/product/gl_entries.
+-- ألغها قبل أي حركة لاحقة وتحقق من استعادة القيم.
+ROLLBACK;
+```
+
+معايير التسوية:
+
+- إنشاء الرأس والسطور معًا أو لا شيء.
+- الترحيل ينتج SLE ويطابق bin وproducts.
+- القيد متوازن في `gl_entries/gl_entry_lines`.
+- replay لا يكرر الحركة.
+- الإلغاء ينشئ reversal SLE غير ملغى ويعيد الحالة السابقة.
+- وجود حركة أحدث يؤدي إلى `LATER_STOCK_MOVEMENT_EXISTS` دون تغيير أي بيانات.
+
+## مراقبة ما بعد النشر
+
+```sql
+SELECT status, count(*) FROM stock_adjustments GROUP BY status;
+
+SELECT product_id, warehouse_id,
+       max(posting_datetime) AS last_movement,
+       sum(actual_qty) FILTER (WHERE NOT COALESCE(is_cancelled, false)) AS ledger_delta
+FROM stock_ledger_entries
+GROUP BY product_id, warehouse_id
+ORDER BY last_movement DESC
+LIMIT 50;
+
+SELECT p.id, p.stock_quantity,
+       COALESCE(sum(b.actual_qty), 0) AS bins_quantity,
+       p.stock_quantity - COALESCE(sum(b.actual_qty), 0) AS difference
+FROM products p
+LEFT JOIN bins b ON b.product_id = p.id AND b.org_id = p.org_id
+GROUP BY p.id, p.stock_quantity
+HAVING abs(p.stock_quantity - COALESCE(sum(b.actual_qty), 0)) > 0.0001;
+```
+
+## الرجوع الآمن
+
+لا يوجد rollback هدّام ضمن هذا التغيير. عند ظهور مشكلة:
+
+1. أوقف استخدام الواجهة الجديدة عبر rollback للـfrontend deployment أو feature flag.
+2. لا تحذف RPCs أو الأعمدة فورًا؛ وجودها لا يغير البيانات بذاته.
+3. استبدل جسم الدالة المتأثرة بنسخة سابقة موثقة في Git دون حذف الكائن.
+4. احتفظ بكل SLE وGL entries لأغراض التدقيق.
+5. صحح البيانات فقط بسند تسوية/عكس قانوني، لا عبر `DELETE` أو تعديل تاريخي صامت.
+
+## ما لا تفعله
+
+- لا تعدّل `stock_quantity` مباشرة.
+- لا تنشئ SLE ثم تحدّث Product في طلب منفصل.
+- لا تعيد إدخال `SELECT *` من جدول يحتوي Generated Columns.
+- لا تلغي تسوية بعد حركات لاحقة دون تحليل طبقات التقييم.
+- لا تضع كلمة مرور قاعدة البيانات في commit أو log.

--- a/docs/db/INTEGRITY_HARDENING_125_127_ADDENDUM.md
+++ b/docs/db/INTEGRITY_HARDENING_125_127_ADDENDUM.md
@@ -1,0 +1,83 @@
+# ملحق Runbook — Migrations 125–127
+
+هذا الملحق يكمل `INTEGRITY_HARDENING_122_124_RUNBOOK.md` ولا يستبدله.
+
+## Migration 125 — الحسابات القانونية للتسوية
+
+أُضيف حقل nullable:
+
+```text
+stock_adjustments.inventory_account_id → gl_accounts(id)
+```
+
+مع إبقاء جميع الحقول التاريخية. الخريطة القانونية:
+
+- زيادة المخزون: مدين مخزون، دائن مكسب/فائض.
+- نقص المخزون: مدين مصروف/خسارة، دائن مخزون.
+
+`canonical_gl_entry_id` و`canonical_reversal_gl_entry_id` يشيران إلى `gl_entries`، ولا تُجبر الحقول القديمة المرتبطة بـ`journal_entries` على حمل UUID من جدول آخر.
+
+## Migration 126 — توقيت اختيار الحسابات ودلالة المخزن
+
+- يسمح بإنشاء Draft دون حسابات، حفاظًا على دورة العمل الحالية.
+- يظل الترحيل Fail-closed ولا يعمل دون الحسابات المطلوبة.
+- لا يعامل `location_id` كـ`warehouse_id`.
+- عند عدم تمرير مخزن لا يُخمن إلا إذا كان للمنتج bin واحد موجب داخل المؤسسة؛ وإلا يعيد `WAREHOUSE_REQUIRED_FOR_CONSUMPTION`.
+
+## Migration 127 — التقييم من Ledger الفعلي
+
+قيمة القيد لا تؤخذ من `value_difference` المرسلة من الواجهة عند الترحيل. بعد تطبيق حركات المخزون داخل المعاملة، تجمع الدالة:
+
+```sql
+SUM(stock_ledger_entries.stock_value_difference)
+```
+
+للتسوية نفسها، ثم تستخدم القيمة الفعلية في GL. هذا مهم لـFIFO/LIFO لأن تكلفة الصرف قد تختلف عن السعر الظاهر في النموذج.
+
+كذلك ترفض الدالة وجود أكثر من سطر لنفس `(product_id, warehouse_id)` داخل التسوية، حتى يكون مسار الإلغاء والاستعادة محددًا وغير ملتبس.
+
+## ترتيب التطبيق الكامل
+
+```text
+122 → 123 → 124 → 125 → 126 → 127
+```
+
+نفذ استعلامات التحقق بعد كل خطوة، ثم اختبارات transaction مع `ROLLBACK` قبل نشر الواجهة.
+
+## تحقق القيد
+
+بعد ترحيل تسوية اختبار داخل transaction:
+
+```sql
+SELECT sa.id,
+       sa.total_value_difference,
+       sum(sle.stock_value_difference) AS ledger_value,
+       sa.canonical_gl_entry_id
+FROM stock_adjustments sa
+JOIN stock_ledger_entries sle
+  ON sle.voucher_type = 'Stock Adjustment'
+ AND sle.voucher_id = sa.id
+WHERE sa.id = :adjustment_id
+  AND NOT COALESCE(sle.is_cancelled, false)
+GROUP BY sa.id;
+```
+
+المعيار: `total_value_difference = ledger_value`.
+
+```sql
+SELECT e.id, e.total_debit, e.total_credit,
+       sum(l.debit) AS lines_debit,
+       sum(l.credit) AS lines_credit
+FROM gl_entries e
+JOIN gl_entry_lines l ON l.entry_id = e.id
+WHERE e.id = :canonical_gl_entry_id
+GROUP BY e.id;
+```
+
+المعيار: الرأس والسطور متوازنة والقيمة تساوي القيمة المطلقة لحركة Ledger.
+
+## الإلغاء
+
+الإلغاء يرفض التنفيذ عند وجود حركة نشطة أحدث لنفس المنتج والمخزن. هذا السلوك مقصود؛ يمنع استعادة snapshot قديمة فوق معاملات لاحقة.
+
+لا تتجاوز هذا الحارس بتعديل مباشر. عند وجود حركات لاحقة استخدم سند تسوية جديدًا أو إجراء عكس متخصص يراعي طبقات التقييم.

--- a/sql/migrations/123_fix_user_profile_trigger_and_active_guards.sql
+++ b/sql/migrations/123_fix_user_profile_trigger_and_active_guards.sql
@@ -1,0 +1,79 @@
+-- migration_number: 123
+-- description: Correct auth profile target and require active organization membership.
+-- safety: replace-only; no table, column, policy, trigger, or data is deleted.
+
+-- Keep the existing auth.users trigger and replace only its target function.
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+  INSERT INTO public.user_profiles (user_id, full_name, email)
+  VALUES (
+    NEW.id,
+    COALESCE(NEW.raw_user_meta_data ->> 'full_name', ''),
+    NEW.email
+  )
+  ON CONFLICT (user_id) DO UPDATE
+  SET full_name = COALESCE(EXCLUDED.full_name, public.user_profiles.full_name),
+      email = COALESCE(EXCLUDED.email, public.user_profiles.email),
+      updated_at = now();
+
+  RETURN NEW;
+EXCEPTION
+  WHEN OTHERS THEN
+    -- Preserve signup availability while surfacing the database error in logs.
+    RAISE WARNING 'handle_new_user failed for user %: %', NEW.id, SQLERRM;
+    RETURN NEW;
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.handle_new_user() FROM PUBLIC, anon, authenticated;
+
+-- Fail closed: NULL or false is not an active membership.
+CREATE OR REPLACE FUNCTION public.wardah_assert_org_member(p_org uuid)
+RETURNS void
+LANGUAGE plpgsql
+STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'NOT_AUTHENTICATED';
+  END IF;
+  IF p_org IS NULL THEN
+    RAISE EXCEPTION 'ORG_UNRESOLVED';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.user_organizations
+    WHERE user_id = auth.uid()
+      AND org_id = p_org
+      AND is_active IS TRUE
+  ) THEN
+    RAISE EXCEPTION 'NOT_ORG_MEMBER';
+  END IF;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.wardah_is_org_admin(p_org uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.user_organizations
+    WHERE user_id = auth.uid()
+      AND org_id = p_org
+      AND is_active IS TRUE
+      AND (COALESCE(is_org_admin, FALSE) OR role IN ('admin', 'owner'))
+  );
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.wardah_assert_org_member(uuid) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.wardah_is_org_admin(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.wardah_is_org_admin(uuid) TO authenticated;

--- a/sql/migrations/124_atomic_stock_adjustments_and_material_consumption.sql
+++ b/sql/migrations/124_atomic_stock_adjustments_and_material_consumption.sql
@@ -1,0 +1,658 @@
+-- migration_number: 124
+-- description: Add canonical atomic inventory RPCs for adjustments, manual movements,
+--              cancellation, and reserved-material consumption.
+-- safety: additive/replace-only. No table, column, function, trigger, policy, or data is deleted.
+
+-- Canonical GL references are additive because the legacy journal_entry_id columns
+-- point to the historical journal_entries table, while current accounting writes gl_entries.
+ALTER TABLE public.stock_adjustments
+  ADD COLUMN IF NOT EXISTS canonical_gl_entry_id uuid REFERENCES public.gl_entries(id),
+  ADD COLUMN IF NOT EXISTS canonical_reversal_gl_entry_id uuid REFERENCES public.gl_entries(id);
+
+CREATE OR REPLACE FUNCTION public.wardah_apply_stock_outgoing(
+  p_org uuid,
+  p_product uuid,
+  p_warehouse uuid,
+  p_qty numeric,
+  p_voucher_type text,
+  p_voucher_id uuid,
+  p_voucher_number text,
+  p_posting_date date
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_method text;
+  v_prev_qty numeric;
+  v_prev_value numeric;
+  v_prev_queue jsonb;
+  v_new_qty numeric;
+  v_new_value numeric;
+  v_new_rate numeric;
+  v_new_queue jsonb;
+  v_remaining numeric;
+  v_take numeric;
+  v_batch_qty numeric;
+  v_batch_rate numeric;
+  v_cogs numeric := 0;
+  v_idx integer;
+  v_len integer;
+  v_prod_qty numeric;
+  v_prod_value numeric;
+  v_prod_rate numeric;
+BEGIN
+  PERFORM public.wardah_assert_org_member(p_org);
+
+  IF p_product IS NULL OR p_warehouse IS NULL OR p_qty IS NULL OR p_qty <= 0 THEN
+    RAISE EXCEPTION 'INVALID_STOCK_OUT_PARAMETERS';
+  END IF;
+
+  SELECT COALESCE(valuation_method::text, 'Weighted Average')
+  INTO v_method
+  FROM public.products
+  WHERE id = p_product AND org_id = p_org;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'PRODUCT_NOT_FOUND_OR_WRONG_ORG';
+  END IF;
+
+  SELECT COALESCE(actual_qty, 0), COALESCE(stock_value, 0),
+         COALESCE(stock_queue, '[]'::jsonb)
+  INTO v_prev_qty, v_prev_value, v_prev_queue
+  FROM public.bins
+  WHERE org_id = p_org AND product_id = p_product AND warehouse_id = p_warehouse
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'BIN_NOT_FOUND';
+  END IF;
+  IF v_prev_qty < p_qty THEN
+    RAISE EXCEPTION 'INSUFFICIENT_STOCK: available=%, required=%', v_prev_qty, p_qty;
+  END IF;
+
+  v_new_qty := v_prev_qty - p_qty;
+  v_new_queue := v_prev_queue;
+
+  IF v_method IN ('FIFO', 'LIFO') AND jsonb_array_length(v_new_queue) > 0 THEN
+    v_remaining := p_qty;
+    WHILE v_remaining > 0 LOOP
+      v_len := jsonb_array_length(v_new_queue);
+      IF v_len = 0 THEN
+        RAISE EXCEPTION 'STOCK_QUEUE_INSUFFICIENT';
+      END IF;
+      v_idx := CASE WHEN v_method = 'FIFO' THEN 0 ELSE v_len - 1 END;
+      v_batch_qty := COALESCE((v_new_queue -> v_idx ->> 'qty')::numeric, 0);
+      v_batch_rate := COALESCE((v_new_queue -> v_idx ->> 'rate')::numeric, 0);
+      IF v_batch_qty <= 0 THEN
+        v_new_queue := v_new_queue - v_idx;
+        CONTINUE;
+      END IF;
+      v_take := LEAST(v_remaining, v_batch_qty);
+      v_cogs := v_cogs + (v_take * v_batch_rate);
+      v_remaining := v_remaining - v_take;
+      IF v_take = v_batch_qty THEN
+        v_new_queue := v_new_queue - v_idx;
+      ELSE
+        v_new_queue := jsonb_set(
+          v_new_queue,
+          ARRAY[v_idx::text, 'qty'],
+          to_jsonb(v_batch_qty - v_take),
+          false
+        );
+      END IF;
+    END LOOP;
+    v_new_value := GREATEST(v_prev_value - v_cogs, 0);
+    IF v_new_qty = 0 THEN
+      v_new_rate := 0;
+      v_new_queue := '[]'::jsonb;
+    ELSE
+      v_len := jsonb_array_length(v_new_queue);
+      v_idx := CASE WHEN v_method = 'FIFO' THEN 0 ELSE v_len - 1 END;
+      v_new_rate := COALESCE((v_new_queue -> v_idx ->> 'rate')::numeric, 0);
+    END IF;
+  ELSE
+    v_batch_rate := CASE WHEN v_prev_qty > 0 THEN v_prev_value / v_prev_qty ELSE 0 END;
+    v_cogs := p_qty * v_batch_rate;
+    v_new_value := GREATEST(v_prev_value - v_cogs, 0);
+    v_new_rate := CASE WHEN v_new_qty > 0 THEN v_new_value / v_new_qty ELSE 0 END;
+    v_new_queue := CASE WHEN v_new_qty > 0
+      THEN jsonb_build_array(jsonb_build_object('qty', v_new_qty, 'rate', v_new_rate))
+      ELSE '[]'::jsonb END;
+  END IF;
+
+  INSERT INTO public.stock_ledger_entries (
+    voucher_type, voucher_id, voucher_number, product_id, warehouse_id,
+    posting_date, actual_qty, qty_after_transaction, outgoing_rate,
+    valuation_rate, stock_value, stock_value_difference, stock_queue,
+    is_cancelled, docstatus, org_id, created_by
+  ) VALUES (
+    p_voucher_type, p_voucher_id, p_voucher_number, p_product, p_warehouse,
+    COALESCE(p_posting_date, CURRENT_DATE), -p_qty, v_new_qty,
+    CASE WHEN p_qty > 0 THEN v_cogs / p_qty ELSE 0 END,
+    v_new_rate, v_new_value, -v_cogs, v_new_queue,
+    false, 1, p_org, auth.uid()
+  );
+
+  UPDATE public.bins
+  SET actual_qty = v_new_qty,
+      valuation_rate = v_new_rate,
+      stock_value = v_new_value,
+      stock_queue = v_new_queue,
+      updated_at = now()
+  WHERE org_id = p_org AND product_id = p_product AND warehouse_id = p_warehouse;
+
+  SELECT COALESCE(SUM(actual_qty), 0), COALESCE(SUM(stock_value), 0)
+  INTO v_prod_qty, v_prod_value
+  FROM public.bins
+  WHERE org_id = p_org AND product_id = p_product;
+  v_prod_rate := CASE WHEN v_prod_qty > 0 THEN v_prod_value / v_prod_qty ELSE 0 END;
+
+  UPDATE public.products
+  SET stock_quantity = v_prod_qty,
+      stock_value = v_prod_value,
+      cost_price = CASE WHEN v_prod_qty > 0 THEN v_prod_rate ELSE cost_price END,
+      updated_at = now()
+  WHERE id = p_product AND org_id = p_org;
+
+  RETURN jsonb_build_object(
+    'applied', true,
+    'new_qty', v_new_qty,
+    'new_rate', round(v_new_rate, 6),
+    'new_value', round(v_new_value, 6),
+    'cogs', round(v_cogs, 6),
+    'method', v_method
+  );
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.wardah_apply_stock_outgoing(uuid, uuid, uuid, numeric, text, uuid, text, date)
+  FROM PUBLIC, anon, authenticated;
+
+CREATE OR REPLACE FUNCTION public.rpc_create_stock_adjustment(p_payload jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_org uuid;
+  v_id uuid := gen_random_uuid();
+  v_number text;
+  v_date date;
+  v_total_value numeric;
+  v_total_qty numeric;
+  v_count integer;
+BEGIN
+  v_org := public.wardah_org_id(NULLIF(p_payload ->> 'org_id', '')::uuid);
+  PERFORM public.wardah_assert_org_member(v_org);
+
+  v_date := COALESCE(NULLIF(p_payload ->> 'adjustment_date', '')::date, CURRENT_DATE);
+  v_number := COALESCE(
+    NULLIF(p_payload ->> 'adjustment_number', ''),
+    'ADJ-' || to_char(v_date, 'YYYYMMDD') || '-' || upper(substr(replace(v_id::text, '-', ''), 1, 8))
+  );
+
+  SELECT COUNT(*),
+         COALESCE(SUM((x ->> 'difference_qty')::numeric), 0),
+         COALESCE(SUM((x ->> 'value_difference')::numeric), 0)
+  INTO v_count, v_total_qty, v_total_value
+  FROM jsonb_array_elements(COALESCE(p_payload -> 'items', '[]'::jsonb)) x;
+
+  IF v_count = 0 THEN
+    RAISE EXCEPTION 'ADJUSTMENT_REQUIRES_ITEMS';
+  END IF;
+
+  INSERT INTO public.stock_adjustments (
+    id, organization_id, org_id, adjustment_number, adjustment_date, posting_date,
+    adjustment_type, reason, reference_number, warehouse_id, status,
+    requires_approval, total_items, total_qty_difference, total_value_difference,
+    created_by, increase_account_id, decrease_account_id
+  ) VALUES (
+    v_id, v_org, v_org, v_number, v_date,
+    COALESCE(NULLIF(p_payload ->> 'posting_date', '')::date, v_date),
+    p_payload ->> 'adjustment_type',
+    p_payload ->> 'reason',
+    NULLIF(p_payload ->> 'reference_number', ''),
+    NULLIF(p_payload ->> 'warehouse_id', '')::uuid,
+    'DRAFT',
+    COALESCE((p_payload ->> 'requires_approval')::boolean, abs(v_total_value) > 10000),
+    v_count, v_total_qty, v_total_value, auth.uid(),
+    NULLIF(p_payload ->> 'increase_account_id', '')::uuid,
+    NULLIF(p_payload ->> 'decrease_account_id', '')::uuid
+  );
+
+  INSERT INTO public.stock_adjustment_items (
+    adjustment_id, organization_id, product_id, warehouse_id,
+    current_qty, new_qty, difference_qty, current_rate, new_rate,
+    value_difference, reason, serial_numbers, batch_numbers
+  )
+  SELECT
+    v_id, v_org,
+    (x ->> 'product_id')::uuid,
+    NULLIF(x ->> 'warehouse_id', '')::uuid,
+    COALESCE((x ->> 'current_qty')::numeric, 0),
+    (x ->> 'new_qty')::numeric,
+    (x ->> 'difference_qty')::numeric,
+    COALESCE((x ->> 'current_rate')::numeric, 0),
+    NULLIF(x ->> 'new_rate', '')::numeric,
+    (x ->> 'value_difference')::numeric,
+    NULLIF(x ->> 'reason', ''),
+    CASE WHEN jsonb_typeof(x -> 'serial_nos') = 'array'
+      THEN ARRAY(SELECT jsonb_array_elements_text(x -> 'serial_nos')) ELSE NULL END,
+    CASE WHEN NULLIF(x ->> 'batch_no', '') IS NOT NULL
+      THEN ARRAY[x ->> 'batch_no'] ELSE NULL END
+  FROM jsonb_array_elements(p_payload -> 'items') x;
+
+  RETURN jsonb_build_object('success', true, 'adjustment_id', v_id, 'adjustment_number', v_number);
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.rpc_create_stock_adjustment(jsonb) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.rpc_create_stock_adjustment(jsonb) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.rpc_submit_stock_adjustment(p_adjustment_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_adj public.stock_adjustments%rowtype;
+  v_item record;
+  v_warehouse uuid;
+  v_result jsonb;
+  v_gl jsonb;
+  v_debit uuid;
+  v_credit uuid;
+  v_amount numeric;
+BEGIN
+  SELECT * INTO v_adj
+  FROM public.stock_adjustments
+  WHERE id = p_adjustment_id
+  FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'ADJUSTMENT_NOT_FOUND'; END IF;
+
+  v_adj.org_id := COALESCE(v_adj.org_id, v_adj.organization_id);
+  PERFORM public.wardah_assert_org_admin(v_adj.org_id);
+
+  IF v_adj.status = 'SUBMITTED' THEN
+    RETURN jsonb_build_object('success', true, 'duplicate', true, 'adjustment_id', v_adj.id);
+  END IF;
+  IF v_adj.status <> 'DRAFT' THEN RAISE EXCEPTION 'ADJUSTMENT_NOT_DRAFT'; END IF;
+  IF COALESCE(v_adj.requires_approval, false) AND v_adj.approved_by IS NULL THEN
+    RAISE EXCEPTION 'ADJUSTMENT_APPROVAL_REQUIRED';
+  END IF;
+
+  FOR v_item IN
+    SELECT * FROM public.stock_adjustment_items WHERE adjustment_id = v_adj.id ORDER BY id
+  LOOP
+    v_warehouse := COALESCE(v_item.warehouse_id, v_adj.warehouse_id);
+    IF v_warehouse IS NULL THEN RAISE EXCEPTION 'WAREHOUSE_REQUIRED'; END IF;
+
+    IF v_item.difference_qty > 0 THEN
+      v_result := public.wardah_apply_stock_incoming(
+        v_adj.org_id, v_item.product_id, v_warehouse, v_item.difference_qty,
+        COALESCE(v_item.new_rate, v_item.current_rate, 0),
+        'Stock Adjustment', v_adj.id, v_adj.adjustment_number, v_adj.posting_date
+      );
+      IF NOT COALESCE((v_result ->> 'applied')::boolean, false) THEN
+        RAISE EXCEPTION 'STOCK_IN_NOT_APPLIED: %', v_result;
+      END IF;
+    ELSIF v_item.difference_qty < 0 THEN
+      PERFORM public.wardah_apply_stock_outgoing(
+        v_adj.org_id, v_item.product_id, v_warehouse, abs(v_item.difference_qty),
+        'Stock Adjustment', v_adj.id, v_adj.adjustment_number, v_adj.posting_date
+      );
+    END IF;
+  END LOOP;
+
+  v_amount := abs(COALESCE(v_adj.total_value_difference, 0));
+  IF v_amount > 0 THEN
+    IF v_adj.increase_account_id IS NULL OR v_adj.decrease_account_id IS NULL THEN
+      RAISE EXCEPTION 'ADJUSTMENT_ACCOUNTS_REQUIRED';
+    END IF;
+    IF v_adj.total_value_difference > 0 THEN
+      v_debit := v_adj.increase_account_id;
+      v_credit := v_adj.decrease_account_id;
+    ELSE
+      v_debit := v_adj.decrease_account_id;
+      v_credit := v_adj.increase_account_id;
+    END IF;
+
+    v_gl := public.rpc_create_journal_entry(jsonb_build_object(
+      'org_id', v_adj.org_id,
+      'entry_date', v_adj.posting_date,
+      'reference_type', 'Stock Adjustment',
+      'reference_number', v_adj.adjustment_number,
+      'description', v_adj.reason,
+      'idempotency_key', 'stock-adjustment:' || v_adj.id::text,
+      'auto_post', true,
+      'lines', jsonb_build_array(
+        jsonb_build_object('line_number', 1, 'account_id', v_debit, 'debit', v_amount, 'credit', 0,
+                           'description', v_adj.reason),
+        jsonb_build_object('line_number', 2, 'account_id', v_credit, 'debit', 0, 'credit', v_amount,
+                           'description', v_adj.reason)
+      )
+    ));
+  END IF;
+
+  UPDATE public.stock_adjustments
+  SET status = 'SUBMITTED',
+      submitted_by = auth.uid(),
+      submitted_at = now(),
+      canonical_gl_entry_id = NULLIF(v_gl ->> 'entry_id', '')::uuid,
+      updated_by = auth.uid(),
+      updated_at = now()
+  WHERE id = v_adj.id;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'adjustment_id', v_adj.id,
+    'gl_entry_id', NULLIF(v_gl ->> 'entry_id', '')::uuid
+  );
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.rpc_submit_stock_adjustment(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.rpc_submit_stock_adjustment(uuid) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.rpc_cancel_stock_adjustment(p_adjustment_id uuid, p_reason text)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_adj public.stock_adjustments%rowtype;
+  v_sle record;
+  v_prev record;
+  v_prod_qty numeric;
+  v_prod_value numeric;
+  v_gl jsonb;
+  v_lines jsonb;
+BEGIN
+  SELECT * INTO v_adj
+  FROM public.stock_adjustments
+  WHERE id = p_adjustment_id
+  FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'ADJUSTMENT_NOT_FOUND'; END IF;
+
+  v_adj.org_id := COALESCE(v_adj.org_id, v_adj.organization_id);
+  PERFORM public.wardah_assert_org_admin(v_adj.org_id);
+
+  IF v_adj.status = 'CANCELLED' THEN
+    RETURN jsonb_build_object('success', true, 'duplicate', true, 'adjustment_id', v_adj.id);
+  END IF;
+  IF v_adj.status <> 'SUBMITTED' THEN RAISE EXCEPTION 'ADJUSTMENT_NOT_SUBMITTED'; END IF;
+  IF NULLIF(trim(p_reason), '') IS NULL THEN RAISE EXCEPTION 'CANCELLATION_REASON_REQUIRED'; END IF;
+
+  -- Fail closed if a later active movement exists; exact restoration is then unsafe.
+  FOR v_sle IN
+    SELECT * FROM public.stock_ledger_entries
+    WHERE voucher_type = 'Stock Adjustment'
+      AND voucher_id = v_adj.id
+      AND COALESCE(is_cancelled, false) = false
+    ORDER BY posting_datetime DESC, id DESC
+  LOOP
+    IF EXISTS (
+      SELECT 1 FROM public.stock_ledger_entries later
+      WHERE later.org_id = v_adj.org_id
+        AND later.product_id = v_sle.product_id
+        AND later.warehouse_id = v_sle.warehouse_id
+        AND COALESCE(later.is_cancelled, false) = false
+        AND later.voucher_id <> v_adj.id
+        AND (later.posting_datetime, later.id) > (v_sle.posting_datetime, v_sle.id)
+    ) THEN
+      RAISE EXCEPTION 'LATER_STOCK_MOVEMENT_EXISTS: product=% warehouse=%',
+        v_sle.product_id, v_sle.warehouse_id;
+    END IF;
+
+    SELECT qty_after_transaction, valuation_rate, stock_value, stock_queue
+    INTO v_prev
+    FROM public.stock_ledger_entries prev
+    WHERE prev.org_id = v_adj.org_id
+      AND prev.product_id = v_sle.product_id
+      AND prev.warehouse_id = v_sle.warehouse_id
+      AND COALESCE(prev.is_cancelled, false) = false
+      AND prev.voucher_id <> v_adj.id
+      AND (prev.posting_datetime, prev.id) < (v_sle.posting_datetime, v_sle.id)
+    ORDER BY prev.posting_datetime DESC, prev.id DESC
+    LIMIT 1;
+
+    UPDATE public.stock_ledger_entries
+    SET is_cancelled = true, modified_at = now(), modified_by = auth.uid()
+    WHERE id = v_sle.id;
+
+    UPDATE public.bins
+    SET actual_qty = COALESCE(v_prev.qty_after_transaction, 0),
+        valuation_rate = COALESCE(v_prev.valuation_rate, 0),
+        stock_value = COALESCE(v_prev.stock_value, 0),
+        stock_queue = COALESCE(v_prev.stock_queue, '[]'::jsonb),
+        updated_at = now()
+    WHERE org_id = v_adj.org_id
+      AND product_id = v_sle.product_id
+      AND warehouse_id = v_sle.warehouse_id;
+
+    INSERT INTO public.stock_ledger_entries (
+      voucher_type, voucher_id, voucher_number, product_id, warehouse_id,
+      posting_date, actual_qty, qty_after_transaction, incoming_rate, outgoing_rate,
+      valuation_rate, stock_value, stock_value_difference, stock_queue,
+      batch_no, serial_nos, is_cancelled, docstatus, org_id, created_by
+    ) VALUES (
+      'Stock Adjustment Reversal', v_adj.id, 'CANCEL-' || v_adj.adjustment_number,
+      v_sle.product_id, v_sle.warehouse_id, CURRENT_DATE,
+      -v_sle.actual_qty, COALESCE(v_prev.qty_after_transaction, 0),
+      v_sle.outgoing_rate, v_sle.incoming_rate,
+      COALESCE(v_prev.valuation_rate, 0), COALESCE(v_prev.stock_value, 0),
+      -v_sle.stock_value_difference, COALESCE(v_prev.stock_queue, '[]'::jsonb),
+      v_sle.batch_no, v_sle.serial_nos, false, 1, v_adj.org_id, auth.uid()
+    );
+
+    SELECT COALESCE(SUM(actual_qty), 0), COALESCE(SUM(stock_value), 0)
+    INTO v_prod_qty, v_prod_value
+    FROM public.bins
+    WHERE org_id = v_adj.org_id AND product_id = v_sle.product_id;
+
+    UPDATE public.products
+    SET stock_quantity = v_prod_qty,
+        stock_value = v_prod_value,
+        cost_price = CASE WHEN v_prod_qty > 0 THEN v_prod_value / v_prod_qty ELSE cost_price END,
+        updated_at = now()
+    WHERE id = v_sle.product_id AND org_id = v_adj.org_id;
+  END LOOP;
+
+  IF v_adj.canonical_gl_entry_id IS NOT NULL THEN
+    SELECT jsonb_agg(jsonb_build_object(
+      'line_number', line_number,
+      'account_id', account_id,
+      'debit', credit,
+      'credit', debit,
+      'currency_code', COALESCE(currency_code, 'SAR'),
+      'description', 'Reversal: ' || COALESCE(description, '')
+    ) ORDER BY line_number)
+    INTO v_lines
+    FROM public.gl_entry_lines
+    WHERE entry_id = v_adj.canonical_gl_entry_id;
+
+    IF jsonb_array_length(COALESCE(v_lines, '[]'::jsonb)) >= 2 THEN
+      v_gl := public.rpc_create_journal_entry(jsonb_build_object(
+        'org_id', v_adj.org_id,
+        'entry_date', CURRENT_DATE,
+        'reference_type', 'Stock Adjustment Reversal',
+        'reference_number', 'CANCEL-' || v_adj.adjustment_number,
+        'description', 'Reversal: ' || p_reason,
+        'idempotency_key', 'stock-adjustment-reversal:' || v_adj.id::text,
+        'auto_post', true,
+        'lines', v_lines
+      ));
+    END IF;
+  END IF;
+
+  UPDATE public.stock_adjustments
+  SET status = 'CANCELLED',
+      cancelled_by = auth.uid(),
+      cancelled_at = now(),
+      cancellation_reason = p_reason,
+      canonical_reversal_gl_entry_id = NULLIF(v_gl ->> 'entry_id', '')::uuid,
+      updated_by = auth.uid(),
+      updated_at = now()
+  WHERE id = v_adj.id;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'adjustment_id', v_adj.id,
+    'reversal_gl_entry_id', NULLIF(v_gl ->> 'entry_id', '')::uuid
+  );
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.rpc_cancel_stock_adjustment(uuid, text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.rpc_cancel_stock_adjustment(uuid, text) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.rpc_manual_stock_movement(
+  p_product_id uuid,
+  p_quantity numeric,
+  p_movement_type text,
+  p_warehouse_id uuid DEFAULT NULL,
+  p_notes text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_org uuid;
+  v_warehouse uuid := p_warehouse_id;
+  v_current numeric;
+  v_delta numeric;
+  v_rate numeric;
+  v_voucher uuid := gen_random_uuid();
+  v_count integer;
+BEGIN
+  SELECT org_id, COALESCE(cost_price, 0)
+  INTO v_org, v_rate
+  FROM public.products
+  WHERE id = p_product_id;
+  IF NOT FOUND THEN RAISE EXCEPTION 'PRODUCT_NOT_FOUND'; END IF;
+  PERFORM public.wardah_assert_org_member(v_org);
+
+  IF v_warehouse IS NULL THEN
+    SELECT COUNT(*), MIN(warehouse_id)
+    INTO v_count, v_warehouse
+    FROM public.bins
+    WHERE org_id = v_org AND product_id = p_product_id;
+    IF v_count <> 1 THEN RAISE EXCEPTION 'WAREHOUSE_REQUIRED'; END IF;
+  END IF;
+
+  SELECT COALESCE(actual_qty, 0) INTO v_current
+  FROM public.bins
+  WHERE org_id = v_org AND product_id = p_product_id AND warehouse_id = v_warehouse;
+  v_current := COALESCE(v_current, 0);
+
+  CASE lower(p_movement_type)
+    WHEN 'in' THEN v_delta := p_quantity;
+    WHEN 'out' THEN v_delta := -p_quantity;
+    WHEN 'adjustment' THEN v_delta := p_quantity - v_current;
+    ELSE RAISE EXCEPTION 'INVALID_MOVEMENT_TYPE';
+  END CASE;
+
+  IF v_delta > 0 THEN
+    RETURN public.wardah_apply_stock_incoming(
+      v_org, p_product_id, v_warehouse, v_delta, v_rate,
+      'Manual Stock Movement', v_voucher, 'MAN-' || substr(v_voucher::text, 1, 8), CURRENT_DATE
+    ) || jsonb_build_object('notes', p_notes);
+  ELSIF v_delta < 0 THEN
+    RETURN public.wardah_apply_stock_outgoing(
+      v_org, p_product_id, v_warehouse, abs(v_delta),
+      'Manual Stock Movement', v_voucher, 'MAN-' || substr(v_voucher::text, 1, 8), CURRENT_DATE
+    ) || jsonb_build_object('notes', p_notes);
+  END IF;
+
+  RETURN jsonb_build_object('applied', false, 'reason', 'NO_CHANGE');
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.rpc_manual_stock_movement(uuid, numeric, text, uuid, text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.rpc_manual_stock_movement(uuid, numeric, text, uuid, text) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.rpc_consume_reserved_materials(p_mo_id uuid, p_consumptions jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_org uuid;
+  v_mo_number text;
+  v_row jsonb;
+  v_res public.material_reservations%rowtype;
+  v_qty numeric;
+  v_warehouse uuid;
+  v_count integer;
+  v_remaining numeric;
+BEGIN
+  SELECT org_id, order_number INTO v_org, v_mo_number
+  FROM public.manufacturing_orders
+  WHERE id = p_mo_id
+  FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'MANUFACTURING_ORDER_NOT_FOUND'; END IF;
+  PERFORM public.wardah_assert_org_member(v_org);
+
+  IF jsonb_typeof(p_consumptions) <> 'array' OR jsonb_array_length(p_consumptions) = 0 THEN
+    RAISE EXCEPTION 'CONSUMPTIONS_REQUIRED';
+  END IF;
+
+  FOR v_row IN SELECT value FROM jsonb_array_elements(p_consumptions)
+  LOOP
+    v_qty := (v_row ->> 'quantity')::numeric;
+    IF v_qty IS NULL OR v_qty <= 0 THEN RAISE EXCEPTION 'INVALID_CONSUMPTION_QUANTITY'; END IF;
+
+    SELECT * INTO v_res
+    FROM public.material_reservations
+    WHERE org_id = v_org
+      AND mo_id = p_mo_id
+      AND item_id = (v_row ->> 'item_id')::uuid
+      AND status = 'reserved'
+    FOR UPDATE;
+    IF NOT FOUND THEN RAISE EXCEPTION 'ACTIVE_RESERVATION_NOT_FOUND'; END IF;
+
+    v_remaining := v_res.quantity_reserved - COALESCE(v_res.quantity_consumed, 0)
+                   - COALESCE(v_res.quantity_released, 0);
+    IF v_qty > v_remaining THEN
+      RAISE EXCEPTION 'CONSUMPTION_EXCEEDS_RESERVATION: remaining=%, requested=%', v_remaining, v_qty;
+    END IF;
+
+    v_warehouse := NULLIF(COALESCE(v_row ->> 'warehouse_id', v_row ->> 'location_id'), '')::uuid;
+    IF v_warehouse IS NULL THEN
+      SELECT COUNT(*), MIN(warehouse_id)
+      INTO v_count, v_warehouse
+      FROM public.bins
+      WHERE org_id = v_org AND product_id = v_res.item_id AND actual_qty > 0;
+      IF v_count <> 1 THEN RAISE EXCEPTION 'WAREHOUSE_REQUIRED_FOR_CONSUMPTION'; END IF;
+    END IF;
+
+    PERFORM public.wardah_apply_stock_outgoing(
+      v_org, v_res.item_id, v_warehouse, v_qty,
+      'Material Consumption', p_mo_id, v_mo_number, CURRENT_DATE
+    );
+
+    UPDATE public.material_reservations
+    SET quantity_consumed = COALESCE(quantity_consumed, 0) + v_qty,
+        status = CASE WHEN COALESCE(quantity_consumed, 0) + v_qty
+                           + COALESCE(quantity_released, 0) >= quantity_reserved
+                      THEN 'consumed' ELSE 'reserved' END,
+        consumed_at = now(),
+        updated_at = now()
+    WHERE id = v_res.id;
+  END LOOP;
+
+  RETURN jsonb_build_object('success', true, 'mo_id', p_mo_id,
+                            'consumption_count', jsonb_array_length(p_consumptions));
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.rpc_consume_reserved_materials(uuid, jsonb) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.rpc_consume_reserved_materials(uuid, jsonb) TO authenticated;

--- a/sql/migrations/125_stock_adjustment_canonical_account_mapping.sql
+++ b/sql/migrations/125_stock_adjustment_canonical_account_mapping.sql
@@ -1,0 +1,200 @@
+-- migration_number: 125
+-- description: Add the canonical inventory GL account to stock adjustments and
+--              correct journal mapping for gains and losses.
+-- safety: additive/replace-only; no historical field or data is removed.
+
+ALTER TABLE public.stock_adjustments
+  ADD COLUMN IF NOT EXISTS inventory_account_id uuid REFERENCES public.gl_accounts(id);
+
+CREATE OR REPLACE FUNCTION public.rpc_create_stock_adjustment(p_payload jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_org uuid;
+  v_id uuid := gen_random_uuid();
+  v_number text;
+  v_date date;
+  v_total_value numeric;
+  v_total_qty numeric;
+  v_count integer;
+BEGIN
+  v_org := public.wardah_org_id(NULLIF(p_payload ->> 'org_id', '')::uuid);
+  PERFORM public.wardah_assert_org_member(v_org);
+
+  v_date := COALESCE(NULLIF(p_payload ->> 'adjustment_date', '')::date, CURRENT_DATE);
+  v_number := COALESCE(
+    NULLIF(p_payload ->> 'adjustment_number', ''),
+    'ADJ-' || to_char(v_date, 'YYYYMMDD') || '-' || upper(substr(replace(v_id::text, '-', ''), 1, 8))
+  );
+
+  SELECT COUNT(*),
+         COALESCE(SUM((x ->> 'difference_qty')::numeric), 0),
+         COALESCE(SUM((x ->> 'value_difference')::numeric), 0)
+  INTO v_count, v_total_qty, v_total_value
+  FROM jsonb_array_elements(COALESCE(p_payload -> 'items', '[]'::jsonb)) x;
+
+  IF v_count = 0 THEN RAISE EXCEPTION 'ADJUSTMENT_REQUIRES_ITEMS'; END IF;
+  IF NULLIF(p_payload ->> 'inventory_account_id', '') IS NULL THEN
+    RAISE EXCEPTION 'INVENTORY_ACCOUNT_REQUIRED';
+  END IF;
+  IF v_total_value > 0 AND NULLIF(p_payload ->> 'increase_account_id', '') IS NULL THEN
+    RAISE EXCEPTION 'INCREASE_ACCOUNT_REQUIRED';
+  END IF;
+  IF v_total_value < 0 AND NULLIF(p_payload ->> 'decrease_account_id', '') IS NULL THEN
+    RAISE EXCEPTION 'DECREASE_ACCOUNT_REQUIRED';
+  END IF;
+
+  INSERT INTO public.stock_adjustments (
+    id, organization_id, org_id, adjustment_number, adjustment_date, posting_date,
+    adjustment_type, reason, reference_number, warehouse_id, status,
+    requires_approval, total_items, total_qty_difference, total_value_difference,
+    created_by, inventory_account_id, increase_account_id, decrease_account_id
+  ) VALUES (
+    v_id, v_org, v_org, v_number, v_date,
+    COALESCE(NULLIF(p_payload ->> 'posting_date', '')::date, v_date),
+    p_payload ->> 'adjustment_type', p_payload ->> 'reason',
+    NULLIF(p_payload ->> 'reference_number', ''),
+    NULLIF(p_payload ->> 'warehouse_id', '')::uuid,
+    'DRAFT',
+    COALESCE((p_payload ->> 'requires_approval')::boolean, abs(v_total_value) > 10000),
+    v_count, v_total_qty, v_total_value, auth.uid(),
+    NULLIF(p_payload ->> 'inventory_account_id', '')::uuid,
+    NULLIF(p_payload ->> 'increase_account_id', '')::uuid,
+    NULLIF(p_payload ->> 'decrease_account_id', '')::uuid
+  );
+
+  INSERT INTO public.stock_adjustment_items (
+    adjustment_id, organization_id, product_id, warehouse_id,
+    current_qty, new_qty, difference_qty, current_rate, new_rate,
+    value_difference, reason, serial_numbers, batch_numbers
+  )
+  SELECT
+    v_id, v_org, (x ->> 'product_id')::uuid,
+    NULLIF(x ->> 'warehouse_id', '')::uuid,
+    COALESCE((x ->> 'current_qty')::numeric, 0),
+    (x ->> 'new_qty')::numeric, (x ->> 'difference_qty')::numeric,
+    COALESCE((x ->> 'current_rate')::numeric, 0),
+    NULLIF(x ->> 'new_rate', '')::numeric,
+    (x ->> 'value_difference')::numeric, NULLIF(x ->> 'reason', ''),
+    CASE WHEN jsonb_typeof(x -> 'serial_nos') = 'array'
+      THEN ARRAY(SELECT jsonb_array_elements_text(x -> 'serial_nos')) ELSE NULL END,
+    CASE WHEN NULLIF(x ->> 'batch_no', '') IS NOT NULL
+      THEN ARRAY[x ->> 'batch_no'] ELSE NULL END
+  FROM jsonb_array_elements(p_payload -> 'items') x;
+
+  RETURN jsonb_build_object('success', true, 'adjustment_id', v_id, 'adjustment_number', v_number);
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.rpc_create_stock_adjustment(jsonb) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.rpc_create_stock_adjustment(jsonb) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.rpc_submit_stock_adjustment(p_adjustment_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_adj public.stock_adjustments%rowtype;
+  v_item record;
+  v_warehouse uuid;
+  v_result jsonb;
+  v_gl jsonb;
+  v_debit uuid;
+  v_credit uuid;
+  v_amount numeric;
+  v_item_count integer;
+BEGIN
+  SELECT * INTO v_adj
+  FROM public.stock_adjustments
+  WHERE id = p_adjustment_id
+  FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'ADJUSTMENT_NOT_FOUND'; END IF;
+
+  v_adj.org_id := COALESCE(v_adj.org_id, v_adj.organization_id);
+  PERFORM public.wardah_assert_org_admin(v_adj.org_id);
+
+  IF v_adj.status = 'SUBMITTED' THEN
+    RETURN jsonb_build_object('success', true, 'duplicate', true, 'adjustment_id', v_adj.id,
+                              'gl_entry_id', v_adj.canonical_gl_entry_id);
+  END IF;
+  IF v_adj.status <> 'DRAFT' THEN RAISE EXCEPTION 'ADJUSTMENT_NOT_DRAFT'; END IF;
+  IF COALESCE(v_adj.requires_approval, false) AND v_adj.approved_by IS NULL THEN
+    RAISE EXCEPTION 'ADJUSTMENT_APPROVAL_REQUIRED';
+  END IF;
+
+  SELECT count(*) INTO v_item_count
+  FROM public.stock_adjustment_items
+  WHERE adjustment_id = v_adj.id;
+  IF v_item_count = 0 THEN RAISE EXCEPTION 'ADJUSTMENT_REQUIRES_ITEMS'; END IF;
+
+  FOR v_item IN
+    SELECT * FROM public.stock_adjustment_items WHERE adjustment_id = v_adj.id ORDER BY id
+  LOOP
+    v_warehouse := COALESCE(v_item.warehouse_id, v_adj.warehouse_id);
+    IF v_warehouse IS NULL THEN RAISE EXCEPTION 'WAREHOUSE_REQUIRED'; END IF;
+
+    IF v_item.difference_qty > 0 THEN
+      v_result := public.wardah_apply_stock_incoming(
+        v_adj.org_id, v_item.product_id, v_warehouse, v_item.difference_qty,
+        COALESCE(v_item.new_rate, v_item.current_rate, 0),
+        'Stock Adjustment', v_adj.id, v_adj.adjustment_number, v_adj.posting_date
+      );
+      IF NOT COALESCE((v_result ->> 'applied')::boolean, false) THEN
+        RAISE EXCEPTION 'STOCK_IN_NOT_APPLIED: %', v_result;
+      END IF;
+    ELSIF v_item.difference_qty < 0 THEN
+      PERFORM public.wardah_apply_stock_outgoing(
+        v_adj.org_id, v_item.product_id, v_warehouse, abs(v_item.difference_qty),
+        'Stock Adjustment', v_adj.id, v_adj.adjustment_number, v_adj.posting_date
+      );
+    END IF;
+  END LOOP;
+
+  v_amount := abs(COALESCE(v_adj.total_value_difference, 0));
+  IF v_amount > 0 THEN
+    IF v_adj.inventory_account_id IS NULL THEN RAISE EXCEPTION 'INVENTORY_ACCOUNT_REQUIRED'; END IF;
+    IF v_adj.total_value_difference > 0 THEN
+      IF v_adj.increase_account_id IS NULL THEN RAISE EXCEPTION 'INCREASE_ACCOUNT_REQUIRED'; END IF;
+      v_debit := v_adj.inventory_account_id;
+      v_credit := v_adj.increase_account_id;
+    ELSE
+      IF v_adj.decrease_account_id IS NULL THEN RAISE EXCEPTION 'DECREASE_ACCOUNT_REQUIRED'; END IF;
+      v_debit := v_adj.decrease_account_id;
+      v_credit := v_adj.inventory_account_id;
+    END IF;
+
+    v_gl := public.rpc_create_journal_entry(jsonb_build_object(
+      'org_id', v_adj.org_id,
+      'entry_date', v_adj.posting_date,
+      'reference_type', 'Stock Adjustment',
+      'reference_number', v_adj.adjustment_number,
+      'description', v_adj.reason,
+      'idempotency_key', 'stock-adjustment:' || v_adj.id::text,
+      'auto_post', true,
+      'lines', jsonb_build_array(
+        jsonb_build_object('line_number', 1, 'account_id', v_debit,
+                           'debit', v_amount, 'credit', 0, 'description', v_adj.reason),
+        jsonb_build_object('line_number', 2, 'account_id', v_credit,
+                           'debit', 0, 'credit', v_amount, 'description', v_adj.reason)
+      )
+    ));
+  END IF;
+
+  UPDATE public.stock_adjustments
+  SET status = 'SUBMITTED', submitted_by = auth.uid(), submitted_at = now(),
+      canonical_gl_entry_id = NULLIF(v_gl ->> 'entry_id', '')::uuid,
+      updated_by = auth.uid(), updated_at = now()
+  WHERE id = v_adj.id;
+
+  RETURN jsonb_build_object('success', true, 'adjustment_id', v_adj.id,
+                            'gl_entry_id', NULLIF(v_gl ->> 'entry_id', '')::uuid);
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.rpc_submit_stock_adjustment(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.rpc_submit_stock_adjustment(uuid) TO authenticated;

--- a/sql/migrations/126_draft_account_timing_and_warehouse_semantics.sql
+++ b/sql/migrations/126_draft_account_timing_and_warehouse_semantics.sql
@@ -1,0 +1,163 @@
+-- migration_number: 126
+-- description: Allow stock-adjustment drafts before account selection, enforce
+--              accounts only at submit, and never treat location_id as warehouse_id.
+-- safety: replace-only; no schema object or data is deleted.
+
+CREATE OR REPLACE FUNCTION public.rpc_create_stock_adjustment(p_payload jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_org uuid;
+  v_id uuid := gen_random_uuid();
+  v_number text;
+  v_date date;
+  v_total_value numeric;
+  v_total_qty numeric;
+  v_count integer;
+BEGIN
+  v_org := public.wardah_org_id(NULLIF(p_payload ->> 'org_id', '')::uuid);
+  PERFORM public.wardah_assert_org_member(v_org);
+
+  v_date := COALESCE(NULLIF(p_payload ->> 'adjustment_date', '')::date, CURRENT_DATE);
+  v_number := COALESCE(
+    NULLIF(p_payload ->> 'adjustment_number', ''),
+    'ADJ-' || to_char(v_date, 'YYYYMMDD') || '-' || upper(substr(replace(v_id::text, '-', ''), 1, 8))
+  );
+
+  SELECT COUNT(*),
+         COALESCE(SUM((x ->> 'difference_qty')::numeric), 0),
+         COALESCE(SUM((x ->> 'value_difference')::numeric), 0)
+  INTO v_count, v_total_qty, v_total_value
+  FROM jsonb_array_elements(COALESCE(p_payload -> 'items', '[]'::jsonb)) x;
+
+  IF v_count = 0 THEN RAISE EXCEPTION 'ADJUSTMENT_REQUIRES_ITEMS'; END IF;
+
+  -- Accounts may be selected after draft creation. rpc_submit_stock_adjustment
+  -- remains fail-closed and refuses posting until all required accounts exist.
+  INSERT INTO public.stock_adjustments (
+    id, organization_id, org_id, adjustment_number, adjustment_date, posting_date,
+    adjustment_type, reason, reference_number, warehouse_id, status,
+    requires_approval, total_items, total_qty_difference, total_value_difference,
+    created_by, inventory_account_id, increase_account_id, decrease_account_id
+  ) VALUES (
+    v_id, v_org, v_org, v_number, v_date,
+    COALESCE(NULLIF(p_payload ->> 'posting_date', '')::date, v_date),
+    p_payload ->> 'adjustment_type', p_payload ->> 'reason',
+    NULLIF(p_payload ->> 'reference_number', ''),
+    NULLIF(p_payload ->> 'warehouse_id', '')::uuid,
+    'DRAFT',
+    COALESCE((p_payload ->> 'requires_approval')::boolean, abs(v_total_value) > 10000),
+    v_count, v_total_qty, v_total_value, auth.uid(),
+    NULLIF(p_payload ->> 'inventory_account_id', '')::uuid,
+    NULLIF(p_payload ->> 'increase_account_id', '')::uuid,
+    NULLIF(p_payload ->> 'decrease_account_id', '')::uuid
+  );
+
+  INSERT INTO public.stock_adjustment_items (
+    adjustment_id, organization_id, product_id, warehouse_id,
+    current_qty, new_qty, difference_qty, current_rate, new_rate,
+    value_difference, reason, serial_numbers, batch_numbers
+  )
+  SELECT
+    v_id, v_org, (x ->> 'product_id')::uuid,
+    NULLIF(x ->> 'warehouse_id', '')::uuid,
+    COALESCE((x ->> 'current_qty')::numeric, 0),
+    (x ->> 'new_qty')::numeric, (x ->> 'difference_qty')::numeric,
+    COALESCE((x ->> 'current_rate')::numeric, 0),
+    NULLIF(x ->> 'new_rate', '')::numeric,
+    (x ->> 'value_difference')::numeric, NULLIF(x ->> 'reason', ''),
+    CASE WHEN jsonb_typeof(x -> 'serial_nos') = 'array'
+      THEN ARRAY(SELECT jsonb_array_elements_text(x -> 'serial_nos')) ELSE NULL END,
+    CASE WHEN NULLIF(x ->> 'batch_no', '') IS NOT NULL
+      THEN ARRAY[x ->> 'batch_no'] ELSE NULL END
+  FROM jsonb_array_elements(p_payload -> 'items') x;
+
+  RETURN jsonb_build_object('success', true, 'adjustment_id', v_id, 'adjustment_number', v_number);
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.rpc_create_stock_adjustment(jsonb) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.rpc_create_stock_adjustment(jsonb) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.rpc_consume_reserved_materials(p_mo_id uuid, p_consumptions jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_org uuid;
+  v_mo_number text;
+  v_row jsonb;
+  v_res public.material_reservations%rowtype;
+  v_qty numeric;
+  v_warehouse uuid;
+  v_count integer;
+  v_remaining numeric;
+BEGIN
+  SELECT org_id, order_number INTO v_org, v_mo_number
+  FROM public.manufacturing_orders
+  WHERE id = p_mo_id
+  FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'MANUFACTURING_ORDER_NOT_FOUND'; END IF;
+  PERFORM public.wardah_assert_org_member(v_org);
+
+  IF jsonb_typeof(p_consumptions) <> 'array' OR jsonb_array_length(p_consumptions) = 0 THEN
+    RAISE EXCEPTION 'CONSUMPTIONS_REQUIRED';
+  END IF;
+
+  FOR v_row IN SELECT value FROM jsonb_array_elements(p_consumptions)
+  LOOP
+    v_qty := (v_row ->> 'quantity')::numeric;
+    IF v_qty IS NULL OR v_qty <= 0 THEN RAISE EXCEPTION 'INVALID_CONSUMPTION_QUANTITY'; END IF;
+
+    SELECT * INTO v_res
+    FROM public.material_reservations
+    WHERE org_id = v_org
+      AND mo_id = p_mo_id
+      AND item_id = (v_row ->> 'item_id')::uuid
+      AND status = 'reserved'
+    FOR UPDATE;
+    IF NOT FOUND THEN RAISE EXCEPTION 'ACTIVE_RESERVATION_NOT_FOUND'; END IF;
+
+    v_remaining := v_res.quantity_reserved - COALESCE(v_res.quantity_consumed, 0)
+                   - COALESCE(v_res.quantity_released, 0);
+    IF v_qty > v_remaining THEN
+      RAISE EXCEPTION 'CONSUMPTION_EXCEEDS_RESERVATION: remaining=%, requested=%', v_remaining, v_qty;
+    END IF;
+
+    -- location_id and warehouse_id are different domain concepts. Only an
+    -- explicit warehouse_id is accepted; otherwise resolve exactly one stocked bin.
+    v_warehouse := NULLIF(v_row ->> 'warehouse_id', '')::uuid;
+    IF v_warehouse IS NULL THEN
+      SELECT COUNT(*), MIN(warehouse_id)
+      INTO v_count, v_warehouse
+      FROM public.bins
+      WHERE org_id = v_org AND product_id = v_res.item_id AND actual_qty > 0;
+      IF v_count <> 1 THEN RAISE EXCEPTION 'WAREHOUSE_REQUIRED_FOR_CONSUMPTION'; END IF;
+    END IF;
+
+    PERFORM public.wardah_apply_stock_outgoing(
+      v_org, v_res.item_id, v_warehouse, v_qty,
+      'Material Consumption', p_mo_id, v_mo_number, CURRENT_DATE
+    );
+
+    UPDATE public.material_reservations
+    SET quantity_consumed = COALESCE(quantity_consumed, 0) + v_qty,
+        status = CASE WHEN COALESCE(quantity_consumed, 0) + v_qty
+                           + COALESCE(quantity_released, 0) >= quantity_reserved
+                      THEN 'consumed' ELSE 'reserved' END,
+        consumed_at = now(), updated_at = now()
+    WHERE id = v_res.id;
+  END LOOP;
+
+  RETURN jsonb_build_object('success', true, 'mo_id', p_mo_id,
+                            'consumption_count', jsonb_array_length(p_consumptions));
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.rpc_consume_reserved_materials(uuid, jsonb) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.rpc_consume_reserved_materials(uuid, jsonb) TO authenticated;

--- a/sql/migrations/127_stock_adjustment_ledger_valued_posting.sql
+++ b/sql/migrations/127_stock_adjustment_ledger_valued_posting.sql
@@ -1,0 +1,140 @@
+-- migration_number: 127
+-- description: Post stock-adjustment GL from actual SLE valuation, not client
+--              estimates, and reject duplicate product/warehouse lines.
+-- safety: replace-only; no schema object or data is deleted.
+
+CREATE OR REPLACE FUNCTION public.rpc_submit_stock_adjustment(p_adjustment_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_adj public.stock_adjustments%rowtype;
+  v_item record;
+  v_warehouse uuid;
+  v_result jsonb;
+  v_gl jsonb;
+  v_debit uuid;
+  v_credit uuid;
+  v_amount numeric;
+  v_signed_value numeric;
+  v_actual_qty numeric;
+  v_item_count integer;
+  v_distinct_count integer;
+BEGIN
+  SELECT * INTO v_adj
+  FROM public.stock_adjustments
+  WHERE id = p_adjustment_id
+  FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'ADJUSTMENT_NOT_FOUND'; END IF;
+
+  v_adj.org_id := COALESCE(v_adj.org_id, v_adj.organization_id);
+  PERFORM public.wardah_assert_org_admin(v_adj.org_id);
+
+  IF v_adj.status = 'SUBMITTED' THEN
+    RETURN jsonb_build_object('success', true, 'duplicate', true,
+                              'adjustment_id', v_adj.id,
+                              'gl_entry_id', v_adj.canonical_gl_entry_id);
+  END IF;
+  IF v_adj.status <> 'DRAFT' THEN RAISE EXCEPTION 'ADJUSTMENT_NOT_DRAFT'; END IF;
+  IF COALESCE(v_adj.requires_approval, false) AND v_adj.approved_by IS NULL THEN
+    RAISE EXCEPTION 'ADJUSTMENT_APPROVAL_REQUIRED';
+  END IF;
+
+  SELECT count(*),
+         count(DISTINCT ROW(product_id, COALESCE(warehouse_id, v_adj.warehouse_id)))
+  INTO v_item_count, v_distinct_count
+  FROM public.stock_adjustment_items
+  WHERE adjustment_id = v_adj.id;
+
+  IF v_item_count = 0 THEN RAISE EXCEPTION 'ADJUSTMENT_REQUIRES_ITEMS'; END IF;
+  IF v_item_count <> v_distinct_count THEN
+    RAISE EXCEPTION 'DUPLICATE_PRODUCT_WAREHOUSE_LINES';
+  END IF;
+
+  FOR v_item IN
+    SELECT * FROM public.stock_adjustment_items
+    WHERE adjustment_id = v_adj.id
+    ORDER BY id
+  LOOP
+    v_warehouse := COALESCE(v_item.warehouse_id, v_adj.warehouse_id);
+    IF v_warehouse IS NULL THEN RAISE EXCEPTION 'WAREHOUSE_REQUIRED'; END IF;
+
+    IF v_item.difference_qty > 0 THEN
+      v_result := public.wardah_apply_stock_incoming(
+        v_adj.org_id, v_item.product_id, v_warehouse, v_item.difference_qty,
+        COALESCE(v_item.new_rate, v_item.current_rate, 0),
+        'Stock Adjustment', v_adj.id, v_adj.adjustment_number, v_adj.posting_date
+      );
+      IF NOT COALESCE((v_result ->> 'applied')::boolean, false) THEN
+        RAISE EXCEPTION 'STOCK_IN_NOT_APPLIED: %', v_result;
+      END IF;
+    ELSIF v_item.difference_qty < 0 THEN
+      PERFORM public.wardah_apply_stock_outgoing(
+        v_adj.org_id, v_item.product_id, v_warehouse, abs(v_item.difference_qty),
+        'Stock Adjustment', v_adj.id, v_adj.adjustment_number, v_adj.posting_date
+      );
+    END IF;
+  END LOOP;
+
+  SELECT COALESCE(SUM(actual_qty), 0),
+         COALESCE(SUM(stock_value_difference), 0)
+  INTO v_actual_qty, v_signed_value
+  FROM public.stock_ledger_entries
+  WHERE org_id = v_adj.org_id
+    AND voucher_type = 'Stock Adjustment'
+    AND voucher_id = v_adj.id
+    AND COALESCE(is_cancelled, false) = false;
+
+  v_amount := abs(v_signed_value);
+  IF v_amount > 0 THEN
+    IF v_adj.inventory_account_id IS NULL THEN RAISE EXCEPTION 'INVENTORY_ACCOUNT_REQUIRED'; END IF;
+    IF v_signed_value > 0 THEN
+      IF v_adj.increase_account_id IS NULL THEN RAISE EXCEPTION 'INCREASE_ACCOUNT_REQUIRED'; END IF;
+      v_debit := v_adj.inventory_account_id;
+      v_credit := v_adj.increase_account_id;
+    ELSE
+      IF v_adj.decrease_account_id IS NULL THEN RAISE EXCEPTION 'DECREASE_ACCOUNT_REQUIRED'; END IF;
+      v_debit := v_adj.decrease_account_id;
+      v_credit := v_adj.inventory_account_id;
+    END IF;
+
+    v_gl := public.rpc_create_journal_entry(jsonb_build_object(
+      'org_id', v_adj.org_id,
+      'entry_date', v_adj.posting_date,
+      'reference_type', 'Stock Adjustment',
+      'reference_number', v_adj.adjustment_number,
+      'description', v_adj.reason,
+      'idempotency_key', 'stock-adjustment:' || v_adj.id::text,
+      'auto_post', true,
+      'lines', jsonb_build_array(
+        jsonb_build_object('line_number', 1, 'account_id', v_debit,
+                           'debit', v_amount, 'credit', 0, 'description', v_adj.reason),
+        jsonb_build_object('line_number', 2, 'account_id', v_credit,
+                           'debit', 0, 'credit', v_amount, 'description', v_adj.reason)
+      )
+    ));
+  END IF;
+
+  UPDATE public.stock_adjustments
+  SET status = 'SUBMITTED',
+      total_qty_difference = v_actual_qty,
+      total_value_difference = v_signed_value,
+      submitted_by = auth.uid(), submitted_at = now(),
+      canonical_gl_entry_id = NULLIF(v_gl ->> 'entry_id', '')::uuid,
+      updated_by = auth.uid(), updated_at = now()
+  WHERE id = v_adj.id;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'adjustment_id', v_adj.id,
+    'actual_qty_difference', v_actual_qty,
+    'actual_value_difference', v_signed_value,
+    'gl_entry_id', NULLIF(v_gl ->> 'entry_id', '')::uuid
+  );
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.rpc_submit_stock_adjustment(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.rpc_submit_stock_adjustment(uuid) TO authenticated;

--- a/sql/migrations/STATUS_122_124.md
+++ b/sql/migrations/STATUS_122_124.md
@@ -1,0 +1,71 @@
+# حالة Migrations 122–124
+
+هذا الملف مكمل لـ`MANIFEST.md` ولا يستبدله أو يحذف أي جزء تاريخي منه.
+
+## الحالة عند إنشاء PR #32
+
+| Migration | الملف | Repository/Fresh DB | Production | ملاحظة |
+|---:|---|---|---|---|
+| 121 | `121_fail_closed_tenant_isolation.sql` | ✅ | ✅ | Baseline cutoff الحالي |
+| 122 | `122_fix_check_entry_approval_dead_code.sql` | ✅ | ⏳ معلقة | يجب تطبيقها أولًا |
+| 123 | `123_fix_user_profile_trigger_and_active_guards.sql` | ✅ ضمن PR #32 | ⏳ بعد الدمج | غير هدامة؛ تستبدل الدوال فقط |
+| 124 | `124_atomic_stock_adjustments_and_material_consumption.sql` | ✅ ضمن PR #32 | ⏳ بعد 123 | Additive RPCs + عمودان nullable |
+
+> وجود migration في GitHub أو نجاح Fresh DB لا يعني أنها مطبقة في Production. المرجع الحي هو `supabase_migrations.schema_migrations`.
+
+## 122 — تنظيف check_entry_approval_required
+
+- يزيل fallback `app.current_org_id` والمؤسسة الافتراضية.
+- لا يغير الجداول أو البيانات.
+
+## 123 — ملف المستخدم والحراس النشطون
+
+- `handle_new_user()` يكتب إلى `user_profiles`.
+- trigger الحالي يبقى دون حذف.
+- `wardah_assert_org_member` يشترط `is_active IS TRUE`.
+- `wardah_is_org_admin` يشترط `is_active IS TRUE`.
+- لا يُحذف جدول النسخة التاريخية أو أي بيانات داخله.
+
+## 124 — ذرية المخزون
+
+### إضافات المخطط
+
+```text
+stock_adjustments.canonical_gl_entry_id
+stock_adjustments.canonical_reversal_gl_entry_id
+```
+
+العمودان nullable ويشيران إلى `gl_entries`. الحقول التاريخية المرتبطة بـ`journal_entries` تبقى دون تغيير.
+
+### RPCs العامة لـauthenticated
+
+```text
+rpc_create_stock_adjustment(jsonb)
+rpc_submit_stock_adjustment(uuid)
+rpc_cancel_stock_adjustment(uuid,text)
+rpc_manual_stock_movement(uuid,numeric,text,uuid,text)
+rpc_consume_reserved_materials(uuid,jsonb)
+```
+
+### Helper داخلي
+
+```text
+wardah_apply_stock_outgoing(uuid,uuid,uuid,numeric,text,uuid,text,date)
+```
+
+لا يُمنح للعملاء مباشرة.
+
+## ترتيب النشر
+
+```text
+122 → تحقق → 123 → تحقق → 124 → اختبارات rollback → نشر الواجهة
+```
+
+التفاصيل الكاملة:
+
+- `docs/db/INTEGRITY_HARDENING_122_124_RUNBOOK.md`
+- `docs/db/BASELINE_PRODUCTION_CUTOFF_POLICY.md`
+
+## قاعدة إعادة Baseline
+
+لا تُشغّل Generate Schema Baseline لتضمين 122–124 إلا بعد ظهور آخر migration مطبقة في سجل Production. الـworkflow الجديد يستخدم cutoff الحي ويتوقف عند عدم تطابق الاسم مع ملف المستودع.

--- a/sql/migrations/STATUS_122_124.md
+++ b/sql/migrations/STATUS_122_124.md
@@ -1,4 +1,6 @@
-# حالة Migrations 122–124
+# حالة Migrations 122–125
+
+> اسم الملف التاريخي بقي `STATUS_122_124.md` احترامًا لقاعدة عدم الحذف/إعادة التسمية، وتم توسيع محتواه ليشمل 125.
 
 هذا الملف مكمل لـ`MANIFEST.md` ولا يستبدله أو يحذف أي جزء تاريخي منه.
 
@@ -9,7 +11,8 @@
 | 121 | `121_fail_closed_tenant_isolation.sql` | ✅ | ✅ | Baseline cutoff الحالي |
 | 122 | `122_fix_check_entry_approval_dead_code.sql` | ✅ | ⏳ معلقة | يجب تطبيقها أولًا |
 | 123 | `123_fix_user_profile_trigger_and_active_guards.sql` | ✅ ضمن PR #32 | ⏳ بعد الدمج | غير هدامة؛ تستبدل الدوال فقط |
-| 124 | `124_atomic_stock_adjustments_and_material_consumption.sql` | ✅ ضمن PR #32 | ⏳ بعد 123 | Additive RPCs + عمودان nullable |
+| 124 | `124_atomic_stock_adjustments_and_material_consumption.sql` | ✅ ضمن PR #32 | ⏳ بعد 123 | RPCs ذرية + مرجعان قانونيان لـGL |
+| 125 | `125_stock_adjustment_canonical_account_mapping.sql` | ✅ ضمن PR #32 | ⏳ بعد 124 | حساب مخزون مستقل وتصحيح خريطة القيد |
 
 > وجود migration في GitHub أو نجاح Fresh DB لا يعني أنها مطبقة في Production. المرجع الحي هو `supabase_migrations.schema_migrations`.
 
@@ -55,17 +58,43 @@ wardah_apply_stock_outgoing(uuid,uuid,uuid,numeric,text,uuid,text,date)
 
 لا يُمنح للعملاء مباشرة.
 
+## 125 — خريطة الحسابات القانونية
+
+Migration 125 تضيف عمودًا nullable:
+
+```text
+stock_adjustments.inventory_account_id → gl_accounts(id)
+```
+
+وتستبدل دالتي الإنشاء والترحيل بحيث تكون القيود:
+
+### زيادة المخزون
+
+```text
+مدين: inventory_account_id
+دائن: increase_account_id (مكسب/فائض الجرد)
+```
+
+### نقص المخزون
+
+```text
+مدين: decrease_account_id (مصروف/خسارة الجرد)
+دائن: inventory_account_id
+```
+
+أسماء الواجهة القديمة `gain_account_id` و`expense_account_id` ما زالت مدعومة وتُحوّل إلى الحقول القانونية. لا يُستخدم أي حقل تاريخي كبديل لحساب المخزون.
+
 ## ترتيب النشر
 
 ```text
-122 → تحقق → 123 → تحقق → 124 → اختبارات rollback → نشر الواجهة
+122 → تحقق → 123 → تحقق → 124 → تحقق → 125 → اختبارات rollback → نشر الواجهة
 ```
 
 التفاصيل الكاملة:
 
-- `docs/db/INTEGRITY_HARDENING_122_124_RUNBOOK.md`
+- `docs/db/INTEGRITY_HARDENING_122_124_RUNBOOK.md` — يشمل 125 رغم الاسم التاريخي.
 - `docs/db/BASELINE_PRODUCTION_CUTOFF_POLICY.md`
 
 ## قاعدة إعادة Baseline
 
-لا تُشغّل Generate Schema Baseline لتضمين 122–124 إلا بعد ظهور آخر migration مطبقة في سجل Production. الـworkflow الجديد يستخدم cutoff الحي ويتوقف عند عدم تطابق الاسم مع ملف المستودع.
+لا تُشغّل Generate Schema Baseline لتضمين 122–125 إلا بعد ظهور آخر migration مطبقة في سجل Production. الـworkflow الجديد يستخدم cutoff الحي ويتوقف عند عدم تطابق الاسم مع ملف المستودع.

--- a/src/hooks/use-items.ts
+++ b/src/hooks/use-items.ts
@@ -1,7 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { itemsService } from '../services/supabase-service'
+import { manualStockMovementService } from '../services/manual-stock-movement-service'
 import type { Item } from '../lib/supabase'
-import { useAuthStore } from '../store/auth-store'
 
 export function useItems() {
   return useQuery({
@@ -21,15 +21,15 @@ export function useItem(id: string) {
   return useQuery({
     queryKey: ['items', id],
     queryFn: () => itemsService.getById(id),
-    enabled: !!id,
+    enabled: Boolean(id),
   })
 }
 
 export function useCreateItem() {
   const queryClient = useQueryClient()
-  
+
   return useMutation({
-    mutationFn: (item: Omit<Item, 'id' | 'created_at' | 'updated_at'>) => 
+    mutationFn: (item: Omit<Item, 'id' | 'created_at' | 'updated_at'>) =>
       itemsService.create(item),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['items'] })
@@ -39,9 +39,9 @@ export function useCreateItem() {
 
 export function useUpdateItem() {
   const queryClient = useQueryClient()
-  
+
   return useMutation({
-    mutationFn: ({ id, ...item }: { id: string } & Partial<Item>) => 
+    mutationFn: ({ id, ...item }: { id: string } & Partial<Item>) =>
       itemsService.update(id, item),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['items'] })
@@ -51,30 +51,40 @@ export function useUpdateItem() {
 
 export function useUpdateStock() {
   const queryClient = useQueryClient()
-  const { user } = useAuthStore()
-  
+
   return useMutation({
-    mutationFn: ({ 
-      itemId, 
-      quantity, 
-      movementType, 
-      notes 
-    }: { 
+    mutationFn: ({
+      itemId,
+      quantity,
+      movementType,
+      warehouseId,
+      notes,
+    }: {
       itemId: string
       quantity: number
       movementType: 'in' | 'out' | 'adjustment'
-      notes?: string 
-    }) => itemsService.updateStock(itemId, quantity, movementType, user?.id || '', notes),
+      warehouseId?: string
+      notes?: string
+    }) =>
+      manualStockMovementService.apply({
+        productId: itemId,
+        quantity,
+        movementType,
+        warehouseId,
+        notes,
+      }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['items'] })
       queryClient.invalidateQueries({ queryKey: ['stock-movements'] })
+      queryClient.invalidateQueries({ queryKey: ['stock-ledger'] })
+      queryClient.invalidateQueries({ queryKey: ['bins'] })
     },
   })
 }
 
 export function useDeleteItem() {
   const queryClient = useQueryClient()
-  
+
   return useMutation({
     mutationFn: itemsService.delete,
     onSuccess: () => {

--- a/src/services/__tests__/manual-stock-movement-service.test.ts
+++ b/src/services/__tests__/manual-stock-movement-service.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const rpc = vi.fn()
+
+vi.mock('@/lib/supabase', () => ({
+  getSupabase: () => ({ rpc }),
+}))
+
+import { manualStockMovementService } from '../manual-stock-movement-service'
+
+describe('manualStockMovementService', () => {
+  beforeEach(() => {
+    rpc.mockReset()
+  })
+
+  it('delegates the movement to the atomic RPC', async () => {
+    rpc.mockResolvedValue({
+      data: { applied: true, new_qty: 12 },
+      error: null,
+    })
+
+    const result = await manualStockMovementService.apply({
+      productId: '00000000-0000-0000-0000-000000000010',
+      quantity: 2,
+      movementType: 'out',
+      warehouseId: '00000000-0000-0000-0000-000000000020',
+      notes: 'cycle count',
+    })
+
+    expect(rpc).toHaveBeenCalledWith('rpc_manual_stock_movement', {
+      p_product_id: '00000000-0000-0000-0000-000000000010',
+      p_quantity: 2,
+      p_movement_type: 'out',
+      p_warehouse_id: '00000000-0000-0000-0000-000000000020',
+      p_notes: 'cycle count',
+    })
+    expect(result).toEqual({ applied: true, new_qty: 12 })
+  })
+
+  it('rejects invalid quantities before calling the database', async () => {
+    await expect(
+      manualStockMovementService.apply({
+        productId: 'product',
+        quantity: -1,
+        movementType: 'in',
+      }),
+    ).rejects.toThrow('Quantity must be a non-negative number')
+    expect(rpc).not.toHaveBeenCalled()
+  })
+
+  it('propagates database errors', async () => {
+    const error = new Error('WAREHOUSE_REQUIRED')
+    rpc.mockResolvedValue({ data: null, error })
+
+    await expect(
+      manualStockMovementService.apply({
+        productId: 'product',
+        quantity: 1,
+        movementType: 'in',
+      }),
+    ).rejects.toBe(error)
+  })
+})

--- a/src/services/__tests__/stock-adjustment-rpc-service.test.ts
+++ b/src/services/__tests__/stock-adjustment-rpc-service.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const rpc = vi.fn()
+
+vi.mock('@/lib/supabase', () => ({
+  getSupabase: () => ({ rpc }),
+}))
+
+import { stockAdjustmentService } from '../stock-adjustment-service'
+
+describe('stockAdjustmentService atomic write flow', () => {
+  beforeEach(() => {
+    rpc.mockReset()
+  })
+
+  it('creates an adjustment through one RPC and maps legacy account aliases', async () => {
+    rpc.mockResolvedValue({
+      data: {
+        success: true,
+        adjustment_id: 'adjustment-id',
+        adjustment_number: 'ADJ-1',
+      },
+      error: null,
+    })
+
+    const result = await stockAdjustmentService.createAdjustment({
+      adjustment_date: '2026-07-18',
+      adjustment_type: 'DAMAGE',
+      reason: 'damaged stock',
+      total_value_difference: -50,
+      status: 'DRAFT',
+      requires_approval: false,
+      inventory_account_id: 'inventory-account',
+      expense_account_id: 'expense-account',
+      items: [
+        {
+          product_id: 'product-id',
+          current_qty: 10,
+          new_qty: 9,
+          difference_qty: -1,
+          current_rate: 50,
+          value_difference: -50,
+          warehouse_id: 'warehouse-id',
+        },
+      ],
+    })
+
+    expect(rpc).toHaveBeenCalledTimes(1)
+    expect(rpc).toHaveBeenCalledWith(
+      'rpc_create_stock_adjustment',
+      expect.objectContaining({
+        p_payload: expect.objectContaining({
+          increase_account_id: 'inventory-account',
+          decrease_account_id: 'expense-account',
+          items: expect.any(Array),
+        }),
+      }),
+    )
+    expect(result).toEqual({
+      id: 'adjustment-id',
+      adjustment_number: 'ADJ-1',
+      status: 'DRAFT',
+    })
+  })
+
+  it('submits through the atomic RPC', async () => {
+    rpc.mockResolvedValue({
+      data: { success: true, gl_entry_id: 'gl-id' },
+      error: null,
+    })
+
+    const result = await stockAdjustmentService.submitAdjustment(
+      'adjustment-id',
+      'legacy-user-id',
+    )
+
+    expect(rpc).toHaveBeenCalledWith('rpc_submit_stock_adjustment', {
+      p_adjustment_id: 'adjustment-id',
+    })
+    expect(result.glEntryId).toBe('gl-id')
+  })
+
+  it('cancels through the atomic RPC with a mandatory reason', async () => {
+    rpc.mockResolvedValue({
+      data: { success: true, reversal_gl_entry_id: 'reversal-id' },
+      error: null,
+    })
+
+    const result = await stockAdjustmentService.cancelAdjustment(
+      'adjustment-id',
+      'approved correction',
+    )
+
+    expect(rpc).toHaveBeenCalledWith('rpc_cancel_stock_adjustment', {
+      p_adjustment_id: 'adjustment-id',
+      p_reason: 'approved correction',
+    })
+    expect(result.reversalGlEntryId).toBe('reversal-id')
+  })
+
+  it('does not call the database when cancellation reason is empty', async () => {
+    await expect(
+      stockAdjustmentService.cancelAdjustment('adjustment-id', '   '),
+    ).rejects.toThrow('سبب الإلغاء مطلوب')
+    expect(rpc).not.toHaveBeenCalled()
+  })
+
+  it('rejects a logical RPC failure even when transport has no error', async () => {
+    rpc.mockResolvedValue({
+      data: { success: false, error: 'ADJUSTMENT_ACCOUNTS_REQUIRED' },
+      error: null,
+    })
+
+    await expect(
+      stockAdjustmentService.submitAdjustment('adjustment-id', 'user-id'),
+    ).rejects.toThrow('ADJUSTMENT_ACCOUNTS_REQUIRED')
+  })
+})

--- a/src/services/__tests__/stock-adjustment-rpc-service.test.ts
+++ b/src/services/__tests__/stock-adjustment-rpc-service.test.ts
@@ -32,6 +32,7 @@ describe('stockAdjustmentService atomic write flow', () => {
       requires_approval: false,
       inventory_account_id: 'inventory-account',
       expense_account_id: 'expense-account',
+      gain_account_id: 'gain-account',
       items: [
         {
           product_id: 'product-id',
@@ -50,7 +51,8 @@ describe('stockAdjustmentService atomic write flow', () => {
       'rpc_create_stock_adjustment',
       expect.objectContaining({
         p_payload: expect.objectContaining({
-          increase_account_id: 'inventory-account',
+          inventory_account_id: 'inventory-account',
+          increase_account_id: 'gain-account',
           decrease_account_id: 'expense-account',
           items: expect.any(Array),
         }),
@@ -107,12 +109,12 @@ describe('stockAdjustmentService atomic write flow', () => {
 
   it('rejects a logical RPC failure even when transport has no error', async () => {
     rpc.mockResolvedValue({
-      data: { success: false, error: 'ADJUSTMENT_ACCOUNTS_REQUIRED' },
+      data: { success: false, error: 'INVENTORY_ACCOUNT_REQUIRED' },
       error: null,
     })
 
     await expect(
       stockAdjustmentService.submitAdjustment('adjustment-id', 'user-id'),
-    ).rejects.toThrow('ADJUSTMENT_ACCOUNTS_REQUIRED')
+    ).rejects.toThrow('INVENTORY_ACCOUNT_REQUIRED')
   })
 })

--- a/src/services/inventory-transaction-service.ts
+++ b/src/services/inventory-transaction-service.ts
@@ -1,172 +1,153 @@
 /**
  * Inventory Transaction Service
- * 
- * Handles all inventory transactions including:
- * - Material reservations
- * - Material consumption
- * - Reservation releases
- * - Stock availability checks
+ *
+ * Reservations remain simple RLS-scoped writes. Material consumption is routed
+ * through rpc_consume_reserved_materials so reservation state, bins, product
+ * aggregates, and stock ledger entries are updated in one database transaction.
  */
 
-import { supabase as _supabase, getEffectiveTenantId } from '@/lib/supabase';
-import { InsufficientInventoryError } from '@/lib/errors/InsufficientInventoryError';
-import { AppError } from '@/lib/errors/AppError';
-const supabase = _supabase as import('@supabase/supabase-js').SupabaseClient
+import { supabase as _supabase, getEffectiveTenantId } from '@/lib/supabase'
+import { InsufficientInventoryError } from '@/lib/errors/InsufficientInventoryError'
+import { AppError } from '@/lib/errors/AppError'
 
-/**
- * Material reservation
- */
+const supabase =
+  _supabase as import('@supabase/supabase-js').SupabaseClient
+
 export interface MaterialReservation {
-  id: string;
-  org_id: string;
-  mo_id: string;
-  item_id: string;
-  quantity_reserved: number;
-  quantity_consumed: number;
-  quantity_released: number;
-  status: 'reserved' | 'consumed' | 'released' | 'expired' | 'cancelled';
-  reserved_at: string;
-  consumed_at?: string;
-  released_at?: string;
-  expires_at?: string;
-  notes?: string;
+  id: string
+  org_id: string
+  mo_id: string
+  item_id: string
+  quantity_reserved: number
+  quantity_consumed: number
+  quantity_released: number
+  status: 'reserved' | 'consumed' | 'released' | 'expired' | 'cancelled'
+  reserved_at: string
+  consumed_at?: string
+  released_at?: string
+  expires_at?: string
+  notes?: string
 }
 
-/**
- * Material requirement for reservation
- */
 export interface MaterialRequirement {
-  item_id: string;
-  quantity: number;
-  location_id?: string;
-  unit_cost?: number;
+  item_id: string
+  quantity: number
+  location_id?: string
+  unit_cost?: number
 }
 
-/**
- * Material consumption record
- */
 export interface MaterialConsumption {
-  item_id: string;
-  quantity: number;
-  quantity_reserved: number;
-  unit_cost: number;
-  location_id?: string;
+  item_id: string
+  quantity: number
+  quantity_reserved: number
+  unit_cost: number
+  location_id?: string
+  warehouse_id?: string
 }
 
-/**
- * Stock availability check result
- */
 export interface StockAvailability {
-  item_id: string;
-  item_name?: string;
-  required: number;
-  available: number;
-  on_hand: number;
-  reserved: number;
-  sufficient: boolean;
+  item_id: string
+  item_name?: string
+  required: number
+  available: number
+  on_hand: number
+  reserved: number
+  sufficient: boolean
 }
 
-/**
- * Inventory Transaction Service
- */
 class InventoryTransactionService {
-  /**
-   * Check stock availability for materials
-   */
-  async checkAvailability(
-    requirements: MaterialRequirement[]
-  ): Promise<StockAvailability[]> {
-    const orgId = await getEffectiveTenantId();
+  private async requireOrgId(): Promise<string> {
+    const orgId = await getEffectiveTenantId()
     if (!orgId) {
-      throw new AppError('TENANT_ERROR', 'Organization ID not found', 400);
+      throw new AppError('TENANT_ERROR', 'Organization ID not found', 400)
     }
+    return orgId
+  }
 
-    const results: StockAvailability[] = [];
+  async checkAvailability(
+    requirements: MaterialRequirement[],
+  ): Promise<StockAvailability[]> {
+    const orgId = await this.requireOrgId()
+    const results: StockAvailability[] = []
 
-    for (const req of requirements) {
+    for (const requirement of requirements) {
       const { data, error } = await supabase.rpc('get_available_quantity', {
         p_org_id: orgId,
-        p_item_id: req.item_id,
-        p_location_id: req.location_id || null,
-      });
-
+        p_item_id: requirement.item_id,
+        p_location_id: requirement.location_id || null,
+      })
       if (error) {
         throw new AppError(
           'STOCK_CHECK_ERROR',
-          `Failed to check stock for item ${req.item_id}: ${error.message}`,
+          `Failed to check stock for item ${requirement.item_id}: ${error.message}`,
           500,
           true,
-          { item_id: req.item_id, error }
-        );
+          { item_id: requirement.item_id, error },
+        )
       }
 
-      const available = data || 0;
-
-      // Get reserved quantity
-      const { data: reservedData } = await supabase
+      const { data: reservations, error: reservationError } = await supabase
         .from('material_reservations')
         .select('quantity_reserved, quantity_consumed, quantity_released')
         .eq('org_id', orgId)
-        .eq('item_id', req.item_id)
-        .eq('status', 'reserved');
+        .eq('item_id', requirement.item_id)
+        .eq('status', 'reserved')
+      if (reservationError) throw reservationError
 
-      const reserved = reservedData?.reduce((sum, r) => {
-        return sum + (r.quantity_reserved - (r.quantity_consumed || 0) - (r.quantity_released || 0));
-      }, 0) || 0;
+      const reserved = (reservations || []).reduce(
+        (sum, reservation) =>
+          sum +
+          Number(reservation.quantity_reserved || 0) -
+          Number(reservation.quantity_consumed || 0) -
+          Number(reservation.quantity_released || 0),
+        0,
+      )
 
-      // Get on-hand quantity
-      const { data: stockData } = await supabase
-        .from('stock_quants')
-        .select('quantity')
+      const { data: bins, error: binsError } = await supabase
+        .from('bins')
+        .select('actual_qty')
         .eq('org_id', orgId)
-        .eq('item_id', req.item_id)
-        .maybeSingle();
+        .eq('product_id', requirement.item_id)
+      if (binsError) throw binsError
 
-      const on_hand = stockData?.quantity || 0;
+      const onHand = (bins || []).reduce(
+        (sum, bin) => sum + Number(bin.actual_qty || 0),
+        0,
+      )
+      const available = Number(data ?? Math.max(onHand - reserved, 0))
 
       results.push({
-        item_id: req.item_id,
-        required: req.quantity,
+        item_id: requirement.item_id,
+        required: requirement.quantity,
         available,
-        on_hand,
+        on_hand: onHand,
         reserved,
-        sufficient: available >= req.quantity,
-      });
+        sufficient: available >= requirement.quantity,
+      })
     }
 
-    return results;
+    return results
   }
 
-  /**
-   * Reserve materials for a manufacturing order
-   */
   async reserveMaterials(
     moId: string,
     materials: MaterialRequirement[],
-    expiresAt?: Date
+    expiresAt?: Date,
   ): Promise<MaterialReservation[]> {
-    const orgId = await getEffectiveTenantId();
-    if (!orgId) {
-      throw new AppError('TENANT_ERROR', 'Organization ID not found', 400);
-    }
+    const orgId = await this.requireOrgId()
+    const availability = await this.checkAvailability(materials)
+    const insufficient = availability.find((item) => !item.sufficient)
 
-    // Check availability first
-    const availability = await this.checkAvailability(materials);
-    const insufficient = availability.filter(a => !a.sufficient);
-
-    if (insufficient.length > 0) {
-      const item = insufficient[0];
+    if (insufficient) {
       throw new InsufficientInventoryError(
-        item.item_id,
-        item.required,
-        item.available,
-        item.item_name
-      );
+        insufficient.item_id,
+        insufficient.required,
+        insufficient.available,
+        insufficient.item_name,
+      )
     }
 
-    // Create reservations
-    const reservations: MaterialReservation[] = [];
-
+    const reservations: MaterialReservation[] = []
     for (const material of materials) {
       const { data, error } = await supabase
         .from('material_reservations')
@@ -179,7 +160,7 @@ class InventoryTransactionService {
           expires_at: expiresAt?.toISOString() || null,
         })
         .select()
-        .single();
+        .single()
 
       if (error) {
         throw new AppError(
@@ -187,99 +168,101 @@ class InventoryTransactionService {
           `Failed to reserve material: ${error.message}`,
           500,
           true,
-          { material, error }
-        );
+          { material, error },
+        )
       }
-
-      reservations.push(data as MaterialReservation);
+      reservations.push(data as MaterialReservation)
     }
-
-    return reservations;
+    return reservations
   }
 
-  /**
-   * Consume reserved materials
-   */
   async consumeReservedMaterials(
     moId: string,
-    consumptions: MaterialConsumption[]
+    consumptions: MaterialConsumption[],
   ): Promise<void> {
-    const orgId = await getEffectiveTenantId();
-    if (!orgId) {
-      throw new AppError('TENANT_ERROR', 'Organization ID not found', 400);
+    await this.requireOrgId()
+    if (!consumptions.length) return
+
+    const { data, error } = await supabase.rpc(
+      'rpc_consume_reserved_materials',
+      {
+        p_mo_id: moId,
+        p_consumptions: consumptions.map((consumption) => ({
+          item_id: consumption.item_id,
+          quantity: consumption.quantity,
+          warehouse_id: consumption.warehouse_id,
+          location_id: consumption.location_id,
+        })),
+      },
+    )
+
+    if (error) {
+      throw new AppError(
+        'CONSUMPTION_ERROR',
+        `Failed to consume reserved materials: ${error.message}`,
+        500,
+        true,
+        { moId, consumptions, error },
+      )
     }
 
-    // Use transaction to ensure atomicity
-    // Note: For now, we'll execute operations sequentially
-    // In production, use database transactions via RPC functions
-    for (const consumption of consumptions) {
-      // Update reservation
-      const { error: updateError } = await supabase
-        .from('material_reservations')
-        .update({
-          status: 'consumed',
-          quantity_consumed: consumption.quantity,
-          consumed_at: new Date().toISOString(),
-        })
-        .eq('org_id', orgId)
-        .eq('mo_id', moId)
-        .eq('item_id', consumption.item_id)
-        .eq('status', 'reserved');
-
-      if (updateError) {
-        throw new AppError(
-          'CONSUMPTION_ERROR',
-          `Failed to consume material: ${updateError.message}`,
-          500,
-          true,
-          { consumption, error: updateError }
-        );
-      }
-
-      // stock_moves table was replaced by stock_ledger_entries (written by RPC functions).
-      // Consumption is already tracked via the reservations update above; no additional
-      // ledger write is needed here.
+    const result = data as { success?: boolean; error?: string } | null
+    if (!result?.success) {
+      throw new AppError(
+        'CONSUMPTION_ERROR',
+        result?.error || 'Material consumption transaction failed',
+        500,
+        true,
+        { moId, consumptions, result },
+      )
     }
   }
 
-  /**
-   * Release reservation
-   */
   async releaseReservation(
     reservationId: string,
-    quantity?: number
+    quantity?: number,
   ): Promise<void> {
-    const orgId = await getEffectiveTenantId();
-    if (!orgId) {
-      throw new AppError('TENANT_ERROR', 'Organization ID not found', 400);
-    }
-
-    const reservation = await supabase
+    const orgId = await this.requireOrgId()
+    const { data: reservation, error: fetchError } = await supabase
       .from('material_reservations')
       .select('*')
       .eq('id', reservationId)
       .eq('org_id', orgId)
-      .single();
+      .single()
 
-    if (reservation.error || !reservation.data) {
-      throw new AppError(
-        'RESERVATION_NOT_FOUND',
-        'Reservation not found',
-        404
-      );
+    if (fetchError || !reservation) {
+      throw new AppError('RESERVATION_NOT_FOUND', 'Reservation not found', 404)
     }
 
-    const releaseQty = quantity || (reservation.data.quantity_reserved - (reservation.data.quantity_consumed || 0));
+    const remaining =
+      Number(reservation.quantity_reserved || 0) -
+      Number(reservation.quantity_consumed || 0) -
+      Number(reservation.quantity_released || 0)
+    const releaseQuantity = quantity ?? remaining
+
+    if (releaseQuantity <= 0 || releaseQuantity > remaining) {
+      throw new AppError(
+        'INVALID_RELEASE_QUANTITY',
+        'Release quantity must be positive and no greater than the remaining reservation',
+        400,
+      )
+    }
+
+    const newReleased =
+      Number(reservation.quantity_released || 0) + releaseQuantity
+    const fullyClosed =
+      newReleased + Number(reservation.quantity_consumed || 0) >=
+      Number(reservation.quantity_reserved || 0)
 
     const { error } = await supabase
       .from('material_reservations')
       .update({
-        status: 'released',
-        quantity_released: releaseQty,
+        status: fullyClosed ? 'released' : 'reserved',
+        quantity_released: newReleased,
         released_at: new Date().toISOString(),
       })
       .eq('id', reservationId)
-      .eq('org_id', orgId);
+      .eq('org_id', orgId)
 
     if (error) {
       throw new AppError(
@@ -287,69 +270,38 @@ class InventoryTransactionService {
         `Failed to release reservation: ${error.message}`,
         500,
         true,
-        { reservationId, error }
-      );
+        { reservationId, error },
+      )
     }
   }
 
-  /**
-   * Release all reservations for a manufacturing order
-   */
   async releaseAllReservations(moId: string): Promise<void> {
-    const orgId = await getEffectiveTenantId();
-    if (!orgId) {
-      throw new AppError('TENANT_ERROR', 'Organization ID not found', 400);
-    }
-
-    // Get current values first, then update
-    const { data: reservations } = await supabase
+    const orgId = await this.requireOrgId()
+    const { data: reservations, error: fetchError } = await supabase
       .from('material_reservations')
-      .select('id, quantity_reserved, quantity_consumed')
+      .select('id, quantity_reserved, quantity_consumed, quantity_released')
       .eq('org_id', orgId)
       .eq('mo_id', moId)
-      .eq('status', 'reserved');
+      .eq('status', 'reserved')
+    if (fetchError) throw fetchError
 
-    if (reservations && reservations.length > 0) {
-      for (const reservation of reservations) {
-        const quantityReleased = (reservation.quantity_reserved || 0) - (reservation.quantity_consumed || 0);
-        
-        const { error } = await supabase
-          .from('material_reservations')
-          .update({
-            status: 'released',
-            quantity_released: quantityReleased,
-            released_at: new Date().toISOString(),
-          })
-          .eq('id', reservation.id);
-        
-        if (error) {
-          throw new AppError(
-            'RELEASE_ERROR',
-            `Failed to release reservation: ${error.message}`,
-            500,
-            true,
-            { reservationId: reservation.id, error }
-          );
-        }
-      }
+    for (const reservation of reservations || []) {
+      const remaining =
+        Number(reservation.quantity_reserved || 0) -
+        Number(reservation.quantity_consumed || 0) -
+        Number(reservation.quantity_released || 0)
+      if (remaining > 0) await this.releaseReservation(reservation.id, remaining)
     }
   }
 
-  /**
-   * Get reservations for a manufacturing order
-   */
   async getReservations(moId: string): Promise<MaterialReservation[]> {
-    const orgId = await getEffectiveTenantId();
-    if (!orgId) {
-      throw new AppError('TENANT_ERROR', 'Organization ID not found', 400);
-    }
-
+    const orgId = await this.requireOrgId()
     const { data, error } = await supabase
       .from('material_reservations')
       .select('*')
       .eq('org_id', orgId)
       .eq('mo_id', moId)
-      .order('created_at', { ascending: true });
+      .order('created_at', { ascending: true })
 
     if (error) {
       throw new AppError(
@@ -357,16 +309,12 @@ class InventoryTransactionService {
         `Failed to fetch reservations: ${error.message}`,
         500,
         true,
-        { moId, error }
-      );
+        { moId, error },
+      )
     }
-
-    return (data || []) as MaterialReservation[];
+    return (data || []) as MaterialReservation[]
   }
 }
 
-// Export singleton instance
-export const inventoryTransactionService = new InventoryTransactionService();
-
-export default inventoryTransactionService;
-
+export const inventoryTransactionService = new InventoryTransactionService()
+export default inventoryTransactionService

--- a/src/services/manual-stock-movement-service.ts
+++ b/src/services/manual-stock-movement-service.ts
@@ -1,0 +1,46 @@
+import { getSupabase } from '@/lib/supabase'
+
+export type ManualStockMovementType = 'in' | 'out' | 'adjustment'
+
+export interface ManualStockMovementInput {
+  productId: string
+  quantity: number
+  movementType: ManualStockMovementType
+  warehouseId?: string
+  notes?: string
+}
+
+export interface ManualStockMovementResult {
+  applied: boolean
+  reason?: string
+  new_qty?: number
+  new_rate?: number
+  new_value?: number
+  cogs?: number
+  method?: string
+}
+
+export const manualStockMovementService = {
+  apply: async (
+    input: ManualStockMovementInput,
+  ): Promise<ManualStockMovementResult> => {
+    if (!input.productId) throw new Error('Product ID is required')
+    if (!Number.isFinite(input.quantity) || input.quantity < 0) {
+      throw new Error('Quantity must be a non-negative number')
+    }
+
+    const supabase = getSupabase()
+    const { data, error } = await supabase.rpc('rpc_manual_stock_movement', {
+      p_product_id: input.productId,
+      p_quantity: input.quantity,
+      p_movement_type: input.movementType,
+      p_warehouse_id: input.warehouseId || null,
+      p_notes: input.notes || null,
+    })
+
+    if (error) throw error
+    return data as ManualStockMovementResult
+  },
+}
+
+export default manualStockMovementService

--- a/src/services/manual-stock-movement-service.ts
+++ b/src/services/manual-stock-movement-service.ts
@@ -1,4 +1,5 @@
 import { getSupabase } from '@/lib/supabase'
+import type { SupabaseClient } from '@supabase/supabase-js'
 
 export type ManualStockMovementType = 'in' | 'out' | 'adjustment'
 
@@ -29,7 +30,7 @@ export const manualStockMovementService = {
       throw new Error('Quantity must be a non-negative number')
     }
 
-    const supabase = getSupabase()
+    const supabase = getSupabase() as SupabaseClient
     const { data, error } = await supabase.rpc('rpc_manual_stock_movement', {
       p_product_id: input.productId,
       p_quantity: input.quantity,

--- a/src/services/stock-adjustment-service.ts
+++ b/src/services/stock-adjustment-service.ts
@@ -53,15 +53,14 @@ export interface StockAdjustment {
   status: 'DRAFT' | 'SUBMITTED' | 'CANCELLED'
   items: StockAdjustmentItem[]
 
-  // Canonical account names used by the current schema.
+  // Canonical accounts: inventory asset + gain on increase + loss on decrease.
+  inventory_account_id?: string
   increase_account_id?: string
   decrease_account_id?: string
 
-  // Legacy caller aliases are retained for compatibility; they are mapped to
-  // the canonical increase/decrease accounts before the RPC call.
+  // Legacy aliases remain supported for callers that still use the old names.
   expense_account_id?: string
   gain_account_id?: string
-  inventory_account_id?: string
 
   requires_approval: boolean
   approved_by?: string
@@ -104,20 +103,16 @@ function assertRpcSuccess(result: RpcResult | null, fallback: string): RpcResult
 }
 
 function resolveAccounts(adjustment: StockAdjustment): {
+  inventory_account_id?: string
   increase_account_id?: string
   decrease_account_id?: string
 } {
-  const total = adjustment.items.reduce(
-    (sum, item) => sum + Number(item.value_difference || 0),
-    0,
-  )
-
   return {
+    inventory_account_id: adjustment.inventory_account_id,
     increase_account_id:
-      adjustment.increase_account_id || adjustment.inventory_account_id,
+      adjustment.increase_account_id || adjustment.gain_account_id,
     decrease_account_id:
-      adjustment.decrease_account_id ||
-      (total >= 0 ? adjustment.gain_account_id : adjustment.expense_account_id),
+      adjustment.decrease_account_id || adjustment.expense_account_id,
   }
 }
 
@@ -146,6 +141,7 @@ export const stockAdjustmentService = {
         warehouse_id: adjustment.warehouse_id,
         requires_approval:
           adjustment.requires_approval || Math.abs(totalValueDifference) > 10000,
+        inventory_account_id: accounts.inventory_account_id,
         increase_account_id: accounts.increase_account_id,
         decrease_account_id: accounts.decrease_account_id,
         items: adjustment.items,

--- a/src/services/stock-adjustment-service.ts
+++ b/src/services/stock-adjustment-service.ts
@@ -1,18 +1,19 @@
 /**
  * Stock Adjustment Service
- * Based on ERPNext, SAP, and Oracle best practices
- * Handles inventory adjustments with proper accounting integration
+ *
+ * Write operations are delegated to PostgreSQL RPCs so the adjustment header,
+ * stock ledger, bins, product aggregate, and canonical GL entry commit or roll
+ * back as one transaction. Read-only/reporting helpers remain client-side.
  */
 
 import { getSupabase as _getSupabase } from '../lib/supabase'
-const getSupabase = () => _getSupabase() as import('@supabase/supabase-js').SupabaseClient
 
-// Helper function to get supabase client
+const getSupabase = () =>
+  _getSupabase() as import('@supabase/supabase-js').SupabaseClient
+
 const getClient = async () => {
   const client = getSupabase()
-  if (!client) {
-    throw new Error('Supabase client not initialized')
-  }
+  if (!client) throw new Error('Supabase client not initialized')
   return client
 }
 
@@ -23,6 +24,7 @@ export interface StockAdjustmentItem {
   new_qty: number
   difference_qty: number
   current_rate: number
+  new_rate?: number
   value_difference: number
   reason?: string
   warehouse_id?: string
@@ -32,26 +34,38 @@ export interface StockAdjustmentItem {
 
 export interface StockAdjustment {
   id?: string
+  org_id?: string
+  adjustment_number?: string
   adjustment_date: string
-  adjustment_type: 'PHYSICAL_COUNT' | 'DAMAGE' | 'THEFT' | 'EXPIRY' | 'QUALITY_ISSUE' | 'REVALUATION' | 'OTHER'
+  posting_date?: string
+  adjustment_type:
+    | 'PHYSICAL_COUNT'
+    | 'DAMAGE'
+    | 'THEFT'
+    | 'EXPIRY'
+    | 'QUALITY_ISSUE'
+    | 'REVALUATION'
+    | 'OTHER'
   reason: string
   reference_number?: string
   warehouse_id?: string
   total_value_difference: number
   status: 'DRAFT' | 'SUBMITTED' | 'CANCELLED'
   items: StockAdjustmentItem[]
-  
-  // Accounting Integration
-  expense_account_id?: string  // For losses (e.g., 5950 - Inventory Adjustments)
-  gain_account_id?: string     // For gains (e.g., 4900 - Other Income)
-  inventory_account_id?: string // Inventory GL account
-  
-  // Approval
+
+  // Canonical account names used by the current schema.
+  increase_account_id?: string
+  decrease_account_id?: string
+
+  // Legacy caller aliases are retained for compatibility; they are mapped to
+  // the canonical increase/decrease accounts before the RPC call.
+  expense_account_id?: string
+  gain_account_id?: string
+  inventory_account_id?: string
+
   requires_approval: boolean
   approved_by?: string
   approved_at?: string
-  
-  // Audit
   created_by?: string
   created_at?: string
   posted_by?: string
@@ -65,240 +79,135 @@ export interface PhysicalCountSession {
   warehouse_id?: string
   counted_by: string
   status: 'IN_PROGRESS' | 'COMPLETED' | 'ADJUSTED'
-  items: {
+  items: Array<{
     product_id: string
     system_qty: number
     counted_qty: number
     difference: number
-  }[]
+  }>
   created_at?: string
 }
 
+type RpcResult = {
+  success?: boolean
+  error?: string
+  adjustment_id?: string
+  adjustment_number?: string
+  duplicate?: boolean
+  gl_entry_id?: string | null
+  reversal_gl_entry_id?: string | null
+}
+
+function assertRpcSuccess(result: RpcResult | null, fallback: string): RpcResult {
+  if (!result?.success) throw new Error(result?.error || fallback)
+  return result
+}
+
+function resolveAccounts(adjustment: StockAdjustment): {
+  increase_account_id?: string
+  decrease_account_id?: string
+} {
+  const total = adjustment.items.reduce(
+    (sum, item) => sum + Number(item.value_difference || 0),
+    0,
+  )
+
+  return {
+    increase_account_id:
+      adjustment.increase_account_id || adjustment.inventory_account_id,
+    decrease_account_id:
+      adjustment.decrease_account_id ||
+      (total >= 0 ? adjustment.gain_account_id : adjustment.expense_account_id),
+  }
+}
+
 export const stockAdjustmentService = {
-  
-  /**
-   * Create a new stock adjustment (Draft)
-   */
   createAdjustment: async (adjustment: StockAdjustment) => {
-    const supabase = await getClient()
-    
-    // Validate
-    if (!adjustment.items || adjustment.items.length === 0) {
+    if (!adjustment.items?.length) {
       throw new Error('يجب إضافة منتج واحد على الأقل')
     }
-    
-    // Calculate total value difference
-    const totalValueDiff = adjustment.items.reduce((sum, item) => 
-      sum + item.value_difference, 0
+
+    const supabase = await getClient()
+    const accounts = resolveAccounts(adjustment)
+    const totalValueDifference = adjustment.items.reduce(
+      (sum, item) => sum + Number(item.value_difference || 0),
+      0,
     )
-    
-    // Create adjustment header
-    const { data: headerData, error: headerError } = await supabase
-      .from('stock_adjustments')
-      .insert({
+
+    const { data, error } = await supabase.rpc('rpc_create_stock_adjustment', {
+      p_payload: {
+        org_id: adjustment.org_id,
+        adjustment_number: adjustment.adjustment_number,
         adjustment_date: adjustment.adjustment_date,
+        posting_date: adjustment.posting_date || adjustment.adjustment_date,
         adjustment_type: adjustment.adjustment_type,
         reason: adjustment.reason,
         reference_number: adjustment.reference_number,
         warehouse_id: adjustment.warehouse_id,
-        total_value_difference: totalValueDiff,
-        status: 'DRAFT',
-        requires_approval: Math.abs(totalValueDiff) > 10000, // Require approval for large adjustments
-        expense_account_id: adjustment.expense_account_id,
-        gain_account_id: adjustment.gain_account_id,
-        inventory_account_id: adjustment.inventory_account_id,
-        remarks: adjustment.remarks
-      })
-      .select()
-      .single()
-    
-    if (headerError) throw headerError
-    
-    // Create adjustment items
-    const itemsData = adjustment.items.map(item => ({
-      adjustment_id: headerData.id,
-      product_id: item.product_id,
-      current_qty: item.current_qty,
-      new_qty: item.new_qty,
-      difference_qty: item.difference_qty,
-      current_rate: item.current_rate,
-      value_difference: item.value_difference,
-      reason: item.reason,
-      warehouse_id: item.warehouse_id,
-      batch_no: item.batch_no,
-      serial_nos: item.serial_nos
-    }))
-    
-    const { error: itemsError } = await supabase
-      .from('stock_adjustment_items')
-      .insert(itemsData)
-    
-    if (itemsError) throw itemsError
-    
-    return headerData
+        requires_approval:
+          adjustment.requires_approval || Math.abs(totalValueDifference) > 10000,
+        increase_account_id: accounts.increase_account_id,
+        decrease_account_id: accounts.decrease_account_id,
+        items: adjustment.items,
+      },
+    })
+
+    if (error) throw error
+    const result = assertRpcSuccess(
+      data as RpcResult | null,
+      'فشل إنشاء تسوية المخزون',
+    )
+
+    return {
+      id: result.adjustment_id,
+      adjustment_number: result.adjustment_number,
+      status: 'DRAFT' as const,
+    }
   },
-  
-  /**
-   * Submit and post adjustment (creates stock ledger entries)
-   */
-  submitAdjustment: async (adjustmentId: string, userId: string) => {
+
+  submitAdjustment: async (adjustmentId: string, _userId: string) => {
     const supabase = await getClient()
-    
-    // Get adjustment with items
-    const { data: adjustment, error: fetchError } = await supabase
-      .from('stock_adjustments')
-      .select(`
-        *,
-        items:stock_adjustment_items(*)
-      `)
-      .eq('id', adjustmentId)
-      .single()
-    
-    if (fetchError) throw fetchError
-    
-    // Check if requires approval
-    if (adjustment.requires_approval && !adjustment.approved_by) {
-      throw new Error('هذه التسوية تتطلب موافقة المدير')
+    const { data, error } = await supabase.rpc('rpc_submit_stock_adjustment', {
+      p_adjustment_id: adjustmentId,
+    })
+    if (error) throw error
+    const result = assertRpcSuccess(
+      data as RpcResult | null,
+      'فشل ترحيل تسوية المخزون',
+    )
+    return {
+      success: true,
+      duplicate: Boolean(result.duplicate),
+      glEntryId: result.gl_entry_id || null,
+      message: result.duplicate
+        ? 'التسوية مرحلة مسبقاً'
+        : 'تم ترحيل التسوية بنجاح',
     }
-    
-    // Check status
-    if (adjustment.status !== 'DRAFT') {
-      throw new Error('يمكن ترحيل التسويات بحالة مسودة فقط')
-    }
-    
-    // Begin transaction: Create stock ledger entries
-    for (const item of adjustment.items) {
-      // Get current product valuation
-      const { data: product } = await supabase
-        .from('products')
-        .select('stock_quantity, cost_price, stock_value, valuation_method')
-        .eq('id', item.product_id)
-        .single()
-      
-      if (!product) {
-        throw new Error(`المنتج غير موجود: ${item.product_id}`)
-      }
-      
-      // Create stock ledger entry
-      const { error: sleError } = await supabase
-        .from('stock_ledger_entries')
-        .insert({
-          voucher_type: 'Stock Adjustment',
-          voucher_id: adjustmentId,
-          voucher_number: adjustment.reference_number,
-          product_id: item.product_id,
-          warehouse_id: item.warehouse_id || adjustment.warehouse_id,
-          posting_date: adjustment.adjustment_date,
-          actual_qty: item.difference_qty,
-          qty_after_transaction: product.stock_quantity + item.difference_qty,
-          incoming_rate: item.difference_qty > 0 ? item.current_rate : 0,
-          outgoing_rate: item.difference_qty < 0 ? item.current_rate : 0,
-          valuation_rate: item.current_rate,
-          stock_value: (product.stock_quantity + item.difference_qty) * item.current_rate,
-          stock_value_difference: item.value_difference,
-          batch_no: item.batch_no,
-          serial_nos: item.serial_nos,
-          docstatus: 1
-        })
-      
-      if (sleError) throw sleError
-      
-      // Update product stock
-      const { error: updateError } = await supabase
-        .from('products')
-        .update({
-          stock_quantity: product.stock_quantity + item.difference_qty,
-          stock_value: product.stock_value + item.value_difference,
-          updated_at: new Date().toISOString()
-        })
-        .eq('id', item.product_id)
-      
-      if (updateError) throw updateError
-    }
-    
-    // Create accounting entries
-    await createAdjustmentAccountingEntries(supabase, adjustment)
-    
-    // Update adjustment status
-    const { error: statusError } = await supabase
-      .from('stock_adjustments')
-      .update({
-        status: 'SUBMITTED',
-        posted_by: userId,
-        posted_at: new Date().toISOString()
-      })
-      .eq('id', adjustmentId)
-    
-    if (statusError) throw statusError
-    
-    return { success: true, message: 'تم ترحيل التسوية بنجاح' }
   },
-  
-  /**
-   * Cancel adjustment
-   */
+
   cancelAdjustment: async (adjustmentId: string, reason: string) => {
+    if (!reason.trim()) throw new Error('سبب الإلغاء مطلوب')
+
     const supabase = await getClient()
-    
-    // Get adjustment
-    const { data: adjustment, error: fetchError } = await supabase
-      .from('stock_adjustments')
-      .select('*')
-      .eq('id', adjustmentId)
-      .single()
-    
-    if (fetchError) throw fetchError
-    
-    if (adjustment.status !== 'SUBMITTED') {
-      throw new Error('يمكن إلغاء التسويات المرحلة فقط')
+    const { data, error } = await supabase.rpc('rpc_cancel_stock_adjustment', {
+      p_adjustment_id: adjustmentId,
+      p_reason: reason,
+    })
+    if (error) throw error
+    const result = assertRpcSuccess(
+      data as RpcResult | null,
+      'فشل إلغاء تسوية المخزون',
+    )
+    return {
+      success: true,
+      duplicate: Boolean(result.duplicate),
+      reversalGlEntryId: result.reversal_gl_entry_id || null,
+      message: result.duplicate
+        ? 'التسوية ملغاة مسبقاً'
+        : 'تم إلغاء التسوية وعكس آثارها بنجاح',
     }
-    
-    // Cancel stock ledger entries
-    const { error: cancelSleError } = await supabase
-      .from('stock_ledger_entries')
-      .update({ is_cancelled: true })
-      .eq('voucher_type', 'Stock Adjustment')
-      .eq('voucher_id', adjustmentId)
-    
-    if (cancelSleError) throw cancelSleError
-    
-    // Create reversal entries
-    const { data: originalEntries } = await supabase
-      .from('stock_ledger_entries')
-      .select('*')
-      .eq('voucher_type', 'Stock Adjustment')
-      .eq('voucher_id', adjustmentId)
-    
-    for (const entry of originalEntries || []) {
-      await supabase
-        .from('stock_ledger_entries')
-        .insert({
-          ...entry,
-          id: undefined,
-          actual_qty: -entry.actual_qty,
-          stock_value_difference: -entry.stock_value_difference,
-          voucher_number: `CANCEL-${entry.voucher_number}`,
-          remarks: `إلغاء: ${reason}`
-        })
-    }
-    
-    // Update adjustment status
-    const { error: statusError } = await supabase
-      .from('stock_adjustments')
-      .update({
-        status: 'CANCELLED',
-        remarks: `إلغاء: ${reason}`
-      })
-      .eq('id', adjustmentId)
-    
-    if (statusError) throw statusError
-    
-    return { success: true, message: 'تم إلغاء التسوية بنجاح' }
   },
-  
-  /**
-   * Get all adjustments
-   */
+
   getAll: async (filters?: {
     status?: string
     adjustment_type?: string
@@ -314,212 +223,115 @@ export const stockAdjustmentService = {
           *,
           product:products(name, code)
         ),
-        warehouse:warehouses(name),
-        created_by_user:users!created_by(name)
+        warehouse:warehouses(name)
       `)
       .order('adjustment_date', { ascending: false })
-    
-    if (filters?.status) {
-      query = query.eq('status', filters.status)
-    }
-    
+
+    if (filters?.status) query = query.eq('status', filters.status)
     if (filters?.adjustment_type) {
       query = query.eq('adjustment_type', filters.adjustment_type)
     }
-    
-    if (filters?.from_date) {
-      query = query.gte('adjustment_date', filters.from_date)
-    }
-    
-    if (filters?.to_date) {
-      query = query.lte('adjustment_date', filters.to_date)
-    }
-    
+    if (filters?.from_date) query = query.gte('adjustment_date', filters.from_date)
+    if (filters?.to_date) query = query.lte('adjustment_date', filters.to_date)
+
     const { data, error } = await query
-    
     if (error) throw error
     return data
   },
-  
-  /**
-   * Start physical count session
-   */
+
   startPhysicalCount: async (session: PhysicalCountSession) => {
     const supabase = await getClient()
-    
     const { data, error } = await supabase
       .from('physical_count_sessions')
       .insert({
         count_date: session.count_date,
         warehouse_id: session.warehouse_id,
         counted_by: session.counted_by,
-        status: 'IN_PROGRESS'
+        status: 'IN_PROGRESS',
       })
       .select()
       .single()
-    
+
     if (error) throw error
     return data
   },
-  
-  /**
-   * Convert physical count to adjustment
-   */
+
   convertCountToAdjustment: async (sessionId: string) => {
     const supabase = await getClient()
-    
-    // Get count session with items
     const { data: session, error: fetchError } = await supabase
       .from('physical_count_sessions')
-      .select(`
-        *,
-        items:physical_count_items(*)
-      `)
+      .select('*, items:physical_count_items(*)')
       .eq('id', sessionId)
       .single()
-    
+
     if (fetchError) throw fetchError
-    
-    // Get products with current stock
-    const productIds = session.items.map((i: any) => i.product_id)
-    const { data: products } = await supabase
+
+    const productIds = (session.items || []).map(
+      (item: { product_id: string }) => item.product_id,
+    )
+    const { data: products, error: productsError } = await supabase
       .from('products')
       .select('id, stock_quantity, cost_price')
       .in('id', productIds)
-    
-    const productsMap = new Map(products?.map(p => [p.id, p]))
-    
-    // Create adjustment items
-    const adjustmentItems: StockAdjustmentItem[] = session.items
-      .map((item: any) => {
-        const product = productsMap.get(item.product_id)
-        if (!product) return null
-        
-        const difference = item.counted_qty - item.system_qty
-        if (difference === 0) return null // No adjustment needed
-        
-        return {
-          product_id: item.product_id,
-          current_qty: item.system_qty,
-          new_qty: item.counted_qty,
-          difference_qty: difference,
-          current_rate: product.cost_price,
-          value_difference: difference * product.cost_price
-        }
-      })
-      .filter(Boolean) as StockAdjustmentItem[]
-    
-    if (adjustmentItems.length === 0) {
+    if (productsError) throw productsError
+
+    const productsMap = new Map(
+      (products || []).map((product) => [product.id, product]),
+    )
+    const adjustmentItems = (session.items || [])
+      .map(
+        (item: {
+          product_id: string
+          system_qty: number
+          counted_qty: number
+        }): StockAdjustmentItem | null => {
+          const product = productsMap.get(item.product_id)
+          if (!product) return null
+          const difference = item.counted_qty - item.system_qty
+          if (difference === 0) return null
+          return {
+            product_id: item.product_id,
+            current_qty: item.system_qty,
+            new_qty: item.counted_qty,
+            difference_qty: difference,
+            current_rate: Number(product.cost_price || 0),
+            value_difference: difference * Number(product.cost_price || 0),
+            warehouse_id: session.warehouse_id,
+          }
+        },
+      )
+      .filter((item: StockAdjustmentItem | null): item is StockAdjustmentItem =>
+        Boolean(item),
+      )
+
+    if (!adjustmentItems.length) {
       throw new Error('لا توجد فروقات تتطلب تسوية')
     }
-    
-    // Create adjustment
-    const adjustment: StockAdjustment = {
+
+    const createdAdjustment = await stockAdjustmentService.createAdjustment({
       adjustment_date: session.count_date,
       adjustment_type: 'PHYSICAL_COUNT',
       reason: `جرد فعلي - ${new Date(session.count_date).toLocaleDateString('ar-SA')}`,
       reference_number: `PC-${sessionId.slice(0, 8)}`,
       warehouse_id: session.warehouse_id,
-      total_value_difference: adjustmentItems.reduce((sum, i) => sum + i.value_difference, 0),
+      total_value_difference: adjustmentItems.reduce(
+        (sum, item) => sum + item.value_difference,
+        0,
+      ),
       status: 'DRAFT',
       requires_approval: true,
       items: adjustmentItems,
-      remarks: `تسوية من جرد فعلي #${sessionId}`
-    }
-    
-    const createdAdjustment = await stockAdjustmentService.createAdjustment(adjustment)
-    
-    // Update session status
-    await supabase
+      remarks: `تسوية من جرد فعلي #${sessionId}`,
+    })
+
+    const { error: updateError } = await supabase
       .from('physical_count_sessions')
-      .update({ 
-        status: 'ADJUSTED',
-        adjustment_id: createdAdjustment.id
-      })
+      .update({ status: 'ADJUSTED', adjustment_id: createdAdjustment.id })
       .eq('id', sessionId)
-    
+    if (updateError) throw updateError
+
     return createdAdjustment
-  }
-}
-
-/**
- * Create accounting entries for stock adjustment
- * Following double-entry accounting principles
- */
-async function createAdjustmentAccountingEntries(
-  supabase: any, 
-  adjustment: any
-) {
-  const totalValueDiff = adjustment.total_value_difference
-  
-  if (totalValueDiff === 0) return // No accounting impact
-  
-  const entries = []
-  
-  if (totalValueDiff > 0) {
-    // Stock increase: Dr increase_account_id (inventory asset) / Cr decrease_account_id (adjustment/gain)
-    entries.push({
-      account_id: adjustment.increase_account_id,
-      debit: totalValueDiff,
-      credit: 0,
-      description: `تسوية مخزون - زيادة: ${adjustment.reference_number}`
-    })
-    entries.push({
-      account_id: adjustment.decrease_account_id,
-      debit: 0,
-      credit: totalValueDiff,
-      description: `ربح تسوية مخزون: ${adjustment.reference_number}`
-    })
-  } else {
-    // Stock decrease: Dr decrease_account_id (adjustment/loss) / Cr increase_account_id (inventory asset)
-    entries.push({
-      account_id: adjustment.decrease_account_id,
-      debit: Math.abs(totalValueDiff),
-      credit: 0,
-      description: `خسارة تسوية مخزون: ${adjustment.reference_number}`
-    })
-    entries.push({
-      account_id: adjustment.increase_account_id,
-      debit: 0,
-      credit: Math.abs(totalValueDiff),
-      description: `تسوية مخزون - نقص: ${adjustment.reference_number}`
-    })
-  }
-  
-  // Create GL entry via canonical RPC (atomic, idempotent)
-  const { data: rpcResult, error: rpcError } = await supabase.rpc(
-    'rpc_create_journal_entry',
-    {
-      p_payload: {
-        org_id: adjustment.org_id,
-        entry_date: adjustment.adjustment_date,
-        entry_type: 'manual',
-        reference_type: 'Stock Adjustment',
-        reference_number: adjustment.reference_number,
-        description: adjustment.reason || `تسوية مخزون ${adjustment.reference_number}`,
-        auto_post: true,
-        idempotency_key: `stock-adj-${adjustment.id}`,
-        lines: entries.map((e, i) => ({
-          line_number: i + 1,
-          account_id: e.account_id,
-          debit: e.debit,
-          credit: e.credit,
-          description: e.description,
-        })),
-      },
-    }
-  )
-
-  if (rpcError) throw rpcError
-  if (!rpcResult?.success) throw new Error(rpcResult?.error || 'فشل إنشاء القيد المحاسبي')
-
-  // Store GL entry reference on the adjustment record
-  if (rpcResult.entry_id) {
-    await supabase
-      .from('stock_adjustments')
-      .update({ journal_entry_id: rpcResult.entry_id })
-      .eq('id', adjustment.id)
-  }
+  },
 }
 
 export default stockAdjustmentService


### PR DESCRIPTION
## الهدف
إغلاق ملاحظات سلامة المخزون وتطابق GitHub/Production دون حذف أي كائن أو بيانات.

## القاعدة الذهبية المطبقة
- لا `DROP TABLE` ولا `DROP COLUMN` ولا حذف بيانات أو ملفات تاريخية.
- الدوال تُستبدل بأمان أو تُضاف دوال جديدة.
- أعمدة المواءمة Additive وnullable.
- لا تطبيق تلقائي على Supabase Production ضمن هذا PR.

## قاعدة البيانات
- **122:** إزالة fallback المؤسسة الافتراضية من `check_entry_approval_required`.
- **123:** إصلاح `handle_new_user()` إلى `user_profiles` وتشديد العضوية بـ`is_active IS TRUE`.
- **124:** RPCs ذرية للتسويات والحركة اليدوية واستهلاك المواد + outbound valuation + مراجع GL القانونية.
- **125:** حساب مخزون مستقل وخريطة محاسبية صحيحة للزيادة والنقص.
- **126:** السماح بإنشاء Draft قبل اختيار الحسابات مع فرضها عند الترحيل، وعدم الخلط بين location وwarehouse.
- **127:** اشتقاق قيمة GL من SLE الفعلية ومنع تكرار المنتج/المخزن داخل التسوية.

## التطبيق
- `stock-adjustment-service.ts` يوجه الإنشاء/الترحيل/الإلغاء إلى RPCs الذرية.
- `inventory-transaction-service.ts` يستهلك الحجوزات عبر معاملة قاعدة واحدة.
- `useUpdateStock` يستخدم خدمة الحركة القانونية بدل تعديل `products.stock_quantity` فقط.
- لا يُعاد إدخال صفوف Ledger بـ`SELECT *`، وبالتالي لا إرسال لـ`posting_datetime` المحسوب.

## CI / Baseline
- Fresh DB على PostgreSQL 17.
- Workflow الـBaseline يقرأ cutoff من سجل Production ويطابق اسم migration بملف المستودع.
- اللقطات الجديدة تحمل timestamp ولا تحذف/تستبدل اللقطات السابقة.

## الاختبارات
- اختبارات خدمة الحركة اليدوية.
- اختبارات تفويض stock-adjustment RPCs وخريطة الحسابات والفشل المنطقي.
- pglast + migration numbering + DEFINER guard + Fresh DB + build ضمن CI.

## التوثيق
- `CLAUDE.md`
- `docs/db/INTEGRITY_HARDENING_122_124_RUNBOOK.md`
- `docs/db/INTEGRITY_HARDENING_125_127_ADDENDUM.md`
- `docs/db/BASELINE_PRODUCTION_CUTOFF_POLICY.md`
- `sql/migrations/STATUS_122_124.md` (اسم تاريخي؛ المحتوى ممتد حتى 127)

## Production deployment
يبقى منفصلًا بعد نجاح CI والمراجعة. ترتيب التطبيق:

`122 → 123 → 124 → 125 → 126 → 127`

بعد كل خطوة تُنفذ استعلامات التحقق الموثقة. لا تُشغّل إعادة Baseline إلا بعد ظهور آخر migration في سجل Production.