### PR TITLE
feat(finance): add migration 153 legal GL amount contract

### DIFF
--- a/.github/workflows/financial-gl-153-fresh-db.yml
+++ b/.github/workflows/financial-gl-153-fresh-db.yml
@@ -1,0 +1,77 @@
+name: Financial GL 153 Fresh DB Acceptance
+
+on:
+  push:
+    branches:
+      - feat/financial-gl-contract-153
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'sql/migrations/153_financial_gl_legal_amount_contract.sql'
+      - 'scripts/ci/fresh-db/setup_153_pre_migration_fixture.sql'
+      - 'scripts/ci/fresh-db/acceptance_153_financial_gl_contract.sql'
+      - 'scripts/ci/fresh-db/acceptance_153_concurrency.sh'
+      - 'scripts/ci/fresh-db/run_financial_gl_153_gate.sh'
+      - 'scripts/ci/fresh-db/**'
+      - 'sql/baseline/**'
+      - '.github/workflows/financial-gl-153-fresh-db.yml'
+
+jobs:
+  financial-gl-153-fresh-db:
+    name: Migration 153 Legal GL Amount Contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install SQL validation dependencies
+        run: |
+          python3 -m pip install --quiet pglast pyyaml
+
+      - name: Parse migrations and enforce DEFINER guards
+        run: |
+          python3 scripts/ci/check_migration_syntax.py
+          python3 scripts/ci/check_definer_guards.py
+
+      - name: Run Financial GL 153 fresh DB gate
+        run: bash scripts/ci/fresh-db/run_financial_gl_153_gate.sh
+        env:
+          PGHOST: localhost
+          PGPORT: 5432
+          PGUSER: postgres
+          PGPASSWORD: postgres
+          PGDATABASE: wardah_fin153
+          REJECT_DB: wardah_fin153_reject
+
+      - name: Upload Financial GL 153 diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: financial-gl-153-diagnostics-${{ github.run_id }}
+          path: |
+            /tmp/f153-writer.sql
+            /tmp/f153-writer.out
+            /tmp/f153-writer.err
+            /tmp/f153-migration.out
+            /tmp/f153-migration.err
+            /tmp/f153-reject.out
+            /tmp/f153-reject.err
+          if-no-files-found: ignore
+          retention-days: 14

--- a/docs/db/FINANCIAL_GL_153_RUNBOOK.md
+++ b/docs/db/FINANCIAL_GL_153_RUNBOOK.md
@@ -1,0 +1,279 @@
+# Migration 153 — Financial GL Legal Amount Contract Runbook
+
+**Migration:** `153_financial_gl_legal_amount_contract.sql`  
+**Contract:** `WRD-FIN-REP-SRS-001` v1.3  
+**Baseline cutoff عند إنشاء هذا الـPR:** 152  
+**الحالة:** Repository implementation؛ **غير مطبقة على Production**.
+
+## 1. الهدف
+
+Migration 153 تنفذ انتقالًا ميكانيكيًا محدودًا لعقد مبالغ دفتر الأستاذ:
+
+- نقل القيمة داخل السطر من `debit_amount/credit_amount` إلى `debit/credit` للأسطر legacy-only.
+- إبقاء هوية الحساب التاريخية كما هي؛ لا Mapping ولا تخمين.
+- فرض قيود قانونية على `debit/credit`.
+- توسيع `gl_entries.total_debit/total_credit` إلى `numeric(18,2)`.
+- إنشاء توافق انتقالي أحادي الاتجاه للكتابات المستقبلية:
+  `account_id + debit/credit → account_code/name + debit_amount/credit_amount`.
+- إعادة حماية أسطر القيود المرحّلة قبل إنهاء المعاملة.
+
+## 2. خارج النطاق
+
+لا تنفذ 153 أيًا من الآتي:
+
+- ربط الأكواد التاريخية الرباعية بحسابات قانونية سداسية.
+- تعبئة `account_id` للأسطر التاريخية.
+- `account_id NOT NULL` أو FK إلى `gl_accounts`.
+- Quarantine أو استبعاد سطر من التقارير.
+- إصلاح الرؤوس المرحّلة التي لا تحمل سطورًا.
+- تحويل خدمات التقارير أو الواجهة إلى المصدر الجديد.
+
+هذه البنود موزعة بين قرار Mapping/Quarantine وMigration 154 والحزم اللاحقة.
+
+## 3. الحالة الحية المثبتة قبل التنفيذ
+
+تمت قراءة Production دون DDL أو تعديل بيانات، وكانت النتيجة:
+
+| الفحص | النتيجة |
+|---|---:|
+| `gl_entries` | 11 |
+| `gl_entry_lines` | 20 |
+| رؤوس `posted` | 9 |
+| رؤوس `draft` | 2 |
+| أسطر `posted` legacy-only | 16 |
+| مجموع legacy posted — مدين/دائن | 19,910.00 / 19,910.00 |
+| أسطر `draft` modern-only | 4 |
+| مجموع legal draft — مدين/دائن | 20,987.00 / 20,987.00 |
+| mixed/missing identity | 0 / 0 |
+| trigger حماية posted | موجود ومفعّل `O` |
+| رؤوس `posted` بلا سطور | 3، بقيمة 9,955.00 لكل طرف |
+
+الرؤوس الثلاثة بلا سطور **Quality finding منفصل**. 153 تبلغ عنها ولا تعيد إنشاء تاريخ محاسبي غير موجود.
+
+## 4. ترتيب التنفيذ داخل المعاملة
+
+1. `BEGIN` مع `lock_timeout` و`statement_timeout` محدودين.
+2. قفل parent-first في statement واحدة:
+
+```sql
+LOCK TABLE public.gl_entries,
+           public.gl_entry_lines
+IN SHARE ROW EXCLUSIVE MODE;
+```
+
+3. Preflight fail-closed على مخطط وبيانات ثابتين تحت القفل.
+4. حفظ snapshot ديناميكي للأعداد والمجاميع وIDs المستهدفة.
+5. توسيع دقة رؤوس القيود وضبط nullability/defaults.
+6. تعطيل `trg_protect_posted_gl_entry_lines` بالاسم فقط.
+7. `UPDATE ... RETURNING` للأسطر المستهدفة وحدها.
+8. إعادة تفعيل trigger الحماية فورًا.
+9. مقارنة العدد وIDs والقيم والمجاميع والاتزان.
+10. إضافة قيود المبالغ القانونية.
+11. إنشاء trigger التوافق legal → legacy وسحب EXECUTE عن دالته الداخلية.
+12. اختبار فعلي أن تعديل سطر `posted` يعيد `POSTED_ENTRY_IMMUTABLE`.
+13. `COMMIT`.
+
+ممنوع استخدام `session_replication_role` أو `DISABLE TRIGGER USER` أو bypass دائم.
+
+## 5. Preflight الحاجز
+
+تفشل Migration كاملة عند أي من الحالات الآتية:
+
+- Trigger حماية posted مفقود أو معطل مسبقًا.
+- NULL أو مبلغ سالب.
+- مدين ودائن موجبان في السطر نفسه.
+- قيمة اقتصادية موجودة في legal وlegacy معًا.
+- `account_id` و`account_code` معبآن معًا أو كلاهما فارغ.
+- شكل لا ينتمي بوضوح إلى modern-only أو legacy-only.
+- اختلاف المؤسسة بين الرأس والسطر.
+- `account_id` حديث غير موجود في `gl_accounts` للمؤسسة نفسها.
+- رأس يحمل سطورًا لكن إجمالياته لا تطابق القيمة الفعلية للسطور.
+
+الأعداد والمبالغ الحية لا تُثبت داخل شرط النجاح؛ تُحسب وقت التنفيذ.
+
+## 6. القيود الناتجة
+
+على `gl_entry_lines`:
+
+- `gl_entry_lines_legal_debit_nonnegative`
+- `gl_entry_lines_legal_credit_nonnegative`
+- `gl_entry_lines_legal_one_sided`
+
+وعلى `gl_entries`:
+
+- `total_debit numeric(18,2) NOT NULL DEFAULT 0`
+- `total_credit numeric(18,2) NOT NULL DEFAULT 0`
+
+تبقى أعمدة legacy `numeric(12,2)` مؤقتًا بسبب اعتماد Views قديمة عليها. Trigger التوافق يرفض قيمة قانونية تتجاوز المدى المؤقت بدل truncation أو overflow غامض.
+
+## 7. بوابة Fresh DB المخصصة
+
+Workflow:
+
+```text
+Financial GL 153 Fresh DB Acceptance
+```
+
+Runner:
+
+```text
+scripts/ci/fresh-db/run_financial_gl_153_gate.sh
+```
+
+يثبت ما يلي:
+
+- Baseline cutoff = 152.
+- إنشاء fixture قبل Migration يحمل legacy posted وmodern draft ورأسًا بلا سطور.
+- اختبار جلستين حقيقي:
+  - الكاتب يحجز `gl_entries` ثم ينتظر قبل إدخال السطور.
+  - 153 تنتظر قفل الرأس parent-first.
+  - لا deadlock ولا drift، والطرفان ينجحان.
+- backfill دقيق بلا Mapping أو تغيير للصفوف الحديثة.
+- الحفاظ على المجاميع والاتزان.
+- إعادة تفعيل حماية posted.
+- عمل قيود السالب والموجب المزدوج والصفر.
+- legal → legacy للكتابات الجديدة.
+- رفض legacy-only وconflicting وcross-org writes.
+- سحب EXECUTE عن trigger function الداخلية.
+- اختبار سلبي مستقل: mixed-source row يسقط Migration ويثبت rollback الكامل.
+
+علامة النجاح النهائية:
+
+```text
+FINANCIAL_GL_153_FRESH_DB_GATE_PASS
+```
+
+## 8. حاجز تطبيق Production المكتشف
+
+يوجد مسار تطبيق ما زال يكتب شكلًا غير قانوني بعد 153:
+
+```text
+src/services/payment-vouchers-service.ts
+```
+
+في إنشاء قيود سندات القبض/الصرف، يرسل المسار:
+
+```text
+account_id + debit_amount/credit_amount
+```
+
+ولا يرسل `debit/credit`. Trigger 153 يرفض هذا الشكل عمدًا لأن الاتجاه العكسي legacy → legal محظور.
+
+### القرار التشغيلي
+
+- يجوز مراجعة ودمج **DB PR** بعد اخضرار بواباته.
+- **يُمنع تطبيق 153 على Production** قبل إصلاح هذا الكاتب إلى `account_id + debit/credit` ونشره والتحقق منه.
+- لا تُضعف 153 لتخمين المبالغ من legacy في كتابة جديدة.
+- إصلاح الكاتب يجب أن يكون متوافقًا مع قاعدة ما قبل 153؛ الأعمدة القانونية موجودة أصلًا، لذلك يمكن نشر الإصلاح أولًا دون اعتماد Schema جديدة.
+- بعد نشر الإصلاح، تُنفذ تجربة سند قبض وسند صرف وتُفحص السطور الناتجة قبل السماح بتطبيق 153.
+
+## 9. فحوص ما قبل تطبيق Production
+
+```sql
+-- 1) شكل السطور الحالي
+SELECT e.status,
+       count(*) AS lines,
+       count(*) FILTER (WHERE l.account_id IS NOT NULL AND l.account_code IS NULL) AS modern_only,
+       count(*) FILTER (WHERE l.account_id IS NULL AND l.account_code IS NOT NULL) AS legacy_only,
+       count(*) FILTER (WHERE l.account_id IS NOT NULL AND l.account_code IS NOT NULL) AS mixed_identity,
+       sum(l.debit) AS legal_debit,
+       sum(l.credit) AS legal_credit,
+       sum(l.debit_amount) AS legacy_debit,
+       sum(l.credit_amount) AS legacy_credit
+FROM public.gl_entry_lines l
+JOIN public.gl_entries e ON e.id=l.entry_id
+GROUP BY e.status ORDER BY e.status;
+
+-- 2) حالة trigger الحماية
+SELECT tgname, tgenabled, pg_get_triggerdef(oid)
+FROM pg_trigger
+WHERE tgrelid='public.gl_entry_lines'::regclass
+  AND tgname='trg_protect_posted_gl_entry_lines'
+  AND NOT tgisinternal;
+
+-- 3) رؤوس بلا سطور — Quality finding لا تعالجها 153
+SELECT e.id, e.entry_number, e.status, e.total_debit, e.total_credit
+FROM public.gl_entries e
+WHERE NOT EXISTS (SELECT 1 FROM public.gl_entry_lines l WHERE l.entry_id=e.id)
+ORDER BY e.entry_date, e.entry_number;
+
+-- 4) علم المحرك يجب أن يبقى غير مفعل خلال هذه المرحلة
+SELECT org_id, value
+FROM public.org_settings
+WHERE key='financial_reporting_engine_v2_enabled';
+```
+
+## 10. فحوص ما بعد تطبيق Production
+
+```sql
+-- legal totals carry all economic value of existing lines
+SELECT e.status, count(*) AS lines,
+       sum(l.debit) AS legal_debit,
+       sum(l.credit) AS legal_credit
+FROM public.gl_entry_lines l
+JOIN public.gl_entries e ON e.id=l.entry_id
+GROUP BY e.status ORDER BY e.status;
+
+-- no line remains legal-zero while legacy-positive
+SELECT count(*) AS incomplete_backfill
+FROM public.gl_entry_lines
+WHERE debit=0 AND credit=0
+  AND (debit_amount>0 OR credit_amount>0);
+
+-- constraints and triggers
+SELECT conname, pg_get_constraintdef(oid)
+FROM pg_constraint
+WHERE conrelid='public.gl_entry_lines'::regclass
+  AND conname LIKE 'gl_entry_lines_legal_%'
+ORDER BY conname;
+
+SELECT tgname, tgenabled
+FROM pg_trigger
+WHERE tgrelid='public.gl_entry_lines'::regclass
+  AND tgname IN ('trg_protect_posted_gl_entry_lines','trg_wardah_gl_line_legal_compat')
+  AND NOT tgisinternal
+ORDER BY tgname;
+
+-- header precision
+SELECT column_name, numeric_precision, numeric_scale, is_nullable
+FROM information_schema.columns
+WHERE table_schema='public' AND table_name='gl_entries'
+  AND column_name IN ('total_debit','total_credit')
+ORDER BY column_name;
+```
+
+## 11. Rollback وRecovery
+
+### قبل COMMIT أو عند فشل التطبيق
+
+كل DDL وDML داخل معاملة واحدة. أي خطأ يعيد:
+
+- backfill.
+- تغييرات الأنواع والقيود.
+- trigger التوافق.
+- تعطيل/إعادة تفعيل trigger الحماية.
+
+إلى الحالة السابقة تلقائيًا.
+
+### بعد نجاح COMMIT
+
+لا تستخدم حذف migration أو تعديل سجل `supabase_migrations`. ولا تُرجع المبالغ القانونية إلى صفر؛ ذلك يفقد المصدر القانوني الجديد.
+
+أي عيب بعد التطبيق يعالج بـMigration إضافية additive موثقة، مع بقاء بيانات legal التي نُقلت وحفظ سجل التدقيق.
+
+## 12. ترتيب النشر
+
+1. دمج DB PR إلى `main` بعد CI والمراجعة.
+2. **لا تطبيق Production بعد الدمج مباشرة بسبب حاجز writer المذكور في §8.**
+3. إصلاح ونشر كاتب سندات القبض/الصرف المتوافق للخلف.
+4. Pilot فعلي لسند قبض وسند صرف والتحقق من `debit/credit`.
+5. إعادة تنفيذ prechecks من Production.
+6. تطبيق الاسم القانوني:
+
+```text
+153_financial_gl_legal_amount_contract
+```
+
+7. تنفيذ postchecks وتوثيق سجل migration مرة واحدة.
+8. إبقاء محرك التقارير v2 غير مفعّل؛ 154 وما بعدها لم تُطبق بعد.
+9. تحديث Baseline لاحقًا عبر workflow وPR مستقل بعد ظهور 153 في سجل Production.

