### PR TITLE
ci(baseline): run the PostgreSQL 17 client, and assert it

### DIFF
--- a/.github/workflows/generate-baseline.yml
+++ b/.github/workflows/generate-baseline.yml
@@ -51,7 +51,24 @@ jobs:
             | sudo tee /etc/apt/sources.list.d/pgdg.list
           sudo apt-get update -q
           sudo apt-get install -y postgresql-client-17
-          pg_dump --version
+
+          # صورة عدّاء GitHub تحمل عميل PostgreSQL 16 في /usr/bin، وحزمة PGDG
+          # تضع ملفات 17 في /usr/lib/postgresql/17/bin دون تقديمها في PATH.
+          # فبلا هذا السطر يبقى pg_dump 16 هو المُنفَّذ، ويرفض التفريغ من خادم 17
+          # بـ"server version mismatch" — بعد خطوتين من هنا لا هنا.
+          echo "/usr/lib/postgresql/17/bin" >> "$GITHUB_PATH"
+          export PATH="/usr/lib/postgresql/17/bin:$PATH"
+
+          # تحقق حاجز لا طباعة: السطر السابق كان `pg_dump --version` وحده، فطبع
+          # 16.14 ومضى ناجحًا وأخفى العطل. أي انحدار مستقبلي يجب أن يفشل هنا.
+          for BIN in pg_dump psql; do
+            VERSION=$("$BIN" --version | grep -oE '[0-9]+' | head -1)
+            if [ "$VERSION" != "17" ]; then
+              echo "❌ $BIN المُنفَّذ إصدار $VERSION لا 17 — $(command -v "$BIN")"
+              exit 1
+            fi
+            echo "✅ $("$BIN" --version) — $(command -v "$BIN")"
+          done
 
       - name: Validate database secret
         env:


### PR DESCRIPTION
## الهدف

`Generate Schema Baseline` كان معطّلًا بعطلين متتاليين. الأول خارج المستودع (صيغة سرّ `SUPABASE_DB_URL`) وقد أُصلح. هذا الـPR يعالج **الثاني، وهو داخل الـworkflow نفسه** — ملف واحد، CI فقط، لا SQL ولا واجهة ولا أثر تشغيلي.

## ما كشفه أول تشغيل يبلغ الخطوة 7

بعد إصلاح السرّ، نجحت قراءة السجل الحي لأول مرة:

| البند | القيمة |
|---|---|
| `CUTOFF` | **148** |
| `LIVE_NAME` | `148_uom_purchase_receipt_snapshots` |
| `LIVE_VERSION` | `20260725145856` |

`validate_migration_ledger.py` قَبِل السجل بلا drift — Production عند 148 والمستودع يطابقه ملفًا بملف، أي أن `repository-first` مُتحقَّقة عمليًا.

ثم فشلت الخطوة 7:

```
pg_dump: error: aborting because of server version mismatch
pg_dump: detail: server version: 17.4; pg_dump version: 16.14 (Ubuntu 16.14-1.pgdg24.04+1)
```

## السبب

خطوة «Install PostgreSQL 17 client» تثبّت الحزمة **بنجاح**، لكن PGDG تضع ملفاتها في `/usr/lib/postgresql/17/bin` دون تقديمها في `PATH`، فيبقى `/usr/bin/pg_dump` إصدار 16 المرفق بصورة عدّاء GitHub هو المُنفَّذ. و`pg_dump` يرفض قطعيًا التفريغ من خادم أحدث منه.

**وما أخّر ظهور العطل خطوتين:** السطر الأخير في خطوة التثبيت كان `pg_dump --version` وحده — يطبع ولا يتحقق. طبع `16.14` ومضى ناجحًا، فظهر الانفجار في «Generate baseline from Production» بدل مصدره.

هذا العطل قائم منذ كتابة الـworkflow، وظلّ مخفيًا لأن كل تشغيل سابق فشل عند قراءة السجل قبل بلوغ الخطوة 7.

## التغيير

1. **تقديم عميل 17 في `PATH`** — يُكتب إلى `GITHUB_PATH` (للخطوات اللاحقة) وإلى `PATH` داخل الخطوة نفسها (للحارس أدناه). يشمل ذلك `createdb` و`psql` في إعادة البناء النظيفة على الخدمة المحلية 17.
2. **تحويل الطباعة إلى حارس** — يفحص `pg_dump` و`psql` معًا، يفشل إن لم يكن أيهما 17، ويطبع المسار المُنفَّذ فعلًا (`command -v`) لتشخيص أسرع مستقبلًا.

## التحقق

- **الحارس غير صوري:** شُغّل منطق استخراج الإصدار على عميل PostgreSQL 16 محلي (`psql (PostgreSQL) 16.13`) فأعطى `16` — أي أن الحارس كان سيفشل. فحص يمرّ على كل شيء لا قيمة له، وهذا لا يمرّ.
- YAML صالح ومُحلَّل: 10 خطوات، الأسماء والترتيب دون تغيير.
- كتلة `DATABASE_STATE` في `CLAUDE.md` لم تُمس — يملكها هذا الـworkflow ويكتبها آليًا.

## بعد الدمج

إعادة تشغيل `Generate Schema Baseline`. المتوقع أن يُكمل التوليد وإعادة البناء النظيفة ويفتح **PR الـbaseline** الذي ينقل cutoff من 121 إلى 148 ويصحح كتلة `DATABASE_STATE`. لن يكتب إلى `main` مباشرة.

## ملاحظة على ترتيب النشر

التغيير في الـCI فقط — لا migration ولا واجهة تعتمد على RPC أو Schema — فلا ينطبق عليه شرط الفصل إلى PRين المضاف في #50.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASrDjrR8BGjPnZ5mp8UtFQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01ASrDjrR8BGjPnZ5mp8UtFQ)_