### PR TITLE
ci(baseline): make the baseline-row guard detect duplicates

### DIFF
--- a/scripts/ci/test_update_baseline_docs.py
+++ b/scripts/ci/test_update_baseline_docs.py
@@ -167,6 +167,33 @@ class UpdateBaselineDocsTests(unittest.TestCase):
         result = self.run_script()
         self.assertEqual(result.returncode, 1)
         self.assertIn("current-baseline table row", result.stdout)
+        self.assertIn("found 0", result.stdout)
+
+    def test_fails_when_baseline_row_duplicated(self) -> None:
+        """صفّا لقطة في README يعنيان وصفين متنافسين للحالة الحية.
+
+        `subn(count=1)` كان يستبدل الأول ويعيد count == 1، فيمر التكرار صامتًا
+        تاركًا صفًا ثانيًا يصف لقطة أخرى في مرجع حاكم.
+        """
+        readme = README_TEMPLATE.format(counts_line=COUNTS_LINE_OLD).replace(
+            "| `000_schema_baseline_20260717.sql` | 2026-07-17 | 121 "
+            "| 611 KB / 13,521 سطر |",
+            "| `000_schema_baseline_20260717.sql` | 2026-07-17 | 121 "
+            "| 611 KB / 13,521 سطر |\n"
+            "| `000_schema_baseline_20260101.sql` | 2026-01-01 | 99 "
+            "| 400 KB / 9,000 سطر |",
+        )
+        self.readme.write_text(readme, encoding="utf-8")
+        readme_before = self.readme.read_text(encoding="utf-8")
+        claude_before = self.claude.read_text(encoding="utf-8")
+
+        result = self.run_script()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("current-baseline table row", result.stdout)
+        self.assertIn("found 2", result.stdout)
+        self.assertEqual(self.readme.read_text(encoding="utf-8"), readme_before)
+        self.assertEqual(self.claude.read_text(encoding="utf-8"), claude_before)
 
     def test_does_not_write_readme_when_counts_invalid(self) -> None:
         """JSON تالف يجب ألا يترك README محدّثة جزئيًا."""

--- a/scripts/ci/update_baseline_docs.py
+++ b/scripts/ci/update_baseline_docs.py
@@ -92,16 +92,17 @@ def render_readme(
         f"| {size_kb} KB / {lines:,} سطر |"
     )
 
-    # الحارس القائم على صف الجدول يبقى كما هو سلوكًا.
-    # دين تقني مسجّل: `subn(count=1)` لا يكشف وجود صفين — يستبدل الأول ويعيد
-    # count == 1، فرسالة "exactly one" أوسع مما يفحصه فعلًا. سلوك سابق لهذا
-    # التغيير، مُبقى عمدًا خارج نطاقه. فحص سطر القياسات أدناه لا يشاركه هذا
-    # القصور: يعدّ المطابقات كلها أولًا.
-    text, count = BASELINE_ROW_RE.subn(row, text, count=1)
-    if count != 1:
+    # كان هذا `subn(..., count=1)`: يستبدل الصف الأول ويعيد count == 1 حتى مع
+    # وجود صفين، فرسالة "exactly one" كانت أوسع مما يفحصه فعلًا. العدّ أولًا
+    # يجعل الرسالة والفحص متطابقين — وREADME مرجع حاكم، فصف لقطة مكرر فيه
+    # يعني وصفين متنافسين للحالة الحية.
+    rows = BASELINE_ROW_RE.findall(text)
+    if len(rows) != 1:
         raise DocUpdateError(
-            "Expected exactly one current-baseline table row in README"
+            "Expected exactly one current-baseline table row in README, "
+            f"found {len(rows)}"
         )
+    text = BASELINE_ROW_RE.sub(lambda _: row, text, count=1)
 
     matches = COUNTS_RE.findall(text)
     if len(matches) != 1:


### PR DESCRIPTION
يغلق الدين التقني المسجَّل في #59.

## العيب

الحارس يقول `"Expected exactly one"` بينما لا يستطيع كشف صفين:

```python
text, count = BASELINE_ROW_RE.subn(row, text, count=1)
if count != 1: ...
```

`subn(count=1)` يستبدل الصف الأول ويعيد `count == 1` **حتى مع وجود صفين**، فيمر التكرار صامتًا. الرسالة كانت أوسع مما يفحصه الحارس فعلًا.

README مرجع حاكم؛ صف لقطة مكرر فيه يعني **وصفين متنافسين للحالة الحية**.

## التغيير

```python
rows = BASELINE_ROW_RE.findall(text)
if len(rows) != 1:
    raise DocUpdateError(
        "Expected exactly one current-baseline table row in README, "
        f"found {len(rows)}"
    )
text = BASELINE_ROW_RE.sub(lambda _: row, text, count=1)
```

العدّ يسبق الاستبدال، فتتطابق الرسالة مع الفحص — وهو ما يفعله فحص سطر القياسات أصلًا.

الاستبدال صار عبر `lambda` كسطر القياسات: نص الاستبدال في `re.sub` يفسّر تسلسلات الإفلات، و`lambda` تُلغي ذلك. اسم اللقطة اليوم بلا backslash فالسلوك واحد؛ التغيير احترازي لا إصلاحي.

## الاختبارات — 13 → 14

| الاختبار | |
|---|---|
| `test_fails_when_baseline_row_duplicated` | يفشل **ولا يكتب أي وثيقة** |
| `test_fails_when_baseline_row_missing` | مُبقى، مع تأكيد `found 0` |

شُغّلا ضد تنفيذ `main`:

```
FAIL: test_fails_when_baseline_row_duplicated
AssertionError: 0 != 1
```

أي أن الحارس القديم كان **ينجح حيث يجب أن يفشل** — الدين كان حقيقيًا لا نظريًا.

## Codacy

`pylint` على الفرع يعطي الملاحظات الثلاث نفسها الموجودة على `main` بلا زيادة، فبوابة «صفر ملاحظات جديدة» يجب أن تمر:

| السطر | القاعدة | |
|---|---|---|
| 46 | `R1732` `TemporaryDirectory` بلا `with` | سابقة — موجودة في `test_validate_migration_ledger.py` أيضًا |
| 71 | `W1510` `subprocess.run` بلا `check` | سابقة |
| 241 | `W0108` lambda غير ضرورية | سابقة |

هذه الثلاث هي سبب `action_required` على #59، ومعالجتها خارج نطاق هذا الـPR — انظر التعليق أدناه.

## النطاق

حارس الصف فقط. لا قياس حجم، ولا `.codacy.yml`، ولا إصلاحات lint.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASrDjrR8BGjPnZ5mp8UtFQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01ASrDjrR8BGjPnZ5mp8UtFQ)_