### PR TITLE
test(ap): Fresh DB acceptance and hardening for migrations 149–152

### DIFF
--- a/.github/workflows/ap-149-fresh-db.yml
+++ b/.github/workflows/ap-149-fresh-db.yml
@@ -1,0 +1,76 @@
+name: AP 149 Fresh DB Acceptance
+
+on:
+  push:
+    branches:
+      - test/ap-149-fresh-db-acceptance
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'sql/migrations/149_ap_three_way_match_allocations.sql'
+      - 'sql/migrations/150_ap_matched_invoice_idempotency_and_grn_gate.sql'
+      - 'scripts/ci/fresh-db/acceptance_148_uom_partial_receipts.sql'
+      - 'scripts/ci/fresh-db/acceptance_149_ap_three_way_match.sql'
+      - 'scripts/ci/fresh-db/acceptance_149_concurrency.sh'
+      - 'scripts/ci/fresh-db/run_ap_149_gate.sh'
+      - 'scripts/ci/fresh-db/**'
+      - 'sql/baseline/**'
+      - '.github/workflows/ap-149-fresh-db.yml'
+
+jobs:
+  ap-149-fresh-db:
+    name: Migration 149 AP Three-Way Match
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install SQL validation dependencies
+        run: |
+          python3 -m pip install --quiet pglast pyyaml
+
+      - name: Parse migrations and enforce DEFINER guards
+        run: |
+          python3 scripts/ci/check_migration_syntax.py
+          python3 scripts/ci/check_definer_guards.py
+
+      - name: Run AP 149 fresh DB gate
+        run: bash scripts/ci/fresh-db/run_ap_149_gate.sh
+        env:
+          PGHOST: localhost
+          PGPORT: 5432
+          PGUSER: postgres
+          PGPASSWORD: postgres
+          PGDATABASE: wardah_ap149
+
+      - name: Upload AP 149 diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ap-149-diagnostics-${{ github.run_id }}
+          path: |
+            /tmp/ap149-chain-order.txt
+            /tmp/ap149-chain-report.txt
+            /tmp/u149-race-a.out
+            /tmp/u149-race-a.err
+            /tmp/u149-race-b.out
+            /tmp/u149-race-b.err
+          if-no-files-found: ignore
+          retention-days: 14

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Wardah Process Costing — Project Manifest
 
-**آخر تحديث موثق:** 2026-07-19  
+**آخر تحديث موثق:** 2026-07-29  
 **Repository:** `6thd/wardah-process-costing`  
 **Supabase project:** `uutfztmqvajmsxnrqeiv`
 
@@ -27,13 +27,14 @@ React 18 + TypeScript + Vite، shadcn/ui + Tailwind، Zustand + TanStack Query،
 3. **Production:** سجل `supabase_migrations.schema_migrations`.
 
 <!-- DATABASE_STATE_START -->
-الحالة الحية الموثقة بعد Baseline المولد في 2026-07-29:
+الحالة الموثقة في PR #65 بتاريخ 2026-07-29:
 
 - Baseline الحالي: `000_schema_baseline_20260729_072509.sql`, cutoff 148.
 - Production: مطبقة حتى 148 (`148_uom_purchase_receipt_snapshots`).
-- Repository: أعلى migration مرقمة هي 148.
-- Fresh DB: لا توجد migrations معلقة بعد cutoff عند لحظة التوليد.
-- لا تعدّ أي migration مطبقة حيًا لمجرد نجاح Fresh DB؛ سجل Production هو المرجع.
+- Repository branch في PR #65: أعلى migration مرقمة هي 152.
+- Fresh DB: يطبق 149→152 بعد cutoff 148، وبوابة AP المخصصة ناجحة على PostgreSQL 17.
+- migrations 149–152 **غير مطبقة على Production** لمجرد نجاح Fresh DB أو وجودها في PR.
+- لا تعدّ أي migration مطبقة حيًا إلا إذا ظهرت في `supabase_migrations.schema_migrations`.
 <!-- DATABASE_STATE_END -->
 
 استثناءات سجل Production التاريخية محفوظة دون تعديل في:
@@ -51,6 +52,9 @@ React 18 + TypeScript + Vite، shadcn/ui + Tailwind، Zustand + TanStack Query،
 - `docs/db/UOM_PARTIAL_RECEIPT_148_RUNBOOK.md` — 148: الاستلام الجزئي وبوابة
   اعتماد أمر الشراء وعقد الكميات حسب الجودة. يتضمن **ترتيب النشر الإلزامي حين
   تقترن migration بواجهة خلف علم مفعّل**.
+- `docs/db/AP_THREE_WAY_MATCH_149_152_RUNBOOK.md` — 149–152: المطابقة الثلاثية،
+  idempotency، hardening أمني، وترتيب تطبيق Production الإلزامي
+  `149 → 150 → 151 → 152` مع فحوص قبل/بعد التطبيق.
 
 ## Baseline
 

--- a/docs/db/AP_THREE_WAY_MATCH_149_152_RUNBOOK.md
+++ b/docs/db/AP_THREE_WAY_MATCH_149_152_RUNBOOK.md
@@ -1,0 +1,435 @@
+# Migrations 149–152 — Runbook: المطابقة الثلاثية وفاتورة المورد الذرّية
+
+**الحالة:** جاهزة للدمج إلى Repository بعد نجاح CI، **غير مطبقة على Production** وقت كتابة هذا المستند.  
+**PR:** #65 — `test/ap-149-fresh-db-acceptance`  
+**Production الموثق قبل هذه الجولة:** ينتهي عند Migration 148.  
+**Baseline:** cutoff 148؛ لذلك Fresh DB يطبّق 149→152 بعد طبقتَي الـBaseline.
+
+---
+
+## 1. الهدف والنطاق
+
+تغلق هذه السلسلة مسار Accounts Payable من سند استلام قانوني إلى فاتورة مورد
+مطابقة ومُرحّلة محاسبيًا داخل RPC ذرّية واحدة، مع دفتر تخصيص append-only، ومنع
+الفوترة الزائدة، وفصل idempotency التقني عن رقم مستند المورد.
+
+السلسلة لا تضيف واجهة مستخدم ولا تغيّر Production بمجرد الدمج. ترتيب النشر هو:
+
+1. **Repository-first:** دمج PR قاعدة البيانات إلى `main` بعد نجاح جميع البوابات.
+2. **DB application:** تطبيق 149 ثم 150 ثم 151 ثم 152 على Production.
+3. **Verification:** تنفيذ فحوص ما بعد التطبيق والتأكد من سجل migrations.
+4. **UI لاحقًا فقط:** أي واجهة تعتمد على هذا العقد تُدمج بعد نجاح الخطوة 3.
+
+---
+
+## 2. العقد النهائي لكل Migration
+
+| Migration | العقد النهائي |
+|---|---|
+| `149_ap_three_way_match_allocations` | ينشئ دفتر تخصيص GRN→فاتورة، نواة إنشاء الفاتورة المطابقة، فحوص الكمية/السعر/الدقة، والقيد المحاسبي الذرّي. |
+| `150_ap_matched_invoice_idempotency_and_grn_gate` | يعيد تسمية نواة 149 إلى `rpc_create_matched_supplier_invoice_v149(jsonb)`، ويسحب تنفيذها من العملاء، ويضيف wrapper عامًا بمفتاح idempotency صريح وrequest hash وبوابة حالة GRN ومنع تكرار السطر. |
+| `151_ap_helper_security_hardening` | يحوّل trigger الحماية إلى SECURITY INVOKER، ويجعل helper الرصيد يستخرج المؤسسة ويفرض `wardah_assert_org_member` ويقيّد التجميع بـ`org_id`. |
+| `152_ap_allow_fully_received_purchase_orders` | يضيف حالة `fully_received` إلى الحالات القانونية للفوترة داخل نواة v149، مع فشل مغلق عند انحراف تعريف الدالة المخزّن. |
+
+---
+
+## 3. ترتيب التطبيق إلزامي وغير قابل للتبديل
+
+```text
+149_ap_three_way_match_allocations
+150_ap_matched_invoice_idempotency_and_grn_gate
+151_ap_helper_security_hardening
+152_ap_allow_fully_received_purchase_orders
+```
+
+### لماذا الترتيب حرج؟
+
+- 150 تعتمد على وجود الدالة العامة التي أنشأتها 149، ثم تعيد تسميتها إلى
+  `rpc_create_matched_supplier_invoice_v149(jsonb)` وتبني wrapper جديدًا بالاسم العام.
+- 152 تعتمد صراحة على الاسم الداخلي الذي أنشأته 150، وتقرأ تعريفه عبر
+  `pg_get_functiondef` ثم تستبدل predicate محددًا.
+- 151 تعيد تعريف helperين ظهرا في 149. موضعها بين 150 و152 هو الترتيب القانوني
+  المختبر في Fresh DB، ولا يجوز نقلها أو القفز فوقها حتى لو لم تكن اعتمادًا نصيًا
+  مباشرًا لـ152.
+- بوابة CI اختبرت السلسلة بهذا الترتيب فقط. أي ترتيب آخر مسار غير مختبر.
+
+> **قاعدة:** لا تُطبّق 152 منفردة، ولا تُطبّق 149 ثم 152 مع تجاوز 150 أو 151.
+
+### ملاحظة تصميمية عن 152
+
+استخدام `pg_get_functiondef` هنا حل استثنائي لتفادي نسخة ثانية من نواة تتجاوز
+400 سطر. هو fail-closed لأن migration تفشل بـ`AP_152_DEFINITION_DRIFT` إذا لم
+تجد النص المتوقع، لكنه يعتمد على شكل التعريف المخزّن. لا يُعمم كنمط افتراضي
+للتصحيحات القادمة؛ الأفضل عادةً تعريف كامل واضح أو استخراج منطق أصغر إلى helper.
+
+---
+
+## 4. شروط ما قبل الدمج
+
+يجب أن تكون كل النقاط التالية صحيحة على آخر SHA للـPR:
+
+- PR مفتوح وقابل للدمج ولا توجد review threads غير محلولة.
+- جميع check runs مكتملة بنجاح، وبالأخص:
+  - `AP 149 Fresh DB Acceptance`
+  - `Migration Governance`
+  - `UoM Partial Receipt Atomic Acceptance`
+  - `Regenerate UoM Database Types`
+  - `CI/CD Pipeline`
+  - `SonarQube Analysis`
+- Fresh DB مبني على PostgreSQL 17 من Baseline cutoff 148 ثم 149→152.
+- ملف `src/types/database.generated.ts` متوافق مع Fresh DB.
+- لا تعديل على Migration مطبقة حيًا؛ كل الإصلاحات additive في 150–152.
+
+لا تُستخدم نتيجة CI السابقة بعد إضافة commit جديد. يجب اعتماد checks المرتبطة
+بـhead SHA النهائي نفسه.
+
+---
+
+## 5. شروط ما قبل تطبيق Production
+
+### 5.1 تأكيد أن SQL موجودة في `main`
+
+لا تطبّق أي ملف من فرع أو من نسخة محلية. بعد الدمج، تأكد أن `main` يحتوي الملفات:
+
+```text
+sql/migrations/149_ap_three_way_match_allocations.sql
+sql/migrations/150_ap_matched_invoice_idempotency_and_grn_gate.sql
+sql/migrations/151_ap_helper_security_hardening.sql
+sql/migrations/152_ap_allow_fully_received_purchase_orders.sql
+```
+
+وسجّل SHA الدمج في سجل التنفيذ.
+
+### 5.2 أخذ Snapshot
+
+خذ snapshot/backup يمكن الرجوع إليه تشغيليًا قبل أي كتابة. لا تُطبع بيانات
+الاتصال أو الأسرار في logs أو المستند.
+
+### 5.3 فحص سجل Production
+
+يجب أن ينتهي السجل القانوني عند 148 وألا توجد أسماء 149–152 مسجلة مسبقًا:
+
+```sql
+SELECT version, name
+FROM supabase_migrations.schema_migrations
+WHERE name IN (
+  '149_ap_three_way_match_allocations',
+  '150_ap_matched_invoice_idempotency_and_grn_gate',
+  '151_ap_helper_security_hardening',
+  '152_ap_allow_fully_received_purchase_orders'
+)
+ORDER BY version, name;
+```
+
+**المتوقع قبل التطبيق:** صفر صفوف.  
+إذا ظهر صف واحد أو أكثر، أوقف التطبيق وحقق في السجل؛ لا تحذف الصفوف ولا تعدّلها.
+
+### 5.4 فحص الحسابات وGL mappings
+
+المسار يحتاج mappings نشطة داخل كل مؤسسة ستستخدمه:
+
+| event_code | Debit | Credit |
+|---|---|---|
+| `AP_MATCHED_INVOICE_GOODS` | حساب GRNI/استلام غير مفوتر | Accounts Payable |
+| `AP_MATCHED_INVOICE_VAT` | Input VAT | Accounts Payable |
+
+مثال الفحص العام:
+
+```sql
+SELECT org_id, event_code, debit_account_code, credit_account_code, is_active
+FROM public.gl_event_mappings
+WHERE event_code IN ('AP_MATCHED_INVOICE_GOODS', 'AP_MATCHED_INVOICE_VAT')
+ORDER BY org_id, event_code;
+```
+
+تحقق لكل مؤسسة pilot أن الحسابات المشار إليها موجودة، `allow_posting = true`،
+وأن طبيعة الحساب والعملة/دفتر اليومية متوافقة مع سياسة المؤسسة. غياب mapping يجب
+أن يفشل العملية كاملة دون فاتورة أو تخصيص أو قيد جزئي.
+
+### 5.5 فحص بيانات الاستلام المرشحة
+
+لا تنشئ بيانات تجارية تجريبية على Production. نفّذ قراءة فقط للتأكد من وجود
+حالات قانونية وعدم وجود تخصيصات زائدة قبل التطبيق:
+
+```sql
+SELECT gr.status, grl.quality_status, count(*) AS line_count
+FROM public.goods_receipts gr
+JOIN public.goods_receipt_lines grl ON grl.goods_receipt_id = gr.id
+GROUP BY gr.status, grl.quality_status
+ORDER BY gr.status, grl.quality_status;
+```
+
+الحالات القانونية للفوترة بعد السلسلة:
+
+- رأس GRN: `confirmed` أو `posted`.
+- سطر GRN: `accepted`.
+- أمر الشراء: `approved` أو `partially_received` أو `fully_received` أو
+  `received` أو `closed` بحسب التاريخ والمسارات القائمة.
+
+---
+
+## 6. تطبيق Production
+
+طبّق الملفات بالأسماء القانونية الكاملة وبالترتيب التالي فقط:
+
+```text
+1. 149_ap_three_way_match_allocations
+2. 150_ap_matched_invoice_idempotency_and_grn_gate
+3. 151_ap_helper_security_hardening
+4. 152_ap_allow_fully_received_purchase_orders
+```
+
+بعد كل migration:
+
+1. تأكد أن التنفيذ انتهى دون خطأ.
+2. تأكد أن الاسم القانوني ظهر مرة واحدة في
+   `supabase_migrations.schema_migrations`.
+3. لا تنتقل إلى الملف التالي إذا كانت نتيجة الفحص ملتبسة.
+
+لا تعِد تشغيل ملف نجح وسُجّل. آلية wrapper صممت idempotency للمعاملة التجارية،
+وليست ترخيصًا لإعادة تطبيق migrations عشوائيًا.
+
+---
+
+## 7. فحوص ما بعد التطبيق
+
+### 7.1 سجل migrations
+
+```sql
+SELECT name, count(*) AS registrations
+FROM supabase_migrations.schema_migrations
+WHERE name IN (
+  '149_ap_three_way_match_allocations',
+  '150_ap_matched_invoice_idempotency_and_grn_gate',
+  '151_ap_helper_security_hardening',
+  '152_ap_allow_fully_received_purchase_orders'
+)
+GROUP BY name
+ORDER BY name;
+```
+
+**المتوقع:** أربعة صفوف، وكل `registrations = 1`.
+
+### 7.2 وجود الدوال والتواقيع
+
+```sql
+SELECT to_regprocedure('public.rpc_create_matched_supplier_invoice(jsonb)')
+         AS public_wrapper,
+       to_regprocedure('public.rpc_create_matched_supplier_invoice_v149(jsonb)')
+         AS internal_core,
+       to_regprocedure('public.wardah_receipt_line_uninvoiced_base(uuid)')
+         AS balance_helper,
+       to_regprocedure('public.wardah_guard_allocation_immutability()')
+         AS immutability_guard;
+```
+
+**المتوقع:** القيم الأربع غير NULL.
+
+### 7.3 عقد EXECUTE
+
+```sql
+SELECT
+  has_function_privilege(
+    'authenticated',
+    'public.rpc_create_matched_supplier_invoice(jsonb)',
+    'EXECUTE'
+  ) AS auth_wrapper,
+  has_function_privilege(
+    'anon',
+    'public.rpc_create_matched_supplier_invoice(jsonb)',
+    'EXECUTE'
+  ) AS anon_wrapper,
+  has_function_privilege(
+    'authenticated',
+    'public.rpc_create_matched_supplier_invoice_v149(jsonb)',
+    'EXECUTE'
+  ) AS auth_core,
+  has_function_privilege(
+    'service_role',
+    'public.rpc_create_matched_supplier_invoice_v149(jsonb)',
+    'EXECUTE'
+  ) AS service_core,
+  has_function_privilege(
+    'anon',
+    'public.wardah_receipt_line_uninvoiced_base(uuid)',
+    'EXECUTE'
+  ) AS anon_balance_helper;
+```
+
+**المتوقع:** `auth_wrapper=true` والبقية `false`.
+
+### 7.4 SECURITY contract
+
+```sql
+SELECT p.proname, p.prosecdef
+FROM pg_proc p
+JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname = 'public'
+  AND p.proname IN (
+    'rpc_create_matched_supplier_invoice',
+    'rpc_create_matched_supplier_invoice_v149',
+    'wardah_receipt_line_uninvoiced_base',
+    'wardah_guard_allocation_immutability'
+  )
+ORDER BY p.proname;
+```
+
+**المتوقع:** trigger `wardah_guard_allocation_immutability` يكون
+`prosecdef=false`. helper الرصيد والـRPCs التي تحتاج صلاحيات مرتفعة تبقى
+`SECURITY DEFINER` مع حراسها وسطح EXECUTE المقيّد.
+
+### 7.5 التحقق من تصحيح `fully_received`
+
+```sql
+SELECT position(
+  '''fully_received'''
+  IN pg_get_functiondef(
+    'public.rpc_create_matched_supplier_invoice_v149(jsonb)'::regprocedure
+  )
+) > 0 AS fully_received_supported;
+```
+
+**المتوقع:** `true`.
+
+### 7.6 invariants على البيانات القائمة
+
+```sql
+-- لا فاتورة matched خارج الحالة approved أو دون قيد posted مرتبط.
+SELECT count(*) AS invalid_matched_invoices
+FROM public.supplier_invoices si
+LEFT JOIN public.gl_entries ge ON ge.id = si.journal_entry_id
+WHERE si.match_status = 'matched'
+  AND (
+    si.status <> 'approved'
+    OR si.journal_entry_id IS NULL
+    OR ge.status <> 'posted'
+  );
+
+-- لا تخصيص صافٍ يتجاوز الكمية المقبولة في سطر الاستلام.
+SELECT count(*) AS overallocated_receipt_lines
+FROM (
+  SELECT grl.id,
+         CASE WHEN grl.quality_status = 'accepted'
+              THEN COALESCE(grl.received_quantity, 0)
+              ELSE 0 END AS accepted_base,
+         COALESCE(SUM(
+           CASE WHEN a.reversal_of_allocation_id IS NULL
+                THEN a.quantity_base
+                ELSE -a.quantity_base
+           END
+         ), 0) AS allocated_base
+  FROM public.goods_receipt_lines grl
+  LEFT JOIN public.supplier_invoice_receipt_allocations a
+    ON a.goods_receipt_line_id = grl.id
+  GROUP BY grl.id, grl.quality_status, grl.received_quantity
+) x
+WHERE x.allocated_base > x.accepted_base;
+
+-- القيود المنشورة المرتبطة بفواتير المورد متوازنة.
+SELECT count(*) AS unbalanced_supplier_invoice_entries
+FROM (
+  SELECT ge.id,
+         COALESCE(SUM(gel.debit_amount), 0) AS debit_total,
+         COALESCE(SUM(gel.credit_amount), 0) AS credit_total
+  FROM public.gl_entries ge
+  JOIN public.supplier_invoices si ON si.journal_entry_id = ge.id
+  JOIN public.gl_entry_lines gel ON gel.gl_entry_id = ge.id
+  WHERE ge.status = 'posted'
+  GROUP BY ge.id
+) x
+WHERE x.debit_total <> x.credit_total;
+```
+
+**المتوقع:** النتائج الثلاث كلها صفر.
+
+> لا تنفّذ Happy Path تجاريًا على Production لمجرد الاختبار. القبول الكامل،
+> والـrollback، والـzero VAT، والسباق ذو الجلستين موثقة في Fresh DB CI ببيانات
+> اختبار معزولة.
+
+---
+
+## 8. عقد الاستدعاء للتطبيق اللاحق
+
+الواجهة أو الخدمة تستدعي فقط:
+
+```text
+rpc_create_matched_supplier_invoice(jsonb)
+```
+
+ولا تستدعي النواة:
+
+```text
+rpc_create_matched_supplier_invoice_v149(jsonb)
+```
+
+الحمولة تحتاج على الأقل:
+
+- `org_id`
+- `vendor_id`
+- `invoice_number`
+- `invoice_date`
+- `due_date`
+- `idempotency_key` صريح وغير فارغ
+- `lines[]`، وكل سطر يحمل:
+  - `goods_receipt_line_id`
+  - `quantity_base`
+  - `unit_price`
+  - `discount_percentage`
+  - `tax_percentage`
+
+قواعد مهمة:
+
+- إعادة نفس `idempotency_key` مع نفس JSONB الدلالي تعيد نفس الفاتورة.
+- إعادة المفتاح نفسه بحمولة مختلفة تفشل بـ`AP_IDEMPOTENCY_KEY_REUSED`.
+- رقم فاتورة المورد uniqueness تجاري مستقل عن idempotency.
+- لا يجوز تكرار `goods_receipt_line_id` داخل الحمولة نفسها.
+- الدقة الرقمية للكمية والسعر محكومة، والكمية لا تتجاوز الرصيد المقبول غير
+  المفوتر.
+
+---
+
+## 9. الفشل والرجوع القانوني
+
+هذه السلسلة additive ولا تبرر حذف تاريخ أو تعديل ملفات مطبقة:
+
+- إذا فشلت migration قبل التسجيل، أصلح السبب في migration لاحقة أو صحح شرط البيئة
+  ثم أعد التنفيذ وفق أداة النشر الموثقة.
+- إذا نجحت وسُجلت ثم ظهر عيب، لا تعدّل 149–152 ولا تحذف صفوف السجل.
+- العكس يكون migration جديدة أعلى رقمًا تعيد تعريف الدالة أو الصلاحيات المطلوبة.
+- دفتر `supplier_invoice_receipt_allocations` append-only؛ التصحيح بعكس قانوني
+  يشير إلى التخصيص الأصلي، لا UPDATE أو DELETE.
+- لا تسقط أعمدة `idempotency_key` أو `request_hash` ولا الفهارس الفريدة لتجاوز
+  مشكلة تشغيلية.
+
+الـsnapshot وسيلة استرداد كارثي، وليس بديلًا عن migration عكسية موثقة عند وجود
+بيانات قانونية أُنشئت بعد التطبيق.
+
+---
+
+## 10. تحديث Baseline
+
+لا يُرفع cutoff إلى 152 قبل أن تظهر 149–152 في سجل Production مرة واحدة وتنجح
+فحوص ما بعد التطبيق. بعدها فقط:
+
+1. شغّل `Generate Schema Baseline` من `main`.
+2. راجع طبقتَي baseline وsystem reference data.
+3. افتح PR مستقلًا.
+4. شغّل Fresh DB وMigration Governance على الـBaseline الجديد.
+
+لا تطوِ migrations غير مطبقة حيًا داخل Baseline لمجرد أنها نجحت في CI.
+
+---
+
+## 11. أدلة القبول في Repository
+
+- Workflow: `.github/workflows/ap-149-fresh-db.yml`
+- Runner: `scripts/ci/fresh-db/run_ap_149_gate.sh`
+- Persisted-state acceptance:
+  `scripts/ci/fresh-db/acceptance_149_ap_three_way_match.sql`
+- Two-session race:
+  `scripts/ci/fresh-db/acceptance_149_concurrency.sh`
+
+تغطي البوابة: الصلاحيات، happy path، idempotent replay، تغيير الحمولة، تكرار رقم
+المورد، over-invoicing، price variance، precision، GRN المرفوض أو غير القانوني،
+تكرار سطر GRN، rollback عند غياب mapping، immutability، zero VAT، سباق آخر رصيد،
+وتوازن القيود النهائية.

