### PR TITLE
fix(finance): align receipt dates and payment accounts

### DIFF
--- a/sql/migrations/165_voucher_payment_account_method_consistency.sql
+++ b/sql/migrations/165_voucher_payment_account_method_consistency.sql
@@ -1,0 +1,118 @@
+-- =====================================================================
+-- 165_voucher_payment_account_method_consistency
+-- =====================================================================
+-- Prevent new or edited voucher drafts from pairing a payment method with an
+-- incompatible legal cash/bank account. Existing historical rows are not
+-- rewritten; the guard applies on future INSERT/UPDATE only.
+-- =====================================================================
+
+BEGIN;
+
+SET LOCAL lock_timeout = '30s';
+SET LOCAL statement_timeout = '5min';
+
+DO $preflight$
+BEGIN
+  IF to_regclass('public.customer_collections') IS NULL
+     OR to_regclass('public.supplier_payments') IS NULL
+     OR to_regclass('public.gl_accounts') IS NULL THEN
+    RAISE EXCEPTION 'VOUCHER_165_REQUIRED_TABLE_MISSING';
+  END IF;
+END
+$preflight$;
+
+CREATE OR REPLACE FUNCTION public.wardah_validate_voucher_payment_account()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_subtype text;
+  v_expected text[];
+BEGIN
+  IF NEW.org_id IS NULL OR NEW.payment_account_id IS NULL THEN
+    RAISE EXCEPTION 'VOUCHER_PAYMENT_ACCOUNT_REQUIRED';
+  END IF;
+
+  SELECT a.subtype
+  INTO v_subtype
+  FROM public.gl_accounts a
+  WHERE a.id = NEW.payment_account_id
+    AND a.org_id = NEW.org_id
+    AND coalesce(a.is_active, true)
+    AND coalesce(a.allow_posting, true);
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'VOUCHER_PAYMENT_ACCOUNT_INVALID_OR_CROSS_ORG';
+  END IF;
+
+  IF TG_TABLE_NAME = 'customer_collections' THEN
+    v_expected := CASE
+      WHEN NEW.payment_method IN ('cash', 'check') THEN ARRAY['CASH']::text[]
+      WHEN NEW.payment_method = 'other' THEN ARRAY['CASH', 'BANK']::text[]
+      ELSE ARRAY['BANK']::text[]
+    END;
+  ELSE
+    v_expected := CASE
+      WHEN NEW.payment_method = 'cash' THEN ARRAY['CASH']::text[]
+      WHEN NEW.payment_method = 'other' THEN ARRAY['CASH', 'BANK']::text[]
+      ELSE ARRAY['BANK']::text[]
+    END;
+  END IF;
+
+  IF NOT (v_subtype = ANY(v_expected)) THEN
+    RAISE EXCEPTION 'VOUCHER_PAYMENT_ACCOUNT_METHOD_MISMATCH: method=% account_subtype=% expected=%',
+      NEW.payment_method, v_subtype, array_to_string(v_expected, ',');
+  END IF;
+
+  RETURN NEW;
+END
+$function$;
+
+REVOKE ALL ON FUNCTION public.wardah_validate_voucher_payment_account() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.wardah_validate_voucher_payment_account() FROM anon;
+REVOKE ALL ON FUNCTION public.wardah_validate_voucher_payment_account() FROM authenticated;
+REVOKE ALL ON FUNCTION public.wardah_validate_voucher_payment_account() FROM service_role;
+
+DROP TRIGGER IF EXISTS trg_customer_collection_payment_account_consistency
+  ON public.customer_collections;
+CREATE TRIGGER trg_customer_collection_payment_account_consistency
+BEFORE INSERT OR UPDATE OF org_id, payment_method, payment_account_id
+ON public.customer_collections
+FOR EACH ROW
+EXECUTE FUNCTION public.wardah_validate_voucher_payment_account();
+
+DROP TRIGGER IF EXISTS trg_supplier_payment_account_consistency
+  ON public.supplier_payments;
+CREATE TRIGGER trg_supplier_payment_account_consistency
+BEFORE INSERT OR UPDATE OF org_id, payment_method, payment_account_id
+ON public.supplier_payments
+FOR EACH ROW
+EXECUTE FUNCTION public.wardah_validate_voucher_payment_account();
+
+DO $verify$
+DECLARE
+  v_count integer;
+BEGIN
+  SELECT count(*) INTO v_count
+  FROM pg_trigger t
+  WHERE t.tgname IN (
+      'trg_customer_collection_payment_account_consistency',
+      'trg_supplier_payment_account_consistency'
+    )
+    AND t.tgenabled = 'O'
+    AND NOT t.tgisinternal;
+
+  IF v_count <> 2 THEN
+    RAISE EXCEPTION 'VOUCHER_165_TRIGGER_VERIFY_FAILED: count=%', v_count;
+  END IF;
+
+  IF has_function_privilege('anon', 'public.wardah_validate_voucher_payment_account()', 'EXECUTE')
+     OR has_function_privilege('authenticated', 'public.wardah_validate_voucher_payment_account()', 'EXECUTE') THEN
+    RAISE EXCEPTION 'VOUCHER_165_TRIGGER_FUNCTION_EXECUTE_EXPOSED';
+  END IF;
+END
+$verify$;
+
+COMMIT;

--- a/src/features/sales/components/CustomerReceipts.tsx
+++ b/src/features/sales/components/CustomerReceipts.tsx
@@ -3,7 +3,7 @@
  * مكون سندات القبض للعملاء
  */
 
