### PR TITLE
test(fresh-db): use a role value that Production actually permits

### DIFF
--- a/scripts/ci/fresh-db/acceptance_144_base_uom_guard.sql
+++ b/scripts/ci/fresh-db/acceptance_144_base_uom_guard.sql
@@ -37,7 +37,7 @@ INSERT INTO public.user_organizations
    '11111111-1111-1111-1111-111111111111', true, true, 'admin'),
   ('a0000000-0000-0000-0000-000000000002',
    'cccccccc-cccc-cccc-cccc-cccccccccccc',
-   '11111111-1111-1111-1111-111111111111', true, false, 'member');
+   '11111111-1111-1111-1111-111111111111', true, false, 'user');
 
 -- Product INSERTs carrying a base unit are now admin-guarded by the trigger.
 SELECT set_config('request.jwt.claim.sub', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', false);

--- a/scripts/ci/fresh-db/acceptance_146_uom_master_data_hardening.sql
+++ b/scripts/ci/fresh-db/acceptance_146_uom_master_data_hardening.sql
@@ -36,7 +36,7 @@ INSERT INTO public.user_organizations
    '46111111-1111-1111-1111-111111111111', true, true, 'admin'),
   ('46000000-0000-0000-0000-000000000002',
    '46bbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
-   '46111111-1111-1111-1111-111111111111', true, false, 'member');
+   '46111111-1111-1111-1111-111111111111', true, false, 'user');
 
 INSERT INTO public.org_settings (org_id, key, value) VALUES
   ('46111111-1111-1111-1111-111111111111', 'uom_engine_enabled', '{"enabled":true}'::jsonb);

--- a/scripts/ci/fresh-db/acceptance_147_atomic_uom_purchase_order.sql
+++ b/scripts/ci/fresh-db/acceptance_147_atomic_uom_purchase_order.sql
@@ -33,10 +33,10 @@ INSERT INTO public.user_organizations
   (id, user_id, org_id, is_active, is_org_admin, role) VALUES
   ('47000000-0000-0000-0000-000000000001',
    '47aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-   '47111111-1111-1111-1111-111111111111', true, false, 'member'),
+   '47111111-1111-1111-1111-111111111111', true, false, 'user'),
   ('47000000-0000-0000-0000-000000000002',
    '47aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-   '47222222-2222-2222-2222-222222222222', true, false, 'member');
+   '47222222-2222-2222-2222-222222222222', true, false, 'user');
 
 INSERT INTO public.org_settings (org_id, key, value) VALUES
   ('47111111-1111-1111-1111-111111111111', 'uom_engine_enabled', '{"enabled":true}'::jsonb),

--- a/scripts/ci/fresh-db/acceptance_148_uom_partial_receipts.sql
+++ b/scripts/ci/fresh-db/acceptance_148_uom_partial_receipts.sql
@@ -79,7 +79,7 @@ INSERT INTO public.user_organizations
   (id, user_id, org_id, is_active, is_org_admin, role) VALUES
   ('48000000-0000-0000-0000-000000000001',
    '48aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-   '48111111-1111-1111-1111-111111111111', true, false, 'member'),
+   '48111111-1111-1111-1111-111111111111', true, false, 'user'),
   ('48000000-0000-0000-0000-000000000002',
    '48bbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
    '48111111-1111-1111-1111-111111111111', true, true, 'admin'),


### PR DESCRIPTION
## ما كشفه Baseline الجديد

بوابة `Migration 148 Quality-Aware Partial Receipt` سقطت على #54 — أي على أول Baseline مولَّد بـ`pg_dump` من Production الحي:

```
psql:scripts/ci/fresh-db/acceptance_148_uom_partial_receipts.sql:88:
ERROR:  new row for relation "user_organizations"
        violates check constraint "user_organizations_role_check"
DETAIL: Failing row contains (..., member, t, ...)
```

Production تحمل هذا القيد:

```sql
CHECK (role::text = ANY (ARRAY['user','manager','admin']::text[]))
```

و**أربعة** ملفات قبول تُدرج `'member'` — قيمة يرفضها القيد:

| الملف | السطر |
|---|---|
| `acceptance_144_base_uom_guard.sql` | 40 |
| `acceptance_146_uom_master_data_hardening.sql` | 39 |
| `acceptance_147_atomic_uom_purchase_order.sql` | 36، 39 |
| `acceptance_148_uom_partial_receipts.sql` | 82 |

## لماذا لم يظهر هذا قبلًا

الـBaseline المدموج حاليًا (cutoff 121) **لا يحتوي القيد إطلاقًا** — صفر مطابقة لـ`user_organizations_role_check`. فكانت هذه الاختبارات تمر على مخطط **أكثر تساهلًا من Production**، أي أنها لم تكن تتحقق من عقد الإنتاج الحقيقي.

وهذا ليس عطلًا في #54 بل **قيمته**: تحديث الـBaseline كشف فجوة كانت قائمة وصامتة. اللقطة القديمة 13,406 سطر مقابل 27,105 في الجديدة.

## الاختيار ولماذا هو آمن

`'user'` هو البديل الوحيد غير الإداري في المجموعة المسموحة. والدلالة محفوظة تمامًا:

```sql
-- wardah_is_org_admin
COALESCE(is_org_admin, FALSE) OR role IN ('admin', 'owner')
```

الصفوف المعدَّلة كلها `is_org_admin = false`، و`'user'` ليست في `('admin','owner')` — فتبقى غير إدارية كما كانت مع `'member'`. لا شيء في ما تختبره هذه الملفات يتغير.

و`'member'` **غير مستخدمة في كود التطبيق** إطلاقًا.

## التحقق — على عنقود PostgreSQL محلي بقيد Production حرفيًا

| الحالة | النتيجة |
|---|---|
| `role = 'member'` | ✅ مرفوض بنفس رسالة CI — الضابط العكسي |
| `role = 'user'` | ✅ مقبول |
| `role='user'` + `is_org_admin=false` | ✅ `is_admin = false` |
| `role='admin'` + `is_org_admin=true` | ✅ `is_admin = true` |

الحالتان الأخيرتان موجودتان لأن تغيير قيمة `role` قد يقلب نتيجة الحارس صامتًا؛ ولولاهما لكان نجاح الإدراج وحده غير كافٍ.

## الترتيب المقترح

هذا الـPR **أولًا**، ثم تحديث فرع #54 من `main` لتُعاد بوابة القبول عليه. فصلته عن #54 لأن الأخير محتوى مولَّد آليًا، وخلطه بتعديلات يدوية يُفقده صفته.

## ملاحظة جانبية خارج النطاق

القيد يسمح بـ`'user','manager','admin'` بينما `wardah_is_org_admin` تفحص `role IN ('admin','owner')` — فـ`'owner'` فرع ميت لا يمكن أن يوجد. لم ألمسه: لا أثر تشغيلي، وإصلاحه تغيير في دالة حية يستحق PR مستقلًا بقرارك.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASrDjrR8BGjPnZ5mp8UtFQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01ASrDjrR8BGjPnZ5mp8UtFQ)_