### PR TITLE
fix(purchasing): open purchase order details from orders list

### DIFF
--- a/src/features/purchasing/PurchasingModuleHotfix.tsx
+++ b/src/features/purchasing/PurchasingModuleHotfix.tsx
@@ -72,7 +72,7 @@ async function loadPurchaseOrderDetails(id: string): Promise<PurchaseOrderDetail
   return data as unknown as PurchaseOrderDetails
 }
 
-function PurchaseOrdersDetailsManagement() {
+export function PurchaseOrdersDetailsManagement() {
   const { t } = useTranslation()
   const [orders, setOrders] = useState<PurchaseOrderListItem[]>([])
   const [loading, setLoading] = useState(true)

--- a/src/features/purchasing/PurchasingModuleHotfix.tsx
+++ b/src/features/purchasing/PurchasingModuleHotfix.tsx
@@ -1,0 +1,252 @@
+import { useEffect, useState } from 'react'
+import { useLocation } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { LoadingSpinner } from '@/components/ui/loading-state'
+import { PurchaseOrderForm } from '@/components/forms/PurchaseOrderForm'
+import { supabase } from '@/lib/supabase'
+import {
+  newPurchaseOrdersService,
+  purchaseOrdersService,
+} from '@/services/supabase-service'
+import { toast } from 'sonner'
+import { PurchasingModule } from './index'
+import {
+  PurchaseOrderDetailsDialog,
+  type PurchaseOrderDetails,
+} from './components/PurchaseOrderDetailsDialog'
+
+type PurchaseOrderListItem = PurchaseOrderDetails & {
+  expected_delivery?: string | null
+  delivery_date?: string | null
+  vat_amount?: number | string | null
+}
+
+const toNumber = (value: number | string | null | undefined) => {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+const statusConfig: Record<
+  string,
+  { label: string; variant: 'default' | 'secondary' | 'destructive' | 'outline' }
+> = {
+  DRAFT: { label: 'مسودة', variant: 'outline' },
+  CONFIRMED: { label: 'مؤكد', variant: 'default' },
+  APPROVED: { label: 'معتمد', variant: 'default' },
+  RECEIVED: { label: 'مستلم', variant: 'secondary' },
+  CANCELLED: { label: 'ملغى', variant: 'destructive' },
+  draft: { label: 'مسودة', variant: 'outline' },
+  confirmed: { label: 'مؤكد', variant: 'default' },
+  approved: { label: 'معتمد', variant: 'default' },
+  received: { label: 'مستلم', variant: 'secondary' },
+  fully_received: { label: 'مستلم بالكامل', variant: 'secondary' },
+  cancelled: { label: 'ملغى', variant: 'destructive' },
+}
+
+function PurchaseOrderStatusBadge({ status }: { status?: string | null }) {
+  const config = statusConfig[status || ''] || {
+    label: status || '—',
+    variant: 'outline' as const,
+  }
+  return <Badge variant={config.variant}>{config.label}</Badge>
+}
+
+async function loadPurchaseOrderDetails(id: string): Promise<PurchaseOrderDetails> {
+  const { data, error } = await supabase
+    .from('purchase_orders')
+    .select(`
+      *,
+      vendor:vendors(id, name, code),
+      purchase_order_lines(
+        *,
+        product:products(id, code, name, product_name),
+        uom:uoms(id, code, name, name_ar, symbol)
+      )
+    `)
+    .eq('id', id)
+    .single()
+
+  if (error) throw error
+  return data as unknown as PurchaseOrderDetails
+}
+
+function PurchaseOrdersDetailsManagement() {
+  const { t } = useTranslation()
+  const [orders, setOrders] = useState<PurchaseOrderListItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [showAddForm, setShowAddForm] = useState(false)
+  const [selectedOrder, setSelectedOrder] = useState<PurchaseOrderDetails | null>(null)
+  const [detailsOpen, setDetailsOpen] = useState(false)
+  const [detailsLoadingId, setDetailsLoadingId] = useState<string | null>(null)
+
+  const loadOrders = async () => {
+    setLoading(true)
+    try {
+      try {
+        const data = await newPurchaseOrdersService.getAll()
+        setOrders((data || []) as unknown as PurchaseOrderListItem[])
+      } catch (newError) {
+        console.warn('New purchase order reader unavailable; using legacy reader.', newError)
+        const data = await purchaseOrdersService.getAll()
+        setOrders((data || []) as unknown as PurchaseOrderListItem[])
+      }
+    } catch (error) {
+      console.error('Error loading purchase orders:', error)
+      toast.error('خطأ في تحميل أوامر الشراء')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void loadOrders()
+  }, [])
+
+  const openDetails = async (order: PurchaseOrderListItem) => {
+    setDetailsLoadingId(order.id)
+    try {
+      const fullOrder = await loadPurchaseOrderDetails(order.id)
+      setSelectedOrder(fullOrder)
+      setDetailsOpen(true)
+    } catch (error) {
+      console.error('Error loading purchase order details:', error)
+      toast.error('تعذر تحميل تفاصيل أمر الشراء')
+    } finally {
+      setDetailsLoadingId(null)
+    }
+  }
+
+  if (loading) {
+    return <LoadingSpinner label={t('common.loading')} />
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold">{t('purchasing.purchaseOrders')}</h1>
+          <p className="text-muted-foreground">أوامر الشراء</p>
+        </div>
+        <Button onClick={() => setShowAddForm(true)}>+ إضافة أمر شراء</Button>
+      </div>
+
+      <PurchaseOrderForm
+        open={showAddForm}
+        onOpenChange={setShowAddForm}
+        onSuccess={() => {
+          void loadOrders()
+        }}
+      />
+
+      <PurchaseOrderDetailsDialog
+        order={selectedOrder}
+        open={detailsOpen}
+        onOpenChange={(open) => {
+          setDetailsOpen(open)
+          if (!open) setSelectedOrder(null)
+        }}
+      />
+
+      <div className="rounded-lg border bg-card">
+        <div className="flex items-center justify-between border-b p-4">
+          <h3 className="font-semibold">قائمة أوامر الشراء ({orders.length})</h3>
+          {orders.length === 0 && <Badge variant="outline">لا توجد بيانات</Badge>}
+        </div>
+
+        <div className="divide-y">
+          {orders.length === 0 ? (
+            <div className="p-8 text-center text-muted-foreground">
+              لا توجد أوامر شراء مسجلة.
+            </div>
+          ) : (
+            orders.map((order) => {
+              const lines = order.purchase_order_lines || []
+              const isOpening = detailsLoadingId === order.id
+              const deliveryDate =
+                order.expected_delivery_date || order.expected_delivery || order.delivery_date
+              const taxAmount = order.tax_amount ?? order.vat_amount
+
+              return (
+                <button
+                  key={order.id}
+                  type="button"
+                  className="block w-full p-4 text-start transition-colors hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset disabled:cursor-wait disabled:opacity-70"
+                  onClick={() => void openDetails(order)}
+                  disabled={detailsLoadingId !== null}
+                  aria-label={`عرض تفاصيل أمر الشراء ${order.order_number || ''}`}
+                >
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <h4 className="break-all text-lg font-medium">{order.order_number}</h4>
+                        {isOpening && <span className="text-xs text-muted-foreground">جاري الفتح...</span>}
+                      </div>
+                      <p className="mt-1 text-sm text-muted-foreground">
+                        {order.vendor?.name || order.supplier?.name || 'مورد غير محدد'}
+                      </p>
+                      <div className="mt-2 flex flex-wrap gap-4 text-sm text-muted-foreground">
+                        <span>📅 {order.order_date ? new Date(order.order_date).toLocaleDateString('en-US') : '—'}</span>
+                        {deliveryDate && (
+                          <span>🚚 التسليم: {new Date(deliveryDate).toLocaleDateString('en-US')}</span>
+                        )}
+                      </div>
+
+                      {lines.length > 0 && (
+                        <div className="mt-3 text-sm">
+                          <p className="mb-1 font-medium text-muted-foreground">
+                            المنتجات ({lines.length}):
+                          </p>
+                          <div className="flex flex-wrap gap-2">
+                            {lines.slice(0, 3).map((line, index) => (
+                              <Badge key={line.id || `${order.id}-${index}`} variant="outline" className="text-xs">
+                                {line.product?.product_name || line.product?.name || line.description || 'منتج'}
+                                {' '}({toNumber(line.qty_entered ?? line.quantity).toLocaleString('en-US')})
+                              </Badge>
+                            ))}
+                            {lines.length > 3 && (
+                              <Badge variant="outline" className="text-xs">+{lines.length - 3} المزيد</Badge>
+                            )}
+                          </div>
+                        </div>
+                      )}
+                    </div>
+
+                    <div className="shrink-0 text-start sm:text-end">
+                      <PurchaseOrderStatusBadge status={order.status} />
+                      <div className="mt-2 text-lg font-bold text-primary">
+                        {toNumber(order.total_amount).toLocaleString('en-US', {
+                          minimumFractionDigits: 2,
+                          maximumFractionDigits: 2,
+                        })}{' '}
+                        ريال
+                      </div>
+                      {toNumber(taxAmount) > 0 && (
+                        <div className="text-xs text-muted-foreground">
+                          شامل ضريبة: {toNumber(taxAmount).toFixed(2)} ريال
+                        </div>
+                      )}
+                      <div className="mt-2 text-xs font-medium text-primary">اضغط لعرض التفاصيل</div>
+                    </div>
+                  </div>
+                </button>
+              )
+            })
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function PurchasingModuleHotfix() {
+  const location = useLocation()
+  const normalizedPath = location.pathname.replace(/\/+$/, '')
+
+  if (normalizedPath === '/purchasing/orders') {
+    return <PurchaseOrdersDetailsManagement />
+  }
+
+  return <PurchasingModule />
+}

--- a/src/features/purchasing/PurchasingModuleHotfix.tsx
+++ b/src/features/purchasing/PurchasingModuleHotfix.tsx
@@ -61,7 +61,7 @@ async function loadPurchaseOrderDetails(id: string): Promise<PurchaseOrderDetail
       vendor:vendors(id, name, code),
       purchase_order_lines(
         *,
-        product:products(id, code, name, product_name),
+        product:products(id, code, name),
         uom:uoms(id, code, name, name_ar, symbol)
       )
     `)

--- a/src/features/purchasing/__tests__/purchase-order-details-dialog.test.tsx
+++ b/src/features/purchasing/__tests__/purchase-order-details-dialog.test.tsx
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { PurchaseOrderDetailsDialog } from '../components/PurchaseOrderDetailsDialog'
+
+const order = {
+  id: 'po-1',
+  order_number: 'PO-20260724-07B821D3',
+  order_date: '2026-07-24',
+  status: 'draft',
+  subtotal: 1000,
+  discount_amount: 0,
+  tax_amount: 150,
+  total_amount: 1150,
+  vendor: { name: 'شركة المواد الخام المحدودة' },
+  purchase_order_lines: [
+    {
+      id: 'line-1',
+      line_number: 1,
+      quantity: 500,
+      qty_entered: 0.5,
+      conversion_factor_snapshot: 1000,
+      unit_price: 2,
+      unit_price_entered: 2000,
+      discount_percentage: 0,
+      tax_percentage: 15,
+      line_total: 1150,
+      product: { code: 'RM-010', name: 'PP Clear Sheet' },
+      uom: { code: 'TON', name: 'Metric ton', name_ar: 'طن', symbol: 't' },
+    },
+  ],
+}
+
+describe('PurchaseOrderDetailsDialog', () => {
+  it('shows the stored commercial and base quantity snapshots', () => {
+    render(
+      <PurchaseOrderDetailsDialog
+        order={order}
+        open
+        onOpenChange={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('PO-20260724-07B821D3')).toBeInTheDocument()
+    expect(screen.getByText('RM-010 - PP Clear Sheet')).toBeInTheDocument()
+    expect(screen.getByText('0.5 طن')).toBeInTheDocument()
+    expect(screen.getByText('1,000')).toBeInTheDocument()
+    expect(screen.getByText('500 كجم')).toBeInTheDocument()
+    expect(screen.getByText('2,000.00')).toBeInTheDocument()
+    expect(screen.getByText('1,150.00 ريال')).toBeInTheDocument()
+  })
+
+  it('can be closed from the explicit close button', async () => {
+    const onOpenChange = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <PurchaseOrderDetailsDialog
+        order={order}
+        open
+        onOpenChange={onOpenChange}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'إغلاق' }))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/src/features/purchasing/__tests__/purchase-order-details-dialog.test.tsx
+++ b/src/features/purchasing/__tests__/purchase-order-details-dialog.test.tsx
@@ -47,7 +47,7 @@ describe('PurchaseOrderDetailsDialog', () => {
     expect(screen.getByText('1,000')).toBeInTheDocument()
     expect(screen.getByText('500 كجم')).toBeInTheDocument()
     expect(screen.getByText('2,000.00')).toBeInTheDocument()
-    expect(screen.getByText('1,150.00 ريال')).toBeInTheDocument()
+    expect(screen.getAllByText('1,150.00 ريال')).toHaveLength(2)
   })
 
   it('can be closed from the explicit close button', async () => {

--- a/src/features/purchasing/__tests__/purchase-orders-details-management.test.tsx
+++ b/src/features/purchasing/__tests__/purchase-orders-details-management.test.tsx
@@ -3,32 +3,34 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 
-const getAllNew = vi.fn()
-const getAllLegacy = vi.fn()
-const single = vi.fn()
-const toastError = vi.fn()
+const mocks = vi.hoisted(() => ({
+  getAllNew: vi.fn(),
+  getAllLegacy: vi.fn(),
+  single: vi.fn(),
+  toastError: vi.fn(),
+}))
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }))
 
 vi.mock('@/services/supabase-service', () => ({
-  newPurchaseOrdersService: { getAll: getAllNew },
-  purchaseOrdersService: { getAll: getAllLegacy },
+  newPurchaseOrdersService: { getAll: mocks.getAllNew },
+  purchaseOrdersService: { getAll: mocks.getAllLegacy },
 }))
 
 vi.mock('@/lib/supabase', () => ({
   supabase: {
     from: vi.fn(() => ({
       select: vi.fn(() => ({
-        eq: vi.fn(() => ({ single })),
+        eq: vi.fn(() => ({ single: mocks.single })),
       })),
     })),
   },
 }))
 
 vi.mock('sonner', () => ({
-  toast: { error: toastError },
+  toast: { error: mocks.toastError },
 }))
 
 vi.mock('@/components/forms/PurchaseOrderForm', () => ({
@@ -98,9 +100,9 @@ const fullOrder = {
 describe('PurchaseOrdersDetailsManagement', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    getAllNew.mockResolvedValue([listOrder])
-    getAllLegacy.mockResolvedValue([])
-    single.mockResolvedValue({ data: fullOrder, error: null })
+    mocks.getAllNew.mockResolvedValue([listOrder])
+    mocks.getAllLegacy.mockResolvedValue([])
+    mocks.single.mockResolvedValue({ data: fullOrder, error: null })
   })
 
   it('opens an order from an accessible card and shows UoM snapshots', async () => {
@@ -119,7 +121,7 @@ describe('PurchaseOrdersDetailsManagement', () => {
     expect(await screen.findByText('0.5 طن')).toBeInTheDocument()
     expect(screen.getByText('500 كجم')).toBeInTheDocument()
     expect(screen.getByText('2,000.00')).toBeInTheDocument()
-    expect(single).toHaveBeenCalledTimes(1)
+    expect(mocks.single).toHaveBeenCalledTimes(1)
   })
 
   it('opens and closes the create form, then reloads after success', async () => {
@@ -131,33 +133,33 @@ describe('PurchaseOrdersDetailsManagement', () => {
     expect(screen.getByText('نموذج أمر الشراء')).toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: 'نجاح الحفظ' }))
-    await waitFor(() => expect(getAllNew).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(mocks.getAllNew).toHaveBeenCalledTimes(2))
 
     await user.click(screen.getByRole('button', { name: 'إغلاق النموذج' }))
     expect(screen.queryByText('نموذج أمر الشراء')).not.toBeInTheDocument()
   })
 
   it('falls back to the legacy reader and renders an empty state', async () => {
-    getAllNew.mockRejectedValue(new Error('new reader unavailable'))
-    getAllLegacy.mockResolvedValue([])
+    mocks.getAllNew.mockRejectedValue(new Error('new reader unavailable'))
+    mocks.getAllLegacy.mockResolvedValue([])
 
     render(<PurchaseOrdersDetailsManagement />)
 
     expect(await screen.findByText('لا توجد أوامر شراء مسجلة.')).toBeInTheDocument()
-    expect(getAllLegacy).toHaveBeenCalledTimes(1)
+    expect(mocks.getAllLegacy).toHaveBeenCalledTimes(1)
   })
 
   it('reports list and details failures without crashing', async () => {
-    getAllNew.mockRejectedValueOnce(new Error('new reader unavailable'))
-    getAllLegacy.mockRejectedValueOnce(new Error('legacy reader unavailable'))
+    mocks.getAllNew.mockRejectedValueOnce(new Error('new reader unavailable'))
+    mocks.getAllLegacy.mockRejectedValueOnce(new Error('legacy reader unavailable'))
 
     const { unmount } = render(<PurchaseOrdersDetailsManagement />)
     expect(await screen.findByText('لا توجد أوامر شراء مسجلة.')).toBeInTheDocument()
-    expect(toastError).toHaveBeenCalledWith('خطأ في تحميل أوامر الشراء')
+    expect(mocks.toastError).toHaveBeenCalledWith('خطأ في تحميل أوامر الشراء')
     unmount()
 
-    getAllNew.mockResolvedValue([listOrder])
-    single.mockResolvedValue({ data: null, error: new Error('details unavailable') })
+    mocks.getAllNew.mockResolvedValue([listOrder])
+    mocks.single.mockResolvedValue({ data: null, error: new Error('details unavailable') })
     const user = userEvent.setup()
     render(<PurchaseOrdersDetailsManagement />)
 
@@ -165,7 +167,7 @@ describe('PurchaseOrdersDetailsManagement', () => {
       name: 'عرض تفاصيل أمر الشراء PO-20260724-07B821D3',
     }))
     await waitFor(() => {
-      expect(toastError).toHaveBeenCalledWith('تعذر تحميل تفاصيل أمر الشراء')
+      expect(mocks.toastError).toHaveBeenCalledWith('تعذر تحميل تفاصيل أمر الشراء')
     })
   })
 })
@@ -173,7 +175,7 @@ describe('PurchaseOrdersDetailsManagement', () => {
 describe('PurchasingModuleHotfix', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    getAllNew.mockResolvedValue([])
+    mocks.getAllNew.mockResolvedValue([])
   })
 
   it('uses the details view for the orders route including a trailing slash', async () => {

--- a/src/features/purchasing/__tests__/purchase-orders-details-management.test.tsx
+++ b/src/features/purchasing/__tests__/purchase-orders-details-management.test.tsx
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+
+const getAllNew = vi.fn()
+const getAllLegacy = vi.fn()
+const single = vi.fn()
+const toastError = vi.fn()
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('@/services/supabase-service', () => ({
+  newPurchaseOrdersService: { getAll: getAllNew },
+  purchaseOrdersService: { getAll: getAllLegacy },
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({ single })),
+      })),
+    })),
+  },
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: toastError },
+}))
+
+vi.mock('@/components/forms/PurchaseOrderForm', () => ({
+  PurchaseOrderForm: ({ open, onOpenChange, onSuccess }: {
+    open: boolean
+    onOpenChange: (open: boolean) => void
+    onSuccess: () => void
+  }) => open ? (
+    <div>
+      <span>نموذج أمر الشراء</span>
+      <button type="button" onClick={() => onOpenChange(false)}>إغلاق النموذج</button>
+      <button type="button" onClick={onSuccess}>نجاح الحفظ</button>
+    </div>
+  ) : null,
+}))
+
+vi.mock('../index', () => ({
+  PurchasingModule: () => <div>الوحدة الأصلية</div>,
+}))
+
+import {
+  PurchaseOrdersDetailsManagement,
+  PurchasingModuleHotfix,
+} from '../PurchasingModuleHotfix'
+
+const listOrder = {
+  id: 'po-1',
+  order_number: 'PO-20260724-07B821D3',
+  order_date: '2026-07-24',
+  expected_delivery_date: '2026-07-30',
+  status: 'draft',
+  tax_amount: 150,
+  total_amount: 1150,
+  vendor: { name: 'شركة المواد الخام المحدودة' },
+  purchase_order_lines: [
+    {
+      id: 'line-1',
+      qty_entered: 0.5,
+      quantity: 500,
+      product: { name: 'PP Clear Sheet' },
+    },
+  ],
+}
+
+const fullOrder = {
+  ...listOrder,
+  subtotal: 1000,
+  discount_amount: 0,
+  purchase_order_lines: [
+    {
+      id: 'line-1',
+      line_number: 1,
+      qty_entered: 0.5,
+      quantity: 500,
+      conversion_factor_snapshot: 1000,
+      unit_price_entered: 2000,
+      unit_price: 2,
+      discount_percentage: 0,
+      tax_percentage: 15,
+      line_total: 1150,
+      product: { code: 'RM-010', name: 'PP Clear Sheet' },
+      uom: { code: 'TON', name_ar: 'طن' },
+    },
+  ],
+}
+
+describe('PurchaseOrdersDetailsManagement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getAllNew.mockResolvedValue([listOrder])
+    getAllLegacy.mockResolvedValue([])
+    single.mockResolvedValue({ data: fullOrder, error: null })
+  })
+
+  it('opens an order from an accessible card and shows UoM snapshots', async () => {
+    const user = userEvent.setup()
+    render(<PurchaseOrdersDetailsManagement />)
+
+    const card = await screen.findByRole('button', {
+      name: 'عرض تفاصيل أمر الشراء PO-20260724-07B821D3',
+    })
+    expect(card).toBeInTheDocument()
+    expect(screen.getByText('PP Clear Sheet (0.5)')).toBeInTheDocument()
+    expect(screen.getByText('شامل ضريبة: 150.00 ريال')).toBeInTheDocument()
+
+    await user.click(card)
+
+    expect(await screen.findByText('0.5 طن')).toBeInTheDocument()
+    expect(screen.getByText('500 كجم')).toBeInTheDocument()
+    expect(screen.getByText('2,000.00')).toBeInTheDocument()
+    expect(single).toHaveBeenCalledTimes(1)
+  })
+
+  it('opens and closes the create form, then reloads after success', async () => {
+    const user = userEvent.setup()
+    render(<PurchaseOrdersDetailsManagement />)
+
+    await screen.findByText('PO-20260724-07B821D3')
+    await user.click(screen.getByRole('button', { name: '+ إضافة أمر شراء' }))
+    expect(screen.getByText('نموذج أمر الشراء')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'نجاح الحفظ' }))
+    await waitFor(() => expect(getAllNew).toHaveBeenCalledTimes(2))
+
+    await user.click(screen.getByRole('button', { name: 'إغلاق النموذج' }))
+    expect(screen.queryByText('نموذج أمر الشراء')).not.toBeInTheDocument()
+  })
+
+  it('falls back to the legacy reader and renders an empty state', async () => {
+    getAllNew.mockRejectedValue(new Error('new reader unavailable'))
+    getAllLegacy.mockResolvedValue([])
+
+    render(<PurchaseOrdersDetailsManagement />)
+
+    expect(await screen.findByText('لا توجد أوامر شراء مسجلة.')).toBeInTheDocument()
+    expect(getAllLegacy).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports list and details failures without crashing', async () => {
+    getAllNew.mockRejectedValueOnce(new Error('new reader unavailable'))
+    getAllLegacy.mockRejectedValueOnce(new Error('legacy reader unavailable'))
+
+    const { unmount } = render(<PurchaseOrdersDetailsManagement />)
+    expect(await screen.findByText('لا توجد أوامر شراء مسجلة.')).toBeInTheDocument()
+    expect(toastError).toHaveBeenCalledWith('خطأ في تحميل أوامر الشراء')
+    unmount()
+
+    getAllNew.mockResolvedValue([listOrder])
+    single.mockResolvedValue({ data: null, error: new Error('details unavailable') })
+    const user = userEvent.setup()
+    render(<PurchaseOrdersDetailsManagement />)
+
+    await user.click(await screen.findByRole('button', {
+      name: 'عرض تفاصيل أمر الشراء PO-20260724-07B821D3',
+    }))
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith('تعذر تحميل تفاصيل أمر الشراء')
+    })
+  })
+})
+
+describe('PurchasingModuleHotfix', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getAllNew.mockResolvedValue([])
+  })
+
+  it('uses the details view for the orders route including a trailing slash', async () => {
+    render(
+      <MemoryRouter initialEntries={['/purchasing/orders/']}>
+        <PurchasingModuleHotfix />
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByText('لا توجد أوامر شراء مسجلة.')).toBeInTheDocument()
+  })
+
+  it('delegates other purchasing routes to the original module', () => {
+    render(
+      <MemoryRouter initialEntries={['/purchasing/receipts']}>
+        <PurchasingModuleHotfix />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByText('الوحدة الأصلية')).toBeInTheDocument()
+  })
+})

--- a/src/features/purchasing/components/PurchaseOrderDetailsDialog.tsx
+++ b/src/features/purchasing/components/PurchaseOrderDetailsDialog.tsx
@@ -1,0 +1,239 @@
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+
+type PurchaseOrderLine = {
+  id?: string
+  line_number?: number
+  description?: string | null
+  quantity?: number | string | null
+  qty_entered?: number | string | null
+  unit_price?: number | string | null
+  unit_price_entered?: number | string | null
+  conversion_factor_snapshot?: number | string | null
+  discount_percentage?: number | string | null
+  tax_percentage?: number | string | null
+  line_total?: number | string | null
+  unit?: string | null
+  product?: {
+    code?: string | null
+    name?: string | null
+    product_name?: string | null
+  } | null
+  uom?: {
+    code?: string | null
+    name?: string | null
+    name_ar?: string | null
+    symbol?: string | null
+  } | null
+}
+
+export type PurchaseOrderDetails = {
+  id: string
+  order_number?: string | null
+  order_date?: string | null
+  expected_delivery?: string | null
+  expected_delivery_date?: string | null
+  delivery_date?: string | null
+  status?: string | null
+  subtotal?: number | string | null
+  discount_amount?: number | string | null
+  tax_amount?: number | string | null
+  vat_amount?: number | string | null
+  total_amount?: number | string | null
+  notes?: string | null
+  vendor?: { name?: string | null } | null
+  supplier?: { name?: string | null } | null
+  purchase_order_lines?: PurchaseOrderLine[] | null
+}
+
+type PurchaseOrderDetailsDialogProps = {
+  order: PurchaseOrderDetails | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+const numberValue = (value: number | string | null | undefined, fallback = 0) => {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+const money = (value: number | string | null | undefined) =>
+  numberValue(value).toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })
+
+const quantity = (value: number | string | null | undefined) =>
+  numberValue(value).toLocaleString('en-US', {
+    maximumFractionDigits: 6,
+  })
+
+const dateLabel = (value: string | null | undefined) =>
+  value ? new Date(value).toLocaleDateString('en-US') : '—'
+
+const uomLabel = (line: PurchaseOrderLine) =>
+  line.uom?.name_ar || line.uom?.name || line.uom?.code || line.unit || '—'
+
+const productLabel = (line: PurchaseOrderLine) => {
+  const code = line.product?.code
+  const name = line.product?.product_name || line.product?.name || line.description
+  return [code, name].filter(Boolean).join(' - ') || 'منتج غير محدد'
+}
+
+export function PurchaseOrderDetailsDialog({
+  order,
+  open,
+  onOpenChange,
+}: PurchaseOrderDetailsDialogProps) {
+  if (!order) return null
+
+  const lines = order.purchase_order_lines || []
+  const supplierName = order.vendor?.name || order.supplier?.name || 'مورد غير محدد'
+  const deliveryDate =
+    order.expected_delivery_date || order.expected_delivery || order.delivery_date
+  const taxAmount = order.tax_amount ?? order.vat_amount
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        dir="rtl"
+        className="max-h-[92vh] w-[calc(100%-1rem)] max-w-5xl overflow-y-auto p-4 sm:p-6"
+      >
+        <DialogHeader className="text-right">
+          <div className="flex flex-wrap items-center justify-between gap-2 pe-8">
+            <DialogTitle>{order.order_number || 'تفاصيل أمر الشراء'}</DialogTitle>
+            <Badge variant="outline">{order.status || '—'}</Badge>
+          </div>
+          <DialogDescription className="text-right">
+            عرض محفوظ لبيانات أمر الشراء ووحدات القياس وقت الإنشاء.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid grid-cols-1 gap-3 rounded-lg border bg-muted/20 p-3 text-sm sm:grid-cols-3">
+          <div>
+            <p className="text-muted-foreground">المورد</p>
+            <p className="font-medium">{supplierName}</p>
+          </div>
+          <div>
+            <p className="text-muted-foreground">تاريخ الأمر</p>
+            <p className="font-medium">{dateLabel(order.order_date)}</p>
+          </div>
+          <div>
+            <p className="text-muted-foreground">التسليم المتوقع</p>
+            <p className="font-medium">{dateLabel(deliveryDate)}</p>
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          <h3 className="font-semibold">بنود أمر الشراء ({lines.length})</h3>
+          {lines.length === 0 ? (
+            <div className="rounded-lg border p-4 text-center text-muted-foreground">
+              لا توجد بنود محفوظة في هذا الأمر.
+            </div>
+          ) : (
+            lines.map((line, index) => {
+              const enteredQuantity = numberValue(line.qty_entered, numberValue(line.quantity))
+              const factor = numberValue(line.conversion_factor_snapshot, 1)
+              const baseQuantity = numberValue(line.quantity, enteredQuantity * factor)
+              const enteredPrice = numberValue(line.unit_price_entered, numberValue(line.unit_price))
+              const normalizedPrice = numberValue(
+                line.unit_price,
+                factor > 0 ? enteredPrice / factor : enteredPrice,
+              )
+
+              return (
+                <article key={line.id || `${order.id}-${index}`} className="rounded-lg border p-3">
+                  <div className="mb-3 flex flex-wrap items-start justify-between gap-2">
+                    <div>
+                      <p className="font-medium">{productLabel(line)}</p>
+                      <p className="text-xs text-muted-foreground">
+                        السطر {line.line_number || index + 1}
+                      </p>
+                    </div>
+                    <p className="font-bold text-primary">{money(line.line_total)} ريال</p>
+                  </div>
+
+                  <div className="grid grid-cols-2 gap-3 text-sm sm:grid-cols-4 lg:grid-cols-7">
+                    <div>
+                      <p className="text-muted-foreground">الكمية التجارية</p>
+                      <p className="font-medium">
+                        {quantity(enteredQuantity)} {uomLabel(line)}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-muted-foreground">معامل التحويل</p>
+                      <p className="font-medium">{quantity(factor)}</p>
+                    </div>
+                    <div>
+                      <p className="text-muted-foreground">كمية الأساس</p>
+                      <p className="font-medium">{quantity(baseQuantity)} كجم</p>
+                    </div>
+                    <div>
+                      <p className="text-muted-foreground">السعر التجاري</p>
+                      <p className="font-medium">{money(enteredPrice)}</p>
+                    </div>
+                    <div>
+                      <p className="text-muted-foreground">سعر وحدة الأساس</p>
+                      <p className="font-medium">{money(normalizedPrice)}</p>
+                    </div>
+                    <div>
+                      <p className="text-muted-foreground">الخصم</p>
+                      <p className="font-medium">{quantity(line.discount_percentage)}%</p>
+                    </div>
+                    <div>
+                      <p className="text-muted-foreground">الضريبة</p>
+                      <p className="font-medium">{quantity(line.tax_percentage)}%</p>
+                    </div>
+                  </div>
+                </article>
+              )
+            })
+          )}
+        </div>
+
+        <div className="grid grid-cols-2 gap-3 rounded-lg border p-3 text-sm sm:grid-cols-4">
+          <div>
+            <p className="text-muted-foreground">الصافي</p>
+            <p className="font-semibold">{money(order.subtotal)} ريال</p>
+          </div>
+          <div>
+            <p className="text-muted-foreground">الخصم</p>
+            <p className="font-semibold">{money(order.discount_amount)} ريال</p>
+          </div>
+          <div>
+            <p className="text-muted-foreground">الضريبة</p>
+            <p className="font-semibold">{money(taxAmount)} ريال</p>
+          </div>
+          <div>
+            <p className="text-muted-foreground">الإجمالي</p>
+            <p className="text-lg font-bold text-primary">{money(order.total_amount)} ريال</p>
+          </div>
+        </div>
+
+        {order.notes && (
+          <div className="rounded-lg border p-3 text-sm">
+            <p className="text-muted-foreground">ملاحظات</p>
+            <p>{order.notes}</p>
+          </div>
+        )}
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button type="button" variant="outline">
+              إغلاق
+            </Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/pages/routes.tsx
+++ b/src/pages/routes.tsx
@@ -121,8 +121,8 @@ export const appRouter = createBrowserRouter([
             path: "purchasing/*",
             lazy: guardedLazy(
               MODULE_CODES.PURCHASING,
-              () => import("@/features/purchasing"),
-              "PurchasingModule"
+              () => import("@/features/purchasing/PurchasingModuleHotfix"),
+              "PurchasingModuleHotfix"
             ),
           },
           {


### PR DESCRIPTION
## الملخص
Hotfix لمعالجة عدم إمكانية فتح أمر الشراء من قائمة الأوامر بعد نجاح تكامل UoM.

## التغييرات
- إضافة مسار عرض تفاصيل مخصص لقائمة أوامر الشراء.
- جعل بطاقة الأمر زرًا فعليًا قابلاً للنقر ولوحة المفاتيح.
- تحميل تفاصيل الأمر عند الطلب من نفس الجداول مع RLS الحالية.
- عرض snapshots الخاصة بوحدات القياس:
  - الكمية التجارية
  - الوحدة
  - معامل التحويل
  - كمية الأساس
  - السعر التجاري
  - السعر الموحّد
  - الخصم والضريبة والإجمالي
- دعم RTL والجوال ونافذة قابلة للتمرير.
- إضافة اختبارين لعرض snapshots والإغلاق.

## التحقق التشغيلي
أمر الاختبار `PO-20260724-07B821D3` محفوظ سليمًا في القاعدة:
- 0.5 طن
- معامل 1000
- 500 كجم أساس
- 2000 ريال/طن
- 1000 صافي + 150 ضريبة = 1150 إجمالي

Closes #43