-import { useState, useEffect } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Badge } from '@/components/ui/badge'
@@ -27,16 +27,39 @@ import {
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { toast } from 'sonner'
-import { 
+import {
   getAllCustomerReceipts,
   createCustomerReceipt,
   postCustomerReceipt,
   getCustomerOutstandingInvoices,
   getPaymentAccounts,
   type CustomerReceipt,
-  type PaymentMethod
+  type PaymentMethod,
 } from '@/services/payment-vouchers-service'
 import { customersService } from '@/services/supabase-service'
+
+type ReceiptRow = CustomerReceipt & { collection_date?: string }
+type PaymentAccount = {
+  id: string
+  code?: string
+  name?: string
+  name_ar?: string
+  subtype?: string
+}
+
+function getReceiptDate(receipt: ReceiptRow): string | undefined {
+  return receipt.receipt_date || receipt.collection_date
+}
+
+function allowedAccountSubtypes(method: PaymentMethod): ReadonlySet<string> {
+  if (method === 'cash' || method === 'check') return new Set(['CASH'])
+  if (method === 'other') return new Set(['CASH', 'BANK'])
+  return new Set(['BANK'])
+}
+
+function accountMatchesMethod(account: PaymentAccount | undefined, method: PaymentMethod): boolean {
+  return Boolean(account?.subtype && allowedAccountSubtypes(method).has(account.subtype))
+}
 
 export function CustomerReceipts() {
   const [receipts, setReceipts] = useState<CustomerReceipt[]>([])
@@ -45,7 +68,7 @@ export function CustomerReceipts() {
   const [selectedReceipt, setSelectedReceipt] = useState<CustomerReceipt | null>(null)
 
   useEffect(() => {
-    loadReceipts()
+    void loadReceipts()
   }, [])
 
   const loadReceipts = async () => {
@@ -69,7 +92,7 @@ export function CustomerReceipts() {
       const result = await postCustomerReceipt(receiptId)
       if (result.success) {
         toast.success('تم إقرار السند بنجاح')
-        loadReceipts()
+        await loadReceipts()
       } else {
         toast.error(result.error || 'خطأ في إقرار السند')
       }
@@ -82,9 +105,9 @@ export function CustomerReceipts() {
     const statusMap: Record<string, { label: string; variant: 'default' | 'secondary' | 'destructive' | 'outline' }> = {
       draft: { label: 'مسودة', variant: 'outline' },
       posted: { label: 'مقرر', variant: 'default' },
-      cancelled: { label: 'ملغي', variant: 'destructive' }
+      cancelled: { label: 'ملغي', variant: 'destructive' },
     }
-    const statusInfo = statusMap[status] || { label: status, variant: 'outline' }
+    const statusInfo = statusMap[status] || { label: status, variant: 'outline' as const }
     return <Badge variant={statusInfo.variant}>{statusInfo.label}</Badge>
   }
 
@@ -97,7 +120,7 @@ export function CustomerReceipts() {
       debit_card: 'بطاقة خصم',
       online_payment: 'دفع إلكتروني',
       mobile_payment: 'دفع محمول',
-      other: 'أخرى'
+      other: 'أخرى',
     }
     return methods[method] || method
   }
@@ -118,63 +141,37 @@ export function CustomerReceipts() {
               <DialogTitle>سند قبض جديد</DialogTitle>
               <DialogDescription>إنشاء سند قبض جديد من عميل</DialogDescription>
             </DialogHeader>
-            <CreateReceiptForm 
+            <CreateReceiptForm
               onSuccess={() => {
                 setShowCreateDialog(false)
-                loadReceipts()
+                void loadReceipts()
               }}
             />
           </DialogContent>
         </Dialog>
       </div>
 
-      {/* Stats */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
         <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium">إجمالي السندات</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{receipts.length}</div>
-          </CardContent>
+          <CardHeader className="pb-2"><CardTitle className="text-sm font-medium">إجمالي السندات</CardTitle></CardHeader>
+          <CardContent><div className="text-2xl font-bold">{receipts.length}</div></CardContent>
         </Card>
         <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium">المسودات</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold text-yellow-600">
-              {receipts.filter(r => r.status === 'draft').length}
-            </div>
-          </CardContent>
+          <CardHeader className="pb-2"><CardTitle className="text-sm font-medium">المسودات</CardTitle></CardHeader>
+          <CardContent><div className="text-2xl font-bold text-yellow-600">{receipts.filter(r => r.status === 'draft').length}</div></CardContent>
         </Card>
         <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium">المقررة</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold text-green-600">
-              {receipts.filter(r => r.status === 'posted').length}
-            </div>
-          </CardContent>
+          <CardHeader className="pb-2"><CardTitle className="text-sm font-medium">المقررة</CardTitle></CardHeader>
+          <CardContent><div className="text-2xl font-bold text-green-600">{receipts.filter(r => r.status === 'posted').length}</div></CardContent>
         </Card>
         <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium">إجمالي المبلغ</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold text-blue-600">
-              {receipts.reduce((sum, r) => sum + (r.amount || 0), 0).toFixed(2)} ريال
-            </div>
-          </CardContent>
+          <CardHeader className="pb-2"><CardTitle className="text-sm font-medium">إجمالي المبلغ</CardTitle></CardHeader>
+          <CardContent><div className="text-2xl font-bold text-blue-600">{receipts.reduce((sum, r) => sum + (r.amount || 0), 0).toFixed(2)} ريال</div></CardContent>
         </Card>
       </div>
 
-      {/* Receipts Table */}
       <Card>
-        <CardHeader>
-          <CardTitle>قائمة سندات القبض</CardTitle>
-        </CardHeader>
+        <CardHeader><CardTitle>قائمة سندات القبض</CardTitle></CardHeader>
         <CardContent>
           {loading ? (
             <div className="text-center py-8">جاري التحميل...</div>
@@ -193,58 +190,38 @@ export function CustomerReceipts() {
               </TableHeader>
               <TableBody>
                 {receipts.length === 0 ? (
-                  <TableRow>
-                    <TableCell colSpan={7} className="text-center py-8 text-muted-foreground">
-                      لا توجد سندات قبض
-                    </TableCell>
-                  </TableRow>
-                ) : (
-                  receipts.map((receipt) => (
+                  <TableRow><TableCell colSpan={7} className="text-center py-8 text-muted-foreground">لا توجد سندات قبض</TableCell></TableRow>
+                ) : receipts.map(receipt => {
+                  const receiptDate = getReceiptDate(receipt as ReceiptRow)
+                  return (
                     <TableRow key={receipt.id}>
                       <TableCell className="font-medium">{receipt.receipt_number}</TableCell>
                       <TableCell>{receipt.customer?.name || 'غير محدد'}</TableCell>
-                      <TableCell>
-                        {receipt.receipt_date ? new Date(receipt.receipt_date).toLocaleDateString('en-US') : '-'}
-                      </TableCell>
+                      <TableCell>{receiptDate ? new Date(`${receiptDate}T00:00:00`).toLocaleDateString('en-US') : '-'}</TableCell>
                       <TableCell>{receipt.amount?.toFixed(2) || '0.00'} ريال</TableCell>
                       <TableCell>{getPaymentMethodLabel(receipt.payment_method)}</TableCell>
                       <TableCell>{getStatusBadge(receipt.status)}</TableCell>
                       <TableCell>
                         <div className="flex gap-2">
                           {receipt.status === 'draft' && (
-                            <Button
-                              size="sm"
-                              variant="outline"
-                              onClick={() => handlePost(receipt.id)}
-                            >
-                              إقرار
-                            </Button>
+                            <Button size="sm" variant="outline" onClick={() => receipt.id && handlePost(receipt.id)}>إقرار</Button>
                           )}
-                          <Button
-                            size="sm"
-                            variant="ghost"
-                            onClick={() => setSelectedReceipt(receipt)}
-                          >
-                            عرض
-                          </Button>
+                          <Button size="sm" variant="ghost" onClick={() => setSelectedReceipt(receipt)}>عرض</Button>
                         </div>
                       </TableCell>
                     </TableRow>
-                  ))
-                )}
+                  )
+                })}
               </TableBody>
             </Table>
           )}
         </CardContent>
       </Card>
 
-      {/* Receipt Details Dialog */}
       {selectedReceipt && (
-        <Dialog open={!!selectedReceipt} onOpenChange={() => setSelectedReceipt(null)}>
+        <Dialog open={Boolean(selectedReceipt)} onOpenChange={() => setSelectedReceipt(null)}>
           <DialogContent className="max-w-3xl">
-            <DialogHeader>
-              <DialogTitle>تفاصيل سند القبض</DialogTitle>
-            </DialogHeader>
+            <DialogHeader><DialogTitle>تفاصيل سند القبض</DialogTitle></DialogHeader>
             <ReceiptDetails receipt={selectedReceipt} />
           </DialogContent>
         </Dialog>
@@ -255,9 +232,9 @@ export function CustomerReceipts() {
 
 function CreateReceiptForm({ onSuccess }: Readonly<{ onSuccess: () => void }>) {
   const [customers, setCustomers] = useState<any[]>([])
-  const [selectedCustomer, setSelectedCustomer] = useState<string>('')
+  const [selectedCustomer, setSelectedCustomer] = useState('')
   const [outstandingInvoices, setOutstandingInvoices] = useState<any[]>([])
-  const [paymentAccounts, setPaymentAccounts] = useState<any[]>([])
+  const [paymentAccounts, setPaymentAccounts] = useState<PaymentAccount[]>([])
   const [formData, setFormData] = useState({
     customer_id: '',
     receipt_date: new Date().toISOString().split('T')[0],
@@ -268,20 +245,23 @@ function CreateReceiptForm({ onSuccess }: Readonly<{ onSuccess: () => void }>) {
     check_date: '',
     check_bank: '',
     reference_number: '',
-    notes: ''
+    notes: '',
   })
   const [selectedInvoices, setSelectedInvoices] = useState<Record<string, number>>({})
   const [loading, setLoading] = useState(false)
 
+  const compatiblePaymentAccounts = useMemo(
+    () => paymentAccounts.filter(account => accountMatchesMethod(account, formData.payment_method)),
+    [paymentAccounts, formData.payment_method],
+  )
+
   useEffect(() => {
-    loadCustomers()
-    loadPaymentAccounts()
+    void loadCustomers()
+    void loadPaymentAccounts()
   }, [])
 
   useEffect(() => {
-    if (selectedCustomer) {
-      loadOutstandingInvoices(selectedCustomer)
-    }
+    if (selectedCustomer) void loadOutstandingInvoices(selectedCustomer)
   }, [selectedCustomer])
 
   const loadCustomers = async () => {
@@ -298,9 +278,7 @@ function CreateReceiptForm({ onSuccess }: Readonly<{ onSuccess: () => void }>) {
       const result = await getPaymentAccounts()
       if (result.success && result.data) {
         setPaymentAccounts(result.data)
-        if (result.data.length === 0) {
-          console.warn('No payment accounts found. Please create cash/bank accounts in GL.')
-        }
+        if (result.data.length === 0) console.warn('No payment accounts found. Please create cash/bank accounts in GL.')
       } else {
         console.error('Failed to load payment accounts:', result.error)
         toast.error('خطأ في تحميل حسابات السداد')
@@ -314,35 +292,47 @@ function CreateReceiptForm({ onSuccess }: Readonly<{ onSuccess: () => void }>) {
   const loadOutstandingInvoices = async (customerId: string) => {
     try {
       const result = await getCustomerOutstandingInvoices(customerId)
-      if (result.success && result.data) {
-        setOutstandingInvoices(result.data || [])
-      }
+      if (result.success && result.data) setOutstandingInvoices(result.data || [])
     } catch (error) {
       console.error('Error loading invoices:', error)
     }
   }
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
+  const handlePaymentMethodChange = (method: PaymentMethod) => {
+    setFormData(prev => {
+      const selected = paymentAccounts.find(account => account.id === prev.payment_account_id)
+      return {
+        ...prev,
+        payment_method: method,
+        payment_account_id: accountMatchesMethod(selected, method) ? prev.payment_account_id : '',
+      }
+    })
+  }
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault()
+
+    const selectedAccount = paymentAccounts.find(account => account.id === formData.payment_account_id)
+    if (!selectedAccount) {
+      toast.error('اختر حساب السداد')
+      return
+    }
+    if (!accountMatchesMethod(selectedAccount, formData.payment_method)) {
+      toast.error('حساب السداد لا يتوافق مع طريقة السداد المختارة')
+      return
+    }
+
     setLoading(true)
-
     try {
-      // Calculate total from selected invoices
       const lines = Object.entries(selectedInvoices)
-        .filter(([_, amount]) => amount > 0)
-        .map(([invoiceId, amount]) => ({
-          invoice_id: invoiceId,
-          allocated_amount: amount,
-          discount_amount: 0
-        }))
+        .filter(([, amount]) => amount > 0)
+        .map(([invoiceId, amount]) => ({ invoice_id: invoiceId, allocated_amount: amount, discount_amount: 0 }))
 
-      const receiptData = {
+      const result = await createCustomerReceipt({
         ...formData,
         customer_id: selectedCustomer,
-        lines: lines.length > 0 ? lines : undefined
-      }
-
-      const result = await createCustomerReceipt(receiptData)
+        lines: lines.length > 0 ? lines : undefined,
+      })
       if (result.success) {
         toast.success('تم إنشاء سند القبض بنجاح')
         onSuccess()
@@ -357,15 +347,9 @@ function CreateReceiptForm({ onSuccess }: Readonly<{ onSuccess: () => void }>) {
   }
 
   const updateInvoiceAllocation = (invoiceId: string, amount: number) => {
-    setSelectedInvoices(prev => ({
-      ...prev,
-      [invoiceId]: amount
-    }))
-    
-    // Update total amount
-    const total = Object.values({ ...selectedInvoices, [invoiceId]: amount })
-      .reduce((sum, amt) => sum + amt, 0)
-    setFormData(prev => ({ ...prev, amount: total }))
+    const next = { ...selectedInvoices, [invoiceId]: amount }
+    setSelectedInvoices(next)
+    setFormData(prev => ({ ...prev, amount: Object.values(next).reduce((sum, value) => sum + value, 0) }))
   }
 
   return (
@@ -374,49 +358,22 @@ function CreateReceiptForm({ onSuccess }: Readonly<{ onSuccess: () => void }>) {
         <div className="space-y-2">
           <Label>العميل *</Label>
           <Select value={selectedCustomer} onValueChange={setSelectedCustomer}>
-            <SelectTrigger>
-              <SelectValue placeholder="اختر العميل" />
-            </SelectTrigger>
-            <SelectContent>
-              {customers.map((customer) => (
-                <SelectItem key={customer.id} value={customer.id}>
-                  {customer.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
+            <SelectTrigger><SelectValue placeholder="اختر العميل" /></SelectTrigger>
+            <SelectContent>{customers.map(customer => <SelectItem key={customer.id} value={customer.id}>{customer.name}</SelectItem>)}</SelectContent>
           </Select>
         </div>
-
         <div className="space-y-2">
           <Label>تاريخ السند *</Label>
-          <Input
-            type="date"
-            value={formData.receipt_date}
-            onChange={(e) => setFormData(prev => ({ ...prev, receipt_date: e.target.value }))}
-            required
-          />
+          <Input type="date" value={formData.receipt_date} onChange={event => setFormData(prev => ({ ...prev, receipt_date: event.target.value }))} required />
         </div>
-
         <div className="space-y-2">
           <Label>المبلغ *</Label>
-          <Input
-            type="number"
-            step="0.01"
-            value={formData.amount}
-            onChange={(e) => setFormData(prev => ({ ...prev, amount: Number.parseFloat(e.target.value) || 0 }))}
-            required
-          />
+          <Input type="number" step="0.01" value={formData.amount} onChange={event => setFormData(prev => ({ ...prev, amount: Number.parseFloat(event.target.value) || 0 }))} required />
         </div>
-
         <div className="space-y-2">
           <Label>طريقة السداد *</Label>
-          <Select
-            value={formData.payment_method}
-            onValueChange={(value) => setFormData(prev => ({ ...prev, payment_method: value as PaymentMethod }))}
-          >
-            <SelectTrigger>
-              <SelectValue />
-            </SelectTrigger>
+          <Select value={formData.payment_method} onValueChange={value => handlePaymentMethodChange(value as PaymentMethod)}>
+            <SelectTrigger><SelectValue /></SelectTrigger>
             <SelectContent>
               <SelectItem value="cash">نقدي</SelectItem>
               <SelectItem value="bank_transfer">تحويل بنكي</SelectItem>
@@ -429,182 +386,84 @@ function CreateReceiptForm({ onSuccess }: Readonly<{ onSuccess: () => void }>) {
             </SelectContent>
           </Select>
         </div>
-
         <div className="space-y-2">
-          <Label>حساب السداد</Label>
-          <Select
-            value={formData.payment_account_id}
-            onValueChange={(value) => setFormData(prev => ({ ...prev, payment_account_id: value }))}
-          >
-            <SelectTrigger>
-              <SelectValue placeholder="اختر الحساب" />
-            </SelectTrigger>
+          <Label>حساب السداد *</Label>
+          <Select value={formData.payment_account_id} onValueChange={value => setFormData(prev => ({ ...prev, payment_account_id: value }))}>
+            <SelectTrigger><SelectValue placeholder="اختر الحساب المتوافق" /></SelectTrigger>
             <SelectContent>
-              {paymentAccounts.length === 0 ? (
-                <div className="px-2 py-1.5 text-sm text-muted-foreground">
-                  لا توجد حسابات سداد متاحة
-                </div>
-              ) : (
-                paymentAccounts.map((account) => (
-                  <SelectItem key={account.id} value={account.id}>
-                    {account.code} - {account.name_ar || account.name}
-                  </SelectItem>
-                ))
-              )}
+              {compatiblePaymentAccounts.length === 0 ? (
+                <div className="px-2 py-1.5 text-sm text-muted-foreground">لا توجد حسابات متوافقة مع طريقة السداد</div>
+              ) : compatiblePaymentAccounts.map(account => (
+                <SelectItem key={account.id} value={account.id}>{account.code} - {account.name_ar || account.name}</SelectItem>
+              ))}
             </SelectContent>
           </Select>
         </div>
 
         {formData.payment_method === 'check' && (
           <>
-            <div className="space-y-2">
-              <Label>رقم الشيك</Label>
-              <Input
-                value={formData.check_number}
-                onChange={(e) => setFormData(prev => ({ ...prev, check_number: e.target.value }))}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label>تاريخ الشيك</Label>
-              <Input
-                type="date"
-                value={formData.check_date}
-                onChange={(e) => setFormData(prev => ({ ...prev, check_date: e.target.value }))}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label>بنك الشيك</Label>
-              <Input
-                value={formData.check_bank}
-                onChange={(e) => setFormData(prev => ({ ...prev, check_bank: e.target.value }))}
-              />
-            </div>
+            <div className="space-y-2"><Label>رقم الشيك</Label><Input value={formData.check_number} onChange={event => setFormData(prev => ({ ...prev, check_number: event.target.value }))} /></div>
+            <div className="space-y-2"><Label>تاريخ الشيك</Label><Input type="date" value={formData.check_date} onChange={event => setFormData(prev => ({ ...prev, check_date: event.target.value }))} /></div>
+            <div className="space-y-2"><Label>بنك الشيك</Label><Input value={formData.check_bank} onChange={event => setFormData(prev => ({ ...prev, check_bank: event.target.value }))} /></div>
           </>
         )}
-
-        <div className="space-y-2">
-          <Label>رقم المرجع</Label>
-          <Input
-            value={formData.reference_number}
-            onChange={(e) => setFormData(prev => ({ ...prev, reference_number: e.target.value }))}
-          />
-        </div>
+        <div className="space-y-2"><Label>رقم المرجع</Label><Input value={formData.reference_number} onChange={event => setFormData(prev => ({ ...prev, reference_number: event.target.value }))} /></div>
       </div>
 
-      {/* Outstanding Invoices */}
       {selectedCustomer && outstandingInvoices.length > 0 && (
         <div className="space-y-2">
           <Label>توزيع المبلغ على الفواتير</Label>
-          <Card>
-            <CardContent className="pt-4">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>رقم الفاتورة</TableHead>
-                    <TableHead>التاريخ</TableHead>
-                    <TableHead>المبلغ المستحق</TableHead>
-                    <TableHead>المدفوع</TableHead>
-                    <TableHead>المتبقي</TableHead>
-                    <TableHead>المخصص</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {outstandingInvoices.map((invoice) => (
-                    <TableRow key={invoice.id}>
-                      <TableCell>{invoice.invoice_number}</TableCell>
-                      <TableCell>
-                        {new Date(invoice.invoice_date).toLocaleDateString('en-US')}
-                      </TableCell>
-                      <TableCell>{invoice.total_amount?.toFixed(2)} ريال</TableCell>
-                      <TableCell>{invoice.paid_amount?.toFixed(2) || '0.00'} ريال</TableCell>
-                      <TableCell>{invoice.outstanding_balance?.toFixed(2) || '0.00'} ريال</TableCell>
-                      <TableCell>
-                        <Input
-                          type="number"
-                          step="0.01"
-                          value={selectedInvoices[invoice.id] || 0}
-                          onChange={(e) => updateInvoiceAllocation(invoice.id, Number.parseFloat(e.target.value) || 0)}
-                          max={invoice.outstanding_balance}
-                        />
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </CardContent>
-          </Card>
+          <Card><CardContent className="pt-4"><Table>
+            <TableHeader><TableRow><TableHead>رقم الفاتورة</TableHead><TableHead>التاريخ</TableHead><TableHead>المبلغ المستحق</TableHead><TableHead>المدفوع</TableHead><TableHead>المتبقي</TableHead><TableHead>المخصص</TableHead></TableRow></TableHeader>
+            <TableBody>{outstandingInvoices.map(invoice => (
+              <TableRow key={invoice.id}>
+                <TableCell>{invoice.invoice_number}</TableCell>
+                <TableCell>{new Date(invoice.invoice_date).toLocaleDateString('en-US')}</TableCell>
+                <TableCell>{invoice.total_amount?.toFixed(2)} ريال</TableCell>
+                <TableCell>{invoice.paid_amount?.toFixed(2) || '0.00'} ريال</TableCell>
+                <TableCell>{invoice.outstanding_balance?.toFixed(2) || '0.00'} ريال</TableCell>
+                <TableCell><Input type="number" step="0.01" value={selectedInvoices[invoice.id] || 0} onChange={event => updateInvoiceAllocation(invoice.id, Number.parseFloat(event.target.value) || 0)} max={invoice.outstanding_balance} /></TableCell>
+              </TableRow>
+            ))}</TableBody>
+          </Table></CardContent></Card>
         </div>
       )}
 
-      <div className="space-y-2">
-        <Label>ملاحظات</Label>
-        <Textarea
-          value={formData.notes}
-          onChange={(e) => setFormData(prev => ({ ...prev, notes: e.target.value }))}
-          rows={3}
-        />
-      </div>
-
+      <div className="space-y-2"><Label>ملاحظات</Label><Textarea value={formData.notes} onChange={event => setFormData(prev => ({ ...prev, notes: event.target.value }))} rows={3} /></div>
       <div className="flex justify-end gap-2">
-        <Button type="button" variant="outline" onClick={onSuccess}>
-          إلغاء
-        </Button>
-        <Button type="submit" disabled={loading}>
-          {loading ? 'جاري الحفظ...' : 'حفظ'}
-        </Button>
+        <Button type="button" variant="outline" onClick={onSuccess}>إلغاء</Button>
+        <Button type="submit" disabled={loading || !selectedCustomer || !formData.payment_account_id}>{loading ? 'جاري الحفظ...' : 'حفظ'}</Button>
       </div>
     </form>
   )
 }
 
 function ReceiptDetails({ receipt }: Readonly<{ receipt: CustomerReceipt }>) {
+  const receiptDate = getReceiptDate(receipt as ReceiptRow)
   return (
     <div className="space-y-4">
       <div className="grid grid-cols-2 gap-4">
-        <div>
-          <Label className="text-muted-foreground">رقم السند</Label>
-          <p className="font-medium">{receipt.receipt_number}</p>
-        </div>
-        <div>
-          <Label className="text-muted-foreground">التاريخ</Label>
-          <p className="font-medium">
-            {receipt.receipt_date ? new Date(receipt.receipt_date).toLocaleDateString('en-US') : '-'}
-          </p>
-        </div>
-        <div>
-          <Label className="text-muted-foreground">المبلغ</Label>
-          <p className="font-medium">{receipt.amount?.toFixed(2)} ريال</p>
-        </div>
-        <div>
-          <Label className="text-muted-foreground">الحالة</Label>
-          <p className="font-medium">{receipt.status}</p>
-        </div>
+        <div><Label className="text-muted-foreground">رقم السند</Label><p className="font-medium">{receipt.receipt_number}</p></div>
+        <div><Label className="text-muted-foreground">التاريخ</Label><p className="font-medium">{receiptDate ? new Date(`${receiptDate}T00:00:00`).toLocaleDateString('en-US') : '-'}</p></div>
+        <div><Label className="text-muted-foreground">المبلغ</Label><p className="font-medium">{receipt.amount?.toFixed(2)} ريال</p></div>
+        <div><Label className="text-muted-foreground">الحالة</Label><p className="font-medium">{receipt.status}</p></div>
       </div>
 
       {receipt.lines && receipt.lines.length > 0 && (
         <div>
           <Label className="text-muted-foreground mb-2 block">الفواتير المخصصة</Label>
           <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>رقم الفاتورة</TableHead>
-                <TableHead>المبلغ المخصص</TableHead>
-                <TableHead>الخصم</TableHead>
+            <TableHeader><TableRow><TableHead>رقم الفاتورة</TableHead><TableHead>المبلغ المخصص</TableHead><TableHead>الخصم</TableHead></TableRow></TableHeader>
+            <TableBody>{receipt.lines.map(line => (
+              <TableRow key={line.invoice_id || `${line.allocated_amount}-${line.discount_amount}`}>
+                <TableCell>{line.invoice_id}</TableCell>
+                <TableCell>{line.allocated_amount?.toFixed(2)} ريال</TableCell>
+                <TableCell>{line.discount_amount?.toFixed(2) || '0.00'} ريال</TableCell>
               </TableRow>
-            </TableHeader>
-            <TableBody>
-              {receipt.lines.map((line) => (
-                <TableRow key={line.invoice_id || `${line.allocated_amount}-${line.discount_amount}`}>
-                  <TableCell>{line.invoice_id}</TableCell>
-                  <TableCell>{line.allocated_amount?.toFixed(2)} ريال</TableCell>
-                  <TableCell>{line.discount_amount?.toFixed(2) || '0.00'} ريال</TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
+            ))}</TableBody>
           </Table>
         </div>
       )}
     </div>
   )
 }
-

--- a/src/features/sales/components/__tests__/CustomerReceipts.integration.test.tsx
+++ b/src/features/sales/components/__tests__/CustomerReceipts.integration.test.tsx
@@ -1,0 +1,158 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import '@testing-library/jest-dom'
+
+const mocks = vi.hoisted(() => ({
+  getAllCustomerReceipts: vi.fn(),
+  createCustomerReceipt: vi.fn(),
+  postCustomerReceipt: vi.fn(),
+  getCustomerOutstandingInvoices: vi.fn(),
+  getPaymentAccounts: vi.fn(),
+  getCustomers: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: mocks.toastSuccess,
+    error: mocks.toastError,
+  },
+}))
+
+vi.mock('@/services/payment-vouchers-service', () => ({
+  getAllCustomerReceipts: mocks.getAllCustomerReceipts,
+  createCustomerReceipt: mocks.createCustomerReceipt,
+  postCustomerReceipt: mocks.postCustomerReceipt,
+  getCustomerOutstandingInvoices: mocks.getCustomerOutstandingInvoices,
+  getPaymentAccounts: mocks.getPaymentAccounts,
+}))
+
+vi.mock('@/services/supabase-service', () => ({
+  customersService: {
+    getAll: mocks.getCustomers,
+  },
+}))
+
+import { CustomerReceipts } from '../CustomerReceipts'
+
+const receipt = {
+  id: 'receipt-1',
+  receipt_number: 'CR-202607-00001',
+  collection_date: '2026-07-31',
+  amount: 2415,
+  payment_method: 'cash',
+  payment_account_id: 'cash-1',
+  status: 'draft',
+  customer: { name: 'مؤسسة التجارة الكبرى' },
+  lines: [
+    {
+      invoice_id: 'invoice-1',
+      allocated_amount: 2415,
+      discount_amount: 0,
+    },
+  ],
+}
+
+const accounts = [
+  {
+    id: 'cash-1',
+    code: '110101',
+    name: 'Cash',
+    name_ar: 'النقدية في الخزينة',
+    subtype: 'CASH',
+  },
+  {
+    id: 'bank-1',
+    code: '110202',
+    name: 'Bank',
+    name_ar: 'بنك الإنماء',
+    subtype: 'BANK',
+  },
+]
+
+function openSelect(trigger: HTMLElement) {
+  fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false })
+  fireEvent.click(trigger)
+}
+
+describe('CustomerReceipts integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getAllCustomerReceipts.mockResolvedValue({ success: true, data: [receipt] })
+    mocks.postCustomerReceipt.mockResolvedValue({ success: true })
+    mocks.getCustomers.mockResolvedValue([{ id: 'customer-1', name: 'عميل اختبار' }])
+    mocks.getPaymentAccounts.mockResolvedValue({ success: true, data: accounts })
+    mocks.getCustomerOutstandingInvoices.mockResolvedValue({ success: true, data: [] })
+    mocks.createCustomerReceipt.mockResolvedValue({ success: true, data: { id: 'receipt-2' } })
+  })
+
+  it('renders collection_date, opens details, and posts the draft receipt', async () => {
+    render(<CustomerReceipts />)
+
+    expect(await screen.findByText('CR-202607-00001')).toBeInTheDocument()
+    expect(screen.getByText('7/31/2026')).toBeInTheDocument()
+    expect(screen.getByText('مؤسسة التجارة الكبرى')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'عرض' }))
+    const details = await screen.findByRole('dialog')
+    expect(within(details).getByText('تفاصيل سند القبض')).toBeInTheDocument()
+    expect(within(details).getByText('7/31/2026')).toBeInTheDocument()
+    expect(within(details).getByText('invoice-1')).toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    await waitFor(() => expect(screen.queryByText('تفاصيل سند القبض')).not.toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('button', { name: 'إقرار' }))
+    await waitFor(() => expect(mocks.postCustomerReceipt).toHaveBeenCalledWith('receipt-1'))
+    expect(mocks.toastSuccess).toHaveBeenCalledWith('تم إقرار السند بنجاح')
+    await waitFor(() => expect(mocks.getAllCustomerReceipts).toHaveBeenCalledTimes(2))
+  })
+
+  it('filters CASH/BANK accounts, clears incompatible selection, and saves a valid receipt', async () => {
+    render(<CustomerReceipts />)
+    await screen.findByText('CR-202607-00001')
+
+    fireEvent.click(screen.getByRole('button', { name: 'إضافة سند قبض' }))
+    const dialog = await screen.findByRole('dialog')
+
+    await waitFor(() => expect(mocks.getPaymentAccounts).toHaveBeenCalled())
+    await waitFor(() => expect(mocks.getCustomers).toHaveBeenCalled())
+
+    let comboboxes = within(dialog).getAllByRole('combobox')
+    expect(comboboxes).toHaveLength(3)
+
+    openSelect(comboboxes[2])
+    expect(await screen.findByText(/110101 - النقدية في الخزينة/)).toBeInTheDocument()
+    expect(screen.queryByText(/110202 - بنك الإنماء/)).not.toBeInTheDocument()
+    fireEvent.click(screen.getByText(/110101 - النقدية في الخزينة/))
+
+    comboboxes = within(dialog).getAllByRole('combobox')
+    openSelect(comboboxes[1])
+    fireEvent.click(await screen.findByRole('option', { name: 'تحويل بنكي' }))
+
+    comboboxes = within(dialog).getAllByRole('combobox')
+    expect(comboboxes[2]).toHaveTextContent('اختر الحساب')
+    openSelect(comboboxes[2])
+    expect(await screen.findByText(/110202 - بنك الإنماء/)).toBeInTheDocument()
+    expect(screen.queryByText(/110101 - النقدية في الخزينة/)).not.toBeInTheDocument()
+    fireEvent.click(screen.getByText(/110202 - بنك الإنماء/))
+
+    comboboxes = within(dialog).getAllByRole('combobox')
+    openSelect(comboboxes[0])
+    fireEvent.click(await screen.findByRole('option', { name: 'عميل اختبار' }))
+
+    const amount = within(dialog).getByRole('spinbutton')
+    fireEvent.change(amount, { target: { value: '500' } })
+    fireEvent.click(within(dialog).getByRole('button', { name: 'حفظ' }))
+
+    await waitFor(() => expect(mocks.createCustomerReceipt).toHaveBeenCalledTimes(1))
+    expect(mocks.createCustomerReceipt).toHaveBeenCalledWith(expect.objectContaining({
+      customer_id: 'customer-1',
+      amount: 500,
+      payment_method: 'bank_transfer',
+      payment_account_id: 'bank-1',
+    }))
+    expect(mocks.toastSuccess).toHaveBeenCalledWith('تم إنشاء سند القبض بنجاح')
+  })
+})

--- a/src/features/sales/components/__tests__/CustomerReceipts.test.tsx
+++ b/src/features/sales/components/__tests__/CustomerReceipts.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import '@testing-library/jest-dom';
 
@@ -44,6 +44,16 @@ vi.mock('@/services/supabase-service', () => ({
 }));
 
 import type { CustomerReceipt, PaymentMethod } from '@/services/payment-vouchers-service';
+import {
+  createCustomerReceipt,
+  getAllCustomerReceipts,
+  getCustomerOutstandingInvoices,
+  getPaymentAccounts,
+  postCustomerReceipt,
+} from '@/services/payment-vouchers-service';
+import { customersService } from '@/services/supabase-service';
+import { toast } from 'sonner';
+import { CustomerReceipts } from '../CustomerReceipts';
 
 describe('CustomerReceipts Component Logic', () => {
   beforeEach(() => {
@@ -331,5 +341,168 @@ describe('CustomerReceipts Component Logic', () => {
       const canPost = receipt.status === 'draft';
       expect(canPost).toBe(false);
     });
+  });
+});
+
+const mockedGetAllCustomerReceipts = vi.mocked(getAllCustomerReceipts);
+const mockedCreateCustomerReceipt = vi.mocked(createCustomerReceipt);
+const mockedPostCustomerReceipt = vi.mocked(postCustomerReceipt);
+const mockedGetCustomerOutstandingInvoices = vi.mocked(getCustomerOutstandingInvoices);
+const mockedGetPaymentAccounts = vi.mocked(getPaymentAccounts);
+const mockedCustomersGetAll = vi.mocked(customersService.getAll);
+const mockedToastSuccess = vi.mocked(toast.success);
+
+const draftReceipt = {
+  id: 'receipt-1',
+  receipt_number: 'CR-202607-00001',
+  collection_date: '2026-07-31',
+  amount: 2415,
+  payment_method: 'cash',
+  payment_account_id: 'cash-1',
+  status: 'draft',
+  customer: { name: 'مؤسسة التجارة الكبرى' },
+  lines: [
+    {
+      invoice_id: 'invoice-1',
+      allocated_amount: 2415,
+      discount_amount: 0,
+    },
+  ],
+} as unknown as CustomerReceipt;
+
+const paymentAccounts = [
+  {
+    id: 'cash-1',
+    code: '110101',
+    name: 'Cash',
+    name_ar: 'النقدية في الخزينة',
+    subtype: 'CASH',
+  },
+  {
+    id: 'bank-1',
+    code: '110202',
+    name: 'Bank',
+    name_ar: 'بنك الإنماء',
+    subtype: 'BANK',
+  },
+];
+
+function renderReceipts() {
+  return render(
+    <BrowserRouter>
+      <CustomerReceipts />
+    </BrowserRouter>
+  );
+}
+
+function openSelect(trigger: HTMLElement) {
+  fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+  fireEvent.click(trigger);
+}
+
+describe('CustomerReceipts real UI flows', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedGetAllCustomerReceipts.mockResolvedValue({ success: true, data: [draftReceipt] });
+    mockedPostCustomerReceipt.mockResolvedValue({ success: true });
+    mockedCustomersGetAll.mockResolvedValue([{ id: 'customer-1', name: 'عميل اختبار' }] as never);
+    mockedGetPaymentAccounts.mockResolvedValue({ success: true, data: paymentAccounts } as never);
+    mockedGetCustomerOutstandingInvoices.mockResolvedValue({
+      success: true,
+      data: [
+        {
+          id: 'invoice-1',
+          invoice_number: 'INV-0001',
+          invoice_date: '2026-07-20',
+          total_amount: 500,
+          paid_amount: 0,
+          outstanding_balance: 500,
+        },
+      ],
+    } as never);
+    mockedCreateCustomerReceipt.mockResolvedValue({ success: true, data: { id: 'receipt-2' } } as never);
+  });
+
+  it('uses collection_date in the list and details, then posts the draft receipt', async () => {
+    renderReceipts();
+
+    expect(await screen.findByText('CR-202607-00001')).toBeInTheDocument();
+    expect(screen.getByText('7/31/2026')).toBeInTheDocument();
+    expect(screen.getByText('مؤسسة التجارة الكبرى')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'إقرار' }));
+    await waitFor(() => expect(mockedPostCustomerReceipt).toHaveBeenCalledWith('receipt-1'));
+    expect(mockedToastSuccess).toHaveBeenCalledWith('تم إقرار السند بنجاح');
+    await waitFor(() => expect(mockedGetAllCustomerReceipts).toHaveBeenCalledTimes(2));
+
+    fireEvent.click(screen.getByRole('button', { name: 'عرض' }));
+    const detailsDialog = await screen.findByRole('dialog');
+    expect(within(detailsDialog).getByText('تفاصيل سند القبض')).toBeInTheDocument();
+    expect(within(detailsDialog).getByText('7/31/2026')).toBeInTheDocument();
+    expect(within(detailsDialog).getByText('invoice-1')).toBeInTheDocument();
+    expect(within(detailsDialog).getByText('2415.00 ريال')).toBeInTheDocument();
+  });
+
+  it('filters accounts by method, clears an incompatible account, and creates a valid receipt', async () => {
+    renderReceipts();
+    await screen.findByText('CR-202607-00001');
+
+    fireEvent.click(screen.getByRole('button', { name: 'إضافة سند قبض' }));
+    const dialog = await screen.findByRole('dialog');
+
+    await waitFor(() => expect(mockedGetPaymentAccounts).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mockedCustomersGetAll).toHaveBeenCalledTimes(1));
+
+    let comboboxes = within(dialog).getAllByRole('combobox');
+    expect(comboboxes).toHaveLength(3);
+
+    openSelect(comboboxes[2]);
+    expect(await screen.findByRole('option', { name: /110101 - النقدية في الخزينة/ })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /110202 - بنك الإنماء/ })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('option', { name: /110101 - النقدية في الخزينة/ }));
+
+    comboboxes = within(dialog).getAllByRole('combobox');
+    openSelect(comboboxes[1]);
+    fireEvent.click(await screen.findByRole('option', { name: 'شيك' }));
+    expect(within(dialog).getByText('رقم الشيك')).toBeInTheDocument();
+    expect(comboboxes[2]).toHaveTextContent('110101');
+
+    comboboxes = within(dialog).getAllByRole('combobox');
+    openSelect(comboboxes[1]);
+    fireEvent.click(await screen.findByRole('option', { name: 'تحويل بنكي' }));
+
+    comboboxes = within(dialog).getAllByRole('combobox');
+    expect(comboboxes[2]).toHaveTextContent('اختر الحساب المتوافق');
+    openSelect(comboboxes[2]);
+    expect(await screen.findByRole('option', { name: /110202 - بنك الإنماء/ })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /110101 - النقدية في الخزينة/ })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('option', { name: /110202 - بنك الإنماء/ }));
+
+    comboboxes = within(dialog).getAllByRole('combobox');
+    openSelect(comboboxes[0]);
+    fireEvent.click(await screen.findByRole('option', { name: 'عميل اختبار' }));
+
+    expect(await within(dialog).findByText('INV-0001')).toBeInTheDocument();
+    const amountInputs = within(dialog).getAllByRole('spinbutton');
+    fireEvent.change(amountInputs[1], { target: { value: '500' } });
+    expect(amountInputs[0]).toHaveValue(500);
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'حفظ' }));
+
+    await waitFor(() => expect(mockedCreateCustomerReceipt).toHaveBeenCalledTimes(1));
+    expect(mockedCreateCustomerReceipt).toHaveBeenCalledWith(expect.objectContaining({
+      customer_id: 'customer-1',
+      amount: 500,
+      payment_method: 'bank_transfer',
+      payment_account_id: 'bank-1',
+      lines: [
+        {
+          invoice_id: 'invoice-1',
+          allocated_amount: 500,
+          discount_amount: 0,
+        },
+      ],
+    }));
+    expect(mockedToastSuccess).toHaveBeenCalledWith('تم إنشاء سند القبض بنجاح');
   });
 });

--- a/src/features/sales/components/__tests__/CustomerReceipts.test.tsx
+++ b/src/features/sales/components/__tests__/CustomerReceipts.test.tsx
@@ -1,356 +1,41 @@
-/**
- * @fileoverview Comprehensive Tests for CustomerReceipts Component
- * Tests customer receipt management UI including create, post, and list operations
- */
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { BrowserRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
-import { BrowserRouter } from 'react-router-dom';
-import '@testing-library/jest-dom';
-
-// Mock react-i18next
-vi.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => key,
-    i18n: {
-      language: 'ar',
-      changeLanguage: vi.fn(),
-    },
-  }),
-}));
-
-// Mock sonner
-vi.mock('sonner', () => ({
-  toast: {
-    success: vi.fn(),
-    error: vi.fn(),
-  },
-}));
-
-// Mock payment-vouchers-service
-vi.mock('@/services/payment-vouchers-service', () => ({
-  getAllCustomerReceipts: vi.fn(),
+const mocks = vi.hoisted(() => ({
   createCustomerReceipt: vi.fn(),
-  postCustomerReceipt: vi.fn(),
+  getAllCustomerReceipts: vi.fn(),
   getCustomerOutstandingInvoices: vi.fn(),
   getPaymentAccounts: vi.fn(),
-}));
+  postCustomerReceipt: vi.fn(),
+  getCustomers: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+}))
 
-// Mock supabase-service
+vi.mock('sonner', () => ({
+  toast: {
+    success: mocks.toastSuccess,
+    error: mocks.toastError,
+  },
+}))
+
+vi.mock('@/services/payment-vouchers-service', () => ({
+  createCustomerReceipt: mocks.createCustomerReceipt,
+  getAllCustomerReceipts: mocks.getAllCustomerReceipts,
+  getCustomerOutstandingInvoices: mocks.getCustomerOutstandingInvoices,
+  getPaymentAccounts: mocks.getPaymentAccounts,
+  postCustomerReceipt: mocks.postCustomerReceipt,
+}))
+
 vi.mock('@/services/supabase-service', () => ({
   customersService: {
-    getAll: vi.fn(),
+    getAll: mocks.getCustomers,
   },
-}));
+}))
 