--- a/scripts/ci/check_definer_guards.py
+++ b/scripts/ci/check_definer_guards.py
@@ -7,7 +7,7 @@ functions. Fails if any is callable by 'authenticated' without a body line that
 calls wardah_assert_org_member, wardah_assert_org_admin, or wardah_is_org_member.
 
 Exemptions:
-  - Functions with REVOKE EXECUTE FROM authenticated immediately after definition
+  - Functions with REVOKE EXECUTE/ALL FROM PUBLIC immediately after definition
   - Functions listed in KNOWN_EXEMPT (intentionally open or superseded, documented)
 """
 
@@ -42,10 +42,10 @@ DEFINER_FUNC_RE = re.compile(
     re.IGNORECASE,
 )
 
-# REVOKE FROM PUBLIC is the only grant that actually prevents authenticated access.
-# REVOKE FROM authenticated alone still leaves the PUBLIC grant active.
+# Both REVOKE EXECUTE and REVOKE ALL remove the inherited PUBLIC EXECUTE grant.
+# REVOKE from authenticated alone is insufficient while PUBLIC still holds it.
 REVOKE_RE = re.compile(
-    r"REVOKE\s+EXECUTE\s+ON\s+FUNCTION\s+.*?\s+FROM\s+PUBLIC\b",
+    r"REVOKE\s+(?:EXECUTE|ALL(?:\s+PRIVILEGES)?)\s+ON\s+FUNCTION\s+.*?\s+FROM\s+PUBLIC\b",
     re.IGNORECASE | re.DOTALL,
 )
 
@@ -136,7 +136,8 @@ def main() -> int:
         print("\n".join(all_errors), file=sys.stderr)
         print(
             "\nأضف wardah_assert_org_member(v_org) أو wardah_assert_org_admin(v_org) "
-            "في أول جسم الدالة، أو أضف اسمها إلى KNOWN_EXEMPT إن كانت مقصودة.",
+            "في أول جسم الدالة، أو اسحب EXECUTE/ALL من PUBLIC، أو أضف اسمها إلى "
+            "KNOWN_EXEMPT إن كانت مقصودة.",
             file=sys.stderr,
         )
         return 1

--- a/scripts/ci/fresh-db/acceptance_153_concurrency.sh
+++ b/scripts/ci/fresh-db/acceptance_153_concurrency.sh
@@ -8,6 +8,7 @@ ORG=53111111-1111-1111-1111-111111111111
 ENTRY=53e00000-0000-0000-0000-000000000020
 DEBIT_ACCOUNT=53a00000-0000-0000-0000-000000000001
 CREDIT_ACCOUNT=53a00000-0000-0000-0000-000000000002
+WRITER_APP=wardah_f153_writer
 
 cat >/tmp/f153-writer.sql <<SQL
 BEGIN;
@@ -29,27 +30,62 @@ VALUES
 COMMIT;
 SQL
 
-start_ms=$(date +%s%3N)
 set +e
-"${PSQL[@]}" -f /tmp/f153-writer.sql \
+writer_start_ms=$(date +%s%3N)
+PGAPPNAME="$WRITER_APP" "${PSQL[@]}" -f /tmp/f153-writer.sql \
   >/tmp/f153-writer.out 2>/tmp/f153-writer.err &
 writer_pid=$!
+set -e
 
-# Ensure the writer has acquired a RowExclusive lock on gl_entries before the
-# migration requests the parent-first SHARE ROW EXCLUSIVE lock.
-sleep 0.25
+# Do not rely on scheduler timing. Wait until the writer session demonstrably owns
+# the granted RowExclusiveLock on the parent table before starting migration 153.
+lock_seen=false
+for _ in $(seq 1 100); do
+  if "${PSQL[@]}" -tAc "
+    SELECT EXISTS (
+      SELECT 1
+      FROM pg_locks l
+      JOIN pg_stat_activity a ON a.pid = l.pid
+      WHERE a.application_name = '$WRITER_APP'
+        AND l.relation = 'public.gl_entries'::regclass
+        AND l.mode = 'RowExclusiveLock'
+        AND l.granted
+    )" | grep -qx t; then
+    lock_seen=true
+    break
+  fi
+
+  if ! kill -0 "$writer_pid" 2>/dev/null; then
+    echo 'ACCEPTANCE_153_CONCURRENCY_FAIL: writer exited before parent lock was observed' >&2
+    cat /tmp/f153-writer.err >&2 || true
+    wait "$writer_pid" || true
+    exit 1
+  fi
+  sleep 0.05
+done
+
+if [[ "$lock_seen" != true ]]; then
+  echo 'ACCEPTANCE_153_CONCURRENCY_FAIL: timed out waiting for writer RowExclusiveLock on gl_entries' >&2
+  kill "$writer_pid" 2>/dev/null || true
+  wait "$writer_pid" || true
+  exit 1
+fi
+
 migration_start_ms=$(date +%s%3N)
-"${PSQL[@]}" -f sql/migrations/153_financial_gl_legal_amount_contract.sql \
+set +e
+PGAPPNAME=wardah_f153_migration "${PSQL[@]}" \
+  -f sql/migrations/153_financial_gl_legal_amount_contract.sql \
   >/tmp/f153-migration.out 2>/tmp/f153-migration.err &
 migration_pid=$!
 
-wait "$writer_pid"; writer_status=$?
 wait "$migration_pid"; migration_status=$?
+migration_end_ms=$(date +%s%3N)
+wait "$writer_pid"; writer_status=$?
+writer_end_ms=$(date +%s%3N)
 set -e
 
-end_ms=$(date +%s%3N)
-migration_elapsed=$((end_ms-migration_start_ms))
-total_elapsed=$((end_ms-start_ms))
+migration_elapsed=$((migration_end_ms-migration_start_ms))
+writer_elapsed=$((writer_end_ms-writer_start_ms))
 
 if [[ $writer_status -ne 0 || $migration_status -ne 0 ]]; then
   echo "ACCEPTANCE_153_CONCURRENCY_FAIL: writer=$writer_status migration=$migration_status" >&2
@@ -57,8 +93,9 @@ if [[ $writer_status -ne 0 || $migration_status -ne 0 ]]; then
   exit 1
 fi
 
-# The writer sleeps for two seconds after owning the parent lock. A migration
-# elapsed time materially below 1.5s means it did not demonstrably wait.
+# The writer sleeps for two seconds after owning the parent lock. Since migration
+# starts only after that granted lock is observed, an elapsed time materially below
+# 1.5s means it did not demonstrably wait on the parent-first lock acquisition.
 if [[ $migration_elapsed -lt 1500 ]]; then
   echo "ACCEPTANCE_153_CONCURRENCY_FAIL: migration did not wait on parent lock (${migration_elapsed}ms)" >&2
   exit 1
@@ -95,4 +132,4 @@ if [[ "$historical_debit" != 125.50 || "$historical_credit" != 125.50 ]]; then
   exit 1
 fi
 
-echo "ACCEPTANCE_153_CONCURRENCY_PASS: migration waited ${migration_elapsed}ms; total ${total_elapsed}ms"
+echo "ACCEPTANCE_153_CONCURRENCY_PASS: observed writer lock; migration waited ${migration_elapsed}ms; writer ${writer_elapsed}ms"

--- a/scripts/ci/fresh-db/acceptance_153_concurrency.sh
+++ b/scripts/ci/fresh-db/acceptance_153_concurrency.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+DB=${PGDATABASE:-wardah_fin153}
+PSQL=(psql -v ON_ERROR_STOP=1 -X -d "$DB")
+
+ORG=53111111-1111-1111-1111-111111111111
+ENTRY=53e00000-0000-0000-0000-000000000020
+DEBIT_ACCOUNT=53a00000-0000-0000-0000-000000000001
+CREDIT_ACCOUNT=53a00000-0000-0000-0000-000000000002
+
+cat >/tmp/f153-writer.sql <<SQL
+BEGIN;
+INSERT INTO public.gl_entries
+  (id, org_id, entry_number, entry_date, entry_type, description,
+   status, total_debit, total_credit)
+VALUES
+  ('$ENTRY', '$ORG', 'F153-CONCURRENT-WRITER', '2026-07-30', 'manual',
+   'Writer holds parent before inserting children', 'draft', 33.33, 33.33);
+SELECT pg_sleep(2);
+INSERT INTO public.gl_entry_lines
+  (id, org_id, tenant_id, entry_id, line_number, account_id,
+   debit, credit, debit_amount, credit_amount, currency_code, description)
+VALUES
+  ('53b00000-0000-0000-0000-000000000020', '$ORG', '$ORG', '$ENTRY', 1,
+   '$DEBIT_ACCOUNT', 33.33, 0, 0, 0, 'SAR', 'Concurrent debit'),
+  ('53b00000-0000-0000-0000-000000000021', '$ORG', '$ORG', '$ENTRY', 2,
+   '$CREDIT_ACCOUNT', 0, 33.33, 0, 0, 'SAR', 'Concurrent credit');
+COMMIT;
+SQL
+
+start_ms=$(date +%s%3N)
+set +e
+"${PSQL[@]}" -f /tmp/f153-writer.sql \
+  >/tmp/f153-writer.out 2>/tmp/f153-writer.err &
+writer_pid=$!
+
+# Ensure the writer has acquired a RowExclusive lock on gl_entries before the
+# migration requests the parent-first SHARE ROW EXCLUSIVE lock.
+sleep 0.25
+migration_start_ms=$(date +%s%3N)
+"${PSQL[@]}" -f sql/migrations/153_financial_gl_legal_amount_contract.sql \
+  >/tmp/f153-migration.out 2>/tmp/f153-migration.err &
+migration_pid=$!
+
+wait "$writer_pid"; writer_status=$?
+wait "$migration_pid"; migration_status=$?
+set -e
+
+end_ms=$(date +%s%3N)
+migration_elapsed=$((end_ms-migration_start_ms))
+total_elapsed=$((end_ms-start_ms))
+
+if [[ $writer_status -ne 0 || $migration_status -ne 0 ]]; then
+  echo "ACCEPTANCE_153_CONCURRENCY_FAIL: writer=$writer_status migration=$migration_status" >&2
+  cat /tmp/f153-writer.err /tmp/f153-migration.err >&2 || true
+  exit 1
+fi
+
+# The writer sleeps for two seconds after owning the parent lock. A migration
+# elapsed time materially below 1.5s means it did not demonstrably wait.
+if [[ $migration_elapsed -lt 1500 ]]; then
+  echo "ACCEPTANCE_153_CONCURRENCY_FAIL: migration did not wait on parent lock (${migration_elapsed}ms)" >&2
+  exit 1
+fi
+
+read -r header_count line_count legal_debit legal_credit legacy_debit legacy_credit trigger_state <<<$(${PSQL[@]} -tA -F' ' -c "
+  SELECT
+    (SELECT count(*) FROM public.gl_entries WHERE id='$ENTRY'),
+    (SELECT count(*) FROM public.gl_entry_lines WHERE entry_id='$ENTRY'),
+    (SELECT coalesce(sum(debit),0) FROM public.gl_entry_lines WHERE entry_id='$ENTRY'),
+    (SELECT coalesce(sum(credit),0) FROM public.gl_entry_lines WHERE entry_id='$ENTRY'),
+    (SELECT coalesce(sum(debit_amount),0) FROM public.gl_entry_lines WHERE entry_id='$ENTRY'),
+    (SELECT coalesce(sum(credit_amount),0) FROM public.gl_entry_lines WHERE entry_id='$ENTRY'),
+    (SELECT tgenabled FROM pg_trigger
+      WHERE tgrelid='public.gl_entry_lines'::regclass
+        AND tgname='trg_protect_posted_gl_entry_lines'
+        AND NOT tgisinternal)")
+
+if [[ "$header_count" != 1 || "$line_count" != 2 \
+   || "$legal_debit" != 33.33 || "$legal_credit" != 33.33 \
+   || "$legacy_debit" != 0.00 || "$legacy_credit" != 0.00 \
+   || "$trigger_state" != O ]]; then
+  echo "ACCEPTANCE_153_CONCURRENCY_FAIL: header=$header_count lines=$line_count legal=$legal_debit/$legal_credit legacy=$legacy_debit/$legacy_credit trigger=$trigger_state" >&2
+  exit 1
+fi
+
+# The historical fixture must have been backfilled in the same migration run.
+read -r historical_debit historical_credit <<<$(${PSQL[@]} -tA -F' ' -c "
+  SELECT coalesce(sum(debit),0), coalesce(sum(credit),0)
+  FROM public.gl_entry_lines
+  WHERE entry_id='53e00000-0000-0000-0000-000000000001'")
+if [[ "$historical_debit" != 125.50 || "$historical_credit" != 125.50 ]]; then
+  echo "ACCEPTANCE_153_CONCURRENCY_FAIL: historical backfill=$historical_debit/$historical_credit" >&2
+  exit 1
+fi
+
+echo "ACCEPTANCE_153_CONCURRENCY_PASS: migration waited ${migration_elapsed}ms; total ${total_elapsed}ms"

--- a/scripts/ci/fresh-db/acceptance_153_financial_gl_contract.sql
+++ b/scripts/ci/fresh-db/acceptance_153_financial_gl_contract.sql
@@ -1,0 +1,261 @@
+\set ON_ERROR_STOP on
+
+CREATE OR REPLACE FUNCTION pg_temp.expect_error(p_sql text, p_needle text)
+RETURNS void LANGUAGE plpgsql AS $$
+DECLARE v_succeeded boolean := false;
+BEGIN
+  BEGIN
+    EXECUTE p_sql;
+    v_succeeded := true;
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM NOT LIKE '%' || p_needle || '%' THEN
+      RAISE EXCEPTION 'ACCEPTANCE_153_FAIL: expected [%] for [%], got [%]', p_needle, p_sql, SQLERRM;
+    END IF;
+  END;
+  IF v_succeeded THEN
+    RAISE EXCEPTION 'ACCEPTANCE_153_FAIL: expected error [%] for [%], but it succeeded', p_needle, p_sql;
+  END IF;
+END $$;
+
+DO $$
+DECLARE
+  v_count bigint;
+  v_precision integer;
+  v_scale integer;
+  v_state "char";
+BEGIN
+  -- The posted legacy fixture is copied exactly into the legal amount columns.
+  SELECT count(*) INTO v_count
+  FROM public.gl_entry_lines
+  WHERE id IN (
+    '53b00000-0000-0000-0000-000000000001',
+    '53b00000-0000-0000-0000-000000000002'
+  )
+    AND (
+      (id = '53b00000-0000-0000-0000-000000000001'
+       AND debit = 125.50 AND credit = 0
+       AND debit_amount = 125.50 AND credit_amount = 0)
+      OR
+      (id = '53b00000-0000-0000-0000-000000000002'
+       AND debit = 0 AND credit = 125.50
+       AND debit_amount = 0 AND credit_amount = 125.50)
+    );
+  IF v_count <> 2 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_153_FAIL: legacy backfill values are incorrect; matched=%', v_count;
+  END IF;
+
+  -- Migration 153 must not map account identity.
+  SELECT count(*) INTO v_count
+  FROM public.gl_entry_lines
+  WHERE id IN (
+    '53b00000-0000-0000-0000-000000000001',
+    '53b00000-0000-0000-0000-000000000002'
+  )
+    AND account_id IS NULL
+    AND account_code IN ('1120','4001');
+  IF v_count <> 2 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_153_FAIL: migration changed historical account identity';
+  END IF;
+
+  -- Existing modern rows are non-targets and remain untouched, including zeroed
+  -- legacy compatibility columns. The trigger applies only to future writes.
+  SELECT count(*) INTO v_count
+  FROM public.gl_entry_lines
+  WHERE id IN (
+    '53b00000-0000-0000-0000-000000000003',
+    '53b00000-0000-0000-0000-000000000004'
+  )
+    AND account_code IS NULL
+    AND debit_amount = 0 AND credit_amount = 0
+    AND (
+      (id = '53b00000-0000-0000-0000-000000000003' AND debit = 55.25 AND credit = 0)
+      OR
+      (id = '53b00000-0000-0000-0000-000000000004' AND debit = 0 AND credit = 55.25)
+    );
+  IF v_count <> 2 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_153_FAIL: modern non-target rows changed';
+  END IF;
+
+  -- Existing header-only quality finding is reported but never reconstructed.
+  SELECT count(*) INTO v_count
+  FROM public.gl_entries e
+  WHERE e.id = '53e00000-0000-0000-0000-000000000003'
+    AND e.total_debit = 25 AND e.total_credit = 25
+    AND NOT EXISTS (SELECT 1 FROM public.gl_entry_lines l WHERE l.entry_id = e.id);
+  IF v_count <> 1 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_153_FAIL: header-only quality finding was mutated';
+  END IF;
+
+  SELECT numeric_precision, numeric_scale
+  INTO v_precision, v_scale
+  FROM information_schema.columns
+  WHERE table_schema='public' AND table_name='gl_entries' AND column_name='total_debit';
+  IF v_precision <> 18 OR v_scale <> 2 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_153_FAIL: total_debit precision is %,% not 18,2', v_precision, v_scale;
+  END IF;
+
+  SELECT numeric_precision, numeric_scale
+  INTO v_precision, v_scale
+  FROM information_schema.columns
+  WHERE table_schema='public' AND table_name='gl_entries' AND column_name='total_credit';
+  IF v_precision <> 18 OR v_scale <> 2 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_153_FAIL: total_credit precision is %,% not 18,2', v_precision, v_scale;
+  END IF;
+
+  SELECT t.tgenabled INTO v_state
+  FROM pg_trigger t
+  WHERE t.tgrelid='public.gl_entry_lines'::regclass
+    AND t.tgname='trg_protect_posted_gl_entry_lines'
+    AND NOT t.tgisinternal;
+  IF v_state <> 'O' THEN
+    RAISE EXCEPTION 'ACCEPTANCE_153_FAIL: posted trigger state is %', v_state;
+  END IF;
+
+  SELECT count(*) INTO v_count
+  FROM pg_constraint
+  WHERE conrelid='public.gl_entry_lines'::regclass
+    AND conname IN (
+      'gl_entry_lines_legal_debit_nonnegative',
+      'gl_entry_lines_legal_credit_nonnegative',
+      'gl_entry_lines_legal_one_sided'
+    );
+  IF v_count <> 3 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_153_FAIL: expected three legal amount constraints, found %', v_count;
+  END IF;
+
+  IF has_function_privilege('anon', 'public.wardah_sync_gl_line_legal_to_legacy()', 'EXECUTE')
+     OR has_function_privilege('authenticated', 'public.wardah_sync_gl_line_legal_to_legacy()', 'EXECUTE')
+     OR has_function_privilege('service_role', 'public.wardah_sync_gl_line_legal_to_legacy()', 'EXECUTE') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_153_FAIL: internal compatibility trigger function is executable by a client role';
+  END IF;
+END $$;
+
+-- Future legal writes mirror one-way into the transitional legacy read columns.
+INSERT INTO public.gl_entries
+  (id, org_id, entry_number, entry_date, entry_type, description,
+   status, total_debit, total_credit)
+VALUES
+  ('53e00000-0000-0000-0000-000000000010', '53111111-1111-1111-1111-111111111111',
+   'F153-NEW-LEGAL', '2026-07-30', 'manual', 'Post-153 legal write',
+   'draft', 77.75, 77.75);
+
+INSERT INTO public.gl_entry_lines
+  (id, org_id, entry_id, line_number, account_id, debit, credit,
+   currency_code, description)
+VALUES
+  ('53b00000-0000-0000-0000-000000000010', '53111111-1111-1111-1111-111111111111',
+   '53e00000-0000-0000-0000-000000000010', 1,
+   '53a00000-0000-0000-0000-000000000001', 77.75, 0, 'SAR', 'New debit'),
+  ('53b00000-0000-0000-0000-000000000011', '53111111-1111-1111-1111-111111111111',
+   '53e00000-0000-0000-0000-000000000010', 2,
+   '53a00000-0000-0000-0000-000000000002', 0, 77.75, 'SAR', 'New credit');
+
+DO $$
+DECLARE v_count bigint;
+BEGIN
+  SELECT count(*) INTO v_count
+  FROM public.gl_entry_lines
+  WHERE id IN (
+    '53b00000-0000-0000-0000-000000000010',
+    '53b00000-0000-0000-0000-000000000011'
+  )
+    AND tenant_id = org_id
+    AND account_code IN ('110100','410100')
+    AND account_name IS NOT NULL
+    AND account_name_ar IS NOT NULL
+    AND debit_amount = debit
+    AND credit_amount = credit;
+  IF v_count <> 2 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_153_FAIL: legal-to-legacy mirror matched % rows', v_count;
+  END IF;
+END $$;
+
+-- Posted immutability is active after the maintenance window.
+SELECT pg_temp.expect_error(
+  $$UPDATE public.gl_entry_lines SET description='forbidden'
+    WHERE id='53b00000-0000-0000-0000-000000000001'$$,
+  'POSTED_ENTRY_IMMUTABLE'
+);
+
+-- New legacy-only, conflicting and cross-org writes fail visibly.
+SELECT pg_temp.expect_error(
+  $$INSERT INTO public.gl_entry_lines
+      (org_id, entry_id, line_number, account_code, debit_amount, credit_amount, debit, credit)
+    VALUES
+      ('53111111-1111-1111-1111-111111111111',
+       '53e00000-0000-0000-0000-000000000010', 3, '1120', 1, 0, 0, 0)$$,
+  'GL_LEGAL_ACCOUNT_REQUIRED'
+);
+
+SELECT pg_temp.expect_error(
+  $$INSERT INTO public.gl_entry_lines
+      (org_id, entry_id, line_number, account_id, debit, credit, debit_amount, credit_amount)
+    VALUES
+      ('53111111-1111-1111-1111-111111111111',
+       '53e00000-0000-0000-0000-000000000010', 3,
+       '53a00000-0000-0000-0000-000000000001', 10, 0, 9, 0)$$,
+  'GL_LEGACY_AMOUNT_WRITE_REJECTED'
+);
+
+SELECT pg_temp.expect_error(
+  $$INSERT INTO public.gl_entry_lines
+      (org_id, entry_id, line_number, account_id, debit, credit)
+    VALUES
+      ('53111111-1111-1111-1111-111111111111',
+       '53e00000-0000-0000-0000-000000000010', 3,
+       '53a00000-0000-0000-0000-000000000003', 1, 0)$$,
+  'GL_ACCOUNT_NOT_FOUND_OR_CROSS_ORG'
+);
+
+-- Prove the database constraints themselves, independently of the BEFORE trigger.
+ALTER TABLE public.gl_entry_lines DISABLE TRIGGER trg_wardah_gl_line_legal_compat;
+
+SELECT pg_temp.expect_error(
+  $$INSERT INTO public.gl_entry_lines
+      (org_id, entry_id, line_number, account_id, debit, credit,
+       debit_amount, credit_amount)
+    VALUES
+      ('53111111-1111-1111-1111-111111111111',
+       '53e00000-0000-0000-0000-000000000010', 3,
+       '53a00000-0000-0000-0000-000000000001', -1, 0, 0, 0)$$,
+  'gl_entry_lines_legal_debit_nonnegative'
+);
+
+SELECT pg_temp.expect_error(
+  $$INSERT INTO public.gl_entry_lines
+      (org_id, entry_id, line_number, account_id, debit, credit,
+       debit_amount, credit_amount)
+    VALUES
+      ('53111111-1111-1111-1111-111111111111',
+       '53e00000-0000-0000-0000-000000000010', 3,
+       '53a00000-0000-0000-0000-000000000001', 1, 1, 0, 0)$$,
+  'gl_entry_lines_legal_one_sided'
+);
+
+SELECT pg_temp.expect_error(
+  $$INSERT INTO public.gl_entry_lines
+      (org_id, entry_id, line_number, account_id, debit, credit,
+       debit_amount, credit_amount)
+    VALUES
+      ('53111111-1111-1111-1111-111111111111',
+       '53e00000-0000-0000-0000-000000000010', 3,
+       '53a00000-0000-0000-0000-000000000001', 0, 0, 0, 0)$$,
+  'gl_entry_lines_legal_one_sided'
+);
+
+ALTER TABLE public.gl_entry_lines ENABLE TRIGGER trg_wardah_gl_line_legal_compat;
+
+DO $$
+DECLARE v_state "char";
+BEGIN
+  SELECT t.tgenabled INTO v_state
+  FROM pg_trigger t
+  WHERE t.tgrelid='public.gl_entry_lines'::regclass
+    AND t.tgname='trg_wardah_gl_line_legal_compat'
+    AND NOT t.tgisinternal;
+  IF v_state <> 'O' THEN
+    RAISE EXCEPTION 'ACCEPTANCE_153_FAIL: compatibility trigger was not restored';
+  END IF;
+END $$;
+
+SELECT 'ACCEPTANCE_153_FINANCIAL_GL_CONTRACT_PASS' AS result;

--- a/scripts/ci/fresh-db/acceptance_153_financial_gl_contract.sql
+++ b/scripts/ci/fresh-db/acceptance_153_financial_gl_contract.sql
@@ -177,13 +177,25 @@ SELECT pg_temp.expect_error(
   'POSTED_ENTRY_IMMUTABLE'
 );
 
--- New legacy-only, conflicting and cross-org writes fail visibly.
+-- New legacy-only, missing-account, conflicting and cross-org writes fail visibly.
+-- A legacy-only caller supplies no legal economic amount, so it is rejected at
+-- the legal-value gate before account resolution.
 SELECT pg_temp.expect_error(
   $$INSERT INTO public.gl_entry_lines
       (org_id, entry_id, line_number, account_code, debit_amount, credit_amount, debit, credit)
     VALUES
       ('53111111-1111-1111-1111-111111111111',
        '53e00000-0000-0000-0000-000000000010', 3, '1120', 1, 0, 0, 0)$$,
+  'GL_ZERO_LEGAL_LINE'
+);
+
+-- A legal amount without legal account identity reaches the distinct account gate.
+SELECT pg_temp.expect_error(
+  $$INSERT INTO public.gl_entry_lines
+      (org_id, entry_id, line_number, debit, credit)
+    VALUES
+      ('53111111-1111-1111-1111-111111111111',
+       '53e00000-0000-0000-0000-000000000010', 3, 1, 0)$$,
   'GL_LEGAL_ACCOUNT_REQUIRED'
 );
 

--- a/scripts/ci/fresh-db/run_financial_gl_153_gate.sh
+++ b/scripts/ci/fresh-db/run_financial_gl_153_gate.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+MAIN_DB=${PGDATABASE:-wardah_fin153}
+REJECT_DB=${REJECT_DB:-wardah_fin153_reject}
+BASELINE_DIR=${BASELINE_DIR:-sql/baseline}
+
+pair=$(bash scripts/ci/fresh-db/resolve_baseline_pair.sh "$BASELINE_DIR")
+pair_field() { printf '%s\n' "$pair" | sed -n "s/^$1=//p"; }
+BASELINE=$(pair_field BASELINE_PATH)
+REFERENCE=$(pair_field REFERENCE_PATH)
+CUTOFF=$(pair_field BASELINE_CUTOFF)
+CUTOFF=${CUTOFF:-0}
+
+if [[ -z "$BASELINE" || -z "$REFERENCE" ]]; then
+  echo 'FINANCIAL_GL_153_GATE_FAIL: baseline pair could not be resolved' >&2
+  exit 1
+fi
+if [[ "$CUTOFF" != 152 ]]; then
+  echo "FINANCIAL_GL_153_GATE_FAIL: expected cutoff 152, got $CUTOFF" >&2
+  exit 1
+fi
+
+echo "Financial GL 153 gate: baseline=$BASELINE reference=$REFERENCE cutoff=$CUTOFF"
+
+setup_pre153_db() {
+  local db=$1
+  dropdb --if-exists "$db"
+  createdb "$db"
+  psql -v ON_ERROR_STOP=1 -X -d "$db" -f scripts/ci/fresh-db/supabase_shim.sql -q
+  psql -v ON_ERROR_STOP=1 -X -d "$db" -f "$BASELINE" -q
+  psql -v ON_ERROR_STOP=1 -X -d "$db" -f "$REFERENCE" -q
+  psql -v ON_ERROR_STOP=1 -X -d "$db" \
+    -f scripts/ci/fresh-db/setup_153_pre_migration_fixture.sql -q
+}
+
+# ----------------------------------------------------------------------
+# Positive path: a real two-session writer/migration race, then acceptance.
+# ----------------------------------------------------------------------
+setup_pre153_db "$MAIN_DB"
+PGDATABASE="$MAIN_DB" bash scripts/ci/fresh-db/acceptance_153_concurrency.sh
+psql -v ON_ERROR_STOP=1 -X -d "$MAIN_DB" \
+  -f scripts/ci/fresh-db/acceptance_153_financial_gl_contract.sql
+
+# ----------------------------------------------------------------------
+# Negative preflight: a mixed legal+legacy value must abort the transaction.
+# ----------------------------------------------------------------------
+setup_pre153_db "$REJECT_DB"
+psql -v ON_ERROR_STOP=1 -X -d "$REJECT_DB" <<'SQL'
+UPDATE public.gl_entry_lines
+SET debit_amount = debit
+WHERE id = '53b00000-0000-0000-0000-000000000003';
+SQL
+
+set +e
+psql -v ON_ERROR_STOP=1 -X -d "$REJECT_DB" \
+  -f sql/migrations/153_financial_gl_legal_amount_contract.sql \
+  >/tmp/f153-reject.out 2>/tmp/f153-reject.err
+reject_status=$?
+set -e
+
+if [[ $reject_status -eq 0 ]]; then
+  echo 'FINANCIAL_GL_153_GATE_FAIL: mixed-source migration unexpectedly succeeded' >&2
+  exit 1
+fi
+if ! grep -q 'GL_153_MIXED_AMOUNT_SOURCE' /tmp/f153-reject.err; then
+  echo 'FINANCIAL_GL_153_GATE_FAIL: reject path did not fail on GL_153_MIXED_AMOUNT_SOURCE' >&2
+  cat /tmp/f153-reject.err >&2 || true
+  exit 1
+fi
+
+read -r precision constraint_count compat_trigger posted_trigger <<<$({
+  psql -X -d "$REJECT_DB" -tA -F' ' -c "
+    SELECT
+      (SELECT numeric_precision FROM information_schema.columns
+       WHERE table_schema='public' AND table_name='gl_entries' AND column_name='total_debit'),
+      (SELECT count(*) FROM pg_constraint
+       WHERE conrelid='public.gl_entry_lines'::regclass
+         AND conname LIKE 'gl_entry_lines_legal_%'),
+      (SELECT count(*) FROM pg_trigger
+       WHERE tgrelid='public.gl_entry_lines'::regclass
+         AND tgname='trg_wardah_gl_line_legal_compat' AND NOT tgisinternal),
+      (SELECT tgenabled FROM pg_trigger
+       WHERE tgrelid='public.gl_entry_lines'::regclass
+         AND tgname='trg_protect_posted_gl_entry_lines' AND NOT tgisinternal)"
+})
+
+if [[ "$precision" != 12 || "$constraint_count" != 0 \
+   || "$compat_trigger" != 0 || "$posted_trigger" != O ]]; then
+  echo "FINANCIAL_GL_153_GATE_FAIL: reject rollback precision=$precision constraints=$constraint_count compat=$compat_trigger posted=$posted_trigger" >&2
+  exit 1
+fi
+
+echo 'FINANCIAL_GL_153_REJECT_PREFLIGHT_PASS'
+echo 'FINANCIAL_GL_153_FRESH_DB_GATE_PASS'

--- a/scripts/ci/fresh-db/run_financial_gl_153_gate.sh
+++ b/scripts/ci/fresh-db/run_financial_gl_153_gate.sh
@@ -25,9 +25,22 @@ echo "Financial GL 153 gate: baseline=$BASELINE reference=$REFERENCE cutoff=$CUT
 
 setup_pre153_db() {
   local db=$1
+  local shim=scripts/ci/fresh-db/supabase_shim.sql
+  local effective_shim=$shim
+
   dropdb --if-exists "$db"
   createdb "$db"
-  psql -v ON_ERROR_STOP=1 -X -d "$db" -f scripts/ci/fresh-db/supabase_shim.sql -q
+
+  # Supabase client roles are cluster-wide, while auth/storage schemas are
+  # database-local. The positive and reject paths use two databases in the same
+  # PostgreSQL service, so only the first setup may execute CREATE ROLE.
+  if psql -X -d postgres -tAc "SELECT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='anon')" | grep -qx t; then
+    effective_shim=/tmp/f153-supabase-shim-with-existing-roles.sql
+    sed '/^CREATE ROLE \(anon\|authenticated\|service_role\|supabase_admin\) NOLOGIN;$/d' \
+      "$shim" > "$effective_shim"
+  fi
+
+  psql -v ON_ERROR_STOP=1 -X -d "$db" -f "$effective_shim" -q
   psql -v ON_ERROR_STOP=1 -X -d "$db" -f "$BASELINE" -q
   psql -v ON_ERROR_STOP=1 -X -d "$db" -f "$REFERENCE" -q
   psql -v ON_ERROR_STOP=1 -X -d "$db" \

--- a/scripts/ci/fresh-db/setup_153_pre_migration_fixture.sql
+++ b/scripts/ci/fresh-db/setup_153_pre_migration_fixture.sql
@@ -1,0 +1,58 @@
+\set ON_ERROR_STOP on
+
+-- Pre-migration fixture deliberately contains both historical contracts:
+-- * one posted legacy entry whose amounts must be backfilled;
+-- * one draft modern entry that must remain byte-for-byte unchanged;
+-- * one posted header without lines, an existing quality finding that 153 reports
+--   but must not reconstruct or mutate.
+
+INSERT INTO public.organizations (id, code, name) VALUES
+  ('53111111-1111-1111-1111-111111111111', 'F153A', 'Finance 153 Org A'),
+  ('53222222-2222-2222-2222-222222222222', 'F153B', 'Finance 153 Org B');
+
+INSERT INTO public.gl_accounts
+  (id, org_id, code, name, name_en, name_ar, category, subtype, normal_balance,
+   allow_posting, is_active)
+VALUES
+  ('53a00000-0000-0000-0000-000000000001', '53111111-1111-1111-1111-111111111111',
+   '110100', 'Cash A', 'Cash A', 'نقدية أ', 'ASSET', 'CASH', 'DEBIT', true, true),
+  ('53a00000-0000-0000-0000-000000000002', '53111111-1111-1111-1111-111111111111',
+   '410100', 'Revenue A', 'Revenue A', 'إيراد أ', 'REVENUE', 'REVENUE', 'CREDIT', true, true),
+  ('53a00000-0000-0000-0000-000000000003', '53222222-2222-2222-2222-222222222222',
+   '110100', 'Cash B', 'Cash B', 'نقدية ب', 'ASSET', 'CASH', 'DEBIT', true, true),
+  ('53a00000-0000-0000-0000-000000000004', '53222222-2222-2222-2222-222222222222',
+   '410100', 'Revenue B', 'Revenue B', 'إيراد ب', 'REVENUE', 'REVENUE', 'CREDIT', true, true);
+
+INSERT INTO public.gl_entries
+  (id, org_id, entry_number, entry_date, entry_type, description,
+   status, total_debit, total_credit, posted_at)
+VALUES
+  ('53e00000-0000-0000-0000-000000000001', '53111111-1111-1111-1111-111111111111',
+   'F153-LEGACY-POSTED', '2026-07-30', 'manual', 'Legacy posted fixture',
+   'posted', 125.50, 125.50, now()),
+  ('53e00000-0000-0000-0000-000000000002', '53111111-1111-1111-1111-111111111111',
+   'F153-MODERN-DRAFT', '2026-07-30', 'manual', 'Modern draft fixture',
+   'draft', 55.25, 55.25, null),
+  ('53e00000-0000-0000-0000-000000000003', '53111111-1111-1111-1111-111111111111',
+   'F153-HEADER-ONLY', '2026-07-30', 'manual', 'Header-only quality finding',
+   'posted', 25.00, 25.00, now());
+
+INSERT INTO public.gl_entry_lines
+  (id, org_id, tenant_id, entry_id, line_number,
+   account_code, account_name, debit_amount, credit_amount,
+   account_id, debit, credit, currency_code, description)
+VALUES
+  ('53b00000-0000-0000-0000-000000000001', '53111111-1111-1111-1111-111111111111',
+   '53111111-1111-1111-1111-111111111111', '53e00000-0000-0000-0000-000000000001', 1,
+   '1120', 'Historical cash', 125.50, 0, null, 0, 0, 'SAR', 'Legacy debit'),
+  ('53b00000-0000-0000-0000-000000000002', '53111111-1111-1111-1111-111111111111',
+   '53111111-1111-1111-1111-111111111111', '53e00000-0000-0000-0000-000000000001', 2,
+   '4001', 'Historical revenue', 0, 125.50, null, 0, 0, 'SAR', 'Legacy credit'),
+  ('53b00000-0000-0000-0000-000000000003', '53111111-1111-1111-1111-111111111111',
+   '53111111-1111-1111-1111-111111111111', '53e00000-0000-0000-0000-000000000002', 1,
+   null, null, 0, 0, '53a00000-0000-0000-0000-000000000001', 55.25, 0, 'SAR', 'Modern debit'),
+  ('53b00000-0000-0000-0000-000000000004', '53111111-1111-1111-1111-111111111111',
+   '53111111-1111-1111-1111-111111111111', '53e00000-0000-0000-0000-000000000002', 2,
+   null, null, 0, 0, '53a00000-0000-0000-0000-000000000002', 0, 55.25, 'SAR', 'Modern credit');
+
+SELECT 'SETUP_153_PRE_MIGRATION_PASS' AS result;

--- a/sql/migrations/153_financial_gl_legal_amount_contract.sql
+++ b/sql/migrations/153_financial_gl_legal_amount_contract.sql
@@ -1,0 +1,561 @@
+-- =====================================================================
+-- 153_financial_gl_legal_amount_contract
+-- =====================================================================
+-- Mechanical amount migration only. This migration deliberately does NOT:
+--   * map historical account codes to gl_accounts;
+--   * make account_id mandatory for historical rows;
+--   * add the same-org account foreign key;
+--   * quarantine or exclude any historical row.
+-- Those decisions belong to Migration 154 after accounting approval.
+--
+-- Contract:
+--   1. lock parent then child before the snapshot/backfill;
+--   2. reject ambiguous/mixed line shapes;
+--   3. backfill legacy amounts into debit/credit without changing identity;
+--   4. restore posted-line immutability before commit;
+--   5. make legal amounts constrained and align header precision to numeric(18,2);
+--   6. mirror future legal writes to transitional legacy columns only.
+-- =====================================================================
+
+BEGIN;
+
+SET LOCAL lock_timeout = '30s';
+SET LOCAL statement_timeout = '10min';
+
+-- Match the normal write order used by rpc_create_journal_entry:
+-- gl_entries first, then gl_entry_lines. One statement prevents child-first
+-- acquisition and the deadlock pattern documented in WRD-FIN-REP-SRS-001 v1.3.
+LOCK TABLE public.gl_entries,
+           public.gl_entry_lines
+IN SHARE ROW EXCLUSIVE MODE;
+
+-- ---------------------------------------------------------------------
+-- 1. Fail-closed preflight under stable table locks
+-- ---------------------------------------------------------------------
+DO $preflight$
+DECLARE
+  v_count bigint;
+  v_header_only bigint;
+  v_unresolved_codes bigint;
+  v_trigger_enabled "char";
+BEGIN
+  IF to_regclass('public.gl_entries') IS NULL
+     OR to_regclass('public.gl_entry_lines') IS NULL
+     OR to_regclass('public.gl_accounts') IS NULL THEN
+    RAISE EXCEPTION 'GL_153_SCHEMA_MISSING: gl_entries, gl_entry_lines and gl_accounts are required';
+  END IF;
+
+  SELECT t.tgenabled
+  INTO v_trigger_enabled
+  FROM pg_trigger t
+  WHERE t.tgrelid = 'public.gl_entry_lines'::regclass
+    AND t.tgname = 'trg_protect_posted_gl_entry_lines'
+    AND NOT t.tgisinternal;
+
+  IF v_trigger_enabled IS NULL THEN
+    RAISE EXCEPTION 'GL_153_POSTED_TRIGGER_MISSING: trg_protect_posted_gl_entry_lines is required';
+  END IF;
+  IF v_trigger_enabled <> 'O' THEN
+    RAISE EXCEPTION 'GL_153_POSTED_TRIGGER_DISABLED: expected enabled state O, got %', v_trigger_enabled;
+  END IF;
+
+  SELECT count(*) INTO v_count
+  FROM public.gl_entry_lines l
+  WHERE l.debit IS NULL OR l.credit IS NULL
+     OR l.debit_amount IS NULL OR l.credit_amount IS NULL;
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'GL_153_NULL_AMOUNT: % lines contain NULL amount fields', v_count;
+  END IF;
+
+  SELECT count(*) INTO v_count
+  FROM public.gl_entries e
+  WHERE e.total_debit IS NULL OR e.total_credit IS NULL;
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'GL_153_NULL_HEADER_TOTAL: % headers contain NULL totals', v_count;
+  END IF;
+
+  SELECT count(*) INTO v_count
+  FROM public.gl_entry_lines l
+  WHERE l.debit < 0 OR l.credit < 0
+     OR l.debit_amount < 0 OR l.credit_amount < 0;
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'GL_153_NEGATIVE_AMOUNT: % lines contain negative amounts', v_count;
+  END IF;
+
+  SELECT count(*) INTO v_count
+  FROM public.gl_entry_lines l
+  WHERE (l.debit > 0 AND l.credit > 0)
+     OR (l.debit_amount > 0 AND l.credit_amount > 0);
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'GL_153_DOUBLE_SIDED_LINE: % lines contain debit and credit together', v_count;
+  END IF;
+
+  -- Any row carrying economic value in both contracts is ambiguous. Even equal
+  -- values are rejected here: the migration will never guess which side won.
+  SELECT count(*) INTO v_count
+  FROM public.gl_entry_lines l
+  WHERE (l.debit > 0 OR l.credit > 0)
+    AND (l.debit_amount > 0 OR l.credit_amount > 0);
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'GL_153_MIXED_AMOUNT_SOURCE: % lines carry legal and legacy value together', v_count;
+  END IF;
+
+  SELECT count(*) INTO v_count
+  FROM public.gl_entry_lines l
+  WHERE (l.account_id IS NOT NULL AND l.account_code IS NOT NULL)
+     OR (l.account_id IS NULL AND l.account_code IS NULL);
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'GL_153_AMBIGUOUS_IDENTITY: % lines have mixed or missing account identity', v_count;
+  END IF;
+
+  -- The only accepted pre-153 shapes are:
+  -- modern-only: account_id + legal one-sided amount + zero legacy amount;
+  -- legacy-only: account_code + legacy one-sided amount + zero legal amount.
+  SELECT count(*) INTO v_count
+  FROM public.gl_entry_lines l
+  WHERE NOT (
+    (
+      l.account_id IS NOT NULL
+      AND l.account_code IS NULL
+      AND ((l.debit > 0 AND l.credit = 0) OR (l.credit > 0 AND l.debit = 0))
+      AND l.debit_amount = 0 AND l.credit_amount = 0
+    )
+    OR
+    (
+      l.account_id IS NULL
+      AND l.account_code IS NOT NULL
+      AND l.debit = 0 AND l.credit = 0
+      AND ((l.debit_amount > 0 AND l.credit_amount = 0)
+        OR (l.credit_amount > 0 AND l.debit_amount = 0))
+    )
+  );
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'GL_153_AMBIGUOUS_LINE_SHAPE: % lines do not match modern-only or legacy-only', v_count;
+  END IF;
+
+  SELECT count(*) INTO v_count
+  FROM public.gl_entry_lines l
+  JOIN public.gl_entries e ON e.id = l.entry_id
+  WHERE e.org_id IS DISTINCT FROM l.org_id;
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'GL_153_CROSS_ORG_ENTRY_LINE: % lines disagree with their header organization', v_count;
+  END IF;
+
+  SELECT count(*) INTO v_count
+  FROM public.gl_entry_lines l
+  LEFT JOIN public.gl_accounts a
+    ON a.id = l.account_id AND a.org_id = l.org_id
+  WHERE l.account_id IS NOT NULL AND a.id IS NULL;
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'GL_153_INVALID_MODERN_ACCOUNT: % modern lines reference a missing/cross-org gl_account', v_count;
+  END IF;
+
+  -- Headers that have lines must match the effective pre-migration line values.
+  -- Header-only posted entries are an existing quality finding and are reported,
+  -- not silently reconstructed in this mechanical line migration.
+  WITH per_entry AS (
+    SELECT e.id, e.total_debit, e.total_credit,
+           count(l.id) AS line_count,
+           coalesce(sum(CASE WHEN l.debit > 0 OR l.credit > 0
+                             THEN l.debit ELSE l.debit_amount END), 0) AS effective_debit,
+           coalesce(sum(CASE WHEN l.debit > 0 OR l.credit > 0
+                             THEN l.credit ELSE l.credit_amount END), 0) AS effective_credit
+    FROM public.gl_entries e
+    LEFT JOIN public.gl_entry_lines l ON l.entry_id = e.id
+    GROUP BY e.id, e.total_debit, e.total_credit
+  )
+  SELECT count(*) INTO v_count
+  FROM per_entry p
+  WHERE p.line_count > 0
+    AND (
+      round(p.total_debit, 2) IS DISTINCT FROM round(p.effective_debit, 2)
+      OR round(p.total_credit, 2) IS DISTINCT FROM round(p.effective_credit, 2)
+      OR round(p.effective_debit, 2) IS DISTINCT FROM round(p.effective_credit, 2)
+    );
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'GL_153_HEADER_LINE_MISMATCH: % entries with lines are not balanced/matched', v_count;
+  END IF;
+
+  SELECT count(*) INTO v_header_only
+  FROM public.gl_entries e
+  WHERE e.status = 'posted'
+    AND NOT EXISTS (SELECT 1 FROM public.gl_entry_lines l WHERE l.entry_id = e.id);
+
+  SELECT count(DISTINCT (l.org_id, l.account_code)) INTO v_unresolved_codes
+  FROM public.gl_entry_lines l
+  JOIN public.gl_entries e ON e.id = l.entry_id
+  WHERE e.status = 'posted'
+    AND l.account_id IS NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM public.gl_accounts a
+      WHERE a.org_id = l.org_id AND a.code = l.account_code
+    );
+
+  RAISE NOTICE 'GL_153_PREFLIGHT: posted_headers_without_lines=% unresolved_posted_codes=%',
+    v_header_only, v_unresolved_codes;
+END
+$preflight$;
+
+-- ---------------------------------------------------------------------
+-- 2. Immutable in-transaction snapshots and target IDs
+-- ---------------------------------------------------------------------
+CREATE TEMP TABLE wardah_153_line_snapshot ON COMMIT DROP AS
+SELECT l.id, l.org_id, l.entry_id, e.status,
+       l.account_id, l.account_code, l.account_name, l.account_name_ar,
+       l.debit, l.credit, l.debit_amount, l.credit_amount,
+       CASE WHEN l.debit > 0 OR l.credit > 0 THEN l.debit ELSE l.debit_amount END AS economic_debit,
+       CASE WHEN l.debit > 0 OR l.credit > 0 THEN l.credit ELSE l.credit_amount END AS economic_credit,
+       (l.account_id IS NULL AND l.account_code IS NOT NULL
+        AND l.debit = 0 AND l.credit = 0
+        AND (l.debit_amount > 0 OR l.credit_amount > 0)) AS is_backfill_target
+FROM public.gl_entry_lines l
+JOIN public.gl_entries e ON e.id = l.entry_id;
+
+CREATE UNIQUE INDEX wardah_153_line_snapshot_pk ON wardah_153_line_snapshot(id);
+
+CREATE TEMP TABLE wardah_153_status_snapshot ON COMMIT DROP AS
+SELECT status,
+       count(*) AS line_count,
+       sum(economic_debit) AS economic_debit,
+       sum(economic_credit) AS economic_credit
+FROM wardah_153_line_snapshot
+GROUP BY status;
+
+CREATE TEMP TABLE wardah_153_targets ON COMMIT DROP AS
+SELECT id, debit_amount AS target_debit, credit_amount AS target_credit
+FROM wardah_153_line_snapshot
+WHERE is_backfill_target;
+
+CREATE UNIQUE INDEX wardah_153_targets_pk ON wardah_153_targets(id);
+
+-- ---------------------------------------------------------------------
+-- 3. Align the legal header range with debit/credit numeric(18,2)
+-- ---------------------------------------------------------------------
+ALTER TABLE public.gl_entries
+  ALTER COLUMN total_debit TYPE numeric(18,2) USING total_debit::numeric(18,2),
+  ALTER COLUMN total_credit TYPE numeric(18,2) USING total_credit::numeric(18,2),
+  ALTER COLUMN total_debit SET DEFAULT 0,
+  ALTER COLUMN total_credit SET DEFAULT 0,
+  ALTER COLUMN total_debit SET NOT NULL,
+  ALTER COLUMN total_credit SET NOT NULL;
+
+-- Transitional legacy columns remain numeric(12,2) because live legacy views
+-- depend on their exact output types. The legal contract and header totals are
+-- numeric(18,2); the compatibility trigger below fails visibly if a value is
+-- outside the temporary legacy representable range.
+ALTER TABLE public.gl_entry_lines
+  ALTER COLUMN debit SET DEFAULT 0,
+  ALTER COLUMN credit SET DEFAULT 0,
+  ALTER COLUMN debit_amount SET DEFAULT 0,
+  ALTER COLUMN credit_amount SET DEFAULT 0,
+  ALTER COLUMN debit SET NOT NULL,
+  ALTER COLUMN credit SET NOT NULL,
+  ALTER COLUMN debit_amount SET NOT NULL,
+  ALTER COLUMN credit_amount SET NOT NULL;
+
+-- ---------------------------------------------------------------------
+-- 4. Narrow maintenance window for posted legacy rows
+-- ---------------------------------------------------------------------
+ALTER TABLE public.gl_entry_lines
+  DISABLE TRIGGER trg_protect_posted_gl_entry_lines;
+
+CREATE TEMP TABLE wardah_153_updated_ids ON COMMIT DROP AS
+WITH updated AS (
+  UPDATE public.gl_entry_lines l
+  SET debit = t.target_debit,
+      credit = t.target_credit
+  FROM wardah_153_targets t
+  WHERE l.id = t.id
+  RETURNING l.id, l.debit, l.credit
+)
+SELECT * FROM updated;
+
+ALTER TABLE public.gl_entry_lines
+  ENABLE TRIGGER trg_protect_posted_gl_entry_lines;
+
+-- ---------------------------------------------------------------------
+-- 5. Exact UPDATE ... RETURNING and preservation checks
+-- ---------------------------------------------------------------------
+DO $verify$
+DECLARE
+  v_expected bigint;
+  v_updated bigint;
+  v_count bigint;
+  v_trigger_enabled "char";
+BEGIN
+  SELECT count(*) INTO v_expected FROM wardah_153_targets;
+  SELECT count(*) INTO v_updated FROM wardah_153_updated_ids;
+  IF v_updated <> v_expected THEN
+    RAISE EXCEPTION 'GL_153_UPDATE_COUNT_MISMATCH: expected %, updated %', v_expected, v_updated;
+  END IF;
+
+  IF EXISTS (
+    SELECT id FROM wardah_153_targets
+    EXCEPT
+    SELECT id FROM wardah_153_updated_ids
+  ) OR EXISTS (
+    SELECT id FROM wardah_153_updated_ids
+    EXCEPT
+    SELECT id FROM wardah_153_targets
+  ) THEN
+    RAISE EXCEPTION 'GL_153_UPDATE_ID_MISMATCH: UPDATE RETURNING IDs differ from the locked target snapshot';
+  END IF;
+
+  SELECT count(*) INTO v_count
+  FROM wardah_153_updated_ids u
+  JOIN wardah_153_targets t USING (id)
+  WHERE u.debit IS DISTINCT FROM t.target_debit
+     OR u.credit IS DISTINCT FROM t.target_credit;
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'GL_153_UPDATE_VALUE_MISMATCH: % updated rows differ from target values', v_count;
+  END IF;
+
+  -- Every non-target row must remain byte-for-byte equal for identity and amounts.
+  SELECT count(*) INTO v_count
+  FROM wardah_153_line_snapshot s
+  JOIN public.gl_entry_lines l ON l.id = s.id
+  WHERE NOT s.is_backfill_target
+    AND (
+      l.account_id IS DISTINCT FROM s.account_id
+      OR l.account_code IS DISTINCT FROM s.account_code
+      OR l.account_name IS DISTINCT FROM s.account_name
+      OR l.account_name_ar IS DISTINCT FROM s.account_name_ar
+      OR l.debit IS DISTINCT FROM s.debit
+      OR l.credit IS DISTINCT FROM s.credit
+      OR l.debit_amount IS DISTINCT FROM s.debit_amount
+      OR l.credit_amount IS DISTINCT FROM s.credit_amount
+    );
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'GL_153_NON_TARGET_CHANGED: % non-target rows changed', v_count;
+  END IF;
+
+  SELECT count(*) INTO v_count
+  FROM wardah_153_targets t
+  JOIN public.gl_entry_lines l ON l.id = t.id
+  WHERE l.debit IS DISTINCT FROM t.target_debit
+     OR l.credit IS DISTINCT FROM t.target_credit
+     OR (l.debit = 0 AND l.credit = 0);
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'GL_153_BACKFILL_INCOMPLETE: % target rows remain incorrect', v_count;
+  END IF;
+
+  -- After the backfill, legal sums must equal the preflight economic sums for
+  -- every status; this catches loss, duplication and accidental draft changes.
+  WITH after_sums AS (
+    SELECT e.status, count(*) AS line_count,
+           sum(l.debit) AS legal_debit,
+           sum(l.credit) AS legal_credit
+    FROM public.gl_entry_lines l
+    JOIN public.gl_entries e ON e.id = l.entry_id
+    GROUP BY e.status
+  )
+  SELECT count(*) INTO v_count
+  FROM wardah_153_status_snapshot s
+  FULL JOIN after_sums a USING (status)
+  WHERE a.status IS NULL OR s.status IS NULL
+     OR a.line_count IS DISTINCT FROM s.line_count
+     OR a.legal_debit IS DISTINCT FROM s.economic_debit
+     OR a.legal_credit IS DISTINCT FROM s.economic_credit;
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'GL_153_ECONOMIC_TOTAL_DRIFT: % status groups differ after backfill', v_count;
+  END IF;
+
+  WITH per_entry AS (
+    SELECT e.id, e.total_debit, e.total_credit, count(l.id) AS line_count,
+           coalesce(sum(l.debit),0) AS line_debit,
+           coalesce(sum(l.credit),0) AS line_credit
+    FROM public.gl_entries e
+    LEFT JOIN public.gl_entry_lines l ON l.entry_id = e.id
+    GROUP BY e.id, e.total_debit, e.total_credit
+  )
+  SELECT count(*) INTO v_count
+  FROM per_entry p
+  WHERE p.line_count > 0
+    AND (
+      round(p.total_debit,2) IS DISTINCT FROM round(p.line_debit,2)
+      OR round(p.total_credit,2) IS DISTINCT FROM round(p.line_credit,2)
+      OR round(p.line_debit,2) IS DISTINCT FROM round(p.line_credit,2)
+    );
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'GL_153_POST_BACKFILL_BALANCE_FAIL: % entries with lines do not reconcile', v_count;
+  END IF;
+
+  SELECT t.tgenabled INTO v_trigger_enabled
+  FROM pg_trigger t
+  WHERE t.tgrelid = 'public.gl_entry_lines'::regclass
+    AND t.tgname = 'trg_protect_posted_gl_entry_lines'
+    AND NOT t.tgisinternal;
+  IF v_trigger_enabled <> 'O' THEN
+    RAISE EXCEPTION 'GL_153_POSTED_TRIGGER_NOT_RESTORED: state=%', v_trigger_enabled;
+  END IF;
+END
+$verify$;
+
+-- ---------------------------------------------------------------------
+-- 6. Legal amount constraints
+-- ---------------------------------------------------------------------
+ALTER TABLE public.gl_entry_lines
+  ADD CONSTRAINT gl_entry_lines_legal_debit_nonnegative CHECK (debit >= 0),
+  ADD CONSTRAINT gl_entry_lines_legal_credit_nonnegative CHECK (credit >= 0),
+  ADD CONSTRAINT gl_entry_lines_legal_one_sided CHECK (
+    (debit > 0 AND credit = 0) OR (credit > 0 AND debit = 0)
+  );
+
+COMMENT ON CONSTRAINT gl_entry_lines_legal_one_sided ON public.gl_entry_lines IS
+  'Migration 153 legal amount contract: exactly one of debit/credit is positive.';
+
+-- ---------------------------------------------------------------------
+-- 7. Legal -> legacy compatibility for future writes only
+-- ---------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.wardah_sync_gl_line_legal_to_legacy()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_code text;
+  v_name text;
+  v_name_en text;
+  v_name_ar text;
+  v_legacy_max constant numeric := 9999999999.99;
+BEGIN
+  IF NEW.org_id IS NULL OR NEW.entry_id IS NULL THEN
+    RAISE EXCEPTION 'GL_LEGAL_SCOPE_REQUIRED: org_id and entry_id are required';
+  END IF;
+
+  IF NEW.tenant_id IS NOT NULL AND NEW.tenant_id <> NEW.org_id THEN
+    RAISE EXCEPTION 'GL_CROSS_ORG_TENANT_ALIAS: tenant_id must equal org_id';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.gl_entries e
+    WHERE e.id = NEW.entry_id AND e.org_id = NEW.org_id
+  ) THEN
+    RAISE EXCEPTION 'GL_CROSS_ORG_ENTRY: entry_id does not belong to org_id';
+  END IF;
+
+  NEW.debit := coalesce(NEW.debit, 0);
+  NEW.credit := coalesce(NEW.credit, 0);
+
+  IF NEW.debit < 0 OR NEW.credit < 0 THEN
+    RAISE EXCEPTION 'GL_NEGATIVE_LEGAL_AMOUNT: debit/credit cannot be negative';
+  END IF;
+  IF NEW.debit > 0 AND NEW.credit > 0 THEN
+    RAISE EXCEPTION 'GL_DOUBLE_SIDED_LEGAL_AMOUNT: debit and credit cannot both be positive';
+  END IF;
+  IF NEW.debit = 0 AND NEW.credit = 0 THEN
+    RAISE EXCEPTION 'GL_ZERO_LEGAL_LINE: a legal GL line must carry value';
+  END IF;
+
+  IF NEW.account_id IS NULL THEN
+    RAISE EXCEPTION 'GL_LEGAL_ACCOUNT_REQUIRED: new writes require account_id';
+  END IF;
+
+  SELECT a.code, a.name, a.name_en, a.name_ar
+  INTO v_code, v_name, v_name_en, v_name_ar
+  FROM public.gl_accounts a
+  WHERE a.id = NEW.account_id AND a.org_id = NEW.org_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'GL_ACCOUNT_NOT_FOUND_OR_CROSS_ORG: account_id is not a gl_account in org_id';
+  END IF;
+
+  IF NEW.account_code IS NOT NULL AND NEW.account_code <> v_code THEN
+    RAISE EXCEPTION 'GL_ACCOUNT_CODE_CONFLICT: supplied account_code does not match account_id';
+  END IF;
+
+  -- If a caller supplied legacy amounts, they may only duplicate the legal
+  -- values exactly. Legacy-only or conflicting writes are rejected visibly.
+  IF coalesce(NEW.debit_amount,0) <> 0 OR coalesce(NEW.credit_amount,0) <> 0 THEN
+    IF round(coalesce(NEW.debit_amount,0),2) IS DISTINCT FROM round(NEW.debit,2)
+       OR round(coalesce(NEW.credit_amount,0),2) IS DISTINCT FROM round(NEW.credit,2) THEN
+      RAISE EXCEPTION 'GL_LEGACY_AMOUNT_WRITE_REJECTED: debit/credit are the only legal input amounts';
+    END IF;
+  END IF;
+
+  IF NEW.debit > v_legacy_max OR NEW.credit > v_legacy_max THEN
+    RAISE EXCEPTION
+      'GL_LEGACY_COMPAT_RANGE_EXCEEDED: temporary numeric(12,2) legacy mirror cannot represent legal amount';
+  END IF;
+
+  NEW.account_code := v_code;
+  NEW.account_name := coalesce(v_name_en, v_name);
+  NEW.account_name_ar := coalesce(v_name_ar, v_name);
+  NEW.debit_amount := NEW.debit;
+  NEW.credit_amount := NEW.credit;
+  NEW.tenant_id := coalesce(NEW.tenant_id, NEW.org_id);
+
+  RETURN NEW;
+END
+$function$;
+
+REVOKE ALL ON FUNCTION public.wardah_sync_gl_line_legal_to_legacy() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.wardah_sync_gl_line_legal_to_legacy() FROM anon;
+REVOKE ALL ON FUNCTION public.wardah_sync_gl_line_legal_to_legacy() FROM authenticated;
+REVOKE ALL ON FUNCTION public.wardah_sync_gl_line_legal_to_legacy() FROM service_role;
+
+DROP TRIGGER IF EXISTS trg_wardah_gl_line_legal_compat ON public.gl_entry_lines;
+CREATE TRIGGER trg_wardah_gl_line_legal_compat
+BEFORE INSERT OR UPDATE ON public.gl_entry_lines
+FOR EACH ROW
+EXECUTE FUNCTION public.wardah_sync_gl_line_legal_to_legacy();
+
+COMMENT ON FUNCTION public.wardah_sync_gl_line_legal_to_legacy() IS
+  'Migration 153 transitional one-way compatibility: validates account/org and mirrors legal account_id+debit/credit into legacy read columns. No client EXECUTE grant.';
+
+-- ---------------------------------------------------------------------
+-- 8. Prove posted immutability is active again before commit
+-- ---------------------------------------------------------------------
+DO $guard_check$
+DECLARE
+  v_line_id uuid;
+  v_guarded boolean := false;
+  v_trigger_enabled "char";
+BEGIN
+  SELECT t.tgenabled INTO v_trigger_enabled
+  FROM pg_trigger t
+  WHERE t.tgrelid = 'public.gl_entry_lines'::regclass
+    AND t.tgname = 'trg_protect_posted_gl_entry_lines'
+    AND NOT t.tgisinternal;
+
+  IF v_trigger_enabled <> 'O' THEN
+    RAISE EXCEPTION 'GL_153_POSTED_TRIGGER_FINAL_STATE_INVALID: state=%', v_trigger_enabled;
+  END IF;
+
+  SELECT s.id INTO v_line_id
+  FROM wardah_153_line_snapshot s
+  WHERE s.status = 'posted'
+  ORDER BY s.id
+  LIMIT 1;
+
+  IF v_line_id IS NOT NULL THEN
+    BEGIN
+      UPDATE public.gl_entry_lines
+      SET description = description
+      WHERE id = v_line_id;
+    EXCEPTION WHEN OTHERS THEN
+      IF SQLERRM LIKE '%POSTED_ENTRY_IMMUTABLE%' THEN
+        v_guarded := true;
+      ELSE
+        RAISE;
+      END IF;
+    END;
+
+    IF NOT v_guarded THEN
+      RAISE EXCEPTION 'GL_153_POSTED_GUARD_INEFFECTIVE: posted line update unexpectedly succeeded';
+    END IF;
+  END IF;
+END
+$guard_check$;
+
+DO $done$
+DECLARE
+  v_targets bigint;
+BEGIN
+  SELECT count(*) INTO v_targets FROM wardah_153_targets;
+  RAISE NOTICE 'GL_153_APPLIED: backfilled_lines=%; legal totals/constraints/compatibility installed', v_targets;
+END
+$done$;
+
+COMMIT;

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -2178,8 +2178,8 @@ export type Database = {
           reference_number: string | null
           reference_type: string | null
           status: string | null
-          total_credit: number | null
-          total_debit: number | null
+          total_credit: number
+          total_debit: number
           updated_at: string | null
         }
         Insert: {
@@ -2200,8 +2200,8 @@ export type Database = {
           reference_number?: string | null
           reference_type?: string | null
           status?: string | null
-          total_credit?: number | null
-          total_debit?: number | null
+          total_credit?: number
+          total_debit?: number
           updated_at?: string | null
         }
         Update: {
@@ -2222,8 +2222,8 @@ export type Database = {
           reference_number?: string | null
           reference_type?: string | null
           status?: string | null
-          total_credit?: number | null
-          total_debit?: number | null
+          total_credit?: number
+          total_debit?: number
           updated_at?: string | null
         }
         Relationships: [
@@ -2243,11 +2243,11 @@ export type Database = {
           account_name: string | null
           account_name_ar: string | null
           created_at: string | null
-          credit: number | null
-          credit_amount: number | null
+          credit: number
+          credit_amount: number
           currency_code: string | null
-          debit: number | null
-          debit_amount: number | null
+          debit: number
+          debit_amount: number
           description: string | null
           description_ar: string | null
           entry_id: string
@@ -2263,11 +2263,11 @@ export type Database = {
           account_name?: string | null
           account_name_ar?: string | null
           created_at?: string | null
-          credit?: number | null
-          credit_amount?: number | null
+          credit?: number
+          credit_amount?: number
           currency_code?: string | null
-          debit?: number | null
-          debit_amount?: number | null
+          debit?: number
+          debit_amount?: number
           description?: string | null
           description_ar?: string | null
           entry_id: string
@@ -2283,11 +2283,11 @@ export type Database = {
           account_name?: string | null
           account_name_ar?: string | null
           created_at?: string | null
-          credit?: number | null
-          credit_amount?: number | null
+          credit?: number
+          credit_amount?: number
           currency_code?: string | null
-          debit?: number | null
-          debit_amount?: number | null
+          debit?: number
+          debit_amount?: number
           description?: string | null
           description_ar?: string | null
           entry_id?: string


### PR DESCRIPTION
## الهدف

تنفيذ **PR-A1-DB** من عقد محرك التقارير المالية v1.3: Migration 153 وحدها لتوحيد عقد مبالغ دفتر الأستاذ قانونيًا، بلا Mapping حسابات أو Quarantine أو FK.

## النطاق

- backfill ميكانيكي للأسطر legacy-only من `debit_amount/credit_amount` إلى `debit/credit`.
- parent-first locking في statement واحدة.
- preflight fail-closed يرفض NULL/negative/double-sided/mixed/ambiguous/cross-org shapes.
- snapshot ديناميكي للأعداد والمجاميع وIDs؛ لا أرقام Production مثبتة في شرط النجاح.
- نافذة صيانة ضيقة لتعطيل `trg_protect_posted_gl_entry_lines` بالاسم فقط وإعادته قبل commit.
- مطابقة `UPDATE ... RETURNING` للعدد والـIDs والقيم.
- توسيع `gl_entries.total_debit/total_credit` إلى `numeric(18,2)`.
- قيود قانونية على `debit/credit`.
- توافق انتقالي أحادي الاتجاه `legal → legacy` مع تحقق account/org ورفض legacy-only/conflicting writes.
- سحب EXECUTE عن trigger function الداخلية.

## الإثبات

- fixture قبل 153 يحمل posted legacy + draft modern + posted header-only quality finding.
- قبول وظيفي بعد التطبيق.
- اختبار جلستين: writer يحجز الرأس ثم يدخل السطور؛ Migration تنتظر parent-first بلا deadlock أو drift.
- اختبار سلبي مستقل: mixed-source row يسقط Migration ويثبت rollback الكامل.
- Workflow مخصص على PostgreSQL 17 مع pglast وDEFINER guard.

## خارج النطاق

- لا Account Mapping.
- لا تعبئة تاريخية لـ`account_id`.
- لا `account_id NOT NULL` أو same-org FK.
- لا Quarantine.
- لا تعديل لخدمات التقارير أو الواجهة.
- لا تطبيق على Production ضمن هذا الـPR.

## حاجز تطبيق Production

الفحص كشف أن `src/services/payment-vouchers-service.ts` ما زال يكتب `account_id + debit_amount/credit_amount` في قيود سندات القبض/الصرف. 153 ترفض هذا الاتجاه عمدًا.

لذلك:

1. يمكن دمج DB PR بعد نجاح البوابات والمراجعة.
2. **يُمنع تطبيق Migration 153 على Production** قبل إصلاح هذا الكاتب إلى `account_id + debit/credit`، نشره، وتجربة سند قبض وسند صرف فعليين.
3. التفاصيل وpre/post checks موثقة في `docs/db/FINANCIAL_GL_153_RUNBOOK.md`.

## حالة قاعدة البيانات

- Baseline/Repository/Production cutoff: 152 قبل هذه الجولة.
- Production لم تتغير.
- الاسم القانوني المحجوز: `153_financial_gl_legal_amount_contract`.