### PR TITLE
ci(baseline): update README counts from verified rebuild

### DIFF
--- a/.github/workflows/generate-baseline.yml
+++ b/.github/workflows/generate-baseline.yml
@@ -261,56 +261,12 @@ jobs:
         shell: bash
         run: |
           set -Eeuo pipefail
-          python3 - <<'PY'
-          import os
-          import re
-          from datetime import datetime, timezone
-          from pathlib import Path
-
-          baseline = Path(os.environ['baseline_path'])
-          cutoff = os.environ['CUTOFF']
-          live_name = os.environ['LIVE_NAME']
-          repo_max = os.environ['REPO_MAX']
-          size_kb = baseline.stat().st_size // 1024
-          lines = sum(1 for _ in baseline.open(encoding='utf-8'))
-          generated_date = datetime.now(timezone.utc).strftime('%Y-%m-%d')
-
-          readme = Path('sql/baseline/README.md')
-          text = readme.read_text(encoding='utf-8')
-          row = f"| `{baseline.name}` | {generated_date} | {cutoff} | {size_kb} KB / {lines:,} سطر |"
-          text, count = re.subn(
-              r"\| `000_schema_baseline_[^`]+\.sql` \|[^\n]+\|",
-              row,
-              text,
-              count=1,
-          )
-          if count != 1:
-              raise SystemExit('Expected exactly one current-baseline table row in README')
-          readme.write_text(text, encoding='utf-8')
-
-          claude = Path('CLAUDE.md')
-          text = claude.read_text(encoding='utf-8')
-          start = '<!-- DATABASE_STATE_START -->'
-          end = '<!-- DATABASE_STATE_END -->'
-          if text.count(start) != 1 or text.count(end) != 1:
-              raise SystemExit('CLAUDE.md database-state markers are missing or duplicated')
-
-          state = (
-              f"{start}\n"
-              f"الحالة الحية الموثقة بعد Baseline المولد في {generated_date}:\n\n"
-              f"- Baseline الحالي: `{baseline.name}`, cutoff {cutoff}.\n"
-              f"- Production: مطبقة حتى {cutoff} (`{live_name}`).\n"
-              f"- Repository: أعلى migration مرقمة هي {repo_max}.\n"
-              "- Fresh DB: لا توجد migrations معلقة بعد cutoff عند لحظة التوليد.\n"
-              "- لا تعدّ أي migration مطبقة حيًا لمجرد نجاح Fresh DB؛ سجل Production هو المرجع.\n"
-              f"{end}"
-          )
-          pattern = re.compile(re.escape(start) + r'.*?' + re.escape(end), re.S)
-          text, count = pattern.subn(state, text, count=1)
-          if count != 1:
-              raise SystemExit('Failed to replace CLAUDE.md database-state block')
-          claude.write_text(text, encoding='utf-8')
-          PY
+          python3 scripts/ci/update_baseline_docs.py \
+            --baseline "$baseline_path" \
+            --counts baseline-diagnostics/rebuild-counts.json \
+            --cutoff "$CUTOFF" \
+            --live-name "$LIVE_NAME" \
+            --repo-max "$REPO_MAX"
 
       - name: Create review branch and pull request
         env:

--- a/.github/workflows/migration-governance.yml
+++ b/.github/workflows/migration-governance.yml
@@ -8,6 +8,8 @@ on:
       - 'sql/baseline/**'
       - 'scripts/ci/validate_migration_ledger.py'
       - 'scripts/ci/test_validate_migration_ledger.py'
+      - 'scripts/ci/update_baseline_docs.py'
+      - 'scripts/ci/test_update_baseline_docs.py'
       - '.github/workflows/generate-baseline.yml'
       - '.github/workflows/migration-governance.yml'
       - 'CLAUDE.md'
@@ -18,6 +20,8 @@ on:
       - 'sql/baseline/**'
       - 'scripts/ci/validate_migration_ledger.py'
       - 'scripts/ci/test_validate_migration_ledger.py'