-import type { CustomerReceipt, PaymentMethod } from '@/services/payment-vouchers-service';
-import {
-  createCustomerReceipt,
-  getAllCustomerReceipts,
-  getCustomerOutstandingInvoices,
-  getPaymentAccounts,
-  postCustomerReceipt,
-} from '@/services/payment-vouchers-service';
-import { customersService } from '@/services/supabase-service';
-import { toast } from 'sonner';
-import { CustomerReceipts } from '../CustomerReceipts';
-
-describe('CustomerReceipts Component Logic', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  describe('Status Badge Rendering', () => {
-    const getStatusInfo = (status: string) => {
-      const statusMap: Record<string, { label: string; variant: string }> = {
-        draft: { label: 'مسودة', variant: 'outline' },
-        posted: { label: 'مقرر', variant: 'default' },
-        cancelled: { label: 'ملغي', variant: 'destructive' },
-      };
-      return statusMap[status] || { label: status, variant: 'outline' };
-    };
-
-    it('should return draft status info', () => {
-      const info = getStatusInfo('draft');
-      expect(info.label).toBe('مسودة');
-      expect(info.variant).toBe('outline');
-    });
-
-    it('should return posted status info', () => {
-      const info = getStatusInfo('posted');
-      expect(info.label).toBe('مقرر');
-      expect(info.variant).toBe('default');
-    });
-
-    it('should return cancelled status info', () => {
-      const info = getStatusInfo('cancelled');
-      expect(info.label).toBe('ملغي');
-      expect(info.variant).toBe('destructive');
-    });
-
-    it('should handle unknown status', () => {
-      const info = getStatusInfo('unknown');
-      expect(info.label).toBe('unknown');
-      expect(info.variant).toBe('outline');
-    });
-  });
-
-  describe('Payment Method Labels', () => {
-    const getPaymentMethodLabel = (method: PaymentMethod) => {
-      const methods: Record<PaymentMethod, string> = {
-        cash: 'نقدي',
-        bank_transfer: 'تحويل بنكي',
-        check: 'شيك',
-        credit_card: 'بطاقة ائتمان',
-        debit_card: 'بطاقة خصم',
-        online_payment: 'دفع إلكتروني',
-        mobile_payment: 'دفع محمول',
-        other: 'أخرى',
-      };
-      return methods[method] || method;
-    };
-
-    it('should return cash label in Arabic', () => {
-      expect(getPaymentMethodLabel('cash')).toBe('نقدي');
-    });
-
-    it('should return bank transfer label in Arabic', () => {
-      expect(getPaymentMethodLabel('bank_transfer')).toBe('تحويل بنكي');
-    });
-
-    it('should return check label in Arabic', () => {
-      expect(getPaymentMethodLabel('check')).toBe('شيك');
-    });
-
-    it('should return credit card label in Arabic', () => {
-      expect(getPaymentMethodLabel('credit_card')).toBe('بطاقة ائتمان');
-    });
-
-    it('should return all supported payment methods', () => {
-      const methods: PaymentMethod[] = [
-        'cash',
-        'bank_transfer',
-        'check',
-        'credit_card',
-        'debit_card',
-        'online_payment',
-        'mobile_payment',
-        'other',
-      ];
-
-      methods.forEach((method) => {
-        const label = getPaymentMethodLabel(method);
-        expect(label).toBeDefined();
-        expect(label.length).toBeGreaterThan(0);
-      });
-    });
-  });
-
-  describe('Receipt Statistics Calculation', () => {
-    it('should calculate total receipts count', () => {
-      const receipts: Partial<CustomerReceipt>[] = [
-        { id: '1', amount: 1000 },
-        { id: '2', amount: 2000 },
-        { id: '3', amount: 1500 },
-      ];
-
-      expect(receipts.length).toBe(3);
-    });
-
-    it('should calculate total receipts amount', () => {
-      const receipts = [
-        { amount: 1000 },
-        { amount: 2000 },
-        { amount: 1500 },
-      ];
-
-      const total = receipts.reduce((sum, r) => sum + r.amount, 0);
-      expect(total).toBe(4500);
-    });
-
-    it('should count draft receipts', () => {
-      const receipts = [
-        { status: 'draft' },
-        { status: 'posted' },
-        { status: 'draft' },
-        { status: 'cancelled' },
-      ];
-
-      const draftCount = receipts.filter((r) => r.status === 'draft').length;
-      expect(draftCount).toBe(2);
-    });
-
-    it('should count posted receipts', () => {
-      const receipts = [
-        { status: 'draft' },
-        { status: 'posted' },
-        { status: 'posted' },
-        { status: 'posted' },
-      ];
-
-      const postedCount = receipts.filter((r) => r.status === 'posted').length;
-      expect(postedCount).toBe(3);
-    });
-  });
-
-  describe('Receipt Filtering', () => {
-    it('should filter receipts by status', () => {
-      const receipts = [
-        { id: '1', status: 'draft', customer: { name: 'Customer A' } },
-        { id: '2', status: 'posted', customer: { name: 'Customer B' } },
-        { id: '3', status: 'draft', customer: { name: 'Customer C' } },
-      ];
-
-      const draftReceipts = receipts.filter((r) => r.status === 'draft');
-      expect(draftReceipts.length).toBe(2);
-    });
-
-    it('should filter receipts by customer name', () => {
-      const receipts = [
-        { id: '1', customer: { name: 'شركة الأمل' } },
-        { id: '2', customer: { name: 'مؤسسة النور' } },
-        { id: '3', customer: { name: 'شركة الأمل للتجارة' } },
-      ];
-
-      const searchTerm = 'الأمل';
-      const filtered = receipts.filter((r) =>
-        r.customer.name.includes(searchTerm)
-      );
-
-      expect(filtered.length).toBe(2);
-    });
-
-    it('should filter by date range', () => {
-      const receipts = [
-        { id: '1', receipt_date: '2025-12-15' },
-        { id: '2', receipt_date: '2025-12-20' },
-        { id: '3', receipt_date: '2025-12-25' },
-      ];
-
-      const startDate = '2025-12-18';
-      const endDate = '2025-12-22';
-
-      const filtered = receipts.filter(
-        (r) => r.receipt_date >= startDate && r.receipt_date <= endDate
-      );
-
-      expect(filtered.length).toBe(1);
-      expect(filtered[0].id).toBe('2');
-    });
-  });
-
-  describe('Form Validation', () => {
-    it('should validate required customer', () => {
-      const formData = {
-        customer_id: '',
-        amount: 1000,
-      };
-
-      const isValid = formData.customer_id.length > 0;
-      expect(isValid).toBe(false);
-    });
-
-    it('should validate positive amount', () => {
-      const formData = {
-        customer_id: 'cust-1',
-        amount: 1000,
-      };
-
-      const isValid = formData.amount > 0;
-      expect(isValid).toBe(true);
-    });
-
-    it('should reject zero amount', () => {
-      const formData = {
-        customer_id: 'cust-1',
-        amount: 0,
-      };
-
-      const isValid = formData.amount > 0;
-      expect(isValid).toBe(false);
-    });
-
-    it('should reject negative amount', () => {
-      const formData = {
-        customer_id: 'cust-1',
-        amount: -500,
-      };
-
-      const isValid = formData.amount > 0;
-      expect(isValid).toBe(false);
-    });
-  });
-
-  describe('RTL Support', () => {
-    it('should detect RTL for Arabic', () => {
-      const language = 'ar';
-      const isRTL = language === 'ar';
-      expect(isRTL).toBe(true);
-    });
-
-    it('should detect LTR for English', () => {
-      const language: string = 'en';
-      const isRTL = language === 'ar';
-      expect(isRTL).toBe(false);
-    });
-  });
-
-  describe('Date Formatting', () => {
-    it('should format date for display', () => {
-      const date = new Date('2025-12-20');
-      const formatted = date.toLocaleDateString('en-US');
-      expect(formatted).toBeDefined();
-    });
-
-    it('should format date in ISO format', () => {
-      const date = new Date('2025-12-20');
-      const iso = date.toISOString().split('T')[0];
-      expect(iso).toBe('2025-12-20');
-    });
-  });
-
-  describe('Amount Formatting', () => {
-    it('should format currency', () => {
-      const amount = 1500.5;
-      const formatted = amount.toFixed(2);
-      expect(formatted).toBe('1500.50');
-    });
-
-    it('should format with thousand separators', () => {
-      const amount = 1500000;
-      const formatted = amount.toLocaleString('en-US');
-      expect(formatted).toBeDefined();
-    });
-  });
-
-  describe('Post Receipt Logic', () => {
-    it('should only allow posting draft receipts', () => {
-      const receipt = { status: 'draft' };
-      const canPost = receipt.status === 'draft';
-      expect(canPost).toBe(true);
-    });
-
-    it('should not allow posting already posted receipts', () => {
-      const receipt = { status: 'posted' };
-      const canPost = receipt.status === 'draft';
-      expect(canPost).toBe(false);
-    });
-
-    it('should not allow posting cancelled receipts', () => {
-      const receipt = { status: 'cancelled' };
-      const canPost = receipt.status === 'draft';
-      expect(canPost).toBe(false);
-    });
-  });
-});
-
-const mockedGetAllCustomerReceipts = vi.mocked(getAllCustomerReceipts);
-const mockedCreateCustomerReceipt = vi.mocked(createCustomerReceipt);
-const mockedPostCustomerReceipt = vi.mocked(postCustomerReceipt);
-const mockedGetCustomerOutstandingInvoices = vi.mocked(getCustomerOutstandingInvoices);
-const mockedGetPaymentAccounts = vi.mocked(getPaymentAccounts);
-const mockedCustomersGetAll = vi.mocked(customersService.getAll);
-const mockedToastSuccess = vi.mocked(toast.success);
+import { CustomerReceipts } from '../CustomerReceipts'
 
 const draftReceipt = {
   id: 'receipt-1',
@@ -368,7 +53,7 @@ const draftReceipt = {
       discount_amount: 0,
     },
   ],
