### PR TITLE
ci(baseline): make the generated baseline replayable, and show why when it isn't

### DIFF
--- a/.github/workflows/generate-baseline.yml
+++ b/.github/workflows/generate-baseline.yml
@@ -132,9 +132,31 @@ jobs:
               --no-tablespaces
           } > "$BASELINE"
 
+          # Supabase تعيد إنشاء مخطط public بمالك غير مالك التمهيد، فيعامله
+          # pg_dump مخططَ مستخدم ويُصدر `CREATE SCHEMA public;`. لكن كل قاعدة
+          # جديدة تملك public أصلًا من initdb، فيفشل التطبيق بـ
+          # `schema "public" already exists`.
+          #
+          # يُصلَح في الأداة لا عند المُستهلك: هذا الملف يُطبَّق هنا في إعادة
+          # البناء، وفي Fresh DB داخل ci-cd.yml بعد دمجه. جعل المُستهلك يُسقِط
+          # public قبل التطبيق كان سيصلح هذه الخطوة ويترك ci-cd.yml معطلًا.
+          PUBLIC_BARE=$(grep -c '^CREATE SCHEMA public;$' "$BASELINE" || true)
+          if [ "$PUBLIC_BARE" -gt 0 ]; then
+            sed -i 's/^CREATE SCHEMA public;$/CREATE SCHEMA IF NOT EXISTS public;/' "$BASELINE"
+            echo "ℹ️ CREATE SCHEMA public → IF NOT EXISTS ($PUBLIC_BARE بيان)"
+          fi
+          if grep -q '^CREATE SCHEMA public;$' "$BASELINE"; then
+            echo "❌ بقي CREATE SCHEMA public غير idempotent بعد التحويل"
+            exit 1
+          fi
+
           echo "baseline_path=$BASELINE" >> "$GITHUB_ENV"
           echo "baseline_name=$(basename "$BASELINE")" >> "$GITHUB_ENV"
           echo "✅ Baseline generated: $BASELINE ($(wc -l < "$BASELINE") lines)"
+
+          # نسخة تشخيصية: الـBaseline المولَّد لم يكن يُرفع قط، فكان كل فشل في
+          # إعادة البناء يحتاج دورة كاملة لتخمين محتواه. الآن يُرفع مع البقية.
+          cp "$BASELINE" baseline-diagnostics/
 
       - name: Verify generated baseline metadata and contents
         shell: bash
@@ -168,10 +190,22 @@ jobs:
         run: |
           set -Eeuo pipefail
           createdb wardah_baseline_verify
-          psql -v ON_ERROR_STOP=1 -d wardah_baseline_verify \
-            -f scripts/ci/fresh-db/supabase_shim.sql -q
-          psql -v ON_ERROR_STOP=1 -d wardah_baseline_verify \
-            -f "$baseline_path" -q
+
+          # `-q` يكتم النجاح لا الأخطاء، لكن فشل الخطوة كان يظهر في سجل حاوية
+          # الخدمة وحده بلا اسم ملف ولا رقم سطر. الآن يُحفظ خرج psql ويُطبع
+          # عند الفشل، فيُشخَّص العطل من التشغيل نفسه لا من دورة تالية.
+          apply_sql() {
+            local LABEL="$1" FILE="$2" LOG="baseline-diagnostics/apply-$1.log"
+            if ! psql -v ON_ERROR_STOP=1 -d wardah_baseline_verify -f "$FILE" -q \
+                 > "$LOG" 2>&1; then
+              echo "❌ فشل تطبيق $LABEL ($FILE):"
+              tail -40 "$LOG"
+              return 1
+            fi
+          }
+
+          apply_sql shim scripts/ci/fresh-db/supabase_shim.sql
+          apply_sql baseline "$baseline_path"
 
           TABLES=$(psql -d wardah_baseline_verify -tAc \
             "SELECT count(*) FROM pg_tables WHERE schemaname='public'")


### PR DESCRIPTION
## الهدف

بعد دمج #52 مرّ الشيم، فبلغ `Generate Schema Baseline` **تطبيق الـBaseline المولَّد لأول مرة** — وفشل. ملف واحد، CI فقط، لا SQL إنتاجية ولا واجهة.

## الحالة بعد #52