+      - 'scripts/ci/update_baseline_docs.py'
+      - 'scripts/ci/test_update_baseline_docs.py'
       - '.github/workflows/generate-baseline.yml'
       - '.github/workflows/migration-governance.yml'
       - 'CLAUDE.md'
@@ -39,6 +43,9 @@ jobs:
 
       - name: Run migration-ledger unit tests
         run: python3 scripts/ci/test_validate_migration_ledger.py
+
+      - name: Run baseline-docs updater unit tests
+        run: python3 scripts/ci/test_update_baseline_docs.py
 
       - name: Validate baseline metadata against repository
         shell: bash

--- a/scripts/ci/test_update_baseline_docs.py
+++ b/scripts/ci/test_update_baseline_docs.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""اختبارات أداة تحديث وثائق الـBaseline.
+
+الحالة السالبة هي الأهم هنا: العيب الأصلي لم يكن خطأً صاخبًا بل **كتابة صامتة**
+تركت README تصف لقطة بأرقام لقطة أخرى. فالاختبارات تثبت الفشل بقدر ما تثبت
+النجاح.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("update_baseline_docs.py")
+
+COUNTS_LINE_OLD = "المحتوى المتحقق بعد إعادة البناء: 125 جدول · 164 دالة · 333 policy"
+COUNTS_LINE_NEW = "المحتوى المتحقق بعد إعادة البناء: 131 جدول · 201 دالة · 316 policy"
+
+README_TEMPLATE = """# Baseline
+
+| الملف | تاريخ التوليد | migration_cutoff | الحجم |
+|---|---|---|---|
+| `000_schema_baseline_20260717.sql` | 2026-07-17 | 121 | 611 KB / 13,521 سطر |
+
+{counts_line}
+
+نص لاحق لا يُمس.
+"""
+
+CLAUDE_TEMPLATE = """# Manifest
+
+<!-- DATABASE_STATE_START -->
+حالة قديمة تُستبدل بالكامل.
+<!-- DATABASE_STATE_END -->
+
+بقية المانيفست.
+"""
+
+
+class UpdateBaselineDocsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.root = Path(self.temp_dir.name)
+
+        self.baseline = self.root / "000_schema_baseline_20260727_125744.sql"
+        self.baseline.write_text("SELECT 1;\n" * 40, encoding="utf-8")
+
+        self.counts = self.root / "rebuild-counts.json"
+        self.write_counts({"tables": 131, "functions": 201, "policies": 316})
+
+        self.readme = self.root / "README.md"
+        self.readme.write_text(
+            README_TEMPLATE.format(counts_line=COUNTS_LINE_OLD), encoding="utf-8"
+        )
+
+        self.claude = self.root / "CLAUDE.md"
+        self.claude.write_text(CLAUDE_TEMPLATE, encoding="utf-8")
+
+    def write_counts(self, payload) -> None:
+        if isinstance(payload, str):
+            self.counts.write_text(payload, encoding="utf-8")
+        else:
+            self.counts.write_text(json.dumps(payload), encoding="utf-8")
+
+    def run_script(self) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--baseline", str(self.baseline),
+                "--counts", str(self.counts),
+                "--cutoff", "148",
+                "--live-name", "148_uom_purchase_receipt_snapshots",
+                "--repo-max", "148",
+                "--readme", str(self.readme),
+                "--claude", str(self.claude),
+                "--generated-date", "2026-07-27",
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+    # ---------- الحالة الموجبة ----------
+
+    def test_updates_counts_and_baseline_row(self) -> None:
+        result = self.run_script()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+        readme = self.readme.read_text(encoding="utf-8")
+        self.assertIn(COUNTS_LINE_NEW, readme)
+        self.assertNotIn(COUNTS_LINE_OLD, readme)
+
+        # صف الجدول يتحدث في النقلة نفسها — وهذا هو العيب الأصلي:
+        # الصف كان يتحدث وحده بينما يبقى سطر القياسات قديمًا.
+        self.assertIn("`000_schema_baseline_20260727_125744.sql`", readme)
+        self.assertIn("| 2026-07-27 | 148 |", readme)
+        self.assertNotIn("`000_schema_baseline_20260717.sql`", readme)
+
+        self.assertIn("نص لاحق لا يُمس.", readme)
+
+    def test_updates_claude_state_block(self) -> None:
+        self.assertEqual(self.run_script().returncode, 0)
+        claude = self.claude.read_text(encoding="utf-8")
+        self.assertIn("cutoff 148", claude)
+        self.assertIn("148_uom_purchase_receipt_snapshots", claude)
+        self.assertNotIn("حالة قديمة تُستبدل بالكامل.", claude)
+        self.assertIn("بقية المانيفست.", claude)
+
+    # ---------- الحالات السالبة ----------
+
+    def test_fails_when_counts_line_missing(self) -> None:
+        self.readme.write_text(
+            README_TEMPLATE.format(counts_line="لا سطر قياسات هنا"), encoding="utf-8"
+        )
+        result = self.run_script()
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("سطر محتوى واحد بالضبط", result.stdout)
+
+    def test_fails_when_counts_line_duplicated(self) -> None:
+        self.readme.write_text(
+            README_TEMPLATE.format(
+                counts_line=f"{COUNTS_LINE_OLD}\n\n{COUNTS_LINE_OLD}"
+            ),
+            encoding="utf-8",
+        )
+        result = self.run_script()
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("سطر محتوى واحد بالضبط", result.stdout)
+
+    def test_fails_when_counts_file_missing(self) -> None:
+        self.counts.unlink()
+        result = self.run_script()
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("غير موجود", result.stdout)
+
+    def test_fails_on_invalid_json(self) -> None:
+        self.write_counts("{not json")
+        result = self.run_script()
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("ليس JSON صالحًا", result.stdout)
+
+    def test_fails_on_missing_key(self) -> None:
+        self.write_counts({"tables": 131, "functions": 201})
+        result = self.run_script()
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("policies", result.stdout)
+
+    def test_fails_on_non_integer_value(self) -> None:
+        for bad in ("316", 316.5, None, True):
+            with self.subTest(bad=bad):
+                self.write_counts(
+                    {"tables": 131, "functions": 201, "policies": bad}
+                )
+                result = self.run_script()
+                self.assertEqual(result.returncode, 1, f"قُبلت قيمة {bad!r}")
+                self.assertIn("ليست عددًا صحيحًا", result.stdout)
+
+    def test_fails_when_baseline_row_missing(self) -> None:
+        self.readme.write_text(
+            f"# Baseline\n\nبلا جدول.\n\n{COUNTS_LINE_OLD}\n", encoding="utf-8"
+        )
+        result = self.run_script()
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("current-baseline table row", result.stdout)
+
+    def test_does_not_write_readme_when_counts_invalid(self) -> None:
+        """JSON تالف يجب ألا يترك README محدّثة جزئيًا."""
+        self.write_counts("{not json")
+        before = self.readme.read_text(encoding="utf-8")
+        self.assertEqual(self.run_script().returncode, 1)
+        self.assertEqual(self.readme.read_text(encoding="utf-8"), before)
+
+    def test_claude_markers_duplicated_fails(self) -> None:
+        self.claude.write_text(
+            CLAUDE_TEMPLATE + CLAUDE_TEMPLATE, encoding="utf-8"
+        )
+        result = self.run_script()
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("markers are missing or duplicated", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test_update_baseline_docs.py
+++ b/scripts/ci/test_update_baseline_docs.py
@@ -183,6 +183,74 @@ class UpdateBaselineDocsTests(unittest.TestCase):
         self.assertEqual(result.returncode, 1)
         self.assertIn("markers are missing or duplicated", result.stdout)
 
+    # ---------- ذرّية الكتابة عبر الوثيقتين ----------
+
+    def test_invalid_claude_does_not_modify_readme(self) -> None:
+        """CLAUDE.md تالفة يجب ألا تترك README مكتوبة.
+
+        هذا هو المسار الذي كان مفتوحًا: README تُكتب أولًا، ثم تُفحص علامات
+        CLAUDE.md وتفشل — فتبقى وثيقة واحدة محدّثة والعملية فاشلة.
+        """
+        self.claude.write_text("بلا علامات إطلاقًا.\n", encoding="utf-8")
+        readme_before = self.readme.read_text(encoding="utf-8")
+
+        result = self.run_script()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("markers are missing or duplicated", result.stdout)
+        self.assertEqual(
+            self.readme.read_text(encoding="utf-8"),
+            readme_before,
+            "README تغيّرت رغم فشل الشوط على CLAUDE.md",
+        )
+
+    def test_no_document_is_written_on_any_validation_failure(self) -> None:
+        """تعميم: أي فشل تحقق يترك الوثيقتين كما كانتا."""
+        readme_ok = self.readme.read_text(encoding="utf-8")
+        claude_ok = self.claude.read_text(encoding="utf-8")
+
+        broken_readme = README_TEMPLATE.format(counts_line="لا سطر قياسات")
+        cases = {
+            "counts-missing": lambda: self.counts.unlink(),
+            "counts-invalid-json": lambda: self.write_counts("{not json"),
+            "counts-missing-key": lambda: self.write_counts({"tables": 1}),
+            "counts-not-int": lambda: self.write_counts(
+                {"tables": 131, "functions": 201, "policies": "316"}
+            ),
+            "readme-counts-line-missing": lambda: self.readme.write_text(
+                broken_readme, encoding="utf-8"
+            ),
+            "claude-markers-missing": lambda: self.claude.write_text(
+                "بلا علامات.\n", encoding="utf-8"
+            ),
+        }
+
+        for label, break_it in cases.items():
+            with self.subTest(case=label):
+                self.setUp()
+                break_it()
+                readme_before = self.readme.read_text(encoding="utf-8")
+                claude_before = self.claude.read_text(encoding="utf-8")
+
+                self.assertEqual(self.run_script().returncode, 1)
+
+                self.assertEqual(
+                    self.readme.read_text(encoding="utf-8"),
+                    readme_before,
+                    f"README كُتبت رغم فشل {label}",
+                )
+                self.assertEqual(
+                    self.claude.read_text(encoding="utf-8"),
+                    claude_before,
+                    f"CLAUDE.md كُتبت رغم فشل {label}",
+                )
+
+        # سلامة الحالة الموجبة بعد كل ما سبق.
+        self.setUp()
+        self.assertEqual(self.readme.read_text(encoding="utf-8"), readme_ok)
+        self.assertEqual(self.claude.read_text(encoding="utf-8"), claude_ok)
+        self.assertEqual(self.run_script().returncode, 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/ci/update_baseline_docs.py
+++ b/scripts/ci/update_baseline_docs.py
@@ -71,13 +71,18 @@ def load_counts(path: Path) -> dict[str, int]:
     return counts
 
 
-def update_readme(
+def render_readme(
     readme: Path,
     baseline: Path,
     cutoff: str,
     counts: dict[str, int],
     generated_date: str,
-) -> None:
+) -> str:
+    """أعد نص README الجديد دون كتابته.
+
+    الفصل بين التحضير والكتابة مقصود: الكتابة هنا كانت تسبق فحص علامات
+    CLAUDE.md، فعلامات مفقودة أو مكررة كانت تترك README محدّثة وحدها.
+    """
     text = readme.read_text(encoding="utf-8")
 
     size_kb = baseline.stat().st_size // 1024
@@ -87,7 +92,11 @@ def update_readme(
         f"| {size_kb} KB / {lines:,} سطر |"
     )
 
-    # الحارس القائم على صف الجدول يبقى كما هو.
+    # الحارس القائم على صف الجدول يبقى كما هو سلوكًا.
+    # دين تقني مسجّل: `subn(count=1)` لا يكشف وجود صفين — يستبدل الأول ويعيد
+    # count == 1، فرسالة "exactly one" أوسع مما يفحصه فعلًا. سلوك سابق لهذا
+    # التغيير، مُبقى عمدًا خارج نطاقه. فحص سطر القياسات أدناه لا يشاركه هذا
+    # القصور: يعدّ المطابقات كلها أولًا.
     text, count = BASELINE_ROW_RE.subn(row, text, count=1)
     if count != 1:
         raise DocUpdateError(
@@ -104,19 +113,18 @@ def update_readme(
         f"المحتوى المتحقق بعد إعادة البناء: {counts['tables']} جدول · "
         f"{counts['functions']} دالة · {counts['policies']} policy"
     )
-    text = COUNTS_RE.sub(lambda _: counts_line, text, count=1)
-
-    readme.write_text(text, encoding="utf-8")
+    return COUNTS_RE.sub(lambda _: counts_line, text, count=1)
 
 
-def update_claude(
+def render_claude(
     claude: Path,
     baseline: Path,
     cutoff: str,
     live_name: str,
     repo_max: str,
     generated_date: str,
-) -> None:
+) -> str:
+    """أعد نص CLAUDE.md الجديد دون كتابته."""
     text = claude.read_text(encoding="utf-8")
     if text.count(CLAUDE_START) != 1 or text.count(CLAUDE_END) != 1:
         raise DocUpdateError(
@@ -139,7 +147,7 @@ def update_claude(
     text, count = pattern.subn(lambda _: state, text, count=1)
     if count != 1:
         raise DocUpdateError("Failed to replace CLAUDE.md database-state block")
-    claude.write_text(text, encoding="utf-8")
+    return text
 
 
 def main() -> int:
@@ -159,13 +167,15 @@ def main() -> int:
     args = parser.parse_args()
 
     try:
-        # القياسات تُقرأ وتُتحقق قبل لمس أي ملف، فلا تُترك README محدّثة
-        # جزئيًا عند JSON تالف.
+        # كل قراءة وتحقق وبناء نص يسبق أي كتابة، فلا يفشل الشوط بعد تعديل
+        # وثيقة واحدة. القياسات التالفة، وسطر القياسات المفقود أو المكرر،
+        # وصف الجدول الغائب، وعلامات CLAUDE.md المفقودة أو المكررة — كلها
+        # تُكتشف والقرص لم يُمس.
         counts = load_counts(args.counts)
-        update_readme(
+        new_readme = render_readme(
             args.readme, args.baseline, args.cutoff, counts, args.generated_date
         )
-        update_claude(
+        new_claude = render_claude(
             args.claude,
             args.baseline,
             args.cutoff,
@@ -176,6 +186,11 @@ def main() -> int:
     except DocUpdateError as exc:
         print(f"❌ {exc}")
         return 1
+
+    # يبقى فشل I/O بين الكتابتين ممكنًا نظريًا؛ ما يمنعه هذا الفصل هو فشل
+    # التحقق بعد كتابة جزئية، وهو المسار الواقعي الذي أوجدته الفحوص.
+    args.readme.write_text(new_readme, encoding="utf-8")
+    args.claude.write_text(new_claude, encoding="utf-8")
 
     print(
         f"✅ وثائق الـBaseline محدّثة: {counts['tables']} جدول · "

--- a/scripts/ci/update_baseline_docs.py
+++ b/scripts/ci/update_baseline_docs.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""تحديث وثائق الـBaseline من مخرجات توليد فعلية.
+
+كان هذا المنطق heredoc داخل `generate-baseline.yml`. فيه عيب متكرر: يستبدل صف
+جدول اللقطة في README ويترك سطر المحتوى تحته حاملًا أرقام اللقطة السابقة. فبعد
+توليد cutoff 148 بقيت README تصف اللقطة الجديدة بإحصاءات Baseline 121:
+
+    المحتوى: 125 جدول · 216 PK/UNIQUE · ... · 164 دالة · ... · 333 policy
+
+بينما إعادة البناء أعطت 131 جدولًا و201 دالة و316 policy. الأرقام موجودة أصلًا
+في `baseline-diagnostics/rebuild-counts.json` — لكن خطوة الوثائق لم تكن تقرأها.
+
+الآن تقرأها، وتفشل بدل الكتابة الصامتة عند أي انحراف. واستُخرج المنطق إلى سكربت
+قابل للاختبار لأن العيب من النوع الذي لا يظهر إلا بعد توليد حقيقي على Production.
+
+القياسات المكتوبة هي الثلاثة التي يقيسها حارس إعادة البناء فقط. لا تُشتق أرقام
+أخرى — PK/UNIQUE أو FK أو الفهارس أو views أو triggers — فوجودها في وثيقة مرجعية
+بلا قياس هو أصل العيب لا علاجه.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+BASELINE_ROW_RE = re.compile(r"\| `000_schema_baseline_[^`]+\.sql` \|[^\n]+\|")
+
+COUNTS_RE = re.compile(
+    r"^المحتوى المتحقق بعد إعادة البناء: \d+ جدول · \d+ دالة · \d+ policy$",
+    re.MULTILINE,
+)
+
+COUNT_KEYS = ("tables", "functions", "policies")
+
+CLAUDE_START = "<!-- DATABASE_STATE_START -->"
+CLAUDE_END = "<!-- DATABASE_STATE_END -->"
+
+
+class DocUpdateError(RuntimeError):
+    """فشل موصوف بدل كتابة صامتة."""
+
+
+def load_counts(path: Path) -> dict[str, int]:
+    """اقرأ القياسات وتحقق منها قبل أي كتابة."""
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        raise DocUpdateError(f"ملف القياسات غير موجود: {path}") from None
+    except json.JSONDecodeError as exc:
+        raise DocUpdateError(f"ملف القياسات ليس JSON صالحًا: {path} — {exc}") from None
+
+    if not isinstance(raw, dict):
+        raise DocUpdateError(f"ملف القياسات ليس كائن JSON: {path}")
+
+    counts: dict[str, int] = {}
+    for key in COUNT_KEYS:
+        if key not in raw:
+            raise DocUpdateError(f"مفتاح مفقود في ملف القياسات: {key}")
+        value = raw[key]
+        # bool هو subclass من int في بايثون؛ استبعده صراحة.
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise DocUpdateError(
+                f"قيمة {key} ليست عددًا صحيحًا: {value!r}"
+            )
+        if value < 0:
+            raise DocUpdateError(f"قيمة {key} سالبة: {value}")
+        counts[key] = value
+    return counts
+
+
+def update_readme(
+    readme: Path,
+    baseline: Path,
+    cutoff: str,
+    counts: dict[str, int],
+    generated_date: str,
+) -> None:
+    text = readme.read_text(encoding="utf-8")
+
+    size_kb = baseline.stat().st_size // 1024
+    lines = sum(1 for _ in baseline.open(encoding="utf-8"))
+    row = (
+        f"| `{baseline.name}` | {generated_date} | {cutoff} "
+        f"| {size_kb} KB / {lines:,} سطر |"
+    )
+
+    # الحارس القائم على صف الجدول يبقى كما هو.
+    text, count = BASELINE_ROW_RE.subn(row, text, count=1)
+    if count != 1:
+        raise DocUpdateError(
+            "Expected exactly one current-baseline table row in README"
+        )
+
+    matches = COUNTS_RE.findall(text)
+    if len(matches) != 1:
+        raise DocUpdateError(
+            f"يُتوقع سطر محتوى واحد بالضبط في README، وُجد {len(matches)}"
+        )
+
+    counts_line = (
+        f"المحتوى المتحقق بعد إعادة البناء: {counts['tables']} جدول · "
+        f"{counts['functions']} دالة · {counts['policies']} policy"
+    )
+    text = COUNTS_RE.sub(lambda _: counts_line, text, count=1)
+
+    readme.write_text(text, encoding="utf-8")
+
+
+def update_claude(
+    claude: Path,
+    baseline: Path,
+    cutoff: str,
+    live_name: str,
+    repo_max: str,
+    generated_date: str,
+) -> None:
+    text = claude.read_text(encoding="utf-8")
+    if text.count(CLAUDE_START) != 1 or text.count(CLAUDE_END) != 1:
+        raise DocUpdateError(
+            "CLAUDE.md database-state markers are missing or duplicated"
+        )
+
+    state = (
+        f"{CLAUDE_START}\n"
+        f"الحالة الحية الموثقة بعد Baseline المولد في {generated_date}:\n\n"
+        f"- Baseline الحالي: `{baseline.name}`, cutoff {cutoff}.\n"
+        f"- Production: مطبقة حتى {cutoff} (`{live_name}`).\n"
+        f"- Repository: أعلى migration مرقمة هي {repo_max}.\n"
+        "- Fresh DB: لا توجد migrations معلقة بعد cutoff عند لحظة التوليد.\n"
+        "- لا تعدّ أي migration مطبقة حيًا لمجرد نجاح Fresh DB؛ سجل Production هو المرجع.\n"
+        f"{CLAUDE_END}"
+    )
+    pattern = re.compile(
+        re.escape(CLAUDE_START) + r".*?" + re.escape(CLAUDE_END), re.S
+    )
+    text, count = pattern.subn(lambda _: state, text, count=1)
+    if count != 1:
+        raise DocUpdateError("Failed to replace CLAUDE.md database-state block")
+    claude.write_text(text, encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline", required=True, type=Path)
+    parser.add_argument("--counts", required=True, type=Path)
+    parser.add_argument("--cutoff", required=True)
+    parser.add_argument("--live-name", required=True)
+    parser.add_argument("--repo-max", required=True)
+    parser.add_argument("--readme", type=Path, default=Path("sql/baseline/README.md"))
+    parser.add_argument("--claude", type=Path, default=Path("CLAUDE.md"))
+    parser.add_argument(
+        "--generated-date",
+        default=datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+        help="لحقن تاريخ ثابت في الاختبارات",
+    )
+    args = parser.parse_args()
+
+    try:
+        # القياسات تُقرأ وتُتحقق قبل لمس أي ملف، فلا تُترك README محدّثة
+        # جزئيًا عند JSON تالف.
+        counts = load_counts(args.counts)
+        update_readme(
+            args.readme, args.baseline, args.cutoff, counts, args.generated_date
+        )
+        update_claude(
+            args.claude,
+            args.baseline,
+            args.cutoff,
+            args.live_name,
+            args.repo_max,
+            args.generated_date,
+        )
+    except DocUpdateError as exc:
+        print(f"❌ {exc}")
+        return 1
+
+    print(
+        f"✅ وثائق الـBaseline محدّثة: {counts['tables']} جدول · "
+        f"{counts['functions']} دالة · {counts['policies']} policy"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## العيب

خطوة تحديث الوثائق تستبدل صف جدول اللقطة في README وتترك **سطر المحتوى تحته** حاملًا أرقام اللقطة السابقة. فبعد توليد cutoff 148:

| | جداول | دوال | policies |
|---|---|---|---|
| ما قالته README عن Baseline 148 | 125 | 164 | 333 |
| ما أعطته إعادة البناء | **131** | **201** | **316** |

الأرقام كانت موجودة أصلًا في `baseline-diagnostics/rebuild-counts.json` — الخطوة لم تكن تقرأ الملف. صُحّح السطر يدويًا في #58؛ هذا يصلح **المولّد** كي يحافظ على صحته تلقائيًا.

## التغيير

استُخرج المنطق من الـheredoc إلى `scripts/ci/update_baseline_docs.py`.

**الكتابة تلي كل تحقق.** `render_readme()` و`render_claude()` تبنيان النص وتعيدانه دون كتابة؛ `main` تكتب الملفين بعد نجاح كل الفحوص:

```python
counts     = load_counts(...)
new_readme = render_readme(...)
new_claude = render_claude(...)

args.readme.write_text(new_readme, encoding="utf-8")
args.claude.write_text(new_claude, encoding="utf-8")
```

**fail-closed على تسع حالات** — كلها تُكتشف والقرص لم يُمس: ملف القياسات غير موجود · JSON غير صالح · مفتاح ناقص · قيمة ليست عددًا صحيحًا · قيمة سالبة · سطر القياسات مفقود · سطر القياسات مكرر · صف الجدول مفقود · علامات `CLAUDE.md` مفقودة أو مكررة.

`bool` مستبعد صراحة لأنه subclass من `int`، فـ`{"policies": true}` كان سيمر فحص «عدد صحيح».

**حارس صف جدول الـBaseline بقي كما هو** سلوكًا.

تُكتب القياسات الثلاثة التي يقيسها حارس إعادة البناء **فقط**. أرقام PK/UNIQUE وFK والفهارس وviews وtriggers لا تُشتق: وجودها في وثيقة مرجعية بلا قياس هو أصل العيب لا علاجه.

## الاختبارات — 13

في `scripts/ci/test_update_baseline_docs.py`، مربوطة بـMigration Governance مع مرشّحات المسارات، تتبع اتفاقية `test_validate_migration_ledger.py` القائمة.

الحالات السالبة أثقل من الموجبة عمدًا: العيب الأصلي لم يكن خطأً صاخبًا بل **كتابة صامتة**.

**اختبارا الذرّية** أُضيفا بعد المراجعة:

| الاختبار | |
|---|---|
| `test_invalid_claude_does_not_modify_readme` | المسار الذي كان مفتوحًا بعينه |
| `test_no_document_is_written_on_any_validation_failure` | تعميم على ست حالات فشل + إعادة تأكيد الحالة الموجبة |

وشُغّلا ضد التنفيذ السابق فأخفقا بالضبط على `claude-markers-missing`، ونجحا على الحالي — فالثغرة كانت حقيقية والاختبار يكشفها. الحالات الأربع الأخرى مرّت على النسخة القديمة أيضًا، وهو متسق: تحققها كان يسبق الكتابة أصلًا.

مؤكَّد من سجل CI على `89b1035`: `Ran 13 tests ... OK`.

## حدّ الضمان

المُغلق هو **فشل التحقق بعد كتابة جزئية**. يبقى فشل I/O بين الكتابتين ممكنًا نظريًا — README تُكتب ثم يفشل القرص عند `CLAUDE.md`. مسجَّل تعليقًا في الشيفرة بدل ادّعاء ذرّية كاملة؛ الذرّية الحقيقية تحتاج ملفات مؤقتة و`os.replace`، وهي أثقل مما يستدعيه هذا العيب.

## تحقق على محتوى `main` الحقيقي

على **نسخ** من `sql/baseline/README.md` و`CLAUDE.md` عند `ba1d050` بقياسات 131/201/316، وأُعيد بعد إعادة الهيكلة:

| | |
|---|---|
| سطر القياسات | ✅ مطابق تمامًا — لا يغيّر القيم الصحيحة الحالية |
| `CLAUDE.md` | ✅ مطابق تمامًا |
| خلية الحجم | ⚠️ 1065 KB في README مقابل 1061 KB محسوبة |

فارق الحجم **سابق لهذا التغيير**: `.gitattributes` يضبط `eol=lf`، والملف المولَّد في CI حمل CRLF على نحو 4096 سطرًا فطبّعه git عند الإيداع (0 من 30379 سطرًا تنتهي بـCR في المودَع). الـheredoc القديم كان يحسبه بـ`stat().st_size` نفسها، فلا انحدار. خارج النطاق.

## دين تقني مسجَّل

حارس صف الجدول يقول `"exactly one"` بينما `subn(count=1)` لا يكشف وجود صفين — يستبدل الأول ويعيد `count == 1`. سلوك سابق، مُبقى عمدًا، موثَّق تعليقًا عند الحارس. فحص سطر القياسات لا يشاركه القصور: يعدّ المطابقات كلها أولًا.

## يبقى مستقلًا بعد الدمج

1. فارق حجم الملف قبل/بعد تطبيع LF.
2. تشديد حارس صف الـBaseline ليكتشف الصفوف المكررة فعلًا.
3. الإثبات المتكامل عند تشغيل `Generate Schema Baseline` الحقيقي مستقبلًا — لم يُشغَّل لهذا الـPR عمدًا؛ الاختبارات على fixtures مؤقتة.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASrDjrR8BGjPnZ5mp8UtFQ