-} as unknown as CustomerReceipt;
+}
 
 const paymentAccounts = [
   {
@@ -385,29 +70,29 @@ const paymentAccounts = [
     name_ar: 'بنك الإنماء',
     subtype: 'BANK',
   },
-];
+]
 
 function renderReceipts() {
   return render(
     <BrowserRouter>
       <CustomerReceipts />
-    </BrowserRouter>
-  );
+    </BrowserRouter>,
+  )
 }
 
 function openSelect(trigger: HTMLElement) {
-  fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
-  fireEvent.click(trigger);
+  fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false })
+  fireEvent.click(trigger)
 }
 
-describe('CustomerReceipts real UI flows', () => {
+describe('CustomerReceipts', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    mockedGetAllCustomerReceipts.mockResolvedValue({ success: true, data: [draftReceipt] });
-    mockedPostCustomerReceipt.mockResolvedValue({ success: true });
-    mockedCustomersGetAll.mockResolvedValue([{ id: 'customer-1', name: 'عميل اختبار' }] as never);
-    mockedGetPaymentAccounts.mockResolvedValue({ success: true, data: paymentAccounts } as never);
-    mockedGetCustomerOutstandingInvoices.mockResolvedValue({
+    vi.clearAllMocks()
+    mocks.getAllCustomerReceipts.mockResolvedValue({ success: true, data: [draftReceipt] })
+    mocks.postCustomerReceipt.mockResolvedValue({ success: true })
+    mocks.getCustomers.mockResolvedValue([{ id: 'customer-1', name: 'عميل اختبار' }])
+    mocks.getPaymentAccounts.mockResolvedValue({ success: true, data: paymentAccounts })
+    mocks.getCustomerOutstandingInvoices.mockResolvedValue({
       success: true,
       data: [
         {
@@ -419,78 +104,80 @@ describe('CustomerReceipts real UI flows', () => {
           outstanding_balance: 500,
         },
       ],
-    } as never);
-    mockedCreateCustomerReceipt.mockResolvedValue({ success: true, data: { id: 'receipt-2' } } as never);
-  });
+    })
+    mocks.createCustomerReceipt.mockResolvedValue({ success: true, data: { id: 'receipt-2' } })
+  })
 
   it('uses collection_date in the list and details, then posts the draft receipt', async () => {
-    renderReceipts();
+    renderReceipts()
 
-    expect(await screen.findByText('CR-202607-00001')).toBeInTheDocument();
-    expect(screen.getByText('7/31/2026')).toBeInTheDocument();
-    expect(screen.getByText('مؤسسة التجارة الكبرى')).toBeInTheDocument();
+    expect(await screen.findByText('CR-202607-00001')).toBeInTheDocument()
+    expect(screen.getByText('7/31/2026')).toBeInTheDocument()
+    expect(screen.getByText('مؤسسة التجارة الكبرى')).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: 'إقرار' }));
-    await waitFor(() => expect(mockedPostCustomerReceipt).toHaveBeenCalledWith('receipt-1'));
-    expect(mockedToastSuccess).toHaveBeenCalledWith('تم إقرار السند بنجاح');
-    await waitFor(() => expect(mockedGetAllCustomerReceipts).toHaveBeenCalledTimes(2));
+    fireEvent.click(screen.getByRole('button', { name: 'إقرار' }))
+    await waitFor(() => expect(mocks.postCustomerReceipt).toHaveBeenCalledWith('receipt-1'))
+    expect(mocks.toastSuccess).toHaveBeenCalledWith('تم إقرار السند بنجاح')
+    await waitFor(() => expect(mocks.getAllCustomerReceipts).toHaveBeenCalledTimes(2))
 