| الخطوة | النتيجة |
|---|---|
| 6 — قراءة السجل الحي | ✅ `CUTOFF=148` بلا drift |
| 7 — توليد الـBaseline | ✅ |
| 8 — التحقق من المحتوى | ✅ |
| 9 — الشيم | ✅ **العطل السابق زال** |
| 9 — تطبيق الـBaseline | ❌ جديد |

```
ERROR:  schema "public" already exists
STATEMENT:  CREATE SCHEMA public;
```

## السبب

Supabase تعيد إنشاء مخطط `public` بمالك غير مالك التمهيد، فيعامله `pg_dump` **مخططَ مستخدم** ويُصدر البيان صريحًا. لكن كل قاعدة جديدة تملك `public` من `initdb`.

**ولماذا لم يظهر قبلًا؟** الـBaseline المدموج حاليًا `000_schema_baseline_20260717.sql` فيه **صفر** `CREATE SCHEMA` وكل بياناته `IF NOT EXISTS` — أي أنه لم يُنتَج بهذا الـworkflow. هذه أول مرة يُطبَّق فيها مخرَج `pg_dump` الخاص به على قاعدة.

## الإصلاح — في الأداة لا عند المُستهلك

التحويل يقع على الملف المولَّد: `CREATE SCHEMA public;` → `CREATE SCHEMA IF NOT EXISTS public;`، يليه حارس يفشل إن بقي البيان الخام.

**لماذا لا يُصلَح عند المُستهلك؟** إسقاط `public` قبل التطبيق كان سيُصلح هذه الخطوة **ويترك `ci-cd.yml` معطلًا** — فالملف نفسه يُطبَّق في Fresh DB بعد دمجه. الإصلاح في الأداة يخدم المُستهلكين معًا.

**النطاق محصور:** الشيم لا ينشئ أي كائن في `public` — يمنح صلاحيات عليه فقط — فالتصادم الوحيد هو المخطط نفسه.

## تشخيص بدل تخمين

كنت أشخّص على العمياء: الـBaseline المولَّد لم يكن يُرفع قط، وخرج `psql` مكتوم بـ`-q`، فكان أثر الفشل الوحيد سطرًا في **سجل حاوية الخدمة** بلا اسم ملف ولا رقم سطر. كل عطل كلّف دورة كاملة. الآن:

- نسخة من الـBaseline تُرفع ضمن `baseline-diagnostics` (الرفع `if: always()`).
- تطبيق الشيم والـBaseline يمر عبر دالة تحفظ الخرج وتطبع آخر 40 سطرًا **عند الفشل**، مع الوسم وملف المصدر.

## التحقق — على عنقود PostgreSQL محلي

| # | الحالة | النتيجة |
|---|---|---|
| A | ضابط عكسي: البيان الخام | ✅ يفشل بـ`schema "public" already exists` — نفس رسالة CI حرفيًا |
| B | بعد تطبيق تحويل الـworkflow نفسه | ✅ يمر، والجدول يُنشأ في `public` |
| C | على قاعدة أُسقِط منها `public` | ✅ يُنشئه — فالتحويل **ليس تخطّيًا صامتًا** |

الحالة C موجودة تحديدًا لأن `IF NOT EXISTS` قد يخفي عدم إنشاء أصلًا؛ ولولاها لكان نجاح B غير كافٍ.

## تحفّظ صريح

`psql -v ON_ERROR_STOP=1` يتوقف عند **أول** خطأ. فنجاح هذا الإصلاح لا يضمن خلوّ بقية الـBaseline من تصادمات أخرى — أستبعدها لأن الشيم لا يضع شيئًا في `public`، لكني لا أجزم. وإن ظهر عطل تالٍ فسيكون **مرئيًا فورًا** بفضل تحسين التشخيص أعلاه، لا مستنتَجًا من سجل الحاوية.

المتبقي غير المطروق بعده: عتبات إعادة البناء (`TABLES ≥ 120`, `FUNCTIONS ≥ 150`, `POLICIES ≥ 300`)، تحديث الوثائق وكتلة `DATABASE_STATE`، ثم فتح PR الـBaseline.

## ملاحظة على ترتيب النشر

CI فقط — لا migration ولا واجهة تعتمد على RPC أو Schema — فلا ينطبق شرط الفصل إلى PRين المضاف في #50.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASrDjrR8BGjPnZ5mp8UtFQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01ASrDjrR8BGjPnZ5mp8UtFQ)_