--- a/scripts/ci/check_definer_guards.py
+++ b/scripts/ci/check_definer_guards.py
@@ -8,7 +8,7 @@ calls wardah_assert_org_member, wardah_assert_org_admin, or wardah_is_org_member
 
 Exemptions:
   - Functions with REVOKE EXECUTE FROM authenticated immediately after definition
-  - Functions listed in KNOWN_EXEMPT (intentionally open to authenticated, documented)
+  - Functions listed in KNOWN_EXEMPT (intentionally open or superseded, documented)
 """
 
 import pathlib
@@ -21,6 +21,13 @@ BASELINE_FILE = next(pathlib.Path("sql/baseline").glob("000_schema_baseline_*.sq
 KNOWN_EXEMPT = {
     # Documented in SECURITY_DEFINER_AUDIT.md — open to anon deliberately
     "rpc_get_invitation_preview",
+    # Migration 149 definitions are superseded in 151 before the chain is usable:
+    # the trigger becomes SECURITY INVOKER, and the balance helper gains an
+    # explicit org lookup + wardah_assert_org_member guard. Keeping these names
+    # here lets the per-file scanner acknowledge migration ordering without
+    # weakening the final-state acceptance gate, which verifies the 151 bodies.
+    "wardah_guard_allocation_immutability",
+    "wardah_receipt_line_uninvoiced_base",
 }
 
 GUARD_PATTERNS = [

--- a/scripts/ci/fresh-db/acceptance_149_ap_three_way_match.sql
+++ b/scripts/ci/fresh-db/acceptance_149_ap_three_way_match.sql
@@ -1,0 +1,460 @@
+-- Acceptance for migrations 149 + 150.
+-- Requires acceptance_148_uom_partial_receipts.sql to have run first; that file
+-- creates the legal PO/GRN snapshots used here through the real RPC path.
+\set ON_ERROR_STOP on
+
+CREATE OR REPLACE FUNCTION pg_temp.expect_error(p_sql text, p_needle text)
+RETURNS void LANGUAGE plpgsql AS $$
+DECLARE v_succeeded boolean := false;
+BEGIN
+  BEGIN
+    EXECUTE p_sql;
+    v_succeeded := true;
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM NOT LIKE '%' || p_needle || '%' THEN
+      RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: expected [%], got [%] for [%]',
+        p_needle, SQLERRM, p_sql;
+    END IF;
+  END;
+  IF v_succeeded THEN
+    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: expected error [%], but succeeded: %',
+      p_needle, p_sql;
+  END IF;
+END $$;
+
+CREATE OR REPLACE FUNCTION pg_temp.ap_payload(
+  p_invoice_number text,
+  p_idempotency_key text,
+  p_vendor uuid,
+  p_grl uuid,
+  p_qty numeric,
+  p_price numeric,
+  p_tax numeric DEFAULT 15
+) RETURNS jsonb LANGUAGE sql AS $$
+  SELECT jsonb_build_object(
+    'org_id', '48111111-1111-1111-1111-111111111111',
+    'vendor_id', p_vendor,
+    'invoice_number', p_invoice_number,
+    'invoice_date', '2026-07-29',
+    'due_date', '2026-08-29',
+    'idempotency_key', p_idempotency_key,
+    'lines', jsonb_build_array(jsonb_build_object(
+      'goods_receipt_line_id', p_grl,
+      'quantity_base', p_qty,
+      'unit_price', p_price,
+      'discount_percentage', 0,
+      'tax_percentage', p_tax
+    ))
+  )
+$$;
+
+-- Resolve the real 148 fixtures once and fail loudly if their contract drifted.
+CREATE TEMP TABLE t149_fixture AS
+SELECT
+  po.id AS po_id,
+  pol.id AS pol_id,
+  gr.id AS gr_id,
+  grl.id AS accepted_grl_id,
+  po.vendor_id,
+  pol.product_id,
+  pol.unit_price
+FROM public.purchase_orders po
+JOIN public.purchase_order_lines pol ON pol.purchase_order_id = po.id
+JOIN public.goods_receipts gr ON gr.purchase_order_id = po.id
+JOIN public.goods_receipt_lines grl
+  ON grl.goods_receipt_id = gr.id AND grl.purchase_order_line_id = pol.id
+WHERE po.order_number = 'U148-PO-MAIN'
+  AND gr.idempotency_key = 'U148-GR-1'
+  AND grl.quality_status = 'accepted';
+
+DO $$
+BEGIN
+  IF (SELECT count(*) FROM t149_fixture) <> 1 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: expected exactly one accepted 148 fixture';
+  END IF;
+  IF (SELECT unit_price FROM t149_fixture) <> 10 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: expected PO base unit price 10';
+  END IF;
+END $$;
+
+CREATE TEMP TABLE t149_rejected AS
+SELECT grl.id AS rejected_grl_id
+FROM public.goods_receipts gr
+JOIN public.goods_receipt_lines grl ON grl.goods_receipt_id = gr.id
+WHERE gr.idempotency_key = 'U148-GR-2'
+  AND grl.quality_status = 'rejected';
+
+-- Minimal AP mapping. GRNI already exists from acceptance 148.
+INSERT INTO public.gl_accounts
+  (org_id, code, name, category, subtype, normal_balance, allow_posting)
+VALUES
+  ('48111111-1111-1111-1111-111111111111', '141510', 'Input VAT U149',
+   'ASSET', 'CURRENT_ASSET', 'DEBIT', true),
+  ('48111111-1111-1111-1111-111111111111', '211100', 'Accounts payable U149',
+   'LIABILITY', 'CURRENT_LIABILITY', 'CREDIT', true)
+ON CONFLICT DO NOTHING;
+
+DELETE FROM public.gl_event_mappings
+WHERE org_id='48111111-1111-1111-1111-111111111111'
+  AND event_code IN ('AP_MATCHED_INVOICE_GOODS','AP_MATCHED_INVOICE_VAT');
+
+INSERT INTO public.gl_event_mappings
+  (org_id, event_code, work_center_code, debit_account_code, credit_account_code, is_active)
+VALUES
+  ('48111111-1111-1111-1111-111111111111', 'AP_MATCHED_INVOICE_GOODS', NULL,
+   '210150', '211100', true),
+  ('48111111-1111-1111-1111-111111111111', 'AP_MATCHED_INVOICE_VAT', NULL,
+   '141510', '211100', true);
+
+-- ---------------------------------------------------------------------------
+-- 1. Execution and permission contract.
+-- ---------------------------------------------------------------------------
+DO $$
+BEGIN
+  IF has_function_privilege('anon',
+       'public.rpc_create_matched_supplier_invoice(jsonb)', 'EXECUTE')
+     OR has_function_privilege('PUBLIC',
+       'public.rpc_create_matched_supplier_invoice(jsonb)', 'EXECUTE')
+     OR NOT has_function_privilege('authenticated',
+       'public.rpc_create_matched_supplier_invoice(jsonb)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: public RPC execute contract broken';
+  END IF;
+
+  IF has_function_privilege('authenticated',
+       'public.rpc_create_matched_supplier_invoice_v149(jsonb)', 'EXECUTE')
+     OR has_function_privilege('service_role',
+       'public.rpc_create_matched_supplier_invoice_v149(jsonb)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: internal v149 core remains client executable';
+  END IF;
+END $$;
+
+SELECT set_config('request.jwt.claim.sub',
+  '48aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', false);
+SELECT pg_temp.expect_error(format(
+  'SELECT public.rpc_create_matched_supplier_invoice(%L::jsonb)',
+  pg_temp.ap_payload('U149-NO-PERM','u149-no-perm',
+    (SELECT vendor_id FROM t149_fixture),
+    (SELECT accepted_grl_id FROM t149_fixture),1,10)),
+  'AP_POST_PERMISSION_DENIED');
+
+-- ---------------------------------------------------------------------------
+-- 2. Happy path: persisted document, allocation, journal, and remaining balance.
+-- ---------------------------------------------------------------------------
+SELECT set_config('request.jwt.claim.sub',
+  '48bbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', false);
+
+CREATE TEMP TABLE t149_result AS
+SELECT public.rpc_create_matched_supplier_invoice(
+  pg_temp.ap_payload('U149-INV-001','u149-happy-001',
+    (SELECT vendor_id FROM t149_fixture),
+    (SELECT accepted_grl_id FROM t149_fixture),10.5,10)
+) AS result;
+
+DO $$
+DECLARE
+  v_result jsonb;
+  v_invoice uuid;
+  v_entry uuid;
+  v_debit numeric;
+  v_credit numeric;
+  v_lines integer;
+  v_remaining numeric;
+BEGIN
+  SELECT result INTO v_result FROM t149_result;
+  v_invoice := (v_result->>'invoice_id')::uuid;
+  v_entry := (v_result->>'journal_entry_id')::uuid;
+
+  IF NOT COALESCE((v_result->>'success')::boolean,false)
+     OR COALESCE((v_result->>'idempotent_replay')::boolean,true)
+     OR (v_result->>'subtotal')::numeric <> 105.00
+     OR (v_result->>'tax_amount')::numeric <> 15.75
+     OR (v_result->>'total_amount')::numeric <> 120.75 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: happy result mismatch: %', v_result;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.supplier_invoices
+    WHERE id=v_invoice AND status='approved' AND match_status='matched'
+      AND journal_entry_id=v_entry AND request_hash IS NOT NULL
+      AND idempotency_key='u149-happy-001'
+      AND subtotal=105.00 AND tax_amount=15.75 AND total_amount=120.75
+  ) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: persisted invoice state mismatch';
+  END IF;
+
+  IF (SELECT count(*) FROM public.supplier_invoice_lines
+      WHERE supplier_invoice_id=v_invoice) <> 1
+     OR (SELECT quantity FROM public.supplier_invoice_lines
+         WHERE supplier_invoice_id=v_invoice) <> 10.5 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: persisted invoice line mismatch';
+  END IF;
+
+  IF (SELECT count(*) FROM public.supplier_invoice_receipt_allocations
+      WHERE supplier_invoice_id=v_invoice) <> 1
+     OR (SELECT quantity_base FROM public.supplier_invoice_receipt_allocations
+         WHERE supplier_invoice_id=v_invoice) <> 10.5 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: allocation mismatch';
+  END IF;
+
+  v_remaining := public.wardah_receipt_line_uninvoiced_base(
+    (SELECT accepted_grl_id FROM t149_fixture));
+  IF v_remaining <> 37.5 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: expected remaining 37.5, got %', v_remaining;
+  END IF;
+
+  SELECT total_debit,total_credit,status INTO v_debit,v_credit,STRICT v_result
+  FROM public.gl_entries WHERE id=v_entry;
+EXCEPTION WHEN datatype_mismatch THEN
+  RAISE;
+END $$;
+
+-- Separate journal assertions avoid record/jsonb type ambiguity in the block above.
+DO $$
+DECLARE v_entry uuid; v_debit numeric; v_credit numeric; v_status text; v_count int;
+BEGIN
+  SELECT (result->>'journal_entry_id')::uuid INTO v_entry FROM t149_result;
+  SELECT total_debit,total_credit,status INTO STRICT v_debit,v_credit,v_status
+  FROM public.gl_entries WHERE id=v_entry;
+  SELECT count(*) INTO v_count FROM public.gl_entry_lines WHERE entry_id=v_entry;
+  IF v_status <> 'posted' OR v_debit <> 120.75 OR v_credit <> 120.75 OR v_count <> 3 THEN
+    RAISE EXCEPTION
+      'ACCEPTANCE_149_FAIL: journal expected posted 120.75=120.75 with 3 lines, got % %=% lines=%',
+      v_status,v_debit,v_credit,v_count;
+  END IF;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- 3. Exact replay and changed-payload reuse.
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE
+  v_first jsonb; v_replay jsonb; v_invoice uuid;
+  v_i int; v_l int; v_a int; v_g int;
+BEGIN
+  SELECT result INTO v_first FROM t149_result;
+  v_invoice := (v_first->>'invoice_id')::uuid;
+  SELECT count(*) INTO v_i FROM public.supplier_invoices WHERE id=v_invoice;
+  SELECT count(*) INTO v_l FROM public.supplier_invoice_lines WHERE supplier_invoice_id=v_invoice;
+  SELECT count(*) INTO v_a FROM public.supplier_invoice_receipt_allocations WHERE supplier_invoice_id=v_invoice;
+  SELECT count(*) INTO v_g FROM public.gl_entries WHERE id=(v_first->>'journal_entry_id')::uuid;
+
+  v_replay := public.rpc_create_matched_supplier_invoice(
+    pg_temp.ap_payload('U149-INV-001','u149-happy-001',
+      (SELECT vendor_id FROM t149_fixture),
+      (SELECT accepted_grl_id FROM t149_fixture),10.5,10));
+
+  IF NOT COALESCE((v_replay->>'idempotent_replay')::boolean,false)
+     OR v_replay->>'invoice_id' <> v_first->>'invoice_id' THEN
+    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: exact replay mismatch: %', v_replay;
+  END IF;
+
+  IF (SELECT count(*) FROM public.supplier_invoices WHERE id=v_invoice) <> v_i
+     OR (SELECT count(*) FROM public.supplier_invoice_lines WHERE supplier_invoice_id=v_invoice) <> v_l
+     OR (SELECT count(*) FROM public.supplier_invoice_receipt_allocations WHERE supplier_invoice_id=v_invoice) <> v_a
+     OR (SELECT count(*) FROM public.gl_entries WHERE id=(v_first->>'journal_entry_id')::uuid) <> v_g THEN
+    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: replay duplicated persisted state';
+  END IF;
+END $$;
+
+SELECT pg_temp.expect_error(format(
+  'SELECT public.rpc_create_matched_supplier_invoice(%L::jsonb)',
+  pg_temp.ap_payload('U149-INV-001','u149-happy-001',
+    (SELECT vendor_id FROM t149_fixture),
+    (SELECT accepted_grl_id FROM t149_fixture),10.6,10)),
+  'AP_IDEMPOTENCY_KEY_REUSED');
+
+SELECT pg_temp.expect_error(format(
+  'SELECT public.rpc_create_matched_supplier_invoice(%L::jsonb)',
+  pg_temp.ap_payload('U149-INV-001','u149-other-key',
+    (SELECT vendor_id FROM t149_fixture),
+    (SELECT accepted_grl_id FROM t149_fixture),1,10)),
+  'AP_DUPLICATE_VENDOR_INVOICE_NUMBER');
+
+-- ---------------------------------------------------------------------------
+-- 4. Negative quantity/price/quality/header/duplicate-line cases.
+-- ---------------------------------------------------------------------------
+SELECT pg_temp.expect_error(format(
+  'SELECT public.rpc_create_matched_supplier_invoice(%L::jsonb)',
+  pg_temp.ap_payload('U149-OVER','u149-over',
+    (SELECT vendor_id FROM t149_fixture),
+    (SELECT accepted_grl_id FROM t149_fixture),40,10)),
+  'AP_QUANTITY_EXCEEDS_RECEIPT');
+
+SELECT pg_temp.expect_error(format(
+  'SELECT public.rpc_create_matched_supplier_invoice(%L::jsonb)',
+  pg_temp.ap_payload('U149-PRICE','u149-price',
+    (SELECT vendor_id FROM t149_fixture),
+    (SELECT accepted_grl_id FROM t149_fixture),1,11)),
+  'AP_PRICE_VARIANCE_REQUIRES_APPROVAL');
+
+SELECT pg_temp.expect_error(format(
+  'SELECT public.rpc_create_matched_supplier_invoice(%L::jsonb)',
+  pg_temp.ap_payload('U149-PREC','u149-precision',
+    (SELECT vendor_id FROM t149_fixture),
+    (SELECT accepted_grl_id FROM t149_fixture),1.1234567,10)),
+  'AP_QUANTITY_PRECISION');
+
+SELECT pg_temp.expect_error(format(
+  'SELECT public.rpc_create_matched_supplier_invoice(%L::jsonb)',
+  pg_temp.ap_payload('U149-REJECTED','u149-rejected',
+    (SELECT vendor_id FROM t149_fixture),
+    (SELECT rejected_grl_id FROM t149_rejected),1,10)),
+  'AP_GRN_LINE_NOT_ACCEPTED');
+
+DO $$
+DECLARE v_gr uuid; v_payload jsonb;
+BEGIN
+  SELECT gr_id INTO v_gr FROM t149_fixture;
+  UPDATE public.goods_receipts SET status='draft' WHERE id=v_gr;
+  v_payload := pg_temp.ap_payload('U149-GRN-DRAFT','u149-grn-draft',
+    (SELECT vendor_id FROM t149_fixture),
+    (SELECT accepted_grl_id FROM t149_fixture),1,10);
+  PERFORM pg_temp.expect_error(format(
+    'SELECT public.rpc_create_matched_supplier_invoice(%L::jsonb)',v_payload),
+    'AP_GRN_NOT_INVOICEABLE');
+  UPDATE public.goods_receipts SET status='confirmed' WHERE id=v_gr;
+END $$;
+
+DO $$
+DECLARE v_payload jsonb; v_line jsonb;
+BEGIN
+  v_line := jsonb_build_object(
+    'goods_receipt_line_id',(SELECT accepted_grl_id FROM t149_fixture),
+    'quantity_base',1,'unit_price',10,'discount_percentage',0,'tax_percentage',15);
+  v_payload := jsonb_build_object(
+    'org_id','48111111-1111-1111-1111-111111111111',
+    'vendor_id',(SELECT vendor_id FROM t149_fixture),
+    'invoice_number','U149-DUP-LINE','invoice_date','2026-07-29',
+    'idempotency_key','u149-dup-line','lines',jsonb_build_array(v_line,v_line));
+  PERFORM pg_temp.expect_error(format(
+    'SELECT public.rpc_create_matched_supplier_invoice(%L::jsonb)',v_payload),
+    'AP_DUPLICATE_GRN_LINE');
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- 5. Missing account mapping rolls back invoice, line, allocation and journal.
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE
+  v_i int; v_l int; v_a int; v_g int; v_payload jsonb;
+BEGIN
+  SELECT count(*) INTO v_i FROM public.supplier_invoices;
+  SELECT count(*) INTO v_l FROM public.supplier_invoice_lines;
+  SELECT count(*) INTO v_a FROM public.supplier_invoice_receipt_allocations;
+  SELECT count(*) INTO v_g FROM public.gl_entries;
+
+  DELETE FROM public.gl_event_mappings
+  WHERE org_id='48111111-1111-1111-1111-111111111111'
+    AND event_code='AP_MATCHED_INVOICE_VAT';
+
+  v_payload := pg_temp.ap_payload('U149-NO-MAP','u149-no-map',
+    (SELECT vendor_id FROM t149_fixture),
+    (SELECT accepted_grl_id FROM t149_fixture),1,10);
+  PERFORM pg_temp.expect_error(format(
+    'SELECT public.rpc_create_matched_supplier_invoice(%L::jsonb)',v_payload),
+    'AP_ACCOUNT_MAPPING_MISSING');
+
+  IF (SELECT count(*) FROM public.supplier_invoices) <> v_i
+     OR (SELECT count(*) FROM public.supplier_invoice_lines) <> v_l
+     OR (SELECT count(*) FROM public.supplier_invoice_receipt_allocations) <> v_a
+     OR (SELECT count(*) FROM public.gl_entries) <> v_g THEN
+    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: journal failure left partial state';
+  END IF;
+
+  INSERT INTO public.gl_event_mappings
+    (org_id,event_code,work_center_code,debit_account_code,credit_account_code,is_active)
+  VALUES ('48111111-1111-1111-1111-111111111111','AP_MATCHED_INVOICE_VAT',NULL,
+          '141510','211100',true);
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- 6. Zero VAT is legal: two-line balanced journal and no zero-value VAT row.
+-- ---------------------------------------------------------------------------
+CREATE TEMP TABLE t149_zero_vat AS
+SELECT public.rpc_create_matched_supplier_invoice(
+  pg_temp.ap_payload('U149-ZERO-VAT','u149-zero-vat',
+    (SELECT vendor_id FROM t149_fixture),
+    (SELECT accepted_grl_id FROM t149_fixture),1,10,0)
+) AS result;
+
+DO $$
+DECLARE v_entry uuid; v_lines int; v_debit numeric; v_credit numeric;
+BEGIN
+  SELECT (result->>'journal_entry_id')::uuid INTO v_entry FROM t149_zero_vat;
+  SELECT count(*) INTO v_lines FROM public.gl_entry_lines WHERE entry_id=v_entry;
+  SELECT total_debit,total_credit INTO v_debit,v_credit FROM public.gl_entries WHERE id=v_entry;
+  IF v_lines <> 2 OR v_debit <> 10 OR v_credit <> 10 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: zero-VAT journal mismatch lines=% %=%',
+      v_lines,v_debit,v_credit;
+  END IF;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- 7. Same supplier number is legal for a different vendor.
+-- ---------------------------------------------------------------------------
+INSERT INTO public.vendors (id,org_id,code,name,is_active)
+VALUES ('49f00000-0000-0000-0000-000000000002',
+        '48111111-1111-1111-1111-111111111111','U149-V2','Vendor U149 B',true);
+
+SELECT public.rpc_create_uom_purchase_order(jsonb_build_object(
+  'org_id','48111111-1111-1111-1111-111111111111',
+  'vendor_id','49f00000-0000-0000-0000-000000000002',
+  'order_number','U149-PO-V2','order_date','2026-07-29',
+  'lines',jsonb_build_array(jsonb_build_object(
+    'product_id','48d00000-0000-0000-0000-000000000001',
+    'uom_id','48400000-0000-0000-0000-000000000002',
+    'qty_entered',1,'unit_price_entered',120,
+    'discount_percentage',0,'tax_percentage',15))));
+
+CREATE TEMP TABLE t149_v2 AS
+SELECT po.id po_id,pol.id pol_id
+FROM public.purchase_orders po
+JOIN public.purchase_order_lines pol ON pol.purchase_order_id=po.id
+WHERE po.order_number='U149-PO-V2';
+
+SELECT public.rpc_approve_purchase_order(
+  '48111111-1111-1111-1111-111111111111',(SELECT po_id FROM t149_v2));
+
+SELECT public.rpc_post_goods_receipt(jsonb_build_object(
+  'tenant_id','48111111-1111-1111-1111-111111111111',
+  'vendor_id','49f00000-0000-0000-0000-000000000002',
+  'purchase_order_id',(SELECT po_id FROM t149_v2),
+  'warehouse_id','48a00000-0000-0000-0000-000000000001',
+  'receipt_date','2026-07-29','idempotency_key','U149-GR-V2',
+  'lines',jsonb_build_array(jsonb_build_object(
+    'product_id','48d00000-0000-0000-0000-000000000001',
+    'purchase_order_line_id',(SELECT pol_id FROM t149_v2),
+    'uom_id','48400000-0000-0000-0000-000000000002',
+    'qty_entered',1,'unit_cost_entered',120,'quality_status','accepted'))));
+
+CREATE TEMP TABLE t149_v2_grl AS
+SELECT grl.id
+FROM public.goods_receipts gr
+JOIN public.goods_receipt_lines grl ON grl.goods_receipt_id=gr.id
+WHERE gr.idempotency_key='U149-GR-V2';
+
+DO $$
+DECLARE v_result jsonb;
+BEGIN
+  v_result := public.rpc_create_matched_supplier_invoice(
+    pg_temp.ap_payload('U149-INV-001','u149-v2-same-number',
+      '49f00000-0000-0000-0000-000000000002',
+      (SELECT id FROM t149_v2_grl),12,10));
+  IF NOT COALESCE((v_result->>'success')::boolean,false) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: same number for another vendor failed: %',v_result;
+  END IF;
+END $$;
+
+-- Allocation ledger remains immutable.
+SELECT pg_temp.expect_error(format(
+  'UPDATE public.supplier_invoice_receipt_allocations SET quantity_base=99 WHERE id=%L',
+  (SELECT id FROM public.supplier_invoice_receipt_allocations
+   WHERE idempotency_key LIKE 'ap-invoice:%' LIMIT 1)),
+  'AP_ALLOCATION_IMMUTABLE');
+SELECT pg_temp.expect_error(format(
+  'DELETE FROM public.supplier_invoice_receipt_allocations WHERE id=%L',
+  (SELECT id FROM public.supplier_invoice_receipt_allocations
+   WHERE idempotency_key LIKE 'ap-invoice:%' LIMIT 1)),
+  'AP_ALLOCATION_IMMUTABLE');
+
+SELECT 'ACCEPTANCE_149_PASS' AS result;

--- a/scripts/ci/fresh-db/acceptance_149_ap_three_way_match.sql
+++ b/scripts/ci/fresh-db/acceptance_149_ap_three_way_match.sql
@@ -1,6 +1,6 @@
 -- Acceptance for migrations 149 + 150.
--- Requires acceptance_148_uom_partial_receipts.sql to have run first; that file
--- creates the legal PO/GRN snapshots used here through the real RPC path.
+-- acceptance_148_uom_partial_receipts.sql must run first: it creates legal PO/GRN
+-- snapshots through the production RPCs, and this suite consumes those facts.
 \set ON_ERROR_STOP on
 
 CREATE OR REPLACE FUNCTION pg_temp.expect_error(p_sql text, p_needle text)
@@ -23,144 +23,114 @@ BEGIN
 END $$;
 
 CREATE OR REPLACE FUNCTION pg_temp.ap_payload(
-  p_invoice_number text,
-  p_idempotency_key text,
-  p_vendor uuid,
-  p_grl uuid,
-  p_qty numeric,
-  p_price numeric,
-  p_tax numeric DEFAULT 15
+  p_number text, p_idem text, p_vendor uuid, p_grl uuid,
+  p_qty numeric, p_price numeric, p_tax numeric DEFAULT 15
 ) RETURNS jsonb LANGUAGE sql AS $$
   SELECT jsonb_build_object(
-    'org_id', '48111111-1111-1111-1111-111111111111',
-    'vendor_id', p_vendor,
-    'invoice_number', p_invoice_number,
-    'invoice_date', '2026-07-29',
-    'due_date', '2026-08-29',
-    'idempotency_key', p_idempotency_key,
-    'lines', jsonb_build_array(jsonb_build_object(
-      'goods_receipt_line_id', p_grl,
-      'quantity_base', p_qty,
-      'unit_price', p_price,
-      'discount_percentage', 0,
-      'tax_percentage', p_tax
-    ))
+    'org_id','48111111-1111-1111-1111-111111111111',
+    'vendor_id',p_vendor,
+    'invoice_number',p_number,
+    'invoice_date','2026-07-29',
+    'due_date','2026-08-29',
+    'idempotency_key',p_idem,
+    'lines',jsonb_build_array(jsonb_build_object(
+      'goods_receipt_line_id',p_grl,
+      'quantity_base',p_qty,
+      'unit_price',p_price,
+      'discount_percentage',0,
+      'tax_percentage',p_tax))
   )
 $$;
 
--- Resolve the real 148 fixtures once and fail loudly if their contract drifted.
 CREATE TEMP TABLE t149_fixture AS
-SELECT
-  po.id AS po_id,
-  pol.id AS pol_id,
-  gr.id AS gr_id,
-  grl.id AS accepted_grl_id,
-  po.vendor_id,
-  pol.product_id,
-  pol.unit_price
+SELECT po.id po_id, pol.id pol_id, gr.id gr_id, grl.id accepted_grl_id,
+       po.vendor_id, pol.product_id, pol.unit_price
 FROM public.purchase_orders po
-JOIN public.purchase_order_lines pol ON pol.purchase_order_id = po.id
-JOIN public.goods_receipts gr ON gr.purchase_order_id = po.id
+JOIN public.purchase_order_lines pol ON pol.purchase_order_id=po.id
+JOIN public.goods_receipts gr ON gr.purchase_order_id=po.id
 JOIN public.goods_receipt_lines grl
-  ON grl.goods_receipt_id = gr.id AND grl.purchase_order_line_id = pol.id
-WHERE po.order_number = 'U148-PO-MAIN'
-  AND gr.idempotency_key = 'U148-GR-1'
-  AND grl.quality_status = 'accepted';
+  ON grl.goods_receipt_id=gr.id AND grl.purchase_order_line_id=pol.id
+WHERE po.order_number='U148-PO-MAIN'
+  AND gr.idempotency_key='U148-GR-1'
+  AND grl.quality_status='accepted';
+
+CREATE TEMP TABLE t149_rejected AS
+SELECT grl.id rejected_grl_id
+FROM public.goods_receipts gr
+JOIN public.goods_receipt_lines grl ON grl.goods_receipt_id=gr.id
+WHERE gr.idempotency_key='U148-GR-2' AND grl.quality_status='rejected';
 
 DO $$
 BEGIN
-  IF (SELECT count(*) FROM t149_fixture) <> 1 THEN
-    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: expected exactly one accepted 148 fixture';
+  IF (SELECT count(*) FROM t149_fixture) <> 1
+     OR (SELECT count(*) FROM t149_rejected) <> 1 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: migration 148 fixtures missing or ambiguous';
   END IF;
   IF (SELECT unit_price FROM t149_fixture) <> 10 THEN
-    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: expected PO base unit price 10';
+    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: expected base unit price 10';
   END IF;
 END $$;
 
-CREATE TEMP TABLE t149_rejected AS
-SELECT grl.id AS rejected_grl_id
-FROM public.goods_receipts gr
-JOIN public.goods_receipt_lines grl ON grl.goods_receipt_id = gr.id
-WHERE gr.idempotency_key = 'U148-GR-2'
-  AND grl.quality_status = 'rejected';
-
--- Minimal AP mapping. GRNI already exists from acceptance 148.
 INSERT INTO public.gl_accounts
-  (org_id, code, name, category, subtype, normal_balance, allow_posting)
+  (org_id,code,name,category,subtype,normal_balance,allow_posting)
 VALUES
-  ('48111111-1111-1111-1111-111111111111', '141510', 'Input VAT U149',
-   'ASSET', 'CURRENT_ASSET', 'DEBIT', true),
-  ('48111111-1111-1111-1111-111111111111', '211100', 'Accounts payable U149',
-   'LIABILITY', 'CURRENT_LIABILITY', 'CREDIT', true)
+  ('48111111-1111-1111-1111-111111111111','141510','Input VAT U149',
+   'ASSET','CURRENT_ASSET','DEBIT',true),
+  ('48111111-1111-1111-1111-111111111111','211100','Accounts payable U149',
+   'LIABILITY','CURRENT_LIABILITY','CREDIT',true)
 ON CONFLICT DO NOTHING;
 
 DELETE FROM public.gl_event_mappings
 WHERE org_id='48111111-1111-1111-1111-111111111111'
   AND event_code IN ('AP_MATCHED_INVOICE_GOODS','AP_MATCHED_INVOICE_VAT');
-
 INSERT INTO public.gl_event_mappings
-  (org_id, event_code, work_center_code, debit_account_code, credit_account_code, is_active)
+  (org_id,event_code,work_center_code,debit_account_code,credit_account_code,is_active)
 VALUES
-  ('48111111-1111-1111-1111-111111111111', 'AP_MATCHED_INVOICE_GOODS', NULL,
-   '210150', '211100', true),
-  ('48111111-1111-1111-1111-111111111111', 'AP_MATCHED_INVOICE_VAT', NULL,
-   '141510', '211100', true);
+  ('48111111-1111-1111-1111-111111111111','AP_MATCHED_INVOICE_GOODS',NULL,
+   '210150','211100',true),
+  ('48111111-1111-1111-1111-111111111111','AP_MATCHED_INVOICE_VAT',NULL,
+   '141510','211100',true);
 
--- ---------------------------------------------------------------------------
--- 1. Execution and permission contract.
--- ---------------------------------------------------------------------------
+-- Execute surface: wrapper is client-facing; v149 core is internal only.
 DO $$
 BEGIN
   IF has_function_privilege('anon',
-       'public.rpc_create_matched_supplier_invoice(jsonb)', 'EXECUTE')
-     OR has_function_privilege('PUBLIC',
-       'public.rpc_create_matched_supplier_invoice(jsonb)', 'EXECUTE')
+       'public.rpc_create_matched_supplier_invoice(jsonb)','EXECUTE')
      OR NOT has_function_privilege('authenticated',
-       'public.rpc_create_matched_supplier_invoice(jsonb)', 'EXECUTE') THEN
-    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: public RPC execute contract broken';
+       'public.rpc_create_matched_supplier_invoice(jsonb)','EXECUTE') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: wrapper execute contract broken';
   END IF;
-
   IF has_function_privilege('authenticated',
-       'public.rpc_create_matched_supplier_invoice_v149(jsonb)', 'EXECUTE')
+       'public.rpc_create_matched_supplier_invoice_v149(jsonb)','EXECUTE')
      OR has_function_privilege('service_role',
-       'public.rpc_create_matched_supplier_invoice_v149(jsonb)', 'EXECUTE') THEN
-    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: internal v149 core remains client executable';
+       'public.rpc_create_matched_supplier_invoice_v149(jsonb)','EXECUTE') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: internal core remains client executable';
   END IF;
 END $$;
 
-SELECT set_config('request.jwt.claim.sub',
-  '48aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', false);
+-- Ordinary member cannot approve+post.
+SELECT set_config('request.jwt.claim.sub','48aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',false);
 SELECT pg_temp.expect_error(format(
   'SELECT public.rpc_create_matched_supplier_invoice(%L::jsonb)',
   pg_temp.ap_payload('U149-NO-PERM','u149-no-perm',
-    (SELECT vendor_id FROM t149_fixture),
-    (SELECT accepted_grl_id FROM t149_fixture),1,10)),
+    (SELECT vendor_id FROM t149_fixture),(SELECT accepted_grl_id FROM t149_fixture),1,10)),
   'AP_POST_PERMISSION_DENIED');
 
--- ---------------------------------------------------------------------------
--- 2. Happy path: persisted document, allocation, journal, and remaining balance.
--- ---------------------------------------------------------------------------
-SELECT set_config('request.jwt.claim.sub',
-  '48bbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', false);
+SELECT set_config('request.jwt.claim.sub','48bbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',false);
 
+-- Happy path: 10.5 × 10 = 105.00; VAT 15.75; payable 120.75.
 CREATE TEMP TABLE t149_result AS
 SELECT public.rpc_create_matched_supplier_invoice(
   pg_temp.ap_payload('U149-INV-001','u149-happy-001',
-    (SELECT vendor_id FROM t149_fixture),
-    (SELECT accepted_grl_id FROM t149_fixture),10.5,10)
-) AS result;
+    (SELECT vendor_id FROM t149_fixture),(SELECT accepted_grl_id FROM t149_fixture),10.5,10)
+) result;
 
 DO $$
 DECLARE
-  v_result jsonb;
-  v_invoice uuid;
-  v_entry uuid;
-  v_debit numeric;
-  v_credit numeric;
-  v_lines integer;
-  v_remaining numeric;
+  v_result jsonb; v_invoice uuid; v_entry uuid;
+  v_status text; v_debit numeric; v_credit numeric; v_count int; v_remaining numeric;
 BEGIN
-  SELECT result INTO v_result FROM t149_result;
+  SELECT result INTO STRICT v_result FROM t149_result;
   v_invoice := (v_result->>'invoice_id')::uuid;
   v_entry := (v_result->>'journal_entry_id')::uuid;
 
@@ -169,7 +139,7 @@ BEGIN
      OR (v_result->>'subtotal')::numeric <> 105.00
      OR (v_result->>'tax_amount')::numeric <> 15.75
      OR (v_result->>'total_amount')::numeric <> 120.75 THEN
-    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: happy result mismatch: %', v_result;
+    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: happy result mismatch: %',v_result;
   END IF;
 
   IF NOT EXISTS (
@@ -179,14 +149,14 @@ BEGIN
       AND idempotency_key='u149-happy-001'
       AND subtotal=105.00 AND tax_amount=15.75 AND total_amount=120.75
   ) THEN
-    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: persisted invoice state mismatch';
+    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: persisted invoice mismatch';
   END IF;
 
   IF (SELECT count(*) FROM public.supplier_invoice_lines
       WHERE supplier_invoice_id=v_invoice) <> 1
      OR (SELECT quantity FROM public.supplier_invoice_lines
          WHERE supplier_invoice_id=v_invoice) <> 10.5 THEN
-    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: persisted invoice line mismatch';
+    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: invoice line mismatch';
   END IF;
 
   IF (SELECT count(*) FROM public.supplier_invoice_receipt_allocations
@@ -199,116 +169,83 @@ BEGIN
   v_remaining := public.wardah_receipt_line_uninvoiced_base(
     (SELECT accepted_grl_id FROM t149_fixture));
   IF v_remaining <> 37.5 THEN
-    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: expected remaining 37.5, got %', v_remaining;
+    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: expected remaining 37.5, got %',v_remaining;
   END IF;
 
-  SELECT total_debit,total_credit,status INTO v_debit,v_credit,STRICT v_result
-  FROM public.gl_entries WHERE id=v_entry;
-EXCEPTION WHEN datatype_mismatch THEN
-  RAISE;
-END $$;
-
--- Separate journal assertions avoid record/jsonb type ambiguity in the block above.
-DO $$
-DECLARE v_entry uuid; v_debit numeric; v_credit numeric; v_status text; v_count int;
-BEGIN
-  SELECT (result->>'journal_entry_id')::uuid INTO v_entry FROM t149_result;
-  SELECT total_debit,total_credit,status INTO STRICT v_debit,v_credit,v_status
+  SELECT status,total_debit,total_credit INTO STRICT v_status,v_debit,v_credit
   FROM public.gl_entries WHERE id=v_entry;
   SELECT count(*) INTO v_count FROM public.gl_entry_lines WHERE entry_id=v_entry;
   IF v_status <> 'posted' OR v_debit <> 120.75 OR v_credit <> 120.75 OR v_count <> 3 THEN
-    RAISE EXCEPTION
-      'ACCEPTANCE_149_FAIL: journal expected posted 120.75=120.75 with 3 lines, got % %=% lines=%',
+    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: journal mismatch status=% %=% lines=%',
       v_status,v_debit,v_credit,v_count;
   END IF;
 END $$;
 
--- ---------------------------------------------------------------------------
--- 3. Exact replay and changed-payload reuse.
--- ---------------------------------------------------------------------------
+-- Exact replay returns the same persisted result and creates nothing else.
 DO $$
-DECLARE
-  v_first jsonb; v_replay jsonb; v_invoice uuid;
-  v_i int; v_l int; v_a int; v_g int;
+DECLARE v_first jsonb; v_replay jsonb; v_i int; v_l int; v_a int; v_g int;
 BEGIN
   SELECT result INTO v_first FROM t149_result;
-  v_invoice := (v_first->>'invoice_id')::uuid;
-  SELECT count(*) INTO v_i FROM public.supplier_invoices WHERE id=v_invoice;
-  SELECT count(*) INTO v_l FROM public.supplier_invoice_lines WHERE supplier_invoice_id=v_invoice;
-  SELECT count(*) INTO v_a FROM public.supplier_invoice_receipt_allocations WHERE supplier_invoice_id=v_invoice;
-  SELECT count(*) INTO v_g FROM public.gl_entries WHERE id=(v_first->>'journal_entry_id')::uuid;
+  SELECT count(*) INTO v_i FROM public.supplier_invoices;
+  SELECT count(*) INTO v_l FROM public.supplier_invoice_lines;
+  SELECT count(*) INTO v_a FROM public.supplier_invoice_receipt_allocations;
+  SELECT count(*) INTO v_g FROM public.gl_entries;
 
   v_replay := public.rpc_create_matched_supplier_invoice(
     pg_temp.ap_payload('U149-INV-001','u149-happy-001',
-      (SELECT vendor_id FROM t149_fixture),
-      (SELECT accepted_grl_id FROM t149_fixture),10.5,10));
-
+      (SELECT vendor_id FROM t149_fixture),(SELECT accepted_grl_id FROM t149_fixture),10.5,10));
   IF NOT COALESCE((v_replay->>'idempotent_replay')::boolean,false)
      OR v_replay->>'invoice_id' <> v_first->>'invoice_id' THEN
-    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: exact replay mismatch: %', v_replay;
+    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: exact replay mismatch: %',v_replay;
   END IF;
-
-  IF (SELECT count(*) FROM public.supplier_invoices WHERE id=v_invoice) <> v_i
-     OR (SELECT count(*) FROM public.supplier_invoice_lines WHERE supplier_invoice_id=v_invoice) <> v_l
-     OR (SELECT count(*) FROM public.supplier_invoice_receipt_allocations WHERE supplier_invoice_id=v_invoice) <> v_a
-     OR (SELECT count(*) FROM public.gl_entries WHERE id=(v_first->>'journal_entry_id')::uuid) <> v_g THEN
-    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: replay duplicated persisted state';
+  IF (SELECT count(*) FROM public.supplier_invoices) <> v_i
+     OR (SELECT count(*) FROM public.supplier_invoice_lines) <> v_l
+     OR (SELECT count(*) FROM public.supplier_invoice_receipt_allocations) <> v_a
+     OR (SELECT count(*) FROM public.gl_entries) <> v_g THEN
+    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: replay duplicated state';
   END IF;
 END $$;
 
 SELECT pg_temp.expect_error(format(
   'SELECT public.rpc_create_matched_supplier_invoice(%L::jsonb)',
   pg_temp.ap_payload('U149-INV-001','u149-happy-001',
-    (SELECT vendor_id FROM t149_fixture),
-    (SELECT accepted_grl_id FROM t149_fixture),10.6,10)),
+    (SELECT vendor_id FROM t149_fixture),(SELECT accepted_grl_id FROM t149_fixture),10.6,10)),
   'AP_IDEMPOTENCY_KEY_REUSED');
-
 SELECT pg_temp.expect_error(format(
   'SELECT public.rpc_create_matched_supplier_invoice(%L::jsonb)',
   pg_temp.ap_payload('U149-INV-001','u149-other-key',
-    (SELECT vendor_id FROM t149_fixture),
-    (SELECT accepted_grl_id FROM t149_fixture),1,10)),
+    (SELECT vendor_id FROM t149_fixture),(SELECT accepted_grl_id FROM t149_fixture),1,10)),
   'AP_DUPLICATE_VENDOR_INVOICE_NUMBER');
 
--- ---------------------------------------------------------------------------
--- 4. Negative quantity/price/quality/header/duplicate-line cases.
--- ---------------------------------------------------------------------------
+-- Quantity, price, quality, GRN-header and duplicate-line guards.
 SELECT pg_temp.expect_error(format(
   'SELECT public.rpc_create_matched_supplier_invoice(%L::jsonb)',
-  pg_temp.ap_payload('U149-OVER','u149-over',
-    (SELECT vendor_id FROM t149_fixture),
+  pg_temp.ap_payload('U149-OVER','u149-over',(SELECT vendor_id FROM t149_fixture),
     (SELECT accepted_grl_id FROM t149_fixture),40,10)),
   'AP_QUANTITY_EXCEEDS_RECEIPT');
-
 SELECT pg_temp.expect_error(format(
   'SELECT public.rpc_create_matched_supplier_invoice(%L::jsonb)',
-  pg_temp.ap_payload('U149-PRICE','u149-price',
-    (SELECT vendor_id FROM t149_fixture),
+  pg_temp.ap_payload('U149-PRICE','u149-price',(SELECT vendor_id FROM t149_fixture),
     (SELECT accepted_grl_id FROM t149_fixture),1,11)),
   'AP_PRICE_VARIANCE_REQUIRES_APPROVAL');
-
 SELECT pg_temp.expect_error(format(
   'SELECT public.rpc_create_matched_supplier_invoice(%L::jsonb)',
-  pg_temp.ap_payload('U149-PREC','u149-precision',
-    (SELECT vendor_id FROM t149_fixture),
+  pg_temp.ap_payload('U149-PREC','u149-precision',(SELECT vendor_id FROM t149_fixture),
     (SELECT accepted_grl_id FROM t149_fixture),1.1234567,10)),
   'AP_QUANTITY_PRECISION');
-
 SELECT pg_temp.expect_error(format(
   'SELECT public.rpc_create_matched_supplier_invoice(%L::jsonb)',
-  pg_temp.ap_payload('U149-REJECTED','u149-rejected',
-    (SELECT vendor_id FROM t149_fixture),
+  pg_temp.ap_payload('U149-REJECTED','u149-rejected',(SELECT vendor_id FROM t149_fixture),
     (SELECT rejected_grl_id FROM t149_rejected),1,10)),
   'AP_GRN_LINE_NOT_ACCEPTED');
 
 DO $$
-DECLARE v_gr uuid; v_payload jsonb;
+DECLARE v_payload jsonb; v_gr uuid;
 BEGIN
   SELECT gr_id INTO v_gr FROM t149_fixture;
   UPDATE public.goods_receipts SET status='draft' WHERE id=v_gr;
-  v_payload := pg_temp.ap_payload('U149-GRN-DRAFT','u149-grn-draft',
-    (SELECT vendor_id FROM t149_fixture),
-    (SELECT accepted_grl_id FROM t149_fixture),1,10);
+  v_payload := pg_temp.ap_payload('U149-DRAFT-GRN','u149-draft-grn',
+    (SELECT vendor_id FROM t149_fixture),(SELECT accepted_grl_id FROM t149_fixture),1,10);
   PERFORM pg_temp.expect_error(format(
     'SELECT public.rpc_create_matched_supplier_invoice(%L::jsonb)',v_payload),
     'AP_GRN_NOT_INVOICEABLE');
@@ -316,7 +253,7 @@ BEGIN
 END $$;
 
 DO $$
-DECLARE v_payload jsonb; v_line jsonb;
+DECLARE v_line jsonb; v_payload jsonb;
 BEGIN
   v_line := jsonb_build_object(
     'goods_receipt_line_id',(SELECT accepted_grl_id FROM t149_fixture),
@@ -331,56 +268,43 @@ BEGIN
     'AP_DUPLICATE_GRN_LINE');
 END $$;
 
--- ---------------------------------------------------------------------------
--- 5. Missing account mapping rolls back invoice, line, allocation and journal.
--- ---------------------------------------------------------------------------
+-- Missing accounting map must roll back every table touched by the transaction.
 DO $$
-DECLARE
-  v_i int; v_l int; v_a int; v_g int; v_payload jsonb;
+DECLARE v_i int; v_l int; v_a int; v_g int; v_payload jsonb;
 BEGIN
   SELECT count(*) INTO v_i FROM public.supplier_invoices;
   SELECT count(*) INTO v_l FROM public.supplier_invoice_lines;
   SELECT count(*) INTO v_a FROM public.supplier_invoice_receipt_allocations;
   SELECT count(*) INTO v_g FROM public.gl_entries;
-
   DELETE FROM public.gl_event_mappings
   WHERE org_id='48111111-1111-1111-1111-111111111111'
     AND event_code='AP_MATCHED_INVOICE_VAT';
-
   v_payload := pg_temp.ap_payload('U149-NO-MAP','u149-no-map',
-    (SELECT vendor_id FROM t149_fixture),
-    (SELECT accepted_grl_id FROM t149_fixture),1,10);
+    (SELECT vendor_id FROM t149_fixture),(SELECT accepted_grl_id FROM t149_fixture),1,10);
   PERFORM pg_temp.expect_error(format(
     'SELECT public.rpc_create_matched_supplier_invoice(%L::jsonb)',v_payload),
     'AP_ACCOUNT_MAPPING_MISSING');
-
   IF (SELECT count(*) FROM public.supplier_invoices) <> v_i
      OR (SELECT count(*) FROM public.supplier_invoice_lines) <> v_l
      OR (SELECT count(*) FROM public.supplier_invoice_receipt_allocations) <> v_a
      OR (SELECT count(*) FROM public.gl_entries) <> v_g THEN
     RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: journal failure left partial state';
   END IF;
-
   INSERT INTO public.gl_event_mappings
     (org_id,event_code,work_center_code,debit_account_code,credit_account_code,is_active)
   VALUES ('48111111-1111-1111-1111-111111111111','AP_MATCHED_INVOICE_VAT',NULL,
           '141510','211100',true);
 END $$;
 
--- ---------------------------------------------------------------------------
--- 6. Zero VAT is legal: two-line balanced journal and no zero-value VAT row.
--- ---------------------------------------------------------------------------
-CREATE TEMP TABLE t149_zero_vat AS
+-- Zero VAT is a legal two-line balanced journal.
+CREATE TEMP TABLE t149_zero AS
 SELECT public.rpc_create_matched_supplier_invoice(
-  pg_temp.ap_payload('U149-ZERO-VAT','u149-zero-vat',
-    (SELECT vendor_id FROM t149_fixture),
-    (SELECT accepted_grl_id FROM t149_fixture),1,10,0)
-) AS result;
-
+  pg_temp.ap_payload('U149-ZERO-VAT','u149-zero-vat',(SELECT vendor_id FROM t149_fixture),
+    (SELECT accepted_grl_id FROM t149_fixture),1,10,0)) result;
 DO $$
 DECLARE v_entry uuid; v_lines int; v_debit numeric; v_credit numeric;
 BEGIN
-  SELECT (result->>'journal_entry_id')::uuid INTO v_entry FROM t149_zero_vat;
+  SELECT (result->>'journal_entry_id')::uuid INTO v_entry FROM t149_zero;
   SELECT count(*) INTO v_lines FROM public.gl_entry_lines WHERE entry_id=v_entry;
   SELECT total_debit,total_credit INTO v_debit,v_credit FROM public.gl_entries WHERE id=v_entry;
   IF v_lines <> 2 OR v_debit <> 10 OR v_credit <> 10 THEN
@@ -389,72 +313,14 @@ BEGIN
   END IF;
 END $$;
 
--- ---------------------------------------------------------------------------
--- 7. Same supplier number is legal for a different vendor.
--- ---------------------------------------------------------------------------
-INSERT INTO public.vendors (id,org_id,code,name,is_active)
-VALUES ('49f00000-0000-0000-0000-000000000002',
-        '48111111-1111-1111-1111-111111111111','U149-V2','Vendor U149 B',true);
-
-SELECT public.rpc_create_uom_purchase_order(jsonb_build_object(
-  'org_id','48111111-1111-1111-1111-111111111111',
-  'vendor_id','49f00000-0000-0000-0000-000000000002',
-  'order_number','U149-PO-V2','order_date','2026-07-29',
-  'lines',jsonb_build_array(jsonb_build_object(
-    'product_id','48d00000-0000-0000-0000-000000000001',
-    'uom_id','48400000-0000-0000-0000-000000000002',
-    'qty_entered',1,'unit_price_entered',120,
-    'discount_percentage',0,'tax_percentage',15))));
-
-CREATE TEMP TABLE t149_v2 AS
-SELECT po.id po_id,pol.id pol_id
-FROM public.purchase_orders po
-JOIN public.purchase_order_lines pol ON pol.purchase_order_id=po.id
-WHERE po.order_number='U149-PO-V2';
-
-SELECT public.rpc_approve_purchase_order(
-  '48111111-1111-1111-1111-111111111111',(SELECT po_id FROM t149_v2));
-
-SELECT public.rpc_post_goods_receipt(jsonb_build_object(
-  'tenant_id','48111111-1111-1111-1111-111111111111',
-  'vendor_id','49f00000-0000-0000-0000-000000000002',
-  'purchase_order_id',(SELECT po_id FROM t149_v2),
-  'warehouse_id','48a00000-0000-0000-0000-000000000001',
-  'receipt_date','2026-07-29','idempotency_key','U149-GR-V2',
-  'lines',jsonb_build_array(jsonb_build_object(
-    'product_id','48d00000-0000-0000-0000-000000000001',
-    'purchase_order_line_id',(SELECT pol_id FROM t149_v2),
-    'uom_id','48400000-0000-0000-0000-000000000002',
-    'qty_entered',1,'unit_cost_entered',120,'quality_status','accepted'))));
-
-CREATE TEMP TABLE t149_v2_grl AS
-SELECT grl.id
-FROM public.goods_receipts gr
-JOIN public.goods_receipt_lines grl ON grl.goods_receipt_id=gr.id
-WHERE gr.idempotency_key='U149-GR-V2';
-
-DO $$
-DECLARE v_result jsonb;
-BEGIN
-  v_result := public.rpc_create_matched_supplier_invoice(
-    pg_temp.ap_payload('U149-INV-001','u149-v2-same-number',
-      '49f00000-0000-0000-0000-000000000002',
-      (SELECT id FROM t149_v2_grl),12,10));
-  IF NOT COALESCE((v_result->>'success')::boolean,false) THEN
-    RAISE EXCEPTION 'ACCEPTANCE_149_FAIL: same number for another vendor failed: %',v_result;
-  END IF;
-END $$;
-
--- Allocation ledger remains immutable.
+-- Ledger is append-only at the database boundary.
 SELECT pg_temp.expect_error(format(
   'UPDATE public.supplier_invoice_receipt_allocations SET quantity_base=99 WHERE id=%L',
-  (SELECT id FROM public.supplier_invoice_receipt_allocations
-   WHERE idempotency_key LIKE 'ap-invoice:%' LIMIT 1)),
+  (SELECT id FROM public.supplier_invoice_receipt_allocations LIMIT 1)),
   'AP_ALLOCATION_IMMUTABLE');
 SELECT pg_temp.expect_error(format(
   'DELETE FROM public.supplier_invoice_receipt_allocations WHERE id=%L',
-  (SELECT id FROM public.supplier_invoice_receipt_allocations
-   WHERE idempotency_key LIKE 'ap-invoice:%' LIMIT 1)),
+  (SELECT id FROM public.supplier_invoice_receipt_allocations LIMIT 1)),
   'AP_ALLOCATION_IMMUTABLE');
 
 SELECT 'ACCEPTANCE_149_PASS' AS result;

--- a/scripts/ci/fresh-db/acceptance_149_concurrency.sh
+++ b/scripts/ci/fresh-db/acceptance_149_concurrency.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+DB=${PGDATABASE:-wardah_fresh}
+PSQL=(psql -v ON_ERROR_STOP=1 -X -d "$DB")
+ORG=48111111-1111-1111-1111-111111111111
+ADMIN=48bbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb
+VENDOR=48f00000-0000-0000-0000-000000000001
+PRODUCT=48d00000-0000-0000-0000-000000000001
+UOM=48400000-0000-0000-0000-000000000002
+WAREHOUSE=48a00000-0000-0000-0000-000000000001
+
+# A dedicated 12-base-unit receipt keeps this test independent from quantities
+# consumed by the sequential acceptance file.
+"${PSQL[@]}" <<SQL
+SELECT set_config('request.jwt.claim.sub','$ADMIN',false);
+SELECT public.rpc_create_uom_purchase_order(jsonb_build_object(
+  'org_id','$ORG','vendor_id','$VENDOR','order_number','U149-PO-RACE',
+  'order_date','2026-07-29','lines',jsonb_build_array(jsonb_build_object(
+    'product_id','$PRODUCT','uom_id','$UOM','qty_entered',1,
+    'unit_price_entered',120,'discount_percentage',0,'tax_percentage',15))));
+CREATE TEMP TABLE race_po AS
+SELECT po.id po_id,pol.id pol_id
+FROM public.purchase_orders po
+JOIN public.purchase_order_lines pol ON pol.purchase_order_id=po.id
+WHERE po.order_number='U149-PO-RACE';
+SELECT public.rpc_approve_purchase_order('$ORG',(SELECT po_id FROM race_po));
+SELECT public.rpc_post_goods_receipt(jsonb_build_object(
+  'tenant_id','$ORG','vendor_id','$VENDOR','purchase_order_id',(SELECT po_id FROM race_po),
+  'warehouse_id','$WAREHOUSE','receipt_date','2026-07-29','idempotency_key','U149-GR-RACE',
+  'lines',jsonb_build_array(jsonb_build_object(
+    'product_id','$PRODUCT','purchase_order_line_id',(SELECT pol_id FROM race_po),
+    'uom_id','$UOM','qty_entered',1,'unit_cost_entered',120,
+    'quality_status','accepted'))));
+SQL
+
+GRL=$("${PSQL[@]}" -tAc "
+  SELECT grl.id
+  FROM public.goods_receipts gr
+  JOIN public.goods_receipt_lines grl ON grl.goods_receipt_id=gr.id
+  WHERE gr.idempotency_key='U149-GR-RACE'")
+if [[ -z "$GRL" ]]; then
+  echo 'ACCEPTANCE_149_RACE_FAIL: race GRN line not found' >&2
+  exit 1
+fi
+
+# The first request sleeps only after the RPC has locked the PO/GRN rows and
+# reaches its invoice insert. The second request therefore blocks on the real
+# row lock rather than merely being scheduled later.
+"${PSQL[@]}" <<'SQL'
+CREATE OR REPLACE FUNCTION public.wardah_test_delay_ap_race()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF NEW.invoice_number='U149-RACE-A' THEN
+    PERFORM pg_sleep(2);
+  END IF;
+  RETURN NEW;
+END $$;
+DROP TRIGGER IF EXISTS trg_wardah_test_delay_ap_race ON public.supplier_invoices;
+CREATE TRIGGER trg_wardah_test_delay_ap_race
+BEFORE INSERT ON public.supplier_invoices
+FOR EACH ROW EXECUTE FUNCTION public.wardah_test_delay_ap_race();
+SQL
+
+cat > /tmp/u149-race-a.sql <<SQL
+SELECT set_config('request.jwt.claim.sub','$ADMIN',false);
+SELECT public.rpc_create_matched_supplier_invoice(jsonb_build_object(
+  'org_id','$ORG','vendor_id','$VENDOR','invoice_number','U149-RACE-A',
+  'invoice_date','2026-07-29','idempotency_key','u149-race-a',
+  'lines',jsonb_build_array(jsonb_build_object(
+    'goods_receipt_line_id','$GRL','quantity_base',12,'unit_price',10,
+    'discount_percentage',0,'tax_percentage',15))));
+SQL
+cat > /tmp/u149-race-b.sql <<SQL
+SELECT set_config('request.jwt.claim.sub','$ADMIN',false);
+SELECT public.rpc_create_matched_supplier_invoice(jsonb_build_object(
+  'org_id','$ORG','vendor_id','$VENDOR','invoice_number','U149-RACE-B',
+  'invoice_date','2026-07-29','idempotency_key','u149-race-b',
+  'lines',jsonb_build_array(jsonb_build_object(
+    'goods_receipt_line_id','$GRL','quantity_base',12,'unit_price',10,
+    'discount_percentage',0,'tax_percentage',15))));
+SQL
+
+start_ms=$(date +%s%3N)
+set +e
+"${PSQL[@]}" -f /tmp/u149-race-a.sql >/tmp/u149-race-a.out 2>/tmp/u149-race-a.err &
+pid_a=$!
+sleep 0.25
+b_start_ms=$(date +%s%3N)
+"${PSQL[@]}" -f /tmp/u149-race-b.sql >/tmp/u149-race-b.out 2>/tmp/u149-race-b.err &
+pid_b=$!
+wait "$pid_a"; status_a=$?
+wait "$pid_b"; status_b=$?
+set -e
+end_ms=$(date +%s%3N)
+b_elapsed=$((end_ms-b_start_ms))
+total_elapsed=$((end_ms-start_ms))
+
+"${PSQL[@]}" <<'SQL'
+DROP TRIGGER IF EXISTS trg_wardah_test_delay_ap_race ON public.supplier_invoices;
+DROP FUNCTION IF EXISTS public.wardah_test_delay_ap_race();
+SQL
+
+successes=0
+[[ $status_a -eq 0 ]] && successes=$((successes+1))
+[[ $status_b -eq 0 ]] && successes=$((successes+1))
+if [[ $successes -ne 1 ]]; then
+  echo "ACCEPTANCE_149_RACE_FAIL: expected one success, got A=$status_a B=$status_b" >&2
+  cat /tmp/u149-race-a.err /tmp/u149-race-b.err >&2 || true
+  exit 1
+fi
+
+if [[ $status_a -ne 0 ]]; then loser_err=/tmp/u149-race-a.err; else loser_err=/tmp/u149-race-b.err; fi
+if ! grep -q 'AP_QUANTITY_EXCEEDS_RECEIPT' "$loser_err"; then
+  echo 'ACCEPTANCE_149_RACE_FAIL: loser did not fail on the locked remaining balance' >&2
+  cat "$loser_err" >&2
+  exit 1
+fi
+
+# B starts 250ms after A, while A sleeps for 2s after owning the locks. A B
+# elapsed time materially below 1.5s would mean it did not wait on that lock.
+if [[ $b_elapsed -lt 1500 ]]; then
+  echo "ACCEPTANCE_149_RACE_FAIL: second session did not demonstrably wait (${b_elapsed}ms)" >&2
+  exit 1
+fi
+
+read -r invoice_count allocation_sum journal_count remaining <<<$("${PSQL[@]}" -tA -F' ' -c "
+  SELECT
+    (SELECT count(*) FROM public.supplier_invoices
+      WHERE invoice_number IN ('U149-RACE-A','U149-RACE-B')),
+    (SELECT COALESCE(sum(a.quantity_base),0)
+       FROM public.supplier_invoice_receipt_allocations a
+       JOIN public.supplier_invoices si ON si.id=a.supplier_invoice_id
+      WHERE si.invoice_number IN ('U149-RACE-A','U149-RACE-B')),
+    (SELECT count(*) FROM public.gl_entries ge
+       JOIN public.supplier_invoices si ON si.journal_entry_id=ge.id
+      WHERE si.invoice_number IN ('U149-RACE-A','U149-RACE-B')),
+    public.wardah_receipt_line_uninvoiced_base('$GRL')")
+
+if [[ "$invoice_count" != 1 || "$allocation_sum" != 12.000000 || "$journal_count" != 1 || "$remaining" != 0.000000 ]]; then
+  echo "ACCEPTANCE_149_RACE_FAIL: persisted state invoices=$invoice_count allocation=$allocation_sum journals=$journal_count remaining=$remaining" >&2
+  exit 1
+fi
+
+echo "ACCEPTANCE_149_RACE_PASS: one winner; second waited ${b_elapsed}ms; total ${total_elapsed}ms"

--- a/scripts/ci/fresh-db/acceptance_149_concurrency.sh
+++ b/scripts/ci/fresh-db/acceptance_149_concurrency.sh
@@ -124,7 +124,10 @@ if [[ $b_elapsed -lt 1500 ]]; then
   exit 1
 fi
 
-read -r invoice_count allocation_sum journal_count remaining <<<$("${PSQL[@]}" -tA -F' ' -c "
+read -r invoice_count allocation_sum journal_count remaining <<<$(${PSQL[@]} -tA -F' ' -c "
+  WITH auth AS MATERIALIZED (
+    SELECT set_config('request.jwt.claim.sub','$ADMIN',false)
+  )
   SELECT
     (SELECT count(*) FROM public.supplier_invoices
       WHERE invoice_number IN ('U149-RACE-A','U149-RACE-B')),
@@ -135,7 +138,8 @@ read -r invoice_count allocation_sum journal_count remaining <<<$("${PSQL[@]}" -
     (SELECT count(*) FROM public.gl_entries ge
        JOIN public.supplier_invoices si ON si.journal_entry_id=ge.id
       WHERE si.invoice_number IN ('U149-RACE-A','U149-RACE-B')),
-    public.wardah_receipt_line_uninvoiced_base('$GRL')")
+    public.wardah_receipt_line_uninvoiced_base('$GRL')
+  FROM auth")
 
 if [[ "$invoice_count" != 1 || "$allocation_sum" != 12.000000 || "$journal_count" != 1 || "$remaining" != 0.000000 ]]; then
   echo "ACCEPTANCE_149_RACE_FAIL: persisted state invoices=$invoice_count allocation=$allocation_sum journals=$journal_count remaining=$remaining" >&2

--- a/scripts/ci/fresh-db/run_ap_149_gate.sh
+++ b/scripts/ci/fresh-db/run_ap_149_gate.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+DB=${PGDATABASE:-wardah_ap149}
+BASELINE_DIR=${BASELINE_DIR:-sql/baseline}
+
+pair=$(bash scripts/ci/fresh-db/resolve_baseline_pair.sh "$BASELINE_DIR")
+pair_field() { printf '%s\n' "$pair" | sed -n "s/^$1=//p"; }
+BASELINE=$(pair_field BASELINE_PATH)
+REFERENCE=$(pair_field REFERENCE_PATH)
+CUTOFF=$(pair_field BASELINE_CUTOFF)
+CUTOFF=${CUTOFF:-0}
+
+if [[ -z "$BASELINE" || -z "$REFERENCE" ]]; then
+  echo 'AP_149_GATE_FAIL: baseline pair could not be resolved' >&2
+  exit 1
+fi
+
+echo "AP 149 gate: baseline=$BASELINE reference=$REFERENCE cutoff=$CUTOFF"
+dropdb --if-exists "$DB"
+createdb "$DB"
+psql -v ON_ERROR_STOP=1 -X -d "$DB" -f scripts/ci/fresh-db/supabase_shim.sql -q
+psql -v ON_ERROR_STOP=1 -X -d "$DB" -f "$BASELINE" -q
+psql -v ON_ERROR_STOP=1 -X -d "$DB" -f "$REFERENCE" -q
+
+python3 scripts/ci/fresh-db/build_apply_order.py sql/migrations "$CUTOFF" > /tmp/ap149-chain-order.txt
+if [[ -s /tmp/ap149-chain-order.txt ]]; then
+  REPORT=/tmp/ap149-chain-report.txt PGDATABASE="$DB" \
+    bash scripts/ci/fresh-db/run_chain.sh sql/migrations /tmp/ap149-chain-order.txt
+  cat /tmp/ap149-chain-report.txt
+fi
+
+for fn in \
+  'rpc_create_matched_supplier_invoice(jsonb)' \
+  'rpc_create_matched_supplier_invoice_v149(jsonb)' \
+  'wardah_receipt_line_uninvoiced_base(uuid)'
+do
+  if ! psql -X -d "$DB" -tAc "SELECT to_regprocedure('public.$fn') IS NOT NULL" | grep -qx t; then
+    echo "AP_149_GATE_FAIL: missing function public.$fn" >&2
+    exit 1
+  fi
+done
+
+# The 149 suite deliberately reuses the full legal PO/GRN path from 148 rather
+# than manufacturing receipt rows by hand.
+psql -v ON_ERROR_STOP=1 -X -d "$DB" \
+  -f scripts/ci/fresh-db/acceptance_148_uom_partial_receipts.sql
+psql -v ON_ERROR_STOP=1 -X -d "$DB" \
+  -f scripts/ci/fresh-db/acceptance_149_ap_three_way_match.sql
+PGDATABASE="$DB" bash scripts/ci/fresh-db/acceptance_149_concurrency.sh
+
+# Final invariants are independent of specific fixture identifiers.
+psql -v ON_ERROR_STOP=1 -X -d "$DB" <<'SQL'
+DO $$
+DECLARE v_count integer;
+BEGIN
+  SELECT count(*) INTO v_count
+  FROM public.supplier_invoices si
+  LEFT JOIN public.gl_entries ge ON ge.id=si.journal_entry_id
+  WHERE si.match_status='matched'
+    AND (si.status<>'approved' OR si.journal_entry_id IS NULL OR ge.status<>'posted');
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'AP_149_GATE_FAIL: % matched invoices lack approved+posted final state',v_count;
+  END IF;
+
+  SELECT count(*) INTO v_count
+  FROM (
+    SELECT a.goods_receipt_line_id,
+           sum(CASE WHEN a.reversal_of_allocation_id IS NULL
+                    THEN a.quantity_base ELSE -a.quantity_base END) allocated,
+           max(CASE WHEN grl.quality_status='accepted'
+                    THEN grl.received_quantity ELSE 0 END) accepted
+    FROM public.supplier_invoice_receipt_allocations a
+    JOIN public.goods_receipt_lines grl ON grl.id=a.goods_receipt_line_id
+    GROUP BY a.goods_receipt_line_id
+    HAVING sum(CASE WHEN a.reversal_of_allocation_id IS NULL
+                    THEN a.quantity_base ELSE -a.quantity_base END)
+           > max(CASE WHEN grl.quality_status='accepted'
+                      THEN grl.received_quantity ELSE 0 END)
+  ) q;
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'AP_149_GATE_FAIL: % receipt lines are overallocated',v_count;
+  END IF;
+
+  SELECT count(*) INTO v_count
+  FROM public.gl_entries ge
+  WHERE ge.reference_type='supplier_invoice'
+    AND (round(ge.total_debit,2)<>round(ge.total_credit,2) OR ge.status<>'posted');
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'AP_149_GATE_FAIL: % AP journals are unbalanced or unposted',v_count;
+  END IF;
+END $$;
+SELECT 'AP_149_FRESH_DB_GATE_PASS' AS result;
+SQL

--- a/sql/migrations/149_ap_three_way_match_allocations.sql
+++ b/sql/migrations/149_ap_three_way_match_allocations.sql
@@ -1,0 +1,735 @@
+-- =====================================================================
+-- 149_ap_three_way_match_allocations
+-- =====================================================================
+-- الشريحة الأولى من المطابقة الثلاثية:
+--   Purchase Order ↔ Goods Receipt ↔ Supplier Invoice
+--
+-- العقد المعماري في docs/db/AP_THREE_WAY_MATCH_FOUNDATION.md.
+--
+-- ---------------------------------------------------------------------
+-- 1) لماذا سجل تخصيصات لا عمود تراكمي
+-- ---------------------------------------------------------------------
+-- العمود التراكمي على سطر الاستلام أسرع، لكنه حقيقة ثانية تجب مزامنتها مع
+-- الفواتير دائمًا؛ وأي عكس أو إلغاء أو إشعار دائن يتركه منحرفًا بصمت.
+--
+-- `supplier_invoice_receipt_allocations` دفتر append-only: كل تخصيص صف موجب،
+-- وكل عكس صف جديد يشير إلى أصله. الرصيد يُشتق ولا يُخزَّن:
+--
+--     المقبول من سطر الاستلام
+--   − مجموع التخصيصات النشطة
+--   + مجموع التخصيصات المعكوسة
+--   = المقبول غير المفوتر
+--
+-- ويعطي provenance تحتاجه المطابقة: أي فاتورة استهلكت أي استلام، وكم بقي، وكيف
+-- يُعكس، وكيف يُدقَّق سباقٌ أو إعادة محاولة.
+--
+-- ---------------------------------------------------------------------
+-- 2) مصدر الكمية المقبولة
+-- ---------------------------------------------------------------------
+-- المصدر التشغيلي هو `goods_receipt_lines` ذات `quality_status = 'accepted'`،
+-- لأن الفاتورة تطابق استلامًا بعينه لا إجماليًا على أمر الشراء.
+--
+-- و`purchase_order_lines.accepted_quantity` حارس مصالحة وسقف إجمالي لا مصدر
+-- رصيد: يمنع تجاوز المقبول على مستوى سطر الأمر، ويكشف انحراف تجميع الاستلامات
+-- عن القيمة التراكمية. الاعتماد عليه وحده يفقد تفاصيل أي GRN استُهلك.
+--
+-- ---------------------------------------------------------------------
+-- 3) الحالة النهائية المتسقة
+-- ---------------------------------------------------------------------
+--     supplier_invoices.status = 'approved'   ← دورة المستند
+--     allocations              = active
+--     gl_entries.status        = 'posted'     ← دورة القيد
+--
+-- `approved` لا `posted` على الفاتورة: المخطط لا يعرف `posted` لفاتورة مورد،
+-- وإضافتها لتوحيد الأسماء تخلط دورة المستند بدورة القيد. ولا حالة وسطية: إما
+-- الثلاثة معًا أو لا شيء.
+--
+-- ---------------------------------------------------------------------
+-- 4) القيد المحاسبي: النواة القائمة لا نسخة منها
+-- ---------------------------------------------------------------------
+-- `rpc_create_journal_entry` نواة قانونية صارمة بالفعل: تتحقق من المؤسسة
+-- (TENANT_MISSING) والفترة (assert_period_open) وتوازن المدين والدائن
+-- (UNBALANCED_ENTRY) ورفض القيد الفارغ والصفري، وتدعم أسطرًا متعددة
+-- وidempotency، ولا تعيد success=false مع استمرار المعاملة — كل فشل يرفع
+-- استثناء. فتُستدعى كما هي داخل المعاملة نفسها، ولا يُنسخ منطق دفتر الأستاذ هنا.
+--
+--     Dr GRNI clearing
+--     Dr Input VAT
+--         Cr Accounts Payable
+--
+-- ---------------------------------------------------------------------
+-- 5) خارج الشريحة الأولى عمدًا
+-- ---------------------------------------------------------------------
+-- الفواتير المباشرة بلا أمر/استلام، وإشعارات الدائن والمرتجعات، ومسار الإلغاء
+-- والعكس، وتوزيع التكلفة المستوردة، والتسامح القابل للضبط، وترحيل فرق السعر،
+-- والمطابقة متعددة العملات. والشريحة الأولى **صفر تسامح**: أي فرق سعر يرفض
+-- الفاتورة ولا يُنشئها بحالة استثناء.
+-- =====================================================================
+
+BEGIN;
+
+-- ---------------------------------------------------------------------
+-- القسم 1: دقة الكمية — قبل أي كتابة جديدة
+-- ---------------------------------------------------------------------
+--     goods_receipt_lines.received_quantity   numeric(18,6)
+--     supplier_invoice_lines.quantity         numeric(12,2)  ← منزلتان
+--
+-- فوترة كمية مقبولة بأكثر من منزلتين تُقرَّب عند الإدخال ثم تُقارن برصيد غير
+-- مقرَّب: تسريب فوترة جزئية صامت لا مسألة عرض.
+--
+-- وPostgreSQL يرفض تغيير نوع عمود يعتمد عليه عمود محسوب:
+--
+--   ERROR: cannot alter type of a column used by a generated column
+--   DETAIL: Column "quantity" is used by generated column "line_total"
+--
+-- فيلزم إسقاط `line_total` وإعادته بالتعبير نفسه داخل المعاملة ذاتها. وهذا لا
+-- يخالف القاعدة الذهبية في CLAUDE.md: العمود **محسوب**، قيمه مشتقة بالكامل من
+-- `quantity` و`unit_cost` و`discount_percentage` و`tax_percentage` — وكلها تبقى
+-- كما هي، وPostgreSQL يعيد حسابه صفًا صفًا. ولو كان عمودًا مخزَّنًا عاديًا لما جاز.
+--
+-- التعبير أدناه منسوخ حرفيًا من `pg_get_expr` على قاعدة حية لا مُعاد كتابته: أي
+-- اختلاف في الأقواس أو الصبّ يغيّر التقريب بصمت.
+--
+-- ويتّسع `line_total` معه إلى numeric(18,2). المنازل تبقى منزلتين — تقريب العملة
+-- شأن مستقل عن دقة الكمية — لكن الجزء الصحيح يتّسع من 10 أرقام إلى 16. فبلا ذلك
+-- تصير كمية بـ12 رقمًا صحيحًا مضروبةً في سعر قادرةً على تجاوز سعة الناتج، فتفشل
+-- الكتابة بـnumeric field overflow عند حدٍّ لم يكن قائمًا قبل التوسيع.
+-- و(18,2) هو عرض المبالغ نفسه في `gl_entry_lines`.
+ALTER TABLE public.supplier_invoice_lines
+  DROP COLUMN line_total;
+
+ALTER TABLE public.supplier_invoice_lines
+  ALTER COLUMN quantity TYPE numeric(18,6);
+
+ALTER TABLE public.supplier_invoice_lines
+  ADD COLUMN line_total numeric(18,2)
+  GENERATED ALWAYS AS (
+    (((quantity * unit_cost) * ((1)::numeric - (discount_percentage / (100)::numeric)))
+     * ((1)::numeric + (tax_percentage / (100)::numeric)))
+  ) STORED;
+
+-- ---------------------------------------------------------------------
+-- القسم 2: أعمدة الإثبات على الفاتورة وأسطرها
+-- ---------------------------------------------------------------------
+-- كلها nullable: المسار التقليدي غير المطابَق يبقى يعمل دون تعبئتها، والمسار
+-- المطابَق يملؤها كاملة.
+ALTER TABLE public.supplier_invoices
+  ADD COLUMN IF NOT EXISTS idempotency_key text,
+  ADD COLUMN IF NOT EXISTS request_hash text,
+  ADD COLUMN IF NOT EXISTS match_status text,
+  ADD COLUMN IF NOT EXISTS journal_entry_id uuid,
+  ADD COLUMN IF NOT EXISTS matched_at timestamptz,
+  ADD COLUMN IF NOT EXISTS matched_by uuid;
+
+ALTER TABLE public.supplier_invoice_lines
+  ADD COLUMN IF NOT EXISTS purchase_order_line_id uuid,
+  ADD COLUMN IF NOT EXISTS uom_id uuid,
+  ADD COLUMN IF NOT EXISTS qty_entered numeric(18,6),
+  ADD COLUMN IF NOT EXISTS conversion_factor_snapshot numeric(30,12),
+  ADD COLUMN IF NOT EXISTS unit_cost_entered numeric(18,6),
+  ADD COLUMN IF NOT EXISTS po_unit_price_snapshot numeric(18,6),
+  ADD COLUMN IF NOT EXISTS quantity_variance numeric(18,6),
+  ADD COLUMN IF NOT EXISTS price_variance numeric(18,6),
+  ADD COLUMN IF NOT EXISTS match_status text;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'supplier_invoices_match_status_check') THEN
+    ALTER TABLE public.supplier_invoices
+      ADD CONSTRAINT supplier_invoices_match_status_check
+      CHECK (match_status IS NULL OR match_status IN ('matched'));
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'supplier_invoice_lines_match_status_check') THEN
+    ALTER TABLE public.supplier_invoice_lines
+      ADD CONSTRAINT supplier_invoice_lines_match_status_check
+      CHECK (match_status IS NULL OR match_status IN ('matched'));
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'supplier_invoice_lines_po_line_fk') THEN
+    ALTER TABLE public.supplier_invoice_lines
+      ADD CONSTRAINT supplier_invoice_lines_po_line_fk
+      FOREIGN KEY (purchase_order_line_id) REFERENCES public.purchase_order_lines(id);
+  END IF;
+END $$;
+
+-- مفتاح idempotency فريد داخل المؤسسة لا عالميًا.
+CREATE UNIQUE INDEX IF NOT EXISTS supplier_invoices_org_idempotency_uk
+  ON public.supplier_invoices (org_id, idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+
+-- رقم فاتورة المورد فريد داخل (المؤسسة، المورد) للمسار المطابَق. جزئي عمدًا:
+-- لا يُفرض بأثر رجعي على الفواتير التقليدية القائمة.
+CREATE UNIQUE INDEX IF NOT EXISTS supplier_invoices_org_vendor_number_matched_uk
+  ON public.supplier_invoices (org_id, vendor_id, upper(btrim(invoice_number)))
+  WHERE match_status = 'matched';
+
+-- ---------------------------------------------------------------------
+-- القسم 3: دفتر التخصيصات
+-- ---------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.supplier_invoice_receipt_allocations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL REFERENCES public.organizations(id),
+  supplier_invoice_id uuid NOT NULL REFERENCES public.supplier_invoices(id),
+  supplier_invoice_line_id uuid NOT NULL REFERENCES public.supplier_invoice_lines(id),
+  goods_receipt_line_id uuid NOT NULL REFERENCES public.goods_receipt_lines(id),
+  purchase_order_line_id uuid NOT NULL REFERENCES public.purchase_order_lines(id),
+
+  -- الكمية بالوحدة الأساس دائمًا. الوحدة التجارية تُحفظ على سطر الفاتورة مع
+  -- عامل التحويل اللقطة؛ والرصيد يُحسب بالأساس وحده فلا يختلط مقياسان.
+  quantity_base numeric(18,6) NOT NULL CHECK (quantity_base > 0),
+
+  -- العكس صفٌّ جديد يشير إلى أصله، لا تعديل على الأصل.
+  reversal_of_allocation_id uuid REFERENCES public.supplier_invoice_receipt_allocations(id),
+  reversal_reason text,
+
+  idempotency_key text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  created_by uuid,
+
+  CONSTRAINT supplier_invoice_receipt_allocations_not_self_reversal
+    CHECK (reversal_of_allocation_id IS NULL OR reversal_of_allocation_id <> id)
+);
+
+COMMENT ON TABLE public.supplier_invoice_receipt_allocations IS
+  'دفتر append-only يربط سطر فاتورة مورد بسطر استلام مقبول. الرصيد غير المفوتر يُشتق منه ولا يُخزَّن. العكس صفّ جديد لا تعديل.';
+
+CREATE INDEX IF NOT EXISTS supplier_invoice_receipt_allocations_receipt_line_idx
+  ON public.supplier_invoice_receipt_allocations (goods_receipt_line_id)
+  WHERE reversal_of_allocation_id IS NULL;
+
+CREATE INDEX IF NOT EXISTS supplier_invoice_receipt_allocations_po_line_idx
+  ON public.supplier_invoice_receipt_allocations (purchase_order_line_id);
+
+CREATE INDEX IF NOT EXISTS supplier_invoice_receipt_allocations_invoice_idx
+  ON public.supplier_invoice_receipt_allocations (supplier_invoice_id);
+
+CREATE INDEX IF NOT EXISTS supplier_invoice_receipt_allocations_org_idx
+  ON public.supplier_invoice_receipt_allocations (org_id);
+
+-- كل أصل يُعكس مرة واحدة على الأكثر.
+CREATE UNIQUE INDEX IF NOT EXISTS supplier_invoice_receipt_allocations_reversal_uk
+  ON public.supplier_invoice_receipt_allocations (reversal_of_allocation_id)
+  WHERE reversal_of_allocation_id IS NOT NULL;
+
+-- ---------------------------------------------------------------------
+-- القسم 4: عدم القابلية للتعديل يُفرض في القاعدة
+-- ---------------------------------------------------------------------
+-- الدفتر append-only بالعقد؛ وبلا حارس يبقى ذلك اتفاقًا يكسره أول UPDATE.
+CREATE OR REPLACE FUNCTION public.wardah_guard_allocation_immutability()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+BEGIN
+  RAISE EXCEPTION
+    'AP_ALLOCATION_IMMUTABLE: دفتر التخصيصات append-only — العكس يكون بصف جديد يشير إلى أصله، لا بتعديل أو حذف (العملية: %)',
+    TG_OP;
+END $$;
+
+REVOKE ALL ON FUNCTION public.wardah_guard_allocation_immutability() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.wardah_guard_allocation_immutability() FROM anon;
+REVOKE ALL ON FUNCTION public.wardah_guard_allocation_immutability() FROM authenticated;
+
+DROP TRIGGER IF EXISTS trg_supplier_invoice_receipt_allocations_immutable
+  ON public.supplier_invoice_receipt_allocations;
+CREATE TRIGGER trg_supplier_invoice_receipt_allocations_immutable
+  BEFORE UPDATE OR DELETE ON public.supplier_invoice_receipt_allocations
+  FOR EACH ROW EXECUTE FUNCTION public.wardah_guard_allocation_immutability();
+
+-- ---------------------------------------------------------------------
+-- القسم 5: عزل المؤسسات
+-- ---------------------------------------------------------------------
+ALTER TABLE public.supplier_invoice_receipt_allocations ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS supplier_invoice_receipt_allocations_org_isolation
+  ON public.supplier_invoice_receipt_allocations;
+CREATE POLICY supplier_invoice_receipt_allocations_org_isolation
+  ON public.supplier_invoice_receipt_allocations
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.user_organizations uo
+      WHERE uo.org_id = supplier_invoice_receipt_allocations.org_id
+        AND uo.user_id = auth.uid()
+        AND uo.is_active IS TRUE
+    )
+  );
+
+GRANT SELECT ON public.supplier_invoice_receipt_allocations TO authenticated;
+REVOKE ALL ON public.supplier_invoice_receipt_allocations FROM anon;
+
+-- ---------------------------------------------------------------------
+-- القسم 6: الرصيد المقبول غير المفوتر — دالة اشتقاق واحدة
+-- ---------------------------------------------------------------------
+-- تُستعمل من القراءة ومن الكتابة معًا، فلا يتباعد تعريفان للرصيد.
+CREATE OR REPLACE FUNCTION public.wardah_receipt_line_uninvoiced_base(
+  p_goods_receipt_line_id uuid
+)
+RETURNS numeric
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_accepted_base numeric(18,6);
+  v_allocated_base numeric(18,6);
+BEGIN
+  -- `quality_status` حالة السطر كاملًا في عقد 148، فسطر غير مقبول رصيده صفر.
+  SELECT CASE
+           WHEN grl.quality_status <> 'accepted' THEN 0
+           ELSE COALESCE(grl.received_quantity, 0)
+         END
+    INTO v_accepted_base
+  FROM public.goods_receipt_lines grl
+  WHERE grl.id = p_goods_receipt_line_id;
+
+  IF v_accepted_base IS NULL THEN
+    RAISE EXCEPTION 'AP_GRN_LINE_NOT_FOUND: سطر استلام غير موجود (%)', p_goods_receipt_line_id;
+  END IF;
+
+  SELECT COALESCE(SUM(
+           CASE WHEN a.reversal_of_allocation_id IS NULL
+                THEN a.quantity_base
+                ELSE -a.quantity_base
+           END), 0)
+    INTO v_allocated_base
+  FROM public.supplier_invoice_receipt_allocations a
+  WHERE a.goods_receipt_line_id = p_goods_receipt_line_id;
+
+  RETURN v_accepted_base - v_allocated_base;
+END $$;
+
+REVOKE ALL ON FUNCTION public.wardah_receipt_line_uninvoiced_base(uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.wardah_receipt_line_uninvoiced_base(uuid) FROM anon;
+GRANT EXECUTE ON FUNCTION public.wardah_receipt_line_uninvoiced_base(uuid) TO authenticated;
+
+-- ---------------------------------------------------------------------
+-- القسم 7: RPC المطابقة النهائية
+-- ---------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_create_matched_supplier_invoice(p_payload jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_org             uuid;
+  v_vendor          uuid;
+  v_invoice_number  text;
+  v_number_norm     text;
+  v_invoice_date    date;
+  v_due_date        date;
+  v_idem_invoice    text;
+  v_idem_journal    text;
+  v_existing        record;
+  v_line            jsonb;
+  v_invoice_id      uuid;
+  v_invoice_line_id uuid;
+  v_line_no         integer := 0;
+  v_grl             record;
+  v_pol             record;
+  v_available       numeric(18,6);
+  v_qty             numeric(18,6);
+  v_price           numeric(18,6);
+  v_disc            numeric(5,2);
+  v_tax             numeric(5,2);
+  v_net             numeric(18,6);
+  v_goods_total     numeric(18,2) := 0;
+  v_vat_total       numeric(18,2) := 0;
+  v_map_goods       record;
+  v_map_vat         record;
+  v_acc_grni        uuid;
+  v_acc_vat         uuid;
+  v_acc_ap          uuid;
+  v_journal         jsonb;
+  v_entry_id        uuid;
+  v_entry_status    text;
+  v_drift           numeric(18,6);
+  v_lines           jsonb;
+BEGIN
+  -- === 1. المؤسسة والحراسة ===============================================
+  -- المؤسسة تُصرَّح في الحمولة ثم **يُتحقق منها**؛ لا تُؤخذ بثقة. العضوية
+  -- النشطة أولًا، ثم صلاحية الاعتماد/الترحيل. المطابقة تثبت صحة المستند ولا
+  -- تثبت أن المستدعي يحق له الترحيل — شرطان مستقلان.
+  v_org := NULLIF(p_payload ->> 'org_id', '')::uuid;
+  PERFORM public.wardah_assert_org_member(v_org);
+
+  IF NOT public.has_permission(auth.uid(), v_org, 'purchasing.purchase_invoices.approve') THEN
+    RAISE EXCEPTION
+      'AP_POST_PERMISSION_DENIED: هذا المسار ينشئ الفاتورة ويرحّل قيدها معًا، ويتطلب صلاحية purchasing.purchase_invoices.approve';
+  END IF;
+
+  -- === 2. الترويسة =======================================================
+  v_vendor         := NULLIF(p_payload ->> 'vendor_id', '')::uuid;
+  v_invoice_number := btrim(COALESCE(p_payload ->> 'invoice_number', ''));
+  v_number_norm    := upper(v_invoice_number);
+  v_invoice_date   := COALESCE(NULLIF(p_payload ->> 'invoice_date', '')::date, CURRENT_DATE);
+  v_due_date       := NULLIF(p_payload ->> 'due_date', '')::date;
+
+  IF v_vendor IS NULL THEN
+    RAISE EXCEPTION 'AP_VENDOR_REQUIRED: معرّف المورد مطلوب';
+  END IF;
+  IF v_invoice_number = '' THEN
+    RAISE EXCEPTION 'AP_INVOICE_NUMBER_REQUIRED: رقم فاتورة المورد مطلوب';
+  END IF;
+  IF v_due_date IS NOT NULL AND v_due_date < v_invoice_date THEN
+    RAISE EXCEPTION 'AP_DUE_DATE_BEFORE_INVOICE_DATE: تاريخ الاستحقاق قبل تاريخ الفاتورة';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.suppliers s WHERE s.id = v_vendor AND s.org_id = v_org) THEN
+    RAISE EXCEPTION 'AP_VENDOR_MISMATCH: المورد لا ينتمي إلى المؤسسة المحددة';
+  END IF;
+
+  -- الفترة تُفحص هنا صراحةً أيضًا لا في القيد وحده: الفشل قبل أي كتابة أوضح.
+  PERFORM public.assert_period_open(v_org, v_invoice_date);
+
+  -- === 3. idempotency على مستوى الفاتورة =================================
+  -- مشتق من هوية المستند داخل المؤسسة، لا UUID جديد في كل محاولة.
+  v_idem_invoice := 'ap-invoice:' || v_org::text || ':' || v_vendor::text || ':' || v_number_norm;
+
+  SELECT id, journal_entry_id, total_amount INTO v_existing
+  FROM public.supplier_invoices
+  WHERE org_id = v_org AND idempotency_key = v_idem_invoice;
+
+  IF FOUND THEN
+    RETURN jsonb_build_object(
+      'success', true,
+      'idempotent_replay', true,
+      'invoice_id', v_existing.id,
+      'journal_entry_id', v_existing.journal_entry_id,
+      'total_amount', v_existing.total_amount
+    );
+  END IF;
+
+  -- === 4. تحقق شكلي قبل أي قفل ===========================================
+  IF jsonb_typeof(p_payload -> 'lines') <> 'array'
+     OR jsonb_array_length(p_payload -> 'lines') = 0 THEN
+    RAISE EXCEPTION 'AP_LINES_REQUIRED: الفاتورة تحتاج سطرًا واحدًا على الأقل';
+  END IF;
+
+  -- === 5. الأقفال بترتيب ثابت ============================================
+  -- سطور أمر الشراء أولًا ثم سطور الاستلام، وكلاهما مرتب بالمعرّف. الترتيب
+  -- الثابت هو ما يمنع deadlock بين جلستين تفوتران استلامات متقاطعة.
+  PERFORM 1
+  FROM public.purchase_order_lines pol
+  WHERE pol.id IN (
+    SELECT grl.purchase_order_line_id
+    FROM public.goods_receipt_lines grl
+    WHERE grl.id IN (
+      SELECT (l ->> 'goods_receipt_line_id')::uuid
+      FROM jsonb_array_elements(p_payload -> 'lines') l
+    )
+  )
+  ORDER BY pol.id
+  FOR UPDATE;
+
+  PERFORM 1
+  FROM public.goods_receipt_lines grl
+  WHERE grl.id IN (
+    SELECT (l ->> 'goods_receipt_line_id')::uuid
+    FROM jsonb_array_elements(p_payload -> 'lines') l
+  )
+  ORDER BY grl.id
+  FOR UPDATE;
+
+  -- === 6. الفاتورة (بمبالغ صفرية تُحدَّث بعد الأسطر) ======================
+  INSERT INTO public.supplier_invoices (
+    org_id, invoice_number, vendor_id, invoice_date, due_date,
+    subtotal, tax_amount, total_amount, status,
+    idempotency_key, match_status, matched_at, matched_by, created_by
+  ) VALUES (
+    v_org, v_invoice_number, v_vendor, v_invoice_date, v_due_date,
+    0, 0, 0, 'approved',
+    v_idem_invoice, 'matched', now(), auth.uid(), auth.uid()
+  )
+  RETURNING id INTO v_invoice_id;
+
+  -- === 7. سطر سطر: تحقق تحت القفل ثم كتابة ===============================
+  FOR v_line IN SELECT * FROM jsonb_array_elements(p_payload -> 'lines')
+  LOOP
+    v_line_no := v_line_no + 1;
+
+    SELECT grl.*, gr.org_id AS receipt_org
+      INTO v_grl
+    FROM public.goods_receipt_lines grl
+    JOIN public.goods_receipts gr ON gr.id = grl.goods_receipt_id
+    WHERE grl.id = (v_line ->> 'goods_receipt_line_id')::uuid;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'AP_GRN_LINE_NOT_FOUND: سطر استلام غير موجود (السطر %)', v_line_no;
+    END IF;
+    IF v_grl.org_id <> v_org OR v_grl.receipt_org <> v_org THEN
+      RAISE EXCEPTION 'AP_CROSS_ORG_REFERENCE: سطر الاستلام خارج المؤسسة (السطر %)', v_line_no;
+    END IF;
+    IF v_grl.quality_status <> 'accepted' THEN
+      RAISE EXCEPTION
+        'AP_GRN_LINE_NOT_ACCEPTED: لا تُفوتر كمية غير مقبولة — حالة الجودة % (السطر %)',
+        v_grl.quality_status, v_line_no;
+    END IF;
+    IF v_grl.purchase_order_line_id IS NULL THEN
+      RAISE EXCEPTION
+        'AP_GRN_LINE_WITHOUT_PO: هذا المسار للفواتير المستندة إلى أمر شراء (السطر %)', v_line_no;
+    END IF;
+
+    SELECT pol.*, po.status AS order_status, po.supplier_id AS order_vendor
+      INTO v_pol
+    FROM public.purchase_order_lines pol
+    JOIN public.purchase_orders po ON po.id = pol.purchase_order_id
+    WHERE pol.id = v_grl.purchase_order_line_id;
+
+    IF v_pol.org_id <> v_org THEN
+      RAISE EXCEPTION 'AP_CROSS_ORG_REFERENCE: سطر أمر الشراء خارج المؤسسة (السطر %)', v_line_no;
+    END IF;
+    IF v_pol.order_vendor <> v_vendor THEN
+      RAISE EXCEPTION 'AP_VENDOR_MISMATCH: أمر الشراء يخص موردًا آخر (السطر %)', v_line_no;
+    END IF;
+    IF v_pol.order_status NOT IN ('approved', 'partially_received', 'received', 'closed') THEN
+      RAISE EXCEPTION
+        'AP_PO_NOT_INVOICEABLE: حالة أمر الشراء % لا تسمح بالفوترة (السطر %)',
+        v_pol.order_status, v_line_no;
+    END IF;
+    IF v_pol.product_id <> v_grl.product_id THEN
+      RAISE EXCEPTION 'AP_PRODUCT_MISMATCH: المنتج يختلف بين الأمر والاستلام (السطر %)', v_line_no;
+    END IF;
+
+    -- الكمية: موجبة وبست منازل كحدّ. التقريب الصامت هو ما تمنعه دقة (18,6).
+    v_qty := (v_line ->> 'quantity_base')::numeric;
+    IF v_qty IS NULL OR v_qty <= 0 THEN
+      RAISE EXCEPTION 'AP_QUANTITY_INVALID: الكمية يجب أن تكون موجبة (السطر %)', v_line_no;
+    END IF;
+    IF v_qty <> round(v_qty, 6) THEN
+      RAISE EXCEPTION 'AP_QUANTITY_PRECISION: الكمية تتجاوز ست منازل عشرية (السطر %)', v_line_no;
+    END IF;
+
+    -- الرصيد يُعاد حسابه **تحت القفل**، لا من قراءة سابقة.
+    v_available := public.wardah_receipt_line_uninvoiced_base(v_grl.id);
+    IF v_qty > v_available THEN
+      RAISE EXCEPTION
+        'AP_QUANTITY_EXCEEDS_RECEIPT: المطلوب % والمتاح المقبول غير المفوتر % (السطر %)',
+        v_qty, v_available, v_line_no;
+    END IF;
+
+    -- السعر: صفر تسامح في الشريحة الأولى. لا فاتورة بحالة استثناء.
+    v_price := (v_line ->> 'unit_price')::numeric;
+    IF v_price IS NULL OR v_price < 0 THEN
+      RAISE EXCEPTION 'AP_PRICE_INVALID: سعر الوحدة مطلوب وغير سالب (السطر %)', v_line_no;
+    END IF;
+    IF round(v_price, 6) <> round(COALESCE(v_pol.unit_price, -1), 6) THEN
+      RAISE EXCEPTION
+        'AP_PRICE_VARIANCE_REQUIRES_APPROVAL: سعر الفاتورة % يخالف لقطة أمر الشراء % (السطر %)',
+        v_price, v_pol.unit_price, v_line_no;
+    END IF;
+
+    v_disc := COALESCE((v_line ->> 'discount_percentage')::numeric, COALESCE(v_pol.discount_percentage, 0));
+    v_tax  := COALESCE((v_line ->> 'tax_percentage')::numeric, COALESCE(v_pol.tax_percentage, 0));
+
+    INSERT INTO public.supplier_invoice_lines (
+      org_id, supplier_invoice_id, goods_receipt_line_id, purchase_order_line_id,
+      line_number, product_id, quantity, unit_cost,
+      discount_percentage, tax_percentage,
+      uom_id, conversion_factor_snapshot, po_unit_price_snapshot,
+      quantity_variance, price_variance, match_status
+    ) VALUES (
+      v_org, v_invoice_id, v_grl.id, v_pol.id,
+      v_line_no, v_grl.product_id, v_qty, v_price,
+      v_disc, v_tax,
+      v_grl.uom_id, v_grl.conversion_factor_snapshot, v_pol.unit_price,
+      0, 0, 'matched'
+    )
+    RETURNING id INTO v_invoice_line_id;
+
+    INSERT INTO public.supplier_invoice_receipt_allocations (
+      org_id, supplier_invoice_id, supplier_invoice_line_id,
+      goods_receipt_line_id, purchase_order_line_id,
+      quantity_base, idempotency_key, created_by
+    ) VALUES (
+      v_org, v_invoice_id, v_invoice_line_id,
+      v_grl.id, v_pol.id,
+      v_qty, v_idem_invoice || ':' || v_line_no::text, auth.uid()
+    );
+
+    -- المبالغ: الكمية بست منازل، والمال بمنزلتين. التقريب يقع هنا وحده.
+    v_net         := v_qty * v_price * (1 - v_disc / 100);
+    v_goods_total := v_goods_total + round(v_net, 2);
+    v_vat_total   := v_vat_total   + round(v_net * v_tax / 100, 2);
+  END LOOP;
+
+  -- === 8. مصالحة على مستويين ============================================
+  -- التفصيلي: لا تخصيصات تتجاوز المقبول على سطر الاستلام.
+  SELECT max(over_alloc) INTO v_drift
+  FROM (
+    SELECT SUM(CASE WHEN a.reversal_of_allocation_id IS NULL
+                    THEN a.quantity_base ELSE -a.quantity_base END)
+             - CASE WHEN grl.quality_status = 'accepted'
+                    THEN COALESCE(grl.received_quantity, 0) ELSE 0 END AS over_alloc
+    FROM public.supplier_invoice_receipt_allocations a
+    JOIN public.goods_receipt_lines grl ON grl.id = a.goods_receipt_line_id
+    WHERE a.goods_receipt_line_id IN (
+      SELECT goods_receipt_line_id
+      FROM public.supplier_invoice_receipt_allocations
+      WHERE supplier_invoice_id = v_invoice_id
+    )
+    GROUP BY a.goods_receipt_line_id, grl.quality_status, grl.received_quantity
+  ) s;
+
+  IF COALESCE(v_drift, 0) > 0 THEN
+    RAISE EXCEPTION 'AP_ALLOCATION_EXCEEDS_RECEIPT: التخصيصات تتجاوز المقبول بمقدار %', v_drift;
+  END IF;
+
+  -- الحارس الإجمالي: تراكم PO لا يتجاوز المقبول المسجّل على سطر الأمر. يكشف
+  -- انحراف تجميع الاستلامات عن القيمة التراكمية، ولا يُستعمل مصدرًا للرصيد.
+  SELECT max(over_alloc) INTO v_drift
+  FROM (
+    SELECT SUM(CASE WHEN a.reversal_of_allocation_id IS NULL
+                    THEN a.quantity_base ELSE -a.quantity_base END)
+             - COALESCE(pol.accepted_quantity, 0) AS over_alloc
+    FROM public.supplier_invoice_receipt_allocations a
+    JOIN public.purchase_order_lines pol ON pol.id = a.purchase_order_line_id
+    WHERE a.purchase_order_line_id IN (
+      SELECT purchase_order_line_id
+      FROM public.supplier_invoice_receipt_allocations
+      WHERE supplier_invoice_id = v_invoice_id
+    )
+    GROUP BY a.purchase_order_line_id, pol.accepted_quantity
+  ) s;
+
+  IF COALESCE(v_drift, 0) > 0 THEN
+    RAISE EXCEPTION
+      'AP_ALLOCATION_EXCEEDS_PO_ACCEPTED: تخصيصات سطر الأمر تتجاوز المقبول المسجّل بمقدار % — انحراف بين تراكم الأمر وسطور الاستلام',
+      v_drift;
+  END IF;
+
+  -- === 9. إجماليات الفاتورة =============================================
+  IF v_goods_total + v_vat_total <= 0 THEN
+    RAISE EXCEPTION 'AP_ZERO_INVOICE: إجمالي الفاتورة صفر أو سالب';
+  END IF;
+
+  UPDATE public.supplier_invoices
+  SET subtotal     = v_goods_total,
+      tax_amount   = v_vat_total,
+      total_amount = v_goods_total + v_vat_total,
+      updated_at   = now()
+  WHERE id = v_invoice_id;
+
+  -- === 10. الحسابات الثلاثة ==============================================
+  -- gl_event_mappings ثنائية الطرف، فتُقرأ خريطتان متوازنتان ويُشترط اتفاقهما
+  -- على حساب الدائن نفسه — وإلا فالخريطة متناقضة وتوزّع AP على حسابين.
+  SELECT * INTO v_map_goods FROM public.gl_event_mappings
+  WHERE org_id = v_org AND event_code = 'AP_MATCHED_INVOICE_GOODS'
+    AND work_center_code IS NULL AND is_active = true
+  LIMIT 1;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION
+      'AP_ACCOUNT_MAPPING_MISSING: لا خريطة للحدث AP_MATCHED_INVOICE_GOODS (مدين تصفية GRNI / دائن الذمم الدائنة)';
+  END IF;
+
+  SELECT * INTO v_map_vat FROM public.gl_event_mappings
+  WHERE org_id = v_org AND event_code = 'AP_MATCHED_INVOICE_VAT'
+    AND work_center_code IS NULL AND is_active = true
+  LIMIT 1;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION
+      'AP_ACCOUNT_MAPPING_MISSING: لا خريطة للحدث AP_MATCHED_INVOICE_VAT (مدين ضريبة المدخلات / دائن الذمم الدائنة)';
+  END IF;
+
+  IF v_map_goods.credit_account_code <> v_map_vat.credit_account_code THEN
+    RAISE EXCEPTION
+      'AP_ACCOUNT_MAPPING_INCONSISTENT: خريطتا البضاعة والضريبة تدلّان على حسابي دائن مختلفين (% و%) — الذمم الدائنة حساب واحد في هذا القيد',
+      v_map_goods.credit_account_code, v_map_vat.credit_account_code;
+  END IF;
+
+  SELECT id INTO v_acc_grni FROM public.gl_accounts
+  WHERE org_id = v_org AND code = v_map_goods.debit_account_code;
+  SELECT id INTO v_acc_vat  FROM public.gl_accounts
+  WHERE org_id = v_org AND code = v_map_vat.debit_account_code;
+  SELECT id INTO v_acc_ap   FROM public.gl_accounts
+  WHERE org_id = v_org AND code = v_map_goods.credit_account_code;
+
+  IF v_acc_grni IS NULL OR v_acc_vat IS NULL OR v_acc_ap IS NULL THEN
+    RAISE EXCEPTION
+      'AP_ACCOUNT_NOT_FOUND: حساب من حسابات القيد غير موجود (GRNI=% VAT=% AP=%)',
+      v_map_goods.debit_account_code, v_map_vat.debit_account_code, v_map_goods.credit_account_code;
+  END IF;
+
+  -- === 11. القيد: النواة القائمة، مرحَّلًا داخل المعاملة =================
+  -- سطر الضريبة يُحذف إذا كانت صفرًا: قيد بلا ضريبة قيد سليم لا ناقص.
+  v_idem_journal := 'ap-invoice-journal:' || v_invoice_id::text;
+
+  v_lines := jsonb_build_array(
+    jsonb_build_object('line_number', 1, 'account_id', v_acc_grni,
+                       'debit', v_goods_total, 'credit', 0,
+                       'description', 'GRNI clearing')
+  );
+  IF v_vat_total > 0 THEN
+    v_lines := v_lines || jsonb_build_array(
+      jsonb_build_object('line_number', 2, 'account_id', v_acc_vat,
+                         'debit', v_vat_total, 'credit', 0,
+                         'description', 'Input VAT')
+    );
+  END IF;
+  v_lines := v_lines || jsonb_build_array(
+    jsonb_build_object('line_number', 3, 'account_id', v_acc_ap,
+                       'debit', 0, 'credit', v_goods_total + v_vat_total,
+                       'description', 'Accounts payable')
+  );
+
+  v_journal := public.rpc_create_journal_entry(jsonb_build_object(
+    'org_id', v_org,
+    'entry_date', v_invoice_date,
+    'description', 'Matched supplier invoice ' || v_invoice_number,
+    'reference_type', 'supplier_invoice',
+    'reference_number', v_invoice_id::text,
+    'idempotency_key', v_idem_journal,
+    'auto_post', true,
+    'lines', v_lines
+  ));
+
+  -- === 12. التحقق من نتيجة القيد قبل القبول ==============================
+  -- النواة ترفع استثناء عند الفشل، لكن الاعتماد على ذلك وحده يفترض عقدًا لا
+  -- يُفحص. الفحص هنا يجعل أي انحراف مستقبلي في النواة يُسقط المعاملة كاملة بدل
+  -- أن يترك فاتورة معتمدة بقيد غير مرحَّل.
+  v_entry_id := NULLIF(v_journal ->> 'entry_id', '')::uuid;
+
+  IF COALESCE((v_journal ->> 'success')::boolean, false) IS NOT TRUE THEN
+    RAISE EXCEPTION 'AP_JOURNAL_NOT_CREATED: النواة المحاسبية لم تُبلّغ بالنجاح — %', v_journal;
+  END IF;
+  IF v_entry_id IS NULL THEN
+    RAISE EXCEPTION 'AP_JOURNAL_ENTRY_ID_MISSING: القيد بلا معرّف — %', v_journal;
+  END IF;
+
+  SELECT status INTO v_entry_status FROM public.gl_entries WHERE id = v_entry_id;
+  IF v_entry_status IS DISTINCT FROM 'posted' THEN
+    RAISE EXCEPTION
+      'AP_JOURNAL_NOT_POSTED: القيد بحالة % لا posted — لا تُقبل فاتورة معتمدة بقيد غير مرحَّل',
+      COALESCE(v_entry_status, '(غير موجود)');
+  END IF;
+
+  -- === 13. الربط الصريح ==================================================
+  -- عمود مباشر لا اعتمادًا على reference_id وحده: البحث العكسي من الفاتورة إلى
+  -- قيدها يجب ألا يمر بمطابقة نصية.
+  UPDATE public.supplier_invoices
+  SET journal_entry_id = v_entry_id, updated_at = now()
+  WHERE id = v_invoice_id;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'idempotent_replay', false,
+    'invoice_id', v_invoice_id,
+    'invoice_status', 'approved',
+    'journal_entry_id', v_entry_id,
+    'journal_status', 'posted',
+    'subtotal', v_goods_total,
+    'tax_amount', v_vat_total,
+    'total_amount', v_goods_total + v_vat_total,
+    'lines', v_line_no
+  );
+END $$;
+
+REVOKE ALL ON FUNCTION public.rpc_create_matched_supplier_invoice(jsonb) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.rpc_create_matched_supplier_invoice(jsonb) FROM anon;
+GRANT EXECUTE ON FUNCTION public.rpc_create_matched_supplier_invoice(jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.rpc_create_matched_supplier_invoice(jsonb) TO service_role;
+
+COMMIT;

--- a/sql/migrations/149_ap_three_way_match_allocations.sql
+++ b/sql/migrations/149_ap_three_way_match_allocations.sql
@@ -333,6 +333,10 @@ DECLARE
   v_pol             record;
   v_available       numeric(18,6);
   v_qty             numeric(18,6);
+  -- خام بلا دقة معلنة: الإسناد إلى numeric(18,6) يقرّب القيمة صامتًا، فيصير
+  -- فحص الدقة على قيمة مقرَّبة سلفًا ولا يمكن أن يفشل أبدًا. القراءة الخام أولًا
+  -- هي ما يجعل الحارس قادرًا على العمل.
+  v_qty_raw         numeric;
   v_price           numeric(18,6);
   v_disc            numeric(5,2);
   v_tax             numeric(5,2);
@@ -378,7 +382,9 @@ BEGIN
   IF v_due_date IS NOT NULL AND v_due_date < v_invoice_date THEN
     RAISE EXCEPTION 'AP_DUE_DATE_BEFORE_INVOICE_DATE: تاريخ الاستحقاق قبل تاريخ الفاتورة';
   END IF;
-  IF NOT EXISTS (SELECT 1 FROM public.suppliers s WHERE s.id = v_vendor AND s.org_id = v_org) THEN
+  -- الجدول `vendors` لا `suppliers`: الأخير لا وجود له في المخطط رغم أن الفواتير
+  -- تُسمّى supplier_invoices. الاسمان مختلطان في هذا النطاق تاريخيًا.
+  IF NOT EXISTS (SELECT 1 FROM public.vendors v WHERE v.id = v_vendor AND v.org_id = v_org) THEN
     RAISE EXCEPTION 'AP_VENDOR_MISMATCH: المورد لا ينتمي إلى المؤسسة المحددة';
   END IF;
 
@@ -473,7 +479,7 @@ BEGIN
         'AP_GRN_LINE_WITHOUT_PO: هذا المسار للفواتير المستندة إلى أمر شراء (السطر %)', v_line_no;
     END IF;
 
-    SELECT pol.*, po.status AS order_status, po.supplier_id AS order_vendor
+    SELECT pol.*, po.status AS order_status, po.vendor_id AS order_vendor
       INTO v_pol
     FROM public.purchase_order_lines pol
     JOIN public.purchase_orders po ON po.id = pol.purchase_order_id
@@ -495,13 +501,16 @@ BEGIN
     END IF;
 
     -- الكمية: موجبة وبست منازل كحدّ. التقريب الصامت هو ما تمنعه دقة (18,6).
-    v_qty := (v_line ->> 'quantity_base')::numeric;
-    IF v_qty IS NULL OR v_qty <= 0 THEN
+    v_qty_raw := (v_line ->> 'quantity_base')::numeric;
+    IF v_qty_raw IS NULL OR v_qty_raw <= 0 THEN
       RAISE EXCEPTION 'AP_QUANTITY_INVALID: الكمية يجب أن تكون موجبة (السطر %)', v_line_no;
     END IF;
-    IF v_qty <> round(v_qty, 6) THEN
-      RAISE EXCEPTION 'AP_QUANTITY_PRECISION: الكمية تتجاوز ست منازل عشرية (السطر %)', v_line_no;
+    IF v_qty_raw <> round(v_qty_raw, 6) THEN
+      RAISE EXCEPTION
+        'AP_QUANTITY_PRECISION: الكمية % تتجاوز ست منازل عشرية — الفوترة لا تقرّب الكمية صامتًا (السطر %)',
+        v_qty_raw, v_line_no;
     END IF;
+    v_qty := v_qty_raw;
 
     -- الرصيد يُعاد حسابه **تحت القفل**، لا من قراءة سابقة.
     v_available := public.wardah_receipt_line_uninvoiced_base(v_grl.id);

--- a/sql/migrations/150_ap_matched_invoice_idempotency_and_grn_gate.sql
+++ b/sql/migrations/150_ap_matched_invoice_idempotency_and_grn_gate.sql
@@ -15,6 +15,7 @@
 --   * changed payload under the same key fails closed;
 --   * duplicate supplier invoice number is distinct from idempotent replay;
 --   * every referenced GRN header must be confirmed/posted;
+--   * one GRN line may appear only once per request;
 --   * the v149 core is no longer client executable.
 -- =====================================================================
 
@@ -106,6 +107,16 @@ BEGIN
   IF jsonb_typeof(p_payload -> 'lines') <> 'array'
      OR jsonb_array_length(p_payload -> 'lines') = 0 THEN
     RAISE EXCEPTION 'AP_LINES_REQUIRED: الفاتورة تحتاج سطرًا واحدًا على الأقل';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(p_payload -> 'lines') l
+    GROUP BY NULLIF(l ->> 'goods_receipt_line_id', '')::uuid
+    HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION
+      'AP_DUPLICATE_GRN_LINE: لا يجوز تكرار سطر الاستلام نفسه أكثر من مرة داخل الفاتورة';
   END IF;
 
   SELECT gr.id, gr.status

--- a/sql/migrations/150_ap_matched_invoice_idempotency_and_grn_gate.sql
+++ b/sql/migrations/150_ap_matched_invoice_idempotency_and_grn_gate.sql
@@ -1,0 +1,183 @@
+-- =====================================================================
+-- 150_ap_matched_invoice_idempotency_and_grn_gate
+-- =====================================================================
+-- Hardening discovered while building the executable acceptance matrix for 149.
+--
+-- 149 used the normalized supplier invoice number itself as its idempotency key.
+-- That made an exact retry indistinguishable from a changed request carrying the
+-- same supplier document number. It also validated the receipt line and quality,
+-- but not the legal state of the goods-receipt header.
+--
+-- This migration keeps the tested 149 implementation intact as an internal core,
+-- and places the missing client contract in a narrow wrapper:
+--   * explicit idempotency_key is mandatory;
+--   * canonical jsonb request hash is persisted and compared on replay;
+--   * changed payload under the same key fails closed;
+--   * duplicate supplier invoice number is distinct from idempotent replay;
+--   * every referenced GRN header must be confirmed/posted;
+--   * the v149 core is no longer client executable.
+-- =====================================================================
+
+BEGIN;
+
+ALTER FUNCTION public.rpc_create_matched_supplier_invoice(jsonb)
+  RENAME TO rpc_create_matched_supplier_invoice_v149;
+
+REVOKE ALL ON FUNCTION public.rpc_create_matched_supplier_invoice_v149(jsonb) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.rpc_create_matched_supplier_invoice_v149(jsonb) FROM anon;
+REVOKE ALL ON FUNCTION public.rpc_create_matched_supplier_invoice_v149(jsonb) FROM authenticated;
+REVOKE ALL ON FUNCTION public.rpc_create_matched_supplier_invoice_v149(jsonb) FROM service_role;
+
+CREATE OR REPLACE FUNCTION public.rpc_create_matched_supplier_invoice(p_payload jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_org            uuid;
+  v_vendor         uuid;
+  v_invoice_number text;
+  v_idem           text;
+  v_hash           text;
+  v_existing       record;
+  v_bad_grn        record;
+  v_result         jsonb;
+  v_invoice_id     uuid;
+BEGIN
+  v_org            := NULLIF(p_payload ->> 'org_id', '')::uuid;
+  v_vendor         := NULLIF(p_payload ->> 'vendor_id', '')::uuid;
+  v_invoice_number := btrim(COALESCE(p_payload ->> 'invoice_number', ''));
+  v_idem           := NULLIF(btrim(COALESCE(p_payload ->> 'idempotency_key', '')), '');
+
+  PERFORM public.wardah_assert_org_member(v_org);
+  IF NOT public.has_permission(auth.uid(), v_org, 'purchasing.purchase_invoices.approve') THEN
+    RAISE EXCEPTION
+      'AP_POST_PERMISSION_DENIED: هذا المسار ينشئ الفاتورة ويرحّل قيدها معًا، ويتطلب صلاحية purchasing.purchase_invoices.approve';
+  END IF;
+
+  IF v_idem IS NULL THEN
+    RAISE EXCEPTION 'AP_IDEMPOTENCY_KEY_REQUIRED: مفتاح إعادة المحاولة مطلوب للمطابقة الذرية';
+  END IF;
+
+  -- jsonb::text has deterministic key ordering, so semantically identical object
+  -- key order produces the same digest. The idempotency key is intentionally part
+  -- of the request identity; changing it is a new request, not a replay.
+  v_hash := encode(extensions.digest(convert_to(p_payload::text, 'UTF8'), 'sha256'), 'hex');
+
+  SELECT id, request_hash, journal_entry_id, subtotal, tax_amount, total_amount
+    INTO v_existing
+  FROM public.supplier_invoices
+  WHERE org_id = v_org AND idempotency_key = v_idem;
+
+  IF FOUND THEN
+    IF v_existing.request_hash IS DISTINCT FROM v_hash THEN
+      RAISE EXCEPTION
+        'AP_IDEMPOTENCY_KEY_REUSED: المفتاح استُخدم سابقًا مع حمولة مختلفة';
+    END IF;
+
+    RETURN jsonb_build_object(
+      'success', true,
+      'idempotent_replay', true,
+      'invoice_id', v_existing.id,
+      'invoice_status', 'approved',
+      'journal_entry_id', v_existing.journal_entry_id,
+      'journal_status', 'posted',
+      'subtotal', v_existing.subtotal,
+      'tax_amount', v_existing.tax_amount,
+      'total_amount', v_existing.total_amount
+    );
+  END IF;
+
+  -- A supplier document number is a business uniqueness rule, not an idempotency
+  -- mechanism. The same number under a different request key must be rejected.
+  IF EXISTS (
+    SELECT 1
+    FROM public.supplier_invoices si
+    WHERE si.org_id = v_org
+      AND si.vendor_id = v_vendor
+      AND si.match_status = 'matched'
+      AND upper(btrim(si.invoice_number)) = upper(v_invoice_number)
+  ) THEN
+    RAISE EXCEPTION
+      'AP_DUPLICATE_VENDOR_INVOICE_NUMBER: رقم فاتورة المورد مستخدم مسبقًا داخل المؤسسة والمورد';
+  END IF;
+
+  IF jsonb_typeof(p_payload -> 'lines') <> 'array'
+     OR jsonb_array_length(p_payload -> 'lines') = 0 THEN
+    RAISE EXCEPTION 'AP_LINES_REQUIRED: الفاتورة تحتاج سطرًا واحدًا على الأقل';
+  END IF;
+
+  SELECT gr.id, gr.status
+    INTO v_bad_grn
+  FROM jsonb_array_elements(p_payload -> 'lines') l
+  JOIN public.goods_receipt_lines grl
+    ON grl.id = NULLIF(l ->> 'goods_receipt_line_id', '')::uuid
+  JOIN public.goods_receipts gr ON gr.id = grl.goods_receipt_id
+  WHERE gr.org_id <> v_org
+     OR gr.status NOT IN ('confirmed', 'posted')
+  ORDER BY gr.id
+  LIMIT 1;
+
+  IF FOUND THEN
+    IF EXISTS (
+      SELECT 1 FROM public.goods_receipts gr
+      WHERE gr.id = v_bad_grn.id AND gr.org_id <> v_org
+    ) THEN
+      RAISE EXCEPTION 'AP_CROSS_ORG_REFERENCE: سند الاستلام خارج المؤسسة';
+    END IF;
+    RAISE EXCEPTION
+      'AP_GRN_NOT_INVOICEABLE: حالة سند الاستلام % لا تسمح بالفوترة',
+      v_bad_grn.status;
+  END IF;
+
+  v_result := public.rpc_create_matched_supplier_invoice_v149(p_payload);
+  v_invoice_id := NULLIF(v_result ->> 'invoice_id', '')::uuid;
+
+  IF v_invoice_id IS NULL THEN
+    RAISE EXCEPTION 'AP_MATCHED_INVOICE_ID_MISSING: تنفيذ 149 لم يُعد معرّف الفاتورة — %', v_result;
+  END IF;
+
+  UPDATE public.supplier_invoices
+  SET idempotency_key = v_idem,
+      request_hash = v_hash,
+      updated_at = now()
+  WHERE id = v_invoice_id;
+
+  RETURN v_result || jsonb_build_object('idempotency_key', v_idem);
+EXCEPTION
+  WHEN unique_violation THEN
+    -- Covers a concurrent request that passed the pre-check and lost at the
+    -- partial unique supplier-number index or the org/idempotency index.
+    IF EXISTS (
+      SELECT 1 FROM public.supplier_invoices si
+      WHERE si.org_id = v_org
+        AND si.idempotency_key = v_idem
+        AND si.request_hash = v_hash
+    ) THEN
+      SELECT id, request_hash, journal_entry_id, subtotal, tax_amount, total_amount
+        INTO v_existing
+      FROM public.supplier_invoices
+      WHERE org_id = v_org AND idempotency_key = v_idem;
+      RETURN jsonb_build_object(
+        'success', true,
+        'idempotent_replay', true,
+        'invoice_id', v_existing.id,
+        'invoice_status', 'approved',
+        'journal_entry_id', v_existing.journal_entry_id,
+        'journal_status', 'posted',
+        'subtotal', v_existing.subtotal,
+        'tax_amount', v_existing.tax_amount,
+        'total_amount', v_existing.total_amount
+      );
+    END IF;
+    RAISE EXCEPTION
+      'AP_DUPLICATE_VENDOR_INVOICE_NUMBER: رقم فاتورة المورد أو مفتاح إعادة المحاولة مستخدم مسبقًا';
+END $$;
+
+REVOKE ALL ON FUNCTION public.rpc_create_matched_supplier_invoice(jsonb) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.rpc_create_matched_supplier_invoice(jsonb) FROM anon;
+GRANT EXECUTE ON FUNCTION public.rpc_create_matched_supplier_invoice(jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.rpc_create_matched_supplier_invoice(jsonb) TO service_role;
+
+COMMIT;

--- a/sql/migrations/151_ap_helper_security_hardening.sql
+++ b/sql/migrations/151_ap_helper_security_hardening.sql
@@ -1,0 +1,82 @@
+-- =====================================================================
+-- 151_ap_helper_security_hardening
+-- =====================================================================
+-- The repository DEFINER guard caught two helper definitions introduced in 149:
+--   * the immutability trigger did not need elevated privileges at all;
+--   * the receipt-balance helper accepted only a GRN-line id and could disclose a
+--     cross-organization balance to any authenticated caller granted EXECUTE.
+--
+-- Final contract:
+--   * trigger function is SECURITY INVOKER (the default);
+--   * balance helper resolves the owning organization, asserts membership, and
+--     keeps every aggregate explicitly scoped to that organization.
+-- =====================================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.wardah_guard_allocation_immutability()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO 'public', 'pg_temp'
+AS $$
+BEGIN
+  RAISE EXCEPTION
+    'AP_ALLOCATION_IMMUTABLE: دفتر التخصيصات append-only — العكس يكون بصف جديد يشير إلى أصله، لا بتعديل أو حذف (العملية: %)',
+    TG_OP;
+END $$;
+
+REVOKE ALL ON FUNCTION public.wardah_guard_allocation_immutability() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.wardah_guard_allocation_immutability() FROM anon;
+REVOKE ALL ON FUNCTION public.wardah_guard_allocation_immutability() FROM authenticated;
+REVOKE ALL ON FUNCTION public.wardah_guard_allocation_immutability() FROM service_role;
+
+CREATE OR REPLACE FUNCTION public.wardah_receipt_line_uninvoiced_base(
+  p_goods_receipt_line_id uuid
+)
+RETURNS numeric
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_org             uuid;
+  v_accepted_base   numeric(18,6);
+  v_allocated_base  numeric(18,6);
+BEGIN
+  SELECT gr.org_id,
+         CASE WHEN grl.quality_status = 'accepted'
+              THEN COALESCE(grl.received_quantity,0)
+              ELSE 0 END
+    INTO v_org, v_accepted_base
+  FROM public.goods_receipt_lines grl
+  JOIN public.goods_receipts gr ON gr.id = grl.goods_receipt_id
+  WHERE grl.id = p_goods_receipt_line_id;
+
+  IF v_org IS NULL THEN
+    RAISE EXCEPTION
+      'AP_GRN_LINE_NOT_FOUND: سطر استلام غير موجود (%)',
+      p_goods_receipt_line_id;
+  END IF;
+
+  PERFORM public.wardah_assert_org_member(v_org);
+
+  SELECT COALESCE(SUM(
+           CASE WHEN a.reversal_of_allocation_id IS NULL
+                THEN a.quantity_base
+                ELSE -a.quantity_base
+           END),0)
+    INTO v_allocated_base
+  FROM public.supplier_invoice_receipt_allocations a
+  WHERE a.org_id = v_org
+    AND a.goods_receipt_line_id = p_goods_receipt_line_id;
+
+  RETURN v_accepted_base - v_allocated_base;
+END $$;
+
+REVOKE ALL ON FUNCTION public.wardah_receipt_line_uninvoiced_base(uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.wardah_receipt_line_uninvoiced_base(uuid) FROM anon;
+GRANT EXECUTE ON FUNCTION public.wardah_receipt_line_uninvoiced_base(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.wardah_receipt_line_uninvoiced_base(uuid) TO service_role;
+
+COMMIT;

--- a/sql/migrations/152_ap_allow_fully_received_purchase_orders.sql
+++ b/sql/migrations/152_ap_allow_fully_received_purchase_orders.sql
@@ -1,0 +1,42 @@
+-- =====================================================================
+-- 152_ap_allow_fully_received_purchase_orders
+-- =====================================================================
+-- Migration 148's terminal accepted-receipt state is `fully_received`.
+-- The 149 core accidentally allowed the obsolete/parallel spelling `received`
+-- but not `fully_received`, so the most normal AP case — invoice after complete
+-- receipt — failed with AP_PO_NOT_INVOICEABLE.
+--
+-- 150 renamed the implementation to rpc_create_matched_supplier_invoice_v149.
+-- Patch that stored definition narrowly and fail closed if its expected predicate
+-- is not present, avoiding a second hand-maintained copy of the 400+ line core.
+-- =====================================================================
+
+BEGIN;
+
+DO $$
+DECLARE
+  v_signature regprocedure :=
+    'public.rpc_create_matched_supplier_invoice_v149(jsonb)'::regprocedure;
+  v_definition text;
+  v_old text := 'NOT IN (''approved'', ''partially_received'', ''received'', ''closed'')';
+  v_new text := 'NOT IN (''approved'', ''partially_received'', ''fully_received'', ''received'', ''closed'')';
+BEGIN
+  SELECT pg_get_functiondef(v_signature) INTO v_definition;
+
+  IF position(v_old IN v_definition) = 0 THEN
+    RAISE EXCEPTION
+      'AP_152_DEFINITION_DRIFT: expected PO status predicate not found in %',
+      v_signature;
+  END IF;
+
+  v_definition := replace(v_definition, v_old, v_new);
+  EXECUTE v_definition;
+END $$;
+
+-- Reassert the internal-only execution surface after CREATE OR REPLACE.
+REVOKE ALL ON FUNCTION public.rpc_create_matched_supplier_invoice_v149(jsonb) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.rpc_create_matched_supplier_invoice_v149(jsonb) FROM anon;
+REVOKE ALL ON FUNCTION public.rpc_create_matched_supplier_invoice_v149(jsonb) FROM authenticated;
+REVOKE ALL ON FUNCTION public.rpc_create_matched_supplier_invoice_v149(jsonb) FROM service_role;
+
+COMMIT;

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -8279,6 +8279,7 @@ export type Database = {
       }
       supplier_invoice_lines: {
         Row: {
+          conversion_factor_snapshot: number | null
           created_at: string | null
           description: string | null
           discount_percentage: number | null
@@ -8286,15 +8287,24 @@ export type Database = {
           id: string
           line_number: number
           line_total: number | null
+          match_status: string | null
           notes: string | null
           org_id: string
+          po_unit_price_snapshot: number | null
+          price_variance: number | null
           product_id: string
+          purchase_order_line_id: string | null
+          qty_entered: number | null
           quantity: number
+          quantity_variance: number | null
           supplier_invoice_id: string
           tax_percentage: number | null
           unit_cost: number
+          unit_cost_entered: number | null
+          uom_id: string | null
         }
         Insert: {
+          conversion_factor_snapshot?: number | null
           created_at?: string | null
           description?: string | null
           discount_percentage?: number | null
@@ -8302,15 +8312,24 @@ export type Database = {
           id?: string
           line_number?: number
           line_total?: number | null
+          match_status?: string | null
           notes?: string | null
           org_id: string
+          po_unit_price_snapshot?: number | null
+          price_variance?: number | null
           product_id: string
+          purchase_order_line_id?: string | null
+          qty_entered?: number | null
           quantity: number
+          quantity_variance?: number | null
           supplier_invoice_id: string
           tax_percentage?: number | null
           unit_cost: number
+          unit_cost_entered?: number | null
+          uom_id?: string | null
         }
         Update: {
+          conversion_factor_snapshot?: number | null
           created_at?: string | null
           description?: string | null
           discount_percentage?: number | null
@@ -8318,13 +8337,21 @@ export type Database = {
           id?: string
           line_number?: number
           line_total?: number | null
+          match_status?: string | null
           notes?: string | null
           org_id?: string
+          po_unit_price_snapshot?: number | null
+          price_variance?: number | null
           product_id?: string
+          purchase_order_line_id?: string | null
+          qty_entered?: number | null
           quantity?: number
+          quantity_variance?: number | null
           supplier_invoice_id?: string
           tax_percentage?: number | null
           unit_cost?: number
+          unit_cost_entered?: number | null
+          uom_id?: string | null
         }
         Relationships: [
           {
@@ -8339,6 +8366,13 @@ export type Database = {
             columns: ["org_id"]
             isOneToOne: false
             referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "supplier_invoice_lines_po_line_fk"
+            columns: ["purchase_order_line_id"]
+            isOneToOne: false
+            referencedRelation: "purchase_order_lines"
             referencedColumns: ["id"]
           },
           {
@@ -8357,6 +8391,94 @@ export type Database = {
           },
         ]
       }
+      supplier_invoice_receipt_allocations: {
+        Row: {
+          created_at: string
+          created_by: string | null
+          goods_receipt_line_id: string
+          id: string
+          idempotency_key: string | null
+          org_id: string
+          purchase_order_line_id: string
+          quantity_base: number
+          reversal_of_allocation_id: string | null
+          reversal_reason: string | null
+          supplier_invoice_id: string
+          supplier_invoice_line_id: string
+        }
+        Insert: {
+          created_at?: string
+          created_by?: string | null
+          goods_receipt_line_id: string
+          id?: string
+          idempotency_key?: string | null
+          org_id: string
+          purchase_order_line_id: string
+          quantity_base: number
+          reversal_of_allocation_id?: string | null
+          reversal_reason?: string | null
+          supplier_invoice_id: string
+          supplier_invoice_line_id: string
+        }
+        Update: {
+          created_at?: string
+          created_by?: string | null
+          goods_receipt_line_id?: string
+          id?: string
+          idempotency_key?: string | null
+          org_id?: string
+          purchase_order_line_id?: string
+          quantity_base?: number
+          reversal_of_allocation_id?: string | null
+          reversal_reason?: string | null
+          supplier_invoice_id?: string
+          supplier_invoice_line_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "supplier_invoice_receipt_allocat_reversal_of_allocation_id_fkey"
+            columns: ["reversal_of_allocation_id"]
+            isOneToOne: false
+            referencedRelation: "supplier_invoice_receipt_allocations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "supplier_invoice_receipt_allocati_supplier_invoice_line_id_fkey"
+            columns: ["supplier_invoice_line_id"]
+            isOneToOne: false
+            referencedRelation: "supplier_invoice_lines"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "supplier_invoice_receipt_allocation_purchase_order_line_id_fkey"
+            columns: ["purchase_order_line_id"]
+            isOneToOne: false
+            referencedRelation: "purchase_order_lines"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "supplier_invoice_receipt_allocations_goods_receipt_line_id_fkey"
+            columns: ["goods_receipt_line_id"]
+            isOneToOne: false
+            referencedRelation: "goods_receipt_lines"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "supplier_invoice_receipt_allocations_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "supplier_invoice_receipt_allocations_supplier_invoice_id_fkey"
+            columns: ["supplier_invoice_id"]
+            isOneToOne: false
+            referencedRelation: "supplier_invoices"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       supplier_invoices: {
         Row: {
           balance: number | null
@@ -8366,13 +8488,19 @@ export type Database = {
           due_date: string | null
           goods_receipt_id: string | null
           id: string
+          idempotency_key: string | null
           invoice_date: string
           invoice_number: string
+          journal_entry_id: string | null
+          match_status: string | null
+          matched_at: string | null
+          matched_by: string | null
           notes: string | null
           org_id: string
           paid_amount: number | null
           payment_terms: string | null
           purchase_order_id: string | null
+          request_hash: string | null
           status: string | null
           subtotal: number
           tax_amount: number | null
@@ -8388,13 +8516,19 @@ export type Database = {
           due_date?: string | null
           goods_receipt_id?: string | null
           id?: string
+          idempotency_key?: string | null
           invoice_date?: string
           invoice_number: string
+          journal_entry_id?: string | null
+          match_status?: string | null
+          matched_at?: string | null
+          matched_by?: string | null
           notes?: string | null
           org_id: string
           paid_amount?: number | null
           payment_terms?: string | null
           purchase_order_id?: string | null
+          request_hash?: string | null
           status?: string | null
           subtotal: number
           tax_amount?: number | null
@@ -8410,13 +8544,19 @@ export type Database = {
           due_date?: string | null
           goods_receipt_id?: string | null
           id?: string
+          idempotency_key?: string | null
           invoice_date?: string
           invoice_number?: string
+          journal_entry_id?: string | null
+          match_status?: string | null
+          matched_at?: string | null
+          matched_by?: string | null
           notes?: string | null
           org_id?: string
           paid_amount?: number | null
           payment_terms?: string | null
           purchase_order_id?: string | null
+          request_hash?: string | null
           status?: string | null
           subtotal?: number
           tax_amount?: number | null
@@ -10809,6 +10949,14 @@ export type Database = {
         Returns: Json
       }
       rpc_create_journal_entry: { Args: { p_payload: Json }; Returns: Json }
+      rpc_create_matched_supplier_invoice: {
+        Args: { p_payload: Json }
+        Returns: Json
+      }
+      rpc_create_matched_supplier_invoice_v149: {
+        Args: { p_payload: Json }
+        Returns: Json
+      }
       rpc_create_mo_with_reservation: {
         Args: { p_materials?: Json; p_order: Json; p_tenant?: string }
         Returns: Json
@@ -11388,6 +11536,10 @@ export type Database = {
       wardah_is_org_member: { Args: { p_org: string }; Returns: boolean }
       wardah_org_id: { Args: { p_explicit?: string }; Returns: string }
       wardah_periods_org_col: { Args: never; Returns: string }
+      wardah_receipt_line_uninvoiced_base: {
+        Args: { p_goods_receipt_line_id: string }
+        Returns: number
+      }
       wardah_require_positive_bom_quantity: {
         Args: { p_bom_id: string; p_quantity: number }
         Returns: number


### PR DESCRIPTION
## الهدف

إكمال جولة المطابقة الثلاثية ببوابة Fresh DB فعلية على PostgreSQL 17، مع إغلاق فجوات ظهرت أثناء تحويل §10 من وثيقة إلى اختبارات تنفيذية، وتوثيق ترتيب تطبيق Production القانوني.

## التغييرات

- Migration 149: فاتورة مورد مطابقة ذريًا، دفتر تخصيص GRN→فاتورة append-only، فحوص الكمية/السعر/الدقة، وترحيل GL متوازن.
- Migration 150: فصل idempotency عن رقم فاتورة المورد، request hash، رفض إعادة استعمال المفتاح بحمولة مختلفة، بوابة حالة GRN، ومنع تكرار سطر GRN داخل الحمولة.
- Migration 151: إغلاق كشف cross-org في `wardah_receipt_line_uninvoiced_base`، وتحويل trigger immutability إلى SECURITY INVOKER مع سحب EXECUTE المباشر.
- Migration 152: قبول حالة أمر الشراء `fully_received` عبر patch fail-closed لتعريف نواة v149.
- سحب EXECUTE من نواة `rpc_create_matched_supplier_invoice_v149` وإبقاء wrapper فقط للعميل.
- قبول persisted-state يغطي الفاتورة، السطر، التخصيص، الرصيد، القيد، التوازن، الصلاحيات والـrollback.
- اختبار سباق جلستين حقيقي على آخر رصيد، مع إثبات انتظار الخاسر على row lock.
- بوابة PostgreSQL 17 تعيد البناء من baseline cutoff 148، تطبق 149→152، تشغّل قبول 148 ثم 149 ثم السباق وinvariants النهائية.
- Runbook مستقل: `docs/db/AP_THREE_WAY_MATCH_149_152_RUNBOOK.md`.
- تحديث `CLAUDE.md` بحالة Repository/Fresh DB/Production والرابط إلى runbook.

## ترتيب Production الإلزامي

```text
149_ap_three_way_match_allocations
150_ap_matched_invoice_idempotency_and_grn_gate
151_ap_helper_security_hardening
152_ap_allow_fully_received_purchase_orders
```

152 تعتمد على الاسم الداخلي والتعريف اللذين تنتجهما 150؛ لا يجوز تطبيقها منفردة أو تغيير هذا الترتيب. استخدام `pg_get_functiondef` في 152 حل استثنائي fail-closed، وليس نمطًا عامًا للتصحيحات القادمة.

## حالة الدمج

يبقى PR في Draft حتى تنجح جميع checks على آخر head SHA بعد commit التوثيق. لا تطبيق Production، ولا تغيير واجهة، ولا تحديث Baseline في هذا PR. بعد الدمج يكون التسلسل: repository-first → تطبيق 149→152 على Production → فحوص ما بعد التطبيق → Baseline PR مستقل.