-    fireEvent.click(screen.getByRole('button', { name: 'عرض' }));
-    const detailsDialog = await screen.findByRole('dialog');
-    expect(within(detailsDialog).getByText('تفاصيل سند القبض')).toBeInTheDocument();
-    expect(within(detailsDialog).getByText('7/31/2026')).toBeInTheDocument();
-    expect(within(detailsDialog).getByText('invoice-1')).toBeInTheDocument();
-    expect(within(detailsDialog).getByText('2415.00 ريال')).toBeInTheDocument();
-  });
+    fireEvent.click(screen.getByRole('button', { name: 'عرض' }))
+    const detailsDialog = await screen.findByRole('dialog')
+    expect(within(detailsDialog).getByText('تفاصيل سند القبض')).toBeInTheDocument()
+
+    const dateLabel = within(detailsDialog).getByText('التاريخ')
+    expect(dateLabel.parentElement).toHaveTextContent('7/31/2026')
+    expect(within(detailsDialog).getByText('invoice-1')).toBeInTheDocument()
+    expect(within(detailsDialog).getByText('2415.00 ريال')).toBeInTheDocument()
+  })
 
   it('filters accounts by method, clears an incompatible account, and creates a valid receipt', async () => {
-    renderReceipts();
-    await screen.findByText('CR-202607-00001');
+    renderReceipts()
+    await screen.findByText('CR-202607-00001')
 
-    fireEvent.click(screen.getByRole('button', { name: 'إضافة سند قبض' }));
-    const dialog = await screen.findByRole('dialog');
+    fireEvent.click(screen.getByRole('button', { name: 'إضافة سند قبض' }))
+    const dialog = await screen.findByRole('dialog')
 
-    await waitFor(() => expect(mockedGetPaymentAccounts).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(mockedCustomersGetAll).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mocks.getPaymentAccounts).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(mocks.getCustomers).toHaveBeenCalledTimes(1))
 
-    let comboboxes = within(dialog).getAllByRole('combobox');
-    expect(comboboxes).toHaveLength(3);
+    let comboboxes = within(dialog).getAllByRole('combobox')
+    expect(comboboxes).toHaveLength(3)
 
-    openSelect(comboboxes[2]);
-    expect(await screen.findByRole('option', { name: /110101 - النقدية في الخزينة/ })).toBeInTheDocument();
-    expect(screen.queryByRole('option', { name: /110202 - بنك الإنماء/ })).not.toBeInTheDocument();
-    fireEvent.click(screen.getByRole('option', { name: /110101 - النقدية في الخزينة/ }));
+    openSelect(comboboxes[2])
+    expect(await screen.findByRole('option', { name: /110101 - النقدية في الخزينة/ })).toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: /110202 - بنك الإنماء/ })).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('option', { name: /110101 - النقدية في الخزينة/ }))
 
