### PR TITLE
ci(fresh-db): add supabase_admin, the grantor in restored default privileges

### DIFF
--- a/scripts/ci/fresh-db/supabase_shim.sql
+++ b/scripts/ci/fresh-db/supabase_shim.sql
@@ -3,6 +3,16 @@ CREATE ROLE anon NOLOGIN;
 CREATE ROLE authenticated NOLOGIN;
 CREATE ROLE service_role NOLOGIN;
 
+-- supabase_admin لا يستقبل صلاحيات في المخطط، لكنه يظهر بوصفه **المانح** في
+-- الصلاحيات الافتراضية التي يُصدرها pg_dump بعد استعادة ACL:
+--
+--   ALTER DEFAULT PRIVILEGES FOR ROLE supabase_admin IN SCHEMA public
+--     GRANT ALL ON SEQUENCES TO postgres;
+--
+-- وبيان كهذا يفشل بـ`role "supabase_admin" does not exist` قبل أن يبلغ أي منح.
+-- فحص المستفيدين وحده لا يكشفه — المانح عمود آخر في pg_default_acl.
+CREATE ROLE supabase_admin NOLOGIN;
+
 CREATE SCHEMA IF NOT EXISTS extensions;
 CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA extensions;
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA extensions;


### PR DESCRIPTION
## النتيجة الجزئية من التشغيل بعد #56

| # | معيار القبول | النتيجة |
|---|---|---|
| 1 | `ACL_STMTS ≥ 100` | ✅ **الخطوة 8 مرّت** — إزالة `--no-acl` أخرجت الصلاحيات فعلًا |
| 2 | تطبيق اللقطة بلا `role does not exist` | ❌ |
| 3 | الحارس الدلالي | ⏸️ لم يُبلغ |
| 4 | إعادة البناء والعتبات | ⏸️ لم تُبلغ |
| 5 | PR baseline جديد | ⏸️ لم يُبلغ |

البند 1 هو الأهم: **إزالة `--no-acl` تعمل**. الجوهر الأمني في #56 صحيح.

## العطل

```
ERROR:  role "supabase_admin" does not exist
STATEMENT: ALTER DEFAULT PRIVILEGES FOR ROLE supabase_admin IN SCHEMA public
           GRANT ALL ON SEQUENCES TO postgres;
```

استعادة ACL جلبت معها بيانات **الصلاحيات الافتراضية**، وفيها دور مانح غير موجود في بيئة CI.

## ثغرة في تحققي السابق

قبل إزالة `--no-acl` فحصتُ الأدوار **المستفيدة** في `pg_proc.proacl` و`pg_class.relacl`، وخلصت في #56 إلى **«لا دور مجهول»**. كانت الخلاصة خاطئة من وجهين:

1. **`pg_default_acl` لم يُفحص إطلاقًا** — و`pg_dump` يُصدر منه بيانات `ALTER DEFAULT PRIVILEGES`.
2. **الدور يظهر فيه بوصفه المانح (`defaclrole`) لا المستفيد** — ففحص المستفيدين وحده لا يكشفه مهما اتسع نطاقه.

### المسح الكامل الآن (على الإنتاج، قراءة فقط)

| المصدر | الأدوار | متاح في CI؟ |
|---|---|---|
| ACL الكائنات (`proacl`/`relacl`) | postgres · service_role · authenticated · anon · PUBLIC | ✅ |
| ACL المخطط (`nspacl`) | ما سبق + `pg_database_owner` | ✅ مدمج في PG 14+ |
| افتراضية — المستفيد | anon · service_role · postgres · authenticated | ✅ |
| افتراضية — **المانح** | postgres · **`supabase_admin`** | ❌ **الوحيد المفقود** |

## الإصلاح

`CREATE ROLE supabase_admin NOLOGIN;` في الشيم. الدور **لا يستقبل** صلاحيات في المخطط، لكن وجوده شرط لتطبيق بيانات الصلاحيات الافتراضية. وتشغيلها بوصف `postgres` مسموح لأنه superuser في CI.

**بديل مرفوض:** تجريد بيانات `ALTER DEFAULT PRIVILEGES` من اللقطة. يُنجح إعادة البناء لكنه يجعل اللقطة أقل وفاءً للإنتاج — وهو عكس غرض #56 تمامًا.

## التحقق — على عنقود PostgreSQL محلي

| # | الحالة | النتيجة |
|---|---|---|
| A | البيان بلا الدور | ✅ فشل بنفس رسالة CI حرفيًا |
| B | البيان بعد إنشاء الدور | ✅ مرّ |
| C | الشيم كاملًا ثم البيان على `wardah_baseline_verify` و`wardah_fresh` | ✅ كلاهما يمر — لا انحدار على مسار Fresh DB القائم |

## حدّ ما يثبته هذا

`ON_ERROR_STOP=1` يتوقف عند أول خطأ، فنجاح هذا لا يضمن خلوّ بقية قسم الصلاحيات من مفاجآت. لكن المسح أعلاه يغطي كل مصدر ACL أعرفه في `public`، ولم يبقَ فيه دور مفقود سوى هذا.

والبنود 3 و4 و5 من معيارك **لم تُختبر بعد** — لم يبلغها التشغيل. تبقى معلقة على التشغيل التالي.

## ملاحظة على ترتيب النشر

CI فقط — لا migration ولا واجهة تعتمد على RPC أو Schema — فلا ينطبق شرط الفصل إلى PRين المضاف في #50.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASrDjrR8BGjPnZ5mp8UtFQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01ASrDjrR8BGjPnZ5mp8UtFQ)_