### PR TITLE
ci(fresh-db): derive the shim's database name from the connection

### DIFF
--- a/scripts/ci/fresh-db/supabase_shim.sql
+++ b/scripts/ci/fresh-db/supabase_shim.sql
@@ -6,7 +6,17 @@ CREATE ROLE service_role NOLOGIN;
 CREATE SCHEMA IF NOT EXISTS extensions;
 CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA extensions;
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA extensions;
-ALTER DATABASE wardah_fresh SET search_path = public, extensions;
+-- اسم القاعدة يُشتق من الاتصال الحالي لا يُثبَّت نصًا. كان مثبتًا على
+-- `wardah_fresh`، فنجح في ci-cd.yml وفشل في generate-baseline.yml الذي ينشئ
+-- `wardah_baseline_verify` — عقد ضمني بين ملف SQL واسم قاعدة في workflow آخر.
+DO $wardah_shim$
+BEGIN
+  EXECUTE format(
+    'ALTER DATABASE %I SET search_path = public, extensions',
+    current_database()
+  );
+END
+$wardah_shim$;
 
 CREATE SCHEMA auth;
 CREATE TABLE auth.users (


### PR DESCRIPTION
## الهدف

بعد دمج #51 بلغ `Generate Schema Baseline` **الخطوة 9 لأول مرة**، فكشف عطلًا ثالثًا. ملف واحد، CI فقط، لا SQL إنتاجية ولا واجهة ولا أثر تشغيلي.

## ما نجح أولًا

| الخطوة | النتيجة |
|---|---|
| 4 — تثبيت عميل PostgreSQL 17 | ✅ الحارس الجديد مرّ |
| 6 — قراءة السجل الحي والتحقق منه | ✅ `CUTOFF=148` بلا drift |
| **7 — توليد الـBaseline** | ✅ `000_schema_baseline_20260726_184103.sql` |
| **8 — التحقق من المحتوى** | ✅ |
| 9 — إعادة البناء النظيفة | ❌ |

إصلاح #51 صحيح إذن: `pg_dump` 17 عمل والتفريغ تمّ.

## العطل

```
psql:scripts/ci/fresh-db/supabase_shim.sql:9:
  ERROR:  database "wardah_fresh" does not exist
STATEMENT:  ALTER DATABASE wardah_fresh SET search_path = public, extensions;
```

السطر 9 يثبّت اسم القاعدة **نصًا**. وهذا عقد ضمني بين ملف SQL مشترك واسم قاعدة يُنشئه workflow بعينه:

| المُستدعي | القاعدة التي ينشئها | النتيجة |
|---|---|---|
| `ci-cd.yml` | `wardah_fresh` | ✅ يوافق النص المثبّت |
| `uom-master-data-hardening.yml` | `wardah_fresh` | ✅ |
| `generate-baseline.yml` | `wardah_baseline_verify` | ❌ |

ظلّ مخفيًا لأن `generate-baseline.yml` لم يبلغ هذه الخطوة قط.

## التغيير

الاسم يُشتق من `current_database()` عبر `EXECUTE format(... %I ...)`، فيصح لأي قاعدة يتصل بها المُستدعي دون أن يعرف الملف اسمها. `%I` تقتبس المُعرِّف بأمان.

اخترت هذا بدل تسمية القاعدة `wardah_fresh` في `generate-baseline.yml`: الأخير يُخفي الاقتران ويُبقي الفخ لأي مُستدعٍ ثالث.

## التحقق — على عنقود PostgreSQL محلي

| # | الحالة | النتيجة |
|---|---|---|
| 1 | `wardah_baseline_verify` | ✅ يمر و`search_path` يُضبط |
| 2 | `wardah_fresh` (انحدار) | ✅ يمر كما كان |
| 3 | عكسي: القاعدتان موجودتان معًا | ✅ الإعداد يهبط على المتصل بها وحدها — صف واحد لها، **صفر** للأخرى |

**والأهم:** بالنسخة السابقة تفشل الحالة 1 بنفس رسالة CI حرفيًا. أي أن هذا يعالج العطل المرصود لا شبيهًا له، والاختبار غير صوري.

`check_migration_syntax.py` و`check_definer_guards.py` يفحصان `sql/migrations` فقط — الملف خارج نطاقهما، لذا كان التحقق المحلي لازمًا.

## بعد الدمج

إعادة تشغيل `Generate Schema Baseline`. المتبقي غير المطروق: عتبات إعادة البناء (`TABLES ≥ 120`, `FUNCTIONS ≥ 150`, `POLICIES ≥ 300`)، ثم تحديث الوثائق وفتح PR الـbaseline. لا أعد بنجاحها قبل رؤيته.

## ملاحظة على ترتيب النشر

CI فقط — لا migration ولا واجهة تعتمد على RPC أو Schema — فلا ينطبق شرط الفصل إلى PRين المضاف في #50.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASrDjrR8BGjPnZ5mp8UtFQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01ASrDjrR8BGjPnZ5mp8UtFQ)_