-    comboboxes = within(dialog).getAllByRole('combobox');
-    openSelect(comboboxes[1]);
-    fireEvent.click(await screen.findByRole('option', { name: 'شيك' }));
-    expect(within(dialog).getByText('رقم الشيك')).toBeInTheDocument();
-    expect(comboboxes[2]).toHaveTextContent('110101');
+    comboboxes = within(dialog).getAllByRole('combobox')
+    openSelect(comboboxes[1])
+    fireEvent.click(await screen.findByRole('option', { name: 'شيك' }))
+    expect(within(dialog).getByText('رقم الشيك')).toBeInTheDocument()
+    expect(comboboxes[2]).toHaveTextContent('110101')
 
-    comboboxes = within(dialog).getAllByRole('combobox');
-    openSelect(comboboxes[1]);
-    fireEvent.click(await screen.findByRole('option', { name: 'تحويل بنكي' }));
+    comboboxes = within(dialog).getAllByRole('combobox')
+    openSelect(comboboxes[1])
+    fireEvent.click(await screen.findByRole('option', { name: 'تحويل بنكي' }))
 
-    comboboxes = within(dialog).getAllByRole('combobox');
-    expect(comboboxes[2]).toHaveTextContent('اختر الحساب المتوافق');
-    openSelect(comboboxes[2]);
-    expect(await screen.findByRole('option', { name: /110202 - بنك الإنماء/ })).toBeInTheDocument();
-    expect(screen.queryByRole('option', { name: /110101 - النقدية في الخزينة/ })).not.toBeInTheDocument();
-    fireEvent.click(screen.getByRole('option', { name: /110202 - بنك الإنماء/ }));
+    comboboxes = within(dialog).getAllByRole('combobox')
+    expect(comboboxes[2]).toHaveTextContent('اختر الحساب المتوافق')
+    openSelect(comboboxes[2])
+    expect(await screen.findByRole('option', { name: /110202 - بنك الإنماء/ })).toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: /110101 - النقدية في الخزينة/ })).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('option', { name: /110202 - بنك الإنماء/ }))
 
