### PR TITLE
ci(baseline): keep the privilege model, and prove it survived

### DIFF
--- a/.github/workflows/generate-baseline.yml
+++ b/.github/workflows/generate-baseline.yml
@@ -226,6 +226,15 @@ jobs:
           apply_sql shim scripts/ci/fresh-db/supabase_shim.sql
           apply_sql baseline "$baseline_path"
 
+          # فحص دلالي لا عددي. حارس عدد بيانات GRANT/REVOKE يثبت وجود نموذج
+          # صلاحيات؛ وهذا يثبت أن العقد الأمني المطلوب نفسه نجا من التوليد ومن
+          # إعادة البناء: authenticated تُنفّذ، وanon لا تُنفّذ — لا عبر منح
+          # مباشر ولا بالوراثة من PUBLIC، فPostgreSQL يمنح PUBLIC صلاحية EXECUTE
+          # افتراضيًا عند إنشاء الدالة ما لم يُستعد بيان السحب.
+          # الدوال غير الموجودة تُتخطى: cutoff أقدم لا يلزمه وجودها.
+          apply_sql acl-contract scripts/ci/fresh-db/verify_baseline_acl.sql
+          echo "✅ عقد التنفيذ نجا من التوليد وإعادة البناء"
+
           TABLES=$(psql -d wardah_baseline_verify -tAc \
             "SELECT count(*) FROM pg_tables WHERE schemaname='public'")
           FUNCTIONS=$(psql -d wardah_baseline_verify -tAc \

--- a/.github/workflows/generate-baseline.yml
+++ b/.github/workflows/generate-baseline.yml
@@ -123,10 +123,17 @@ jobs:
             echo "-- Apply with: psql -f supabase_shim.sql && psql -f this file"
             echo "-- ============================================================"
             echo ""
+            # --no-acl مُزال عمدًا. الـBaseline يحل محل كل migration دون cutoff،
+            # ومعها بيانات GRANT/REVOKE التي تحملها (نحو 130 بيانًا عبر 27 ملفًا
+            # حتى 148). بإسقاط الصلاحيات كان رفع cutoff يمحو نموذج التنفيذ كاملًا
+            # بصمت: قاعدة مبنية من اللقطة لا تمنح authenticated ولا تسحب من anon.
+            #
+            # --no-owner يبقى: ملكية Supabase تشير إلى أدوار غير موجودة في CI.
+            # أما المستفيدون من الصلاحيات في public فهم postgres وservice_role
+            # وauthenticated وanon وPUBLIC — وكلهم متاحون في بيئة إعادة البناء.
             pg_dump "$SUPABASE_DB_URL" \
               --schema-only \
               --no-owner \
-              --no-acl \
               --no-comments \
               --schema=public \
               --no-tablespaces
@@ -180,6 +187,18 @@ jobs:
             || { echo '❌ no CREATE TABLE statements'; exit 1; }
           grep -q 'CREATE.*FUNCTION' "$baseline_path" \
             || { echo '❌ no function statements'; exit 1; }
+
+          # الـBaseline يحل محل كل migration دون cutoff، ومعها صلاحياتها. لقطة
+          # بلا GRANT/REVOKE تعني قاعدة بلا نموذج تنفيذ: authenticated بلا منح
+          # وanon بلا سحب — وهو تدهور أمني صامت لا يوقفه أي فحص آخر هنا.
+          # العتبة متحفظة جدًا: الإنتاج يحمل آلاف مدخلات ACL في public.
+          ACL_STMTS=$(grep -cE '^(GRANT|REVOKE) ' "$baseline_path" || true)
+          if [ "$ACL_STMTS" -lt 100 ]; then
+            echo "❌ الـBaseline يحمل $ACL_STMTS بيان صلاحيات فقط — يُتوقع مئات."
+            echo "   تحقق من عدم عودة --no-acl إلى pg_dump."
+            exit 1
+          fi
+          echo "✅ صلاحيات محفوظة: $ACL_STMTS بيان GRANT/REVOKE"
 
       - name: Rebuild clean PostgreSQL from generated baseline
         env:

--- a/scripts/ci/fresh-db/verify_baseline_acl.sql
+++ b/scripts/ci/fresh-db/verify_baseline_acl.sql
@@ -1,0 +1,49 @@
+-- فحص دلالي لعقد التنفيذ على قاعدة أُعيد بناؤها من Baseline مولَّد.
+--
+-- حارس عدد بيانات GRANT/REVOKE في ملف اللقطة يثبت أن نموذج صلاحيات موجود.
+-- هذا الملف يثبت ما هو أدق: أن العقد الأمني المطلوب نفسه نجا من التوليد ومن
+-- إعادة البناء — authenticated تُنفّذ، وanon لا تُنفّذ.
+--
+-- والشق الثاني ليس تحصيل حاصل: PostgreSQL يمنح PUBLIC صلاحية EXECUTE افتراضيًا
+-- على كل دالة عند إنشائها. فبغياب بيان REVOKE في اللقطة ترث anon التنفيذ ضمنًا
+-- دون أي GRANT صريح لها. و has_function_privilege يحسب الوراثة من PUBLIC، لذلك
+-- يمسك هذا الفحص الحالتين معًا: المنح المباشر والوراثة الصامتة.
+--
+-- الدوال غير الموجودة تُتخطى لا تُفشل: لقطة عند cutoff أقدم لا يلزمها وجودها.
+
+DO $acl$
+DECLARE
+  v_fn      text;
+  v_checked int := 0;
+  v_skipped int := 0;
+BEGIN
+  FOREACH v_fn IN ARRAY ARRAY[
+    'public.rpc_submit_purchase_order(uuid,uuid)',
+    'public.rpc_approve_purchase_order(uuid,uuid)',
+    'public.rpc_list_uom_receivable_purchase_orders(uuid)',
+    'public.rpc_post_goods_receipt(jsonb)'
+  ] LOOP
+    IF to_regprocedure(v_fn) IS NULL THEN
+      v_skipped := v_skipped + 1;
+      RAISE NOTICE 'تخطي % — غير موجودة في هذه اللقطة', v_fn;
+      CONTINUE;
+    END IF;
+
+    v_checked := v_checked + 1;
+
+    IF NOT has_function_privilege('authenticated', v_fn, 'EXECUTE') THEN
+      RAISE EXCEPTION 'BASELINE_ACL_FAIL: authenticated تفتقد EXECUTE على %', v_fn;
+    END IF;
+
+    IF has_function_privilege('anon', v_fn, 'EXECUTE') THEN
+      RAISE EXCEPTION 'BASELINE_ACL_FAIL: anon تملك EXECUTE على %', v_fn;
+    END IF;
+  END LOOP;
+
+  IF v_checked = 0 THEN
+    RAISE EXCEPTION 'BASELINE_ACL_FAIL: لم تُفحص أي دالة — % متخطاة', v_skipped;
+  END IF;
+
+  RAISE NOTICE 'عقد التنفيذ سليم على % دالة (% متخطاة)', v_checked, v_skipped;
+END
+$acl$;

--- a/sql/baseline/README.md
+++ b/sql/baseline/README.md
@@ -28,54 +28,43 @@
 
 ## توليد الـBaseline
 
-### الطريقة المُوصى بها — GitHub Actions (تلقائي)
+### المسار القانوني الوحيد — `Generate Schema Baseline`
 
-1. أضف السر `SUPABASE_DB_URL` في إعدادات المستودع:
-   `Settings → Secrets and variables → Actions → New repository secret`
+`Actions → Generate Schema Baseline → Run workflow`
 
-   القيمة:
-   ```
-   postgresql://postgres:[DB_PASSWORD]@db.uutfztmqvajmsxnrqeiv.supabase.co:5432/postgres?sslmode=require
-   ```
+يتطلب سرّ `SUPABASE_DB_URL` بصيغة مجمّع الاتصالات (session mode)، واسم مستخدم
+مؤهَّل بمعرّف المشروع. الصيغة والمزالق موثقة في
+`docs/db/UOM_PARTIAL_RECEIPT_148_RUNBOOK.md`. لا تكتب كلمة مرور هنا ولا في أي
+ملف بالمستودع.
 
-2. شغّل الـworkflow يدوياً:
-   `Actions → Generate Schema Baseline → Run workflow`
+**لا تولّد Baseline يدويًا.** حُذفت الوصفة اليدوية من هذا الملف عمدًا: كانت
+تنتج لقطة معطوبة بأربع طرق، كلٌّ منها صامت.
 
-3. سيُولد الـbaseline ويُودَع تلقائياً في `sql/baseline/`.
+| ما كانت تفعله الوصفة اليدوية | الأثر |
+|---|---|
+| `--no-acl` | تُسقط نموذج الصلاحيات كاملًا. الـBaseline يحل محل كل migration دون cutoff ومعها منحها، فتصبح القاعدة بلا `GRANT` لـ`authenticated`؛ وأخطر منه أن PostgreSQL يمنح `PUBLIC` صلاحية `EXECUTE` افتراضيًا على الدوال عند إنشائها، فبغياب `REVOKE` قد يرث `anon` تنفيذ دوال سحبها الإنتاج منه |
+| `MAX` من أعلى ملف في المستودع | cutoff من المستودع لا من سجل Production. مع سياسة `repository-first` قد يكون `main` عند 149 وProduction عند 148، فتُوسم لقطة الإنتاج بـ149 وتُتخطى 149 في Fresh DB |
+| لا تحوّل `CREATE SCHEMA public` | يفشل التطبيق على أي قاعدة جديدة بـ`schema "public" already exists` |
+| لا حارس ولا إعادة بناء | لا شيء يكشف أيًّا مما سبق قبل الدمج |
 
-### توليد يدوي (محلي)
+الـworkflow يفرض هذه العقود كلها: cutoff من سجل Production الحي، صلاحيات محفوظة
+مع حارس عددي، تحويل `CREATE SCHEMA`، إعادة بناء نظيفة على PostgreSQL 17،
+وعتبات كائنات. ولا يكتب إلى `main` — يفتح PR للمراجعة.
 
-```bash
-pg_dump "$SUPABASE_DB_URL" \
-  --schema-only \
-  --no-owner \
-  --no-acl \
-  --no-comments \
-  --schema=public \
-  --no-tablespaces \
-  | grep -v '^--' \
-  > sql/baseline/000_schema_baseline_$(date +%Y%m%d).sql
+### ملاحظة تاريخية: كيف وُلد baseline 20260717
 
-# أضف سطر migration_cutoff في أول الملف
-MAX=$(ls sql/migrations/ | grep -oE '^[0-9]+' | sort -n | uniq | tail -1)
-sed -i "1s/^/-- migration_cutoff: $MAX\n/" sql/baseline/000_schema_baseline_$(date +%Y%m%d).sql
-```
+لم يُولَّد بـ`pg_dump`، بل أُعيد بناؤه من `pg_catalog` عبر Supabase MCP
+بالاستعلام من `pg_class`, `pg_attribute`, `pg_constraint`, `pg_index`,
+`pg_trigger`, `pg_policy` مع `pg_get_functiondef()` وأخواتها.
 
-### بديل — Supabase MCP (عند تعذّر `pg_dump`)
+وهذا يفسّر فجوتين انكشفتا عند أول توليد حقيقي بـ`pg_dump`:
 
-إذا كان Direct Connection IPv6-only (لا يدعمه `psql` محلياً)، يمكن إعادة بناء
-الـbaseline من `pg_catalog` عبر **Supabase MCP** مباشرةً (بدون Connection URL).
+- **صفر `GRANT`/`REVOKE`** — لا نموذج صلاحيات إطلاقًا.
+- **قيود ومفاتيح مفقودة** — منها `user_organizations_role_check` وخمسة مفاتيح
+  أجنبية مركّبة على `employee_id, org_id`، موجودة في الإنتاج وغائبة عن اللقطة.
 
-بديل Transaction Pooler (يتطلب صلاحيات كاملة):
-```
-postgresql://postgres.uutfztmqvajmsxnrqeiv:[PASSWORD]@aws-0-eu-central-1.pooler.supabase.com:6543/postgres
-```
-**تحذير**: منطقة المجمّع (`eu-central-1`) قد تختلف — تحقق من لوحة Supabase →
-Project Settings → Database → Connection Pooling.
-
-الـbaseline الحالي (`20260717`) مُولَّد عبر **Supabase MCP** بالاستعلام من:
-`pg_class`, `pg_attribute`, `pg_constraint`, `pg_index`, `pg_trigger`, `pg_policy`
-مع `pg_get_functiondef()`, `pg_get_indexdef()`, `pg_get_viewdef()`, `pg_get_triggerdef()`.
+تُحفظ هذه الملاحظة ولا تُحذف: هي سبب وجود فجوة lineage بين حالة Production
+وسلسلة الإنشاء في المستودع.
 
 ## استخدام CI
 
@@ -90,4 +79,4 @@ Project Settings → Database → Connection Pooling.
 
 - الـbaseline **لا يُلغي** ملفات المهاجرات القديمة — تبقى للتاريخ
 - عند إضافة مهاجرات جديدة كثيرة (>50 بعد الـbaseline)، أعِد التوليد
-- المعيار: `psql -f baseline` على PostgreSQL 16 نظيف (بعد shim) ينجح بلا أخطاء
+- المعيار: `psql -f baseline` على PostgreSQL 17 نظيف (بعد shim) ينجح بلا أخطاء


### PR DESCRIPTION
## العطل

بوابة قبول 148 سقطت على الـBaseline المولَّد:

```
ACCEPTANCE_FAIL: execute contract broken for rpc_submit_purchase_order(uuid,uuid)
```

`pg_dump` كان يعمل بـ`--no-acl`، فاللقطة بلا أي `GRANT` أو `REVOKE`.

## لماذا هذا بنيوي لا عابر

الـBaseline يحل محل **كل** migration دون cutoff، ومعها صلاحياتها:

| النطاق | العدد |
|---|---|
| migrations حاملة للصلاحيات (120 → 148) | **27 ملفًا** |
| بيانات `GRANT`/`REVOKE` فيها | **~130** |
| في 148 وحدها | 12 |

ما دام cutoff عند 121 كانت 122→148 تُعيد تطبيق منحها **بعد** اللقطة، فبقي العقد سليمًا **بالمصادفة لا بالتصميم**. وبرفع cutoff إلى 148 لم يعد شيء يُعيدها.

**والضرر شقّان لا شق واحد:**

1. `authenticated` تفقد المنح فتعجز عن تنفيذ RPC القانونية.
2. PostgreSQL يمنح `PUBLIC` صلاحية `EXECUTE` **افتراضيًا** عند إنشاء الدالة. فبغياب بيان السحب ترث `anon` تنفيذ دوال **سحبها الإنتاج منها**.

أي أن الأثر ليس تعطيلًا فحسب، بل **توسيع صامت للسطح المتاح لغير المصادَق**.

## الإصلاح

إزالة `--no-acl`. `--no-owner` يبقى: ملكية Supabase تشير إلى أدوار غير موجودة في CI.

**تحقق مباشر على الإنتاج (قراءة فقط)** من أن كل المستفيدين متاحون في بيئة إعادة البناء:

| الدور | مدخلات ACL في `public` | متاح في CI؟ |
|---|---|---|
| `postgres` | 1421 | ✅ مستخدم CI |
| `service_role` | 1421 | ✅ الشيم |
| `authenticated` | 1370 | ✅ الشيم |
| `anon` | 1222 | ✅ الشيم |
| `PUBLIC` (`-`) | 69 | ✅ ضمني |

لا دور مجهول — فلن يفشل التطبيق بـ`role does not exist`.

## حارسان لا حارس

**١. عددي عند التوليد** — يفشل إن حملت اللقطة أقل من 100 بيان `GRANT`/`REVOKE`. يمسك عودة `--no-acl` عند مصدرها.

**٢. دلالي بعد إعادة البناء** — `scripts/ci/fresh-db/verify_baseline_acl.sql` يتحقق على أربع دوال أن `authenticated` تُنفّذ وأن `anon` لا تُنفّذ. الحارس العددي يثبت **وجود** نموذج صلاحيات؛ وهذا يثبت أن **العقد المطلوب نفسه** نجا من التوليد وإعادة البناء.

`has_function_privilege` يحسب الوراثة من `PUBLIC`، فيمسك الحالتين: المنح المباشر والوراثة الصامتة.

### تحقق على عنقود PostgreSQL محلي

| # | الحالة | النتيجة |
|---|---|---|
| A | دالة بلا أي بيان ACL (حالة `--no-acl`) | ✅ فشل — `anon` تملك `EXECUTE` بالوراثة |
| B | سحب من `PUBLIC` وanon ثم منح `authenticated` | ✅ مرّ |
| C | منح `authenticated` **دون** سحب `PUBLIC` | ✅ فشل |
| D | لا دالة إطلاقًا | ✅ فشل صريح بدل مرور صوري |

**الحالة C أدقّها**: منح صحيح ظاهريًا مع تسرب ضمني — وهي ما لا يمسكه أي حارس عددي.

## حذف المسار اليدوي من `sql/baseline/README.md`

الوصفة اليدوية كانت تُعيد إنتاج **كل** عطل عالجناه في هذه السلسلة:

| ما كانت تفعله | الأثر |
|---|---|
| `--no-acl` | العطل موضوع هذا الـPR |
| `MAX` من أعلى ملف في المستودع | cutoff من المستودع لا من سجل Production. مع `repository-first` قد يكون `main` عند 149 وProduction عند 148، فتُوسم لقطة الإنتاج بـ149 وتُتخطى 149 في Fresh DB |
| لا تحوّل `CREATE SCHEMA public` | فشل التطبيق — عولج في #53 |
| لا حارس ولا إعادة بناء | لا شيء يكشف أيًّا مما سبق قبل الدمج |

أخذت بالخيار الأول من توصيتك: **حُذفت الوصفة**، وصار الـworkflow المسار القانوني الوحيد، مع جدول يوثق ما كانت تفعله ولماذا حُذفت. نسخ منطق الـworkflow إلى README كان سيولّد drift جديدًا — وهو بالضبط ما وقعنا فيه.

أُزيلت أيضًا سلاسل الاتصال المضلِّلة (المضيف المباشر IPv6-only، ومنطقة مجمّع خاطئة `eu-central-1` بدل `us-east-1`)، وصُحّح `PostgreSQL 16` إلى `17`.

### ملاحظة تاريخية محفوظة

baseline `20260717` **لم يُولَّد بـ`pg_dump`** بل من `pg_catalog` عبر Supabase MCP. وهذا يفسّر فجوتين انكشفتا عند أول توليد حقيقي:

- **صفر `GRANT`/`REVOKE`** — لا نموذج صلاحيات إطلاقًا.
- **قيود ومفاتيح مفقودة** — `user_organizations_role_check` وخمسة مفاتيح مركّبة على `(employee_id, org_id)`.

حُفظت الملاحظة ولم تُحذف: هي سبب فجوة الـlineage بين Production وسلسلة الإنشاء.

## حدود ما أثبته

لم أتمكن من تشغيل `pg_dump` بلا `--no-acl` على الإنتاج — لا أملك بيانات الاتصال. الدليل الحاسم هو التشغيل التالي للـworkflow، والحارسان يجعلان أي فشل واضحًا عند مصدره.

## الترتيب

#54 **أُغلق** بوصفه superseded. بعد دمج هذا: إعادة تشغيل `Generate Schema Baseline` → لقطة بديلة تحمل الصلاحيات → PR baseline جديد.

## ملاحظة على ترتيب النشر

CI ووثائق فقط — لا migration ولا واجهة تعتمد على RPC أو Schema — فلا ينطبق شرط الفصل إلى PRين المضاف في #50.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASrDjrR8BGjPnZ5mp8UtFQ