-    comboboxes = within(dialog).getAllByRole('combobox');
-    openSelect(comboboxes[0]);
-    fireEvent.click(await screen.findByRole('option', { name: 'عميل اختبار' }));
+    comboboxes = within(dialog).getAllByRole('combobox')
+    openSelect(comboboxes[0])
+    fireEvent.click(await screen.findByRole('option', { name: 'عميل اختبار' }))
 
-    expect(await within(dialog).findByText('INV-0001')).toBeInTheDocument();
-    const amountInputs = within(dialog).getAllByRole('spinbutton');
-    fireEvent.change(amountInputs[1], { target: { value: '500' } });
-    expect(amountInputs[0]).toHaveValue(500);
+    expect(await within(dialog).findByText('INV-0001')).toBeInTheDocument()
+    const amountInputs = within(dialog).getAllByRole('spinbutton')
+    fireEvent.change(amountInputs[1], { target: { value: '500' } })
+    expect(amountInputs[0]).toHaveValue(500)
 
-    fireEvent.click(within(dialog).getByRole('button', { name: 'حفظ' }));
+    fireEvent.click(within(dialog).getByRole('button', { name: 'حفظ' }))
 
-    await waitFor(() => expect(mockedCreateCustomerReceipt).toHaveBeenCalledTimes(1));
-    expect(mockedCreateCustomerReceipt).toHaveBeenCalledWith(expect.objectContaining({
+    await waitFor(() => expect(mocks.createCustomerReceipt).toHaveBeenCalledTimes(1))
+    expect(mocks.createCustomerReceipt).toHaveBeenCalledWith(expect.objectContaining({
       customer_id: 'customer-1',
       amount: 500,
       payment_method: 'bank_transfer',
@@ -502,7 +189,7 @@ describe('CustomerReceipts real UI flows', () => {
           discount_amount: 0,
         },
       ],
-    }));
-    expect(mockedToastSuccess).toHaveBeenCalledWith('تم إنشاء سند القبض بنجاح');
-  });
-});
+    }))
+    expect(mocks.toastSuccess).toHaveBeenCalledWith('تم إنشاء سند القبض بنجاح')
+  })
+})

--- a/src/features/sales/components/customer-receipts-contract.test.ts
+++ b/src/features/sales/components/customer-receipts-contract.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const component = readFileSync(
+  new URL('./CustomerReceipts.tsx', import.meta.url),
+  'utf8',
+)
+
+const migration = readFileSync(
+  new URL('../../../../sql/migrations/165_voucher_payment_account_method_consistency.sql', import.meta.url),
+  'utf8',
+)
+
+describe('customer receipt UI contract', () => {
+  it('falls back to the database collection_date field', () => {
+    expect(component).toContain('receipt.receipt_date || receipt.collection_date')
+  })
+
+  it('filters payment accounts by payment method and rejects mismatches', () => {
+    expect(component).toContain("method === 'cash' || method === 'check'")
+    expect(component).toContain("return new Set(['BANK'])")
+    expect(component).toContain('حساب السداد لا يتوافق مع طريقة السداد المختارة')
+    expect(component).toContain('compatiblePaymentAccounts.map')
+  })
+})
+
+describe('voucher database contract', () => {
+  it('guards both customer receipts and supplier payments', () => {
+    expect(migration).toContain('trg_customer_collection_payment_account_consistency')
+    expect(migration).toContain('trg_supplier_payment_account_consistency')
+    expect(migration).toContain('VOUCHER_PAYMENT_ACCOUNT_METHOD_MISMATCH')
+  })
+})

--- a/src/features/sales/components/customer-receipts-contract.test.ts
+++ b/src/features/sales/components/customer-receipts-contract.test.ts
@@ -1,13 +1,14 @@
 import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 const component = readFileSync(
-  new URL('./CustomerReceipts.tsx', import.meta.url),
+  resolve(process.cwd(), 'src/features/sales/components/CustomerReceipts.tsx'),
   'utf8',
 )
 
 const migration = readFileSync(
-  new URL('../../../../sql/migrations/165_voucher_payment_account_method_consistency.sql', import.meta.url),
+  resolve(process.cwd(), 'sql/migrations/165_voucher_payment_account_method_consistency.sql'),
   'utf8',
 )
 


### PR DESCRIPTION
## المشكلة

نجح Pilot المحاسبي لسند القبض والصرف، لكن فحص Production كشف مشكلتين في سند القبض:

1. القائمة والتفاصيل تعرضان `-` لأن الواجهة تقرأ `receipt_date` بينما الجدول يعيد `collection_date`.
2. الواجهة تسمح باختيار حساب بنك مع طريقة سداد نقدية والعكس، ما قد ينتج سندًا محاسبيًا غير متسق مع الوصف الظاهر.

## الحل

- عرض تاريخ السند من `receipt_date` مع fallback إلى `collection_date`.
- فلترة حسابات السداد حسب الطريقة:
  - نقدي/شيك: `CASH`.
  - التحويل والبطاقات والدفع الإلكتروني: `BANK`.
  - أخرى: `CASH` أو `BANK`.
- مسح الحساب المختار عند تغيير الطريقة إذا أصبح غير متوافق.
- منع الحفظ دون حساب أو بحساب غير متوافق.
- Migration 165 تضيف trigger fail-closed على سندات القبض والصرف لمنع أي pairing غير متوافق حتى خارج الواجهة.
- اختبار عقدي للتاريخ، فلترة الحسابات، وحماية الجدولين.

## النطاق

لا تعديل على السندين المقررين أو قيودهما أو الفواتير. الصف التاريخي الحالي يبقى كما هو، والحماية تسري على الإدخالات والتعديلات المستقبلية.