### PR TITLE
feat(db): add voucher reset-to-draft correction cycle

### DIFF
--- a/.github/workflows/voucher-reset-166-acceptance.yml
+++ b/.github/workflows/voucher-reset-166-acceptance.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'sql/migrations/166_voucher_reset_to_draft_workflow.sql'
       - 'scripts/ci/fresh-db/acceptance_166_voucher_reset.sql'
+      - 'scripts/ci/fresh-db/acceptance_166_voucher_reset_isolation.sql'
       - '.github/workflows/voucher-reset-166-acceptance.yml'
       - 'scripts/ci/fresh-db/resolve_baseline_pair.sh'
       - 'scripts/ci/fresh-db/build_apply_order.py'
@@ -74,15 +75,41 @@ jobs:
           PGUSER: postgres
           PGPASSWORD: postgres
 
-      - name: Execute post-reset-correct-repost acceptance
-        run: >-
-          psql -v ON_ERROR_STOP=1 -d wardah_fresh
-          -f scripts/ci/fresh-db/acceptance_166_voucher_reset.sql
-          | tee /tmp/voucher-reset-166.out
+      - name: Execute voucher reset acceptance suites
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          : > /tmp/voucher-reset-166.out
+
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh \
+            -f scripts/ci/fresh-db/acceptance_166_voucher_reset.sql \
+            | tee -a /tmp/voucher-reset-166.out
+
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh \
+            -f scripts/ci/fresh-db/acceptance_166_voucher_reset_isolation.sql \
+            | tee -a /tmp/voucher-reset-166.out
         env:
           PGHOST: localhost
           PGUSER: postgres
           PGPASSWORD: postgres
 
-      - name: Verify acceptance marker
-        run: grep -q 'VOUCHER_RESET_166_ACCEPTANCE_PASS' /tmp/voucher-reset-166.out
+      # These markers are an independent completion contract, not duplicate
+      # logging. They prevent a future shell/pipeline change from reporting a
+      # green job after psql stopped before the end of either acceptance suite.
+      - name: Verify acceptance markers
+        run: |
+          set -Eeuo pipefail
+          grep -q 'VOUCHER_RESET_166_ACCEPTANCE_PASS' /tmp/voucher-reset-166.out
+          grep -q 'VOUCHER_RESET_166_ISOLATION_IDEMPOTENCY_PASS' /tmp/voucher-reset-166.out
+
+      - name: Upload voucher reset acceptance evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: voucher-reset-166-${{ github.run_id }}
+          path: |
+            /tmp/voucher-reset-166.out
+            /tmp/chain_order.txt
+            /tmp/chain_report.txt
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/voucher-reset-166-acceptance.yml
+++ b/.github/workflows/voucher-reset-166-acceptance.yml
@@ -1,0 +1,88 @@
+name: Voucher Reset 166 Acceptance
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'sql/migrations/166_voucher_reset_to_draft_workflow.sql'
+      - 'scripts/ci/fresh-db/acceptance_166_voucher_reset.sql'
+      - '.github/workflows/voucher-reset-166-acceptance.yml'
+      - 'scripts/ci/fresh-db/resolve_baseline_pair.sh'
+      - 'scripts/ci/fresh-db/build_apply_order.py'
+      - 'scripts/ci/fresh-db/run_chain.sh'
+      - 'scripts/ci/fresh-db/supabase_shim.sql'
+      - 'sql/baseline/**'
+  workflow_dispatch:
+
+jobs:
+  acceptance:
+    name: Migration 166 Voucher Reset Cycle
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build fresh database through migration 166
+        run: |
+          set -Eeuo pipefail
+          set +e
+          PAIR=$(bash scripts/ci/fresh-db/resolve_baseline_pair.sh sql/baseline)
+          PAIR_STATUS=$?
+          set -e
+          test "$PAIR_STATUS" -eq 0
+
+          pair_field() { printf '%s\n' "$PAIR" | sed -n "s/^$1=//p"; }
+          BASELINE=$(pair_field BASELINE_PATH)
+          REFERENCE=$(pair_field REFERENCE_PATH)
+          CUTOFF=$(pair_field BASELINE_CUTOFF)
+          CUTOFF=${CUTOFF:-0}
+
+          createdb wardah_fresh
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh \
+            -f scripts/ci/fresh-db/supabase_shim.sql -q
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh -f "$BASELINE" -q
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh -f "$REFERENCE" -q
+
+          python3 scripts/ci/fresh-db/build_apply_order.py \
+            sql/migrations "$CUTOFF" > /tmp/chain_order.txt
+          REPORT=/tmp/chain_report.txt PGDATABASE=wardah_fresh \
+            bash scripts/ci/fresh-db/run_chain.sh sql/migrations /tmp/chain_order.txt
+
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh -tAc \
+            "SELECT to_regprocedure('public.rpc_reset_customer_receipt_to_draft(uuid,text)') IS NOT NULL
+                    AND to_regprocedure('public.rpc_reset_supplier_payment_to_draft(uuid,text)') IS NOT NULL
+                    AND to_regprocedure('public.wardah_has_exact_permission(uuid,uuid,text)') IS NOT NULL" \
+            | grep -qx t
+        env:
+          PGHOST: localhost
+          PGUSER: postgres
+          PGPASSWORD: postgres
+
+      - name: Execute post-reset-correct-repost acceptance
+        run: >-
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh
+          -f scripts/ci/fresh-db/acceptance_166_voucher_reset.sql
+          | tee /tmp/voucher-reset-166.out
+        env:
+          PGHOST: localhost
+          PGUSER: postgres
+          PGPASSWORD: postgres
+
+      - name: Verify acceptance marker
+        run: grep -q 'VOUCHER_RESET_166_ACCEPTANCE_PASS' /tmp/voucher-reset-166.out

--- a/docs/db/VOUCHER_RESET_166_RUNBOOK.md
+++ b/docs/db/VOUCHER_RESET_166_RUNBOOK.md
@@ -1,0 +1,412 @@
+# Migration 166 — Voucher Reset-to-Draft Runbook
+
+**Migration:** `166_voucher_reset_to_draft_workflow.sql`  
+**Scope:** Customer receipts and supplier payments  
+**State:** Repository implementation; do not apply to Production until the dedicated Fresh DB acceptance is green.
+
+## 1. Purpose
+
+Migration 166 introduces a controlled correction cycle for posted vouchers while the accounting period remains open:
+
+```text
+posted → draft → corrected → posted
+```
+
+The same `gl_entry_id` is retained. The linked GL lines are rebuilt from the corrected voucher instead of creating a reversal entry and a replacement entry.
+
+This workflow is intended only for correcting a voucher that does not yet belong to a closed accounting period. A closed-period correction must use the normal reversal workflow.
+
+## 2. Security contract
+
+The operation requires the sensitive exact permission:
+
+```text
+accounting.vouchers.unpost
+```
+
+Migration 166 deliberately does **not** use the general `has_permission` module fallback. That function may treat another `accounting.*` permission as sufficient for an accounting key.
+
+The reset RPCs use:
+
+```text
+wardah_has_exact_permission(user_id, org_id, 'accounting.vouchers.unpost')
+```
+
+The exact helper allows:
+
+- an active super admin;
+- an active organization admin for the selected organization;
+- a user assigned to an active role in the same organization, where that role has the exact permission and the user-role assignment has not expired.
+
+It rejects:
+
+- a user who only has `accounting.accounts.read` or another accounting permission;
+- an inactive role;
+- a role belonging to another organization;
+- an expired user-role assignment.
+
+Do not replace this helper with `has_permission` without an explicit security review.
+
+## 3. Granting the permission to a non-admin role
+
+The permission is inserted by Migration 166 but is not assigned automatically to ordinary roles.
+
+Review candidate roles first:
+
+```sql
+SELECT id, org_id, name, name_ar, is_active, is_system_role
+FROM public.roles
+WHERE org_id = '<ORG_ID>'::uuid
+ORDER BY name;
+```
+
+Confirm the permission row:
+
+```sql
+SELECT id, permission_key, description
+FROM public.permissions
+WHERE permission_key = 'accounting.vouchers.unpost';
+```
+
+Grant it to one approved role:
+
+```sql
+INSERT INTO public.role_permissions (role_id, permission_id, created_by)
+SELECT
+  '<ROLE_ID>'::uuid,
+  p.id,
+  '<ADMIN_USER_ID>'::uuid
+FROM public.permissions p
+WHERE p.permission_key = 'accounting.vouchers.unpost'
+ON CONFLICT (role_id, permission_id) DO NOTHING;
+```
+
+Verify the grant:
+
+```sql
+SELECT r.org_id, r.name, p.permission_key
+FROM public.role_permissions rp
+JOIN public.roles r ON r.id = rp.role_id
+JOIN public.permissions p ON p.id = rp.permission_id
+WHERE r.id = '<ROLE_ID>'::uuid
+  AND p.permission_key = 'accounting.vouchers.unpost';
+```
+
+Grant this permission only to a narrowly controlled correction or finance-supervisor role. Do not add it to generic accountant or read-only roles.
+
+## 4. Revoking the permission
+
+```sql
+DELETE FROM public.role_permissions rp
+USING public.permissions p
+WHERE rp.permission_id = p.id
+  AND rp.role_id = '<ROLE_ID>'::uuid
+  AND p.permission_key = 'accounting.vouchers.unpost';
+```
+
+Existing posted or draft vouchers are not modified by revoking the role grant. The user simply loses permission for later reset calls.
+
+## 5. RPCs introduced
+
+```text
+rpc_reset_customer_receipt_to_draft(uuid, text)
+rpc_reset_supplier_payment_to_draft(uuid, text)
+```
+
+Both RPCs:
+
+- derive the active organization from the authenticated session;
+- require active organization membership;
+- require the exact sensitive permission;
+- require a correction reason of at least five characters;
+- lock the voucher, linked invoices, and linked GL entry;
+- reject cross-organization or inconsistent references;
+- reject a closed or permanently closed period;
+- reverse allocated amounts from invoice `paid_amount`;
+- allow the invoice `balance` generated column to recalculate automatically;
+- change the linked GL entry from `posted` to `draft` through a transaction-local guard;
+- immediately turn that guard off after the single GL update;
+- record the reset action and reason in `audit_logs`.
+
+## 6. Immutability boundary
+
+Direct client updates remain forbidden:
+
+```sql
+UPDATE public.gl_entries
+SET status = 'draft'
+WHERE id = '<POSTED_GL_ENTRY_ID>'::uuid;
+```
+
+The statement must fail with `POSTED_ENTRY_IMMUTABLE`.
+
+Migration 166 permits `posted → draft` only when all of the following are true:
+
+- the caller is inside one of the reset RPCs;
+- `wardah.voucher_unpost` is transaction-locally set to `on`;
+- the GL reference type is `CUSTOMER_RECEIPT` or `SUPPLIER_PAYMENT`;
+- the GL entry has a non-null voucher reference.
+
+The GUC is set immediately before the GL update and reset to `off` immediately afterward.
+
+## 7. Generated invoice balances
+
+These columns are generated by PostgreSQL:
+
+```text
+sales_invoices.balance
+supplier_invoices.balance
+```
+
+They derive from:
+
+```text
+total_amount - paid_amount
+```
+
+Migration 166 updates `paid_amount` and invoice status only. Never include `balance` in an `INSERT` or `UPDATE` statement.
+
+## 8. Dedicated Fresh DB acceptance
+
+Workflow:
+
+```text
+Voucher Reset 166 Acceptance
+```
+
+Files:
+
+```text
+.github/workflows/voucher-reset-166-acceptance.yml
+scripts/ci/fresh-db/acceptance_166_voucher_reset.sql
+```
+
+The acceptance gate builds a Fresh DB through the complete migration chain and executes the actual RPC bodies. It proves:
+
+- posting a customer receipt with an invoice allocation;
+- posting a supplier payment with an invoice allocation;
+- generated balances after posting;
+- rejection of a user who only owns an ordinary accounting permission;
+- acceptance of a user who owns the exact unpost permission;
+- rejection of direct `posted → draft` GL updates;
+- rejection when the accounting period is closed;
+- reset of voucher, GL, invoice paid amount, generated balance, and status;
+- creation of the reset audit records;
+- correction of voucher amount and allocation while draft;
+- reposting with the same `gl_entry_id`;
+- rebuilding exactly two balanced GL lines with corrected amounts;
+- idempotent duplicate post calls;
+- no leaked `wardah.voucher_unpost = on` state.
+
+Success marker:
+
+```text
+VOUCHER_RESET_166_ACCEPTANCE_PASS
+```
+
+## 9. Pre-deployment checks
+
+Do not apply Migration 166 unless:
+
+1. every required PR check is green on the exact head SHA;
+2. `Voucher Reset 166 Acceptance` is green;
+3. the PR remains mergeable and its reviewed head has not moved;
+4. no UI deployment depending on 166 has been enabled;
+5. the Production accounting period and voucher state preflight below returns no unexpected result.
+
+Check current RPC and trigger state:
+
+```sql
+SELECT to_regprocedure('public.rpc_post_customer_receipt(uuid)'),
+       to_regprocedure('public.rpc_post_supplier_payment(uuid)'),
+       to_regprocedure('public.rpc_reset_customer_receipt_to_draft(uuid,text)'),
+       to_regprocedure('public.rpc_reset_supplier_payment_to_draft(uuid,text)');
+
+SELECT tgname, tgenabled, pg_get_triggerdef(oid)
+FROM pg_trigger
+WHERE tgrelid = 'public.gl_entries'::regclass
+  AND tgname = 'trg_protect_posted_gl_entries'
+  AND NOT tgisinternal;
+```
+
+Check generated balances:
+
+```sql
+SELECT table_name, column_name, is_generated, generation_expression
+FROM information_schema.columns
+WHERE table_schema = 'public'
+  AND table_name IN ('sales_invoices', 'supplier_invoices')
+  AND column_name = 'balance'
+ORDER BY table_name;
+```
+
+Expected: both rows show `is_generated = 'ALWAYS'`.
+
+Review posted vouchers before rollout:
+
+```sql
+SELECT 'customer_receipt' AS voucher_type,
+       c.id, c.collection_number AS voucher_number,
+       c.status, c.gl_entry_id, e.status AS gl_status, e.entry_date
+FROM public.customer_collections c
+LEFT JOIN public.gl_entries e ON e.id = c.gl_entry_id
+WHERE c.status = 'posted'
+UNION ALL
+SELECT 'supplier_payment',
+       p.id, p.payment_number,
+       p.status, p.gl_entry_id, e.status, e.entry_date
+FROM public.supplier_payments p
+LEFT JOIN public.gl_entries e ON e.id = p.gl_entry_id
+WHERE p.status = 'posted'
+ORDER BY entry_date, voucher_number;
+```
+
+Investigate any posted voucher with a missing GL entry, a non-posted linked GL entry, or a mismatched reference before applying 166.
+
+## 10. Apply Migration 166
+
+Apply the exact merged migration file as one migration. Do not copy selected function bodies manually.
+
+After application, record:
+
+- Production project reference;
+- migration name and version;
+- merged main SHA;
+- operator and timestamp;
+- output of the structural checks in the next section.
+
+## 11. Post-deployment structural verification
+
+```sql
+SELECT to_regprocedure('public.wardah_has_exact_permission(uuid,uuid,text)') IS NOT NULL
+       AS exact_guard_exists,
+       to_regprocedure('public.rpc_reset_customer_receipt_to_draft(uuid,text)') IS NOT NULL
+       AS receipt_reset_exists,
+       to_regprocedure('public.rpc_reset_supplier_payment_to_draft(uuid,text)') IS NOT NULL
+       AS payment_reset_exists;
+```
+
+Verify grants:
+
+```sql
+SELECT
+  has_function_privilege('anon',
+    'public.rpc_reset_customer_receipt_to_draft(uuid,text)', 'EXECUTE') AS anon_receipt,
+  has_function_privilege('authenticated',
+    'public.rpc_reset_customer_receipt_to_draft(uuid,text)', 'EXECUTE') AS auth_receipt,
+  has_function_privilege('anon',
+    'public.rpc_reset_supplier_payment_to_draft(uuid,text)', 'EXECUTE') AS anon_payment,
+  has_function_privilege('authenticated',
+    'public.rpc_reset_supplier_payment_to_draft(uuid,text)', 'EXECUTE') AS auth_payment,
+  has_function_privilege('authenticated',
+    'public.wardah_has_exact_permission(uuid,uuid,text)', 'EXECUTE') AS auth_exact_helper;
+```
+
+Expected:
+
+```text
+anon_receipt = false
+auth_receipt = true
+anon_payment = false
+auth_payment = true
+auth_exact_helper = false
+```
+
+Verify the permission is not automatically granted to ordinary roles:
+
+```sql
+SELECT r.org_id, r.name, p.permission_key
+FROM public.role_permissions rp
+JOIN public.roles r ON r.id = rp.role_id
+JOIN public.permissions p ON p.id = rp.permission_id
+WHERE p.permission_key = 'accounting.vouchers.unpost'
+ORDER BY r.org_id, r.name;
+```
+
+Every returned role must be an explicitly approved grant.
+
+## 12. Controlled Production verification
+
+Use a dedicated test organization and test vouchers only. Do not mutate an existing real posted voucher merely to prove deployment.
+
+Required sequence:
+
+1. Create one test sales invoice and one draft receipt with one allocation.
+2. Create one test supplier invoice and one draft payment with one allocation.
+3. Post both through the normal application/RPC path.
+4. Capture both `gl_entry_id` values.
+5. Verify a test user with an ordinary accounting read permission is rejected.
+6. Grant the exact permission to a dedicated test role.
+7. Reset both vouchers with documented reasons.
+8. Correct amounts and allocation lines.
+9. Repost both.
+10. Verify the two captured `gl_entry_id` values did not change.
+11. Verify each GL entry has exactly two balanced lines and corrected totals.
+12. Verify invoice `paid_amount`, generated `balance`, and payment status.
+13. Verify two audit records.
+14. Revoke the test role permission when verification is complete.
+
+This controlled verification is deployment evidence, not human Pilot UI signoff.
+
+## 13. Failure handling
+
+### Migration application failure
+
+Migration 166 runs inside one transaction. A failure before `COMMIT` must leave the prior functions and permissions unchanged.
+
+Do not edit the already reviewed migration in Production. Fix the repository migration, rerun Fresh DB and acceptance gates, merge a new reviewed head, and apply the corrected migration version.
+
+### Reset RPC failure
+
+The reset is atomic. Any failure rolls back:
+
+- invoice paid/status changes;
+- generated balance recalculation;
+- GL status change;
+- voucher status change;
+- audit insert.
+
+Capture the full database error and investigate the specific fail-closed code. Do not bypass the guard with direct SQL updates.
+
+### Voucher already draft
+
+The RPC is idempotent only when both the voucher and its linked GL entry are valid drafts. A draft voucher with a missing or non-draft linked GL entry raises an integrity error and must be investigated.
+
+## 14. Rollback policy
+
+After Production use begins, do not drop the functions or permission while any voucher remains in the correction cycle.
+
+Before removing or replacing Migration 166 behavior, confirm:
+
+```sql
+SELECT count(*) AS draft_receipts_with_linked_gl
+FROM public.customer_collections c
+JOIN public.gl_entries e ON e.id = c.gl_entry_id
+WHERE c.status='draft'
+  AND e.status='draft'
+  AND e.reference_type='CUSTOMER_RECEIPT';
+
+SELECT count(*) AS draft_payments_with_linked_gl
+FROM public.supplier_payments p
+JOIN public.gl_entries e ON e.id = p.gl_entry_id
+WHERE p.status='draft'
+  AND e.status='draft'
+  AND e.reference_type='SUPPLIER_PAYMENT';
+```
+
+Both counts must be reviewed and resolved. A voucher in draft correction must be either corrected and reposted or handled through a separately approved recovery plan.
+
+## 15. Evidence to retain
+
+Keep the following with the deployment record:
+
+- PR number and merged main SHA;
+- all green check names and run IDs;
+- dedicated acceptance run ID and success marker;
+- migration version from Production;
+- post-deployment function/privilege output;
+- approved role grant and later revocation, when applicable;
+- controlled test voucher IDs and stable GL entry IDs;
+- balanced GL totals and invoice paid/balance status;
+- audit-log evidence;
+- any remaining Pilot or UI rollout issue kept open until human signoff.

--- a/scripts/ci/fresh-db/acceptance_166_voucher_reset.sql
+++ b/scripts/ci/fresh-db/acceptance_166_voucher_reset.sql
@@ -1,0 +1,579 @@
+-- Acceptance for Migration 166.
+-- Executes the real customer-receipt and supplier-payment RPCs on a fresh DB.
+-- Proves exact permission enforcement, posted-entry immutability, closed-period
+-- fail-closed behavior, generated invoice balances, and stable GL identity
+-- across post -> reset -> correct -> repost.
+\set ON_ERROR_STOP on
+
+CREATE OR REPLACE FUNCTION pg_temp.expect_error(p_sql text, p_needle text)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_succeeded boolean := false;
+BEGIN
+  BEGIN
+    EXECUTE p_sql;
+    v_succeeded := true;
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM NOT LIKE '%' || p_needle || '%' THEN
+      RAISE EXCEPTION
+        'ACCEPTANCE_FAIL: expected [%] for [%], got [%]',
+        p_needle, p_sql, SQLERRM;
+    END IF;
+  END;
+
+  IF v_succeeded THEN
+    RAISE EXCEPTION
+      'ACCEPTANCE_FAIL: expected error [%] for [%], but it succeeded',
+      p_needle, p_sql;
+  END IF;
+END;
+$$;
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- 1. Minimal tenant, users, RBAC, accounting map, invoices, and vouchers.
+-- ---------------------------------------------------------------------------
+INSERT INTO auth.users (id, email) VALUES
+  ('66aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'voucher166-admin@example.test'),
+  ('66bbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'voucher166-reader@example.test'),
+  ('66cccccc-cccc-cccc-cccc-cccccccccccc', 'voucher166-corrector@example.test');
+
+INSERT INTO public.organizations (id, code, name) VALUES
+  ('66111111-1111-1111-1111-111111111111', 'V166', 'Voucher Reset 166 Org');
+
+INSERT INTO public.user_organizations
+  (id, user_id, org_id, role, is_active, is_org_admin) VALUES
+  ('66000000-0000-0000-0000-000000000001',
+   '66aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+   '66111111-1111-1111-1111-111111111111', 'admin', true, true),
+  ('66000000-0000-0000-0000-000000000002',
+   '66bbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+   '66111111-1111-1111-1111-111111111111', 'user', true, false),
+  ('66000000-0000-0000-0000-000000000003',
+   '66cccccc-cccc-cccc-cccc-cccccccccccc',
+   '66111111-1111-1111-1111-111111111111', 'user', true, false);
+
+INSERT INTO public.roles
+  (id, org_id, name, name_ar, is_system_role, is_active) VALUES
+  ('66700000-0000-0000-0000-000000000001',
+   '66111111-1111-1111-1111-111111111111',
+   'Voucher 166 accounting reader', 'قارئ محاسبة 166', false, true),
+  ('66700000-0000-0000-0000-000000000002',
+   '66111111-1111-1111-1111-111111111111',
+   'Voucher 166 corrector', 'مصحح السندات 166', false, true);
+
+-- The reader receives one ordinary accounting permission. Under the legacy
+-- module fallback this is sufficient for any accounting.* key, but it must not
+-- satisfy the exact unpost guard.
+INSERT INTO public.role_permissions (role_id, permission_id)
+SELECT '66700000-0000-0000-0000-000000000001'::uuid, p.id
+FROM public.permissions p
+WHERE p.permission_key LIKE 'accounting.%'
+  AND p.permission_key <> 'accounting.vouchers.unpost'
+ORDER BY p.permission_key
+LIMIT 1;
+
+INSERT INTO public.role_permissions (role_id, permission_id)
+SELECT '66700000-0000-0000-0000-000000000002'::uuid, p.id
+FROM public.permissions p
+WHERE p.permission_key = 'accounting.vouchers.unpost';
+
+INSERT INTO public.user_roles
+  (id, user_id, role_id, org_id) VALUES
+  ('66800000-0000-0000-0000-000000000001',
+   '66bbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+   '66700000-0000-0000-0000-000000000001',
+   '66111111-1111-1111-1111-111111111111'),
+  ('66800000-0000-0000-0000-000000000002',
+   '66cccccc-cccc-cccc-cccc-cccccccccccc',
+   '66700000-0000-0000-0000-000000000002',
+   '66111111-1111-1111-1111-111111111111');
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.role_permissions rp
+    JOIN public.permissions p ON p.id = rp.permission_id
+    WHERE rp.role_id = '66700000-0000-0000-0000-000000000001'
+      AND p.permission_key LIKE 'accounting.%'
+      AND p.permission_key <> 'accounting.vouchers.unpost'
+  ) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: ordinary accounting permission fixture missing';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.role_permissions rp
+    JOIN public.permissions p ON p.id = rp.permission_id
+    WHERE rp.role_id = '66700000-0000-0000-0000-000000000002'
+      AND p.permission_key = 'accounting.vouchers.unpost'
+  ) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: exact unpost permission fixture missing';
+  END IF;
+END;
+$$;
+
+INSERT INTO public.customers (id, org_id, code, name, is_active) VALUES
+  ('66d00000-0000-0000-0000-000000000001',
+   '66111111-1111-1111-1111-111111111111', 'V166-CUST', 'Voucher 166 Customer', true);
+
+INSERT INTO public.vendors (id, org_id, code, name, is_active) VALUES
+  ('66e00000-0000-0000-0000-000000000001',
+   '66111111-1111-1111-1111-111111111111', 'V166-VEND', 'Voucher 166 Vendor', true);
+
+INSERT INTO public.gl_accounts
+  (id, org_id, code, name, category, subtype, normal_balance, allow_posting, is_active)
+VALUES
+  ('66a10000-0000-0000-0000-000000000001',
+   '66111111-1111-1111-1111-111111111111', '110101', 'Voucher 166 Cash',
+   'ASSET', 'CASH', 'DEBIT', true, true),
+  ('66a10000-0000-0000-0000-000000000002',
+   '66111111-1111-1111-1111-111111111111', '110102', 'Voucher 166 Bank',
+   'ASSET', 'BANK', 'DEBIT', true, true),
+  ('66a10000-0000-0000-0000-000000000003',
+   '66111111-1111-1111-1111-111111111111', '110300', 'Voucher 166 AR',
+   'ASSET', 'AR', 'DEBIT', true, true),
+  ('66a10000-0000-0000-0000-000000000004',
+   '66111111-1111-1111-1111-111111111111', '210100', 'Voucher 166 AP',
+   'LIABILITY', 'AP', 'CREDIT', true, true);
+
+INSERT INTO public.journals
+  (id, org_id, code, name, journal_type, is_active) VALUES
+  ('66f00000-0000-0000-0000-000000000001',
+   '66111111-1111-1111-1111-111111111111', 'V166-JRN',
+   'Voucher 166 Journal', 'cash', true);
+
+INSERT INTO public.accounting_periods
+  (id, org_id, period_code, period_name, period_type,
+   start_date, end_date, fiscal_year, status) VALUES
+  ('66d10000-0000-0000-0000-000000000001',
+   '66111111-1111-1111-1111-111111111111', 'V166-2026-08',
+   'Voucher 166 August 2026', 'month',
+   DATE '2026-08-01', DATE '2026-08-31', 2026, 'open');
+
+INSERT INTO public.sales_invoices
+  (id, org_id, invoice_number, customer_id, invoice_date,
+   subtotal, discount_amount, tax_amount, total_amount, paid_amount,
+   payment_status, status)
+VALUES
+  ('66b10000-0000-0000-0000-000000000001',
+   '66111111-1111-1111-1111-111111111111', 'V166-SI-001',
+   '66d00000-0000-0000-0000-000000000001', DATE '2026-08-05',
+   1000, 0, 0, 1000, 0, 'unpaid', 'POSTED');
+
+INSERT INTO public.supplier_invoices
+  (id, org_id, invoice_number, vendor_id, invoice_date, due_date,
+   subtotal, discount_amount, tax_amount, total_amount, paid_amount, status)
+VALUES
+  ('66b20000-0000-0000-0000-000000000001',
+   '66111111-1111-1111-1111-111111111111', 'V166-PI-001',
+   '66e00000-0000-0000-0000-000000000001', DATE '2026-08-05', NULL,
+   1000, 0, 0, 1000, 0, 'approved');
+
+INSERT INTO public.customer_collections
+  (id, org_id, collection_number, customer_id, collection_date,
+   amount, payment_method, payment_account_id, status, created_by)
+VALUES
+  ('66c10000-0000-0000-0000-000000000001',
+   '66111111-1111-1111-1111-111111111111', 'V166-CR-001',
+   '66d00000-0000-0000-0000-000000000001', DATE '2026-08-05',
+   400, 'cash', '66a10000-0000-0000-0000-000000000001', 'draft',
+   '66aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
+
+INSERT INTO public.customer_collection_lines
+  (id, collection_id, invoice_id, allocated_amount, discount_amount)
+VALUES
+  ('66c11000-0000-0000-0000-000000000001',
+   '66c10000-0000-0000-0000-000000000001',
+   '66b10000-0000-0000-0000-000000000001', 400, 0);
+
+INSERT INTO public.supplier_payments
+  (id, org_id, payment_number, vendor_id, payment_date,
+   amount, payment_method, payment_account_id, status, created_by)
+VALUES
+  ('66c20000-0000-0000-0000-000000000001',
+   '66111111-1111-1111-1111-111111111111', 'V166-SP-001',
+   '66e00000-0000-0000-0000-000000000001', DATE '2026-08-05',
+   300, 'bank_transfer', '66a10000-0000-0000-0000-000000000002', 'draft',
+   '66aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
+
+INSERT INTO public.supplier_payment_lines
+  (id, payment_id, invoice_id, allocated_amount, discount_amount)
+VALUES
+  ('66c21000-0000-0000-0000-000000000001',
+   '66c20000-0000-0000-0000-000000000001',
+   '66b20000-0000-0000-0000-000000000001', 300, 0);
+
+-- ---------------------------------------------------------------------------
+-- 2. Prove the exact guard differs from the legacy module fallback.
+-- ---------------------------------------------------------------------------
+DO $$
+BEGIN
+  IF NOT public.has_permission(
+    '66bbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+    '66111111-1111-1111-1111-111111111111',
+    'accounting.vouchers.unpost'
+  ) THEN
+    RAISE EXCEPTION
+      'ACCEPTANCE_FAIL: reader fixture did not demonstrate legacy accounting fallback';
+  END IF;
+
+  IF public.wardah_has_exact_permission(
+    '66bbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+    '66111111-1111-1111-1111-111111111111',
+    'accounting.vouchers.unpost'
+  ) THEN
+    RAISE EXCEPTION
+      'ACCEPTANCE_FAIL: ordinary accounting permission satisfied exact unpost guard';
+  END IF;
+
+  IF NOT public.wardah_has_exact_permission(
+    '66cccccc-cccc-cccc-cccc-cccccccccccc',
+    '66111111-1111-1111-1111-111111111111',
+    'accounting.vouchers.unpost'
+  ) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: explicitly granted corrector was rejected';
+  END IF;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 3. Post both vouchers through the real Migration 166 RPC bodies.
+-- ---------------------------------------------------------------------------
+SELECT set_config('request.jwt.claim.sub',
+                  '66aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', false);
+SELECT set_config('request.jwt.claims',
+                  '{"org_id":"66111111-1111-1111-1111-111111111111"}', false);
+
+SELECT public.rpc_post_customer_receipt(
+  '66c10000-0000-0000-0000-000000000001');
+SELECT public.rpc_post_supplier_payment(
+  '66c20000-0000-0000-0000-000000000001');
+
+CREATE TEMP TABLE v166_entries AS
+SELECT
+  (SELECT gl_entry_id FROM public.customer_collections
+   WHERE id='66c10000-0000-0000-0000-000000000001') AS receipt_entry_id,
+  (SELECT gl_entry_id FROM public.supplier_payments
+   WHERE id='66c20000-0000-0000-0000-000000000001') AS payment_entry_id;
+
+DO $$
+DECLARE
+  v_receipt_entry uuid;
+  v_payment_entry uuid;
+BEGIN
+  SELECT receipt_entry_id, payment_entry_id
+  INTO v_receipt_entry, v_payment_entry
+  FROM v166_entries;
+
+  IF v_receipt_entry IS NULL OR v_payment_entry IS NULL
+     OR v_receipt_entry = v_payment_entry THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: posting did not create two distinct GL identities';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.customer_collections
+    WHERE id='66c10000-0000-0000-0000-000000000001'
+      AND status='posted' AND gl_entry_id=v_receipt_entry
+  ) OR NOT EXISTS (
+    SELECT 1 FROM public.supplier_payments
+    WHERE id='66c20000-0000-0000-0000-000000000001'
+      AND status='posted' AND gl_entry_id=v_payment_entry
+  ) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: voucher post state mismatch';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.sales_invoices
+    WHERE id='66b10000-0000-0000-0000-000000000001'
+      AND paid_amount=400 AND balance=600 AND payment_status='partially_paid'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM public.supplier_invoices
+    WHERE id='66b20000-0000-0000-0000-000000000001'
+      AND paid_amount=300 AND balance=700 AND status='partially_paid'
+  ) THEN
+    RAISE EXCEPTION
+      'ACCEPTANCE_FAIL: invoice paid/generated-balance state mismatch after post';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.gl_entries
+    WHERE id=v_receipt_entry AND status='posted'
+      AND total_debit=400 AND total_credit=400
+  ) OR NOT EXISTS (
+    SELECT 1 FROM public.gl_entries
+    WHERE id=v_payment_entry AND status='posted'
+      AND total_debit=300 AND total_credit=300
+  ) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: GL headers mismatch after post';
+  END IF;
+
+  IF (SELECT count(*) FROM public.gl_entry_lines WHERE entry_id=v_receipt_entry) <> 2
+     OR (SELECT count(*) FROM public.gl_entry_lines WHERE entry_id=v_payment_entry) <> 2 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: posted voucher GL must contain exactly two lines';
+  END IF;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 4. Ordinary accounting permission must not authorize unposting.
+-- ---------------------------------------------------------------------------
+SELECT set_config('request.jwt.claim.sub',
+                  '66bbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', false);
+
+SELECT pg_temp.expect_error(
+  $$SELECT public.rpc_reset_customer_receipt_to_draft(
+      '66c10000-0000-0000-0000-000000000001', 'reader denied')$$,
+  'VOUCHER_UNPOST_PERMISSION_REQUIRED');
+
+SELECT pg_temp.expect_error(
+  $$SELECT public.rpc_reset_supplier_payment_to_draft(
+      '66c20000-0000-0000-0000-000000000001', 'reader denied')$$,
+  'VOUCHER_UNPOST_PERMISSION_REQUIRED');
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM public.customer_collections
+    WHERE id='66c10000-0000-0000-0000-000000000001' AND status='posted'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM public.supplier_payments
+    WHERE id='66c20000-0000-0000-0000-000000000001' AND status='posted'
+  ) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: denied unpost changed voucher state';
+  END IF;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 5. Direct posted -> draft remains forbidden outside the controlled RPC.
+-- ---------------------------------------------------------------------------
+SELECT pg_temp.expect_error(
+  $$UPDATE public.gl_entries
+    SET status='draft'
+    WHERE id=(SELECT receipt_entry_id FROM v166_entries)$$,
+  'POSTED_ENTRY_IMMUTABLE');
+
+SELECT pg_temp.expect_error(
+  $$UPDATE public.gl_entries
+    SET status='draft'
+    WHERE id=(SELECT payment_entry_id FROM v166_entries)$$,
+  'POSTED_ENTRY_IMMUTABLE');
+
+-- ---------------------------------------------------------------------------
+-- 6. Exact corrector is still blocked while the accounting period is closed.
+-- ---------------------------------------------------------------------------
+UPDATE public.accounting_periods
+SET status='closed'
+WHERE id='66d10000-0000-0000-0000-000000000001';
+
+SELECT set_config('request.jwt.claim.sub',
+                  '66cccccc-cccc-cccc-cccc-cccccccccccc', false);
+
+SELECT pg_temp.expect_error(
+  $$SELECT public.rpc_reset_customer_receipt_to_draft(
+      '66c10000-0000-0000-0000-000000000001', 'closed period')$$,
+  'PERIOD_CLOSED');
+
+SELECT pg_temp.expect_error(
+  $$SELECT public.rpc_reset_supplier_payment_to_draft(
+      '66c20000-0000-0000-0000-000000000001', 'closed period')$$,
+  'PERIOD_CLOSED');
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM public.gl_entries
+    WHERE id=(SELECT receipt_entry_id FROM v166_entries) AND status='posted'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM public.gl_entries
+    WHERE id=(SELECT payment_entry_id FROM v166_entries) AND status='posted'
+  ) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: closed-period rejection changed GL state';
+  END IF;
+END;
+$$;
+
+UPDATE public.accounting_periods
+SET status='open'
+WHERE id='66d10000-0000-0000-0000-000000000001';
+
+-- ---------------------------------------------------------------------------
+-- 7. Reset both vouchers with the explicit permission.
+-- ---------------------------------------------------------------------------
+SELECT public.rpc_reset_customer_receipt_to_draft(
+  '66c10000-0000-0000-0000-000000000001', 'correct receipt allocation');
+SELECT public.rpc_reset_supplier_payment_to_draft(
+  '66c20000-0000-0000-0000-000000000001', 'correct payment allocation');
+
+DO $$
+DECLARE
+  v_guc text := coalesce(current_setting('wardah.voucher_unpost', true), '');
+BEGIN
+  IF v_guc <> 'off' THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: voucher_unpost GUC leaked after RPC: [%]', v_guc;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.customer_collections c, v166_entries x
+    WHERE c.id='66c10000-0000-0000-0000-000000000001'
+      AND c.status='draft' AND c.gl_entry_id=x.receipt_entry_id
+  ) OR NOT EXISTS (
+    SELECT 1 FROM public.supplier_payments p, v166_entries x
+    WHERE p.id='66c20000-0000-0000-0000-000000000001'
+      AND p.status='draft' AND p.gl_entry_id=x.payment_entry_id
+  ) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: reset did not preserve voucher GL identity';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.gl_entries e, v166_entries x
+    WHERE e.id=x.receipt_entry_id AND e.status='draft'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM public.gl_entries e, v166_entries x
+    WHERE e.id=x.payment_entry_id AND e.status='draft'
+  ) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: reset did not move linked GL entries to draft';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.sales_invoices
+    WHERE id='66b10000-0000-0000-0000-000000000001'
+      AND paid_amount=0 AND balance=1000 AND payment_status='unpaid'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM public.supplier_invoices
+    WHERE id='66b20000-0000-0000-0000-000000000001'
+      AND paid_amount=0 AND balance=1000 AND status='approved'
+  ) THEN
+    RAISE EXCEPTION
+      'ACCEPTANCE_FAIL: reset did not reverse allocations/generated balances';
+  END IF;
+
+  IF (SELECT count(*) FROM public.audit_logs
+      WHERE action='voucher_reset_to_draft'
+        AND entity_id IN (
+          '66c10000-0000-0000-0000-000000000001',
+          '66c20000-0000-0000-0000-000000000001'
+        )) <> 2 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: reset audit trail missing';
+  END IF;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 8. Correct draft amounts and allocations, then repost.
+-- ---------------------------------------------------------------------------
+UPDATE public.customer_collections
+SET amount=250, notes='corrected by acceptance 166'
+WHERE id='66c10000-0000-0000-0000-000000000001' AND status='draft';
+
+UPDATE public.customer_collection_lines
+SET allocated_amount=250
+WHERE id='66c11000-0000-0000-0000-000000000001';
+
+UPDATE public.supplier_payments
+SET amount=200, notes='corrected by acceptance 166'
+WHERE id='66c20000-0000-0000-0000-000000000001' AND status='draft';
+
+UPDATE public.supplier_payment_lines
+SET allocated_amount=200
+WHERE id='66c21000-0000-0000-0000-000000000001';
+
+SELECT public.rpc_post_customer_receipt(
+  '66c10000-0000-0000-0000-000000000001');
+SELECT public.rpc_post_supplier_payment(
+  '66c20000-0000-0000-0000-000000000001');
+
+DO $$
+DECLARE
+  v_receipt_entry uuid;
+  v_payment_entry uuid;
+BEGIN
+  SELECT receipt_entry_id, payment_entry_id
+  INTO v_receipt_entry, v_payment_entry
+  FROM v166_entries;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.customer_collections
+    WHERE id='66c10000-0000-0000-0000-000000000001'
+      AND status='posted' AND gl_entry_id=v_receipt_entry
+  ) OR NOT EXISTS (
+    SELECT 1 FROM public.supplier_payments
+    WHERE id='66c20000-0000-0000-0000-000000000001'
+      AND status='posted' AND gl_entry_id=v_payment_entry
+  ) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: repost created or linked a different GL identity';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.sales_invoices
+    WHERE id='66b10000-0000-0000-0000-000000000001'
+      AND paid_amount=250 AND balance=750 AND payment_status='partially_paid'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM public.supplier_invoices
+    WHERE id='66b20000-0000-0000-0000-000000000001'
+      AND paid_amount=200 AND balance=800 AND status='partially_paid'
+  ) THEN
+    RAISE EXCEPTION
+      'ACCEPTANCE_FAIL: corrected repost invoice/generated-balance mismatch';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.gl_entries
+    WHERE id=v_receipt_entry AND status='posted'
+      AND total_debit=250 AND total_credit=250
+  ) OR NOT EXISTS (
+    SELECT 1 FROM public.gl_entries
+    WHERE id=v_payment_entry AND status='posted'
+      AND total_debit=200 AND total_credit=200
+  ) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: corrected repost GL header mismatch';
+  END IF;
+
+  IF (SELECT count(*) FROM public.gl_entry_lines WHERE entry_id=v_receipt_entry) <> 2
+     OR (SELECT sum(debit) FROM public.gl_entry_lines WHERE entry_id=v_receipt_entry) <> 250
+     OR (SELECT sum(credit) FROM public.gl_entry_lines WHERE entry_id=v_receipt_entry) <> 250
+     OR (SELECT count(*) FROM public.gl_entry_lines WHERE entry_id=v_payment_entry) <> 2
+     OR (SELECT sum(debit) FROM public.gl_entry_lines WHERE entry_id=v_payment_entry) <> 200
+     OR (SELECT sum(credit) FROM public.gl_entry_lines WHERE entry_id=v_payment_entry) <> 200 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: corrected GL lines were not rebuilt exactly';
+  END IF;
+
+  IF (SELECT count(*) FROM public.gl_entries
+      WHERE idempotency_key='CUSTOMER_RECEIPT:66c10000-0000-0000-0000-000000000001') <> 1
+     OR (SELECT count(*) FROM public.gl_entries
+      WHERE idempotency_key='SUPPLIER_PAYMENT:66c20000-0000-0000-0000-000000000001') <> 1 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: repost duplicated voucher GL entries';
+  END IF;
+END;
+$$;
+
+-- Duplicate post calls remain idempotent and do not alter allocations again.
+SELECT public.rpc_post_customer_receipt(
+  '66c10000-0000-0000-0000-000000000001');
+SELECT public.rpc_post_supplier_payment(
+  '66c20000-0000-0000-0000-000000000001');
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM public.sales_invoices
+    WHERE id='66b10000-0000-0000-0000-000000000001'
+      AND paid_amount=250 AND balance=750
+  ) OR NOT EXISTS (
+    SELECT 1 FROM public.supplier_invoices
+    WHERE id='66b20000-0000-0000-0000-000000000001'
+      AND paid_amount=200 AND balance=800
+  ) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: duplicate post changed invoice state';
+  END IF;
+END;
+$$;
+
+COMMIT;
+
+SELECT 'VOUCHER_RESET_166_ACCEPTANCE_PASS' AS result;

--- a/scripts/ci/fresh-db/acceptance_166_voucher_reset_isolation.sql
+++ b/scripts/ci/fresh-db/acceptance_166_voucher_reset_isolation.sql
@@ -1,0 +1,226 @@
+-- Additional acceptance for Migration 166.
+-- Runs after acceptance_166_voucher_reset.sql on the same fresh database.
+-- Proves cross-organization fail-closed behavior and idempotent duplicate reset.
+\set ON_ERROR_STOP on
+
+CREATE OR REPLACE FUNCTION pg_temp.expect_error(p_sql text, p_needle text)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_succeeded boolean := false;
+BEGIN
+  BEGIN
+    EXECUTE p_sql;
+    v_succeeded := true;
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM NOT LIKE '%' || p_needle || '%' THEN
+      RAISE EXCEPTION
+        'ACCEPTANCE_FAIL: expected [%] for [%], got [%]',
+        p_needle, p_sql, SQLERRM;
+    END IF;
+  END;
+
+  IF v_succeeded THEN
+    RAISE EXCEPTION
+      'ACCEPTANCE_FAIL: expected error [%] for [%], but it succeeded',
+      p_needle, p_sql;
+  END IF;
+END;
+$$;
+
+BEGIN;
+
+-- The primary acceptance leaves both vouchers posted after correction/repost.
+CREATE TEMP TABLE v166_isolation_entries AS
+SELECT
+  (SELECT gl_entry_id
+   FROM public.customer_collections
+   WHERE id='66c10000-0000-0000-0000-000000000001') AS receipt_entry_id,
+  (SELECT gl_entry_id
+   FROM public.supplier_payments
+   WHERE id='66c20000-0000-0000-0000-000000000001') AS payment_entry_id;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM public.customer_collections
+    WHERE id='66c10000-0000-0000-0000-000000000001'
+      AND status='posted'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM public.supplier_payments
+    WHERE id='66c20000-0000-0000-0000-000000000001'
+      AND status='posted'
+  ) THEN
+    RAISE EXCEPTION
+      'ACCEPTANCE_FAIL: primary acceptance did not leave vouchers posted';
+  END IF;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 1. A fully privileged admin of another organization cannot address Org A's
+-- voucher IDs. PostgreSQL superuser bypasses RLS in this fixture, so this
+-- explicitly executes the org_id predicates inside the SECURITY DEFINER RPCs.
+-- ---------------------------------------------------------------------------
+INSERT INTO auth.users (id, email) VALUES
+  ('66dddddd-dddd-dddd-dddd-dddddddddddd', 'voucher166-orgb-admin@example.test');
+
+INSERT INTO public.organizations (id, code, name) VALUES
+  ('66222222-2222-2222-2222-222222222222', 'V166B', 'Voucher Reset 166 Org B');
+
+INSERT INTO public.user_organizations
+  (id, user_id, org_id, role, is_active, is_org_admin) VALUES
+  ('66000000-0000-0000-0000-000000000004',
+   '66dddddd-dddd-dddd-dddd-dddddddddddd',
+   '66222222-2222-2222-2222-222222222222', 'admin', true, true);
+
+SELECT set_config('request.jwt.claim.sub',
+                  '66dddddd-dddd-dddd-dddd-dddddddddddd', false);
+SELECT set_config('request.jwt.claims',
+                  '{"org_id":"66222222-2222-2222-2222-222222222222"}', false);
+
+SELECT pg_temp.expect_error(
+  $$SELECT public.rpc_reset_customer_receipt_to_draft(
+      '66c10000-0000-0000-0000-000000000001', 'cross org receipt')$$,
+  'CUSTOMER_RECEIPT_NOT_FOUND_OR_CROSS_ORG');
+
+SELECT pg_temp.expect_error(
+  $$SELECT public.rpc_reset_supplier_payment_to_draft(
+      '66c20000-0000-0000-0000-000000000001', 'cross org payment')$$,
+  'SUPPLIER_PAYMENT_NOT_FOUND_OR_CROSS_ORG');
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM public.customer_collections c, v166_isolation_entries x
+    WHERE c.id='66c10000-0000-0000-0000-000000000001'
+      AND c.status='posted' AND c.gl_entry_id=x.receipt_entry_id
+  ) OR NOT EXISTS (
+    SELECT 1 FROM public.supplier_payments p, v166_isolation_entries x
+    WHERE p.id='66c20000-0000-0000-0000-000000000001'
+      AND p.status='posted' AND p.gl_entry_id=x.payment_entry_id
+  ) OR NOT EXISTS (
+    SELECT 1 FROM public.sales_invoices
+    WHERE id='66b10000-0000-0000-0000-000000000001'
+      AND paid_amount=250 AND balance=750
+  ) OR NOT EXISTS (
+    SELECT 1 FROM public.supplier_invoices
+    WHERE id='66b20000-0000-0000-0000-000000000001'
+      AND paid_amount=200 AND balance=800
+  ) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: cross-org rejection changed financial state';
+  END IF;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 2. The explicitly authorized corrector resets both vouchers. A repeated
+-- call must return duplicate=true, preserve the same draft GL identities,
+-- avoid a second allocation reversal, and avoid extra audit rows.
+-- ---------------------------------------------------------------------------
+SELECT set_config('request.jwt.claim.sub',
+                  '66cccccc-cccc-cccc-cccc-cccccccccccc', false);
+SELECT set_config('request.jwt.claims',
+                  '{"org_id":"66111111-1111-1111-1111-111111111111"}', false);
+
+DO $$
+DECLARE
+  v_receipt jsonb;
+  v_payment jsonb;
+BEGIN
+  v_receipt := public.rpc_reset_customer_receipt_to_draft(
+    '66c10000-0000-0000-0000-000000000001',
+    'second correction cycle');
+  v_payment := public.rpc_reset_supplier_payment_to_draft(
+    '66c20000-0000-0000-0000-000000000001',
+    'second correction cycle');
+
+  IF v_receipt->>'duplicate' <> 'false'
+     OR v_payment->>'duplicate' <> 'false' THEN
+    RAISE EXCEPTION
+      'ACCEPTANCE_FAIL: first reset in second cycle was marked duplicate';
+  END IF;
+END;
+$$;
+
+DO $$
+DECLARE
+  v_receipt jsonb;
+  v_payment jsonb;
+BEGIN
+  v_receipt := public.rpc_reset_customer_receipt_to_draft(
+    '66c10000-0000-0000-0000-000000000001',
+    'duplicate receipt reset');
+  v_payment := public.rpc_reset_supplier_payment_to_draft(
+    '66c20000-0000-0000-0000-000000000001',
+    'duplicate payment reset');
+
+  IF v_receipt->>'duplicate' <> 'true'
+     OR v_payment->>'duplicate' <> 'true'
+     OR v_receipt->>'status' <> 'draft'
+     OR v_payment->>'status' <> 'draft' THEN
+    RAISE EXCEPTION
+      'ACCEPTANCE_FAIL: repeated reset did not return the duplicate draft contract';
+  END IF;
+END;
+$$;
+
+DO $$
+DECLARE
+  v_guc text := coalesce(current_setting('wardah.voucher_unpost', true), '');
+BEGIN
+  IF v_guc <> 'off' THEN
+    RAISE EXCEPTION
+      'ACCEPTANCE_FAIL: voucher_unpost GUC leaked after duplicate reset: [%]', v_guc;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.customer_collections c, v166_isolation_entries x
+    WHERE c.id='66c10000-0000-0000-0000-000000000001'
+      AND c.status='draft' AND c.gl_entry_id=x.receipt_entry_id
+  ) OR NOT EXISTS (
+    SELECT 1 FROM public.supplier_payments p, v166_isolation_entries x
+    WHERE p.id='66c20000-0000-0000-0000-000000000001'
+      AND p.status='draft' AND p.gl_entry_id=x.payment_entry_id
+  ) OR NOT EXISTS (
+    SELECT 1 FROM public.gl_entries e, v166_isolation_entries x
+    WHERE e.id=x.receipt_entry_id AND e.status='draft'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM public.gl_entries e, v166_isolation_entries x
+    WHERE e.id=x.payment_entry_id AND e.status='draft'
+  ) THEN
+    RAISE EXCEPTION
+      'ACCEPTANCE_FAIL: duplicate reset changed or detached draft GL identity';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.sales_invoices
+    WHERE id='66b10000-0000-0000-0000-000000000001'
+      AND paid_amount=0 AND balance=1000 AND payment_status='unpaid'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM public.supplier_invoices
+    WHERE id='66b20000-0000-0000-0000-000000000001'
+      AND paid_amount=0 AND balance=1000 AND status='approved'
+  ) THEN
+    RAISE EXCEPTION
+      'ACCEPTANCE_FAIL: duplicate reset reversed allocations more than once';
+  END IF;
+
+  IF (SELECT count(*)
+      FROM public.audit_logs
+      WHERE action='voucher_reset_to_draft'
+        AND entity_id='66c10000-0000-0000-0000-000000000001') <> 2
+     OR (SELECT count(*)
+         FROM public.audit_logs
+         WHERE action='voucher_reset_to_draft'
+           AND entity_id='66c20000-0000-0000-0000-000000000001') <> 2 THEN
+    RAISE EXCEPTION
+      'ACCEPTANCE_FAIL: duplicate reset inserted an extra audit event';
+  END IF;
+END;
+$$;
+
+COMMIT;
+
+SELECT 'VOUCHER_RESET_166_ISOLATION_IDEMPOTENCY_PASS' AS result;

--- a/sql/migrations/166_voucher_reset_to_draft_workflow.sql
+++ b/sql/migrations/166_voucher_reset_to_draft_workflow.sql
@@ -6,8 +6,9 @@
 --
 --   posted -> draft -> corrected -> posted
 --
--- The same GL entry identity is retained. Invoice paid/balance state, voucher
--- state and GL state move atomically. Closed periods remain fail-closed.
+-- The same GL entry identity is retained. Invoice paid state (and therefore
+-- its generated balance), voucher state and GL state move atomically. Closed
+-- periods remain fail-closed.
 -- =====================================================================
 
 BEGIN;
@@ -33,8 +34,8 @@ $preflight$;
 
 -- ---------------------------------------------------------------------
 -- 1. Sensitive permission: not automatically assigned to ordinary roles.
--- Org admins and super admins already receive all active permissions through
--- the existing RBAC functions; other users require an explicit role grant.
+-- Org admins and super admins retain their existing all-permission behavior;
+-- every other user must hold this exact permission through an active role.
 -- ---------------------------------------------------------------------
 INSERT INTO public.permissions (
   module_id, resource, resource_ar, action, action_ar,
@@ -52,6 +53,55 @@ SELECT
 FROM public.modules m
 WHERE m.name = 'accounting'
 ON CONFLICT (permission_key) DO NOTHING;
+
+-- has_permission intentionally supports module-level fallback for ordinary
+-- screens. Unposting is an exceptional control and must bypass that fallback.
+CREATE OR REPLACE FUNCTION public.wardah_has_exact_permission(
+  p_user_id uuid,
+  p_org_id uuid,
+  p_permission_key text
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+  SELECT
+    EXISTS (
+      SELECT 1
+      FROM public.super_admins sa
+      WHERE sa.user_id = p_user_id
+        AND sa.is_active = true
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.user_organizations uo
+      WHERE uo.user_id = p_user_id
+        AND uo.org_id = p_org_id
+        AND uo.is_active = true
+        AND uo.is_org_admin = true
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.user_roles ur
+      JOIN public.roles r
+        ON r.id = ur.role_id
+       AND r.org_id = p_org_id
+       AND coalesce(r.is_active, true)
+      JOIN public.role_permissions rp ON rp.role_id = ur.role_id
+      JOIN public.permissions p ON p.id = rp.permission_id
+      WHERE ur.user_id = p_user_id
+        AND ur.org_id = p_org_id
+        AND p.permission_key = p_permission_key
+        AND (ur.expires_at IS NULL OR ur.expires_at > now())
+    );
+$function$;
+
+REVOKE ALL ON FUNCTION public.wardah_has_exact_permission(uuid,uuid,text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.wardah_has_exact_permission(uuid,uuid,text) FROM anon;
+REVOKE ALL ON FUNCTION public.wardah_has_exact_permission(uuid,uuid,text) FROM authenticated;
+REVOKE ALL ON FUNCTION public.wardah_has_exact_permission(uuid,uuid,text) FROM service_role;
 
 -- ---------------------------------------------------------------------
 -- 2. Preserve posted-entry immutability while allowing exactly one internal
@@ -275,6 +325,7 @@ DECLARE
   v_entry public.gl_entries%ROWTYPE;
   v_line record;
   v_new_paid numeric;
+  v_gl_update_count integer;
 BEGIN
   IF v_actor IS NULL THEN RAISE EXCEPTION 'AUTH_REQUIRED'; END IF;
   IF length(trim(coalesce(p_reason,''))) < 5 THEN
@@ -285,7 +336,7 @@ BEGIN
   IF v_org IS NULL OR NOT public.wardah_is_org_member(v_org) THEN
     RAISE EXCEPTION 'TENANT_MEMBERSHIP_REQUIRED';
   END IF;
-  IF NOT public.has_permission(v_actor, v_org, 'accounting.vouchers.unpost') THEN
+  IF NOT public.wardah_has_exact_permission(v_actor, v_org, 'accounting.vouchers.unpost') THEN
     RAISE EXCEPTION 'VOUCHER_UNPOST_PERMISSION_REQUIRED';
   END IF;
 
@@ -338,7 +389,6 @@ BEGIN
     v_new_paid := round(v_line.paid_amount - v_line.allocated_amount,2);
     UPDATE public.sales_invoices
     SET paid_amount=v_new_paid,
-        balance=round(total_amount-v_new_paid,2),
         payment_status=CASE
           WHEN v_new_paid <= 0 THEN 'unpaid'
           WHEN v_new_paid >= round(total_amount,2) THEN 'paid'
@@ -352,7 +402,9 @@ BEGIN
   UPDATE public.gl_entries
   SET status='draft', posted_at=NULL, posted_by=NULL, updated_at=now()
   WHERE id=v_entry.id AND org_id=v_org AND status='posted';
-  IF NOT FOUND THEN RAISE EXCEPTION 'CUSTOMER_RECEIPT_GL_STATE_CHANGED'; END IF;
+  GET DIAGNOSTICS v_gl_update_count = ROW_COUNT;
+  PERFORM set_config('wardah.voucher_unpost','off',true);
+  IF v_gl_update_count <> 1 THEN RAISE EXCEPTION 'CUSTOMER_RECEIPT_GL_STATE_CHANGED'; END IF;
 
   UPDATE public.customer_collections
   SET status='draft', posted_at=NULL, posted_by=NULL, updated_at=now()
@@ -393,6 +445,7 @@ DECLARE
   v_entry public.gl_entries%ROWTYPE;
   v_line record;
   v_new_paid numeric;
+  v_gl_update_count integer;
 BEGIN
   IF v_actor IS NULL THEN RAISE EXCEPTION 'AUTH_REQUIRED'; END IF;
   IF length(trim(coalesce(p_reason,''))) < 5 THEN
@@ -403,7 +456,7 @@ BEGIN
   IF v_org IS NULL OR NOT public.wardah_is_org_member(v_org) THEN
     RAISE EXCEPTION 'TENANT_MEMBERSHIP_REQUIRED';
   END IF;
-  IF NOT public.has_permission(v_actor, v_org, 'accounting.vouchers.unpost') THEN
+  IF NOT public.wardah_has_exact_permission(v_actor, v_org, 'accounting.vouchers.unpost') THEN
     RAISE EXCEPTION 'VOUCHER_UNPOST_PERMISSION_REQUIRED';
   END IF;
 
@@ -456,7 +509,6 @@ BEGIN
     v_new_paid := round(v_line.paid_amount-v_line.allocated_amount,2);
     UPDATE public.supplier_invoices
     SET paid_amount=v_new_paid,
-        balance=round(total_amount-v_new_paid,2),
         status=CASE
           WHEN v_new_paid >= round(total_amount,2) THEN 'paid'
           WHEN v_new_paid > 0 THEN 'partially_paid'
@@ -471,7 +523,9 @@ BEGIN
   UPDATE public.gl_entries
   SET status='draft', posted_at=NULL, posted_by=NULL, updated_at=now()
   WHERE id=v_entry.id AND org_id=v_org AND status='posted';
-  IF NOT FOUND THEN RAISE EXCEPTION 'SUPPLIER_PAYMENT_GL_STATE_CHANGED'; END IF;
+  GET DIAGNOSTICS v_gl_update_count = ROW_COUNT;
+  PERFORM set_config('wardah.voucher_unpost','off',true);
+  IF v_gl_update_count <> 1 THEN RAISE EXCEPTION 'SUPPLIER_PAYMENT_GL_STATE_CHANGED'; END IF;
 
   UPDATE public.supplier_payments
   SET status='draft', posted_at=NULL, posted_by=NULL, updated_at=now()
@@ -504,7 +558,8 @@ REVOKE ALL ON FUNCTION public.rpc_reset_supplier_payment_to_draft(uuid,text) FRO
 GRANT EXECUTE ON FUNCTION public.rpc_reset_supplier_payment_to_draft(uuid,text) TO authenticated;
 
 -- ---------------------------------------------------------------------
--- 6. Keep invoice balance synchronized during normal posting too.
+-- 6. Keep invoice paid state synchronized during normal posting. The balance
+-- columns are GENERATED ALWAYS from total_amount - paid_amount.
 -- ---------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION public.rpc_post_customer_receipt(p_receipt_id uuid)
 RETURNS jsonb
@@ -545,7 +600,7 @@ BEGIN
   v_entry_id:=public.wardah_create_posted_voucher_gl(v_org,'CUSTOMER_RECEIPT',v_receipt.id,v_receipt.collection_number,v_receipt.collection_date,'سند قبض '||v_receipt.collection_number,v_payment_account,v_ar_account,v_receipt.amount,v_actor);
   FOR v_line IN SELECT l.invoice_id,l.allocated_amount,i.total_amount,coalesce(i.paid_amount,0) paid_amount FROM public.customer_collection_lines l JOIN public.sales_invoices i ON i.id=l.invoice_id WHERE l.collection_id=v_receipt.id ORDER BY i.id FOR UPDATE OF i LOOP
     v_new_paid:=round(v_line.paid_amount+v_line.allocated_amount,2);
-    UPDATE public.sales_invoices SET paid_amount=v_new_paid,balance=round(total_amount-v_new_paid,2),payment_status=CASE WHEN v_new_paid>=round(total_amount,2) THEN 'paid' ELSE 'partially_paid' END,updated_at=now() WHERE id=v_line.invoice_id AND org_id=v_org;
+    UPDATE public.sales_invoices SET paid_amount=v_new_paid,payment_status=CASE WHEN v_new_paid>=round(total_amount,2) THEN 'paid' ELSE 'partially_paid' END,updated_at=now() WHERE id=v_line.invoice_id AND org_id=v_org;
   END LOOP;
   UPDATE public.customer_collections SET status='posted',gl_entry_id=v_entry_id,posted_at=now(),posted_by=v_actor,updated_at=now() WHERE id=v_receipt.id AND org_id=v_org AND status='draft';
   IF NOT FOUND THEN RAISE EXCEPTION 'CUSTOMER_RECEIPT_STATE_CHANGED'; END IF;
@@ -593,7 +648,7 @@ BEGIN
   v_entry_id:=public.wardah_create_posted_voucher_gl(v_org,'SUPPLIER_PAYMENT',v_payment.id,v_payment.payment_number,v_payment.payment_date,'سند صرف '||v_payment.payment_number,v_ap_account,v_payment_account,v_payment.amount,v_actor);
   FOR v_line IN SELECT l.invoice_id,l.allocated_amount,i.total_amount,coalesce(i.paid_amount,0) paid_amount FROM public.supplier_payment_lines l JOIN public.supplier_invoices i ON i.id=l.invoice_id WHERE l.payment_id=v_payment.id ORDER BY i.id FOR UPDATE OF i LOOP
     v_new_paid:=round(v_line.paid_amount+v_line.allocated_amount,2);
-    UPDATE public.supplier_invoices SET paid_amount=v_new_paid,balance=round(total_amount-v_new_paid,2),status=CASE WHEN v_new_paid>=round(total_amount,2) THEN 'paid' ELSE 'partially_paid' END,updated_at=now() WHERE id=v_line.invoice_id AND org_id=v_org;
+    UPDATE public.supplier_invoices SET paid_amount=v_new_paid,status=CASE WHEN v_new_paid>=round(total_amount,2) THEN 'paid' ELSE 'partially_paid' END,updated_at=now() WHERE id=v_line.invoice_id AND org_id=v_org;
   END LOOP;
   UPDATE public.supplier_payments SET status='posted',gl_entry_id=v_entry_id,posted_at=now(),posted_by=v_actor,updated_at=now() WHERE id=v_payment.id AND org_id=v_org AND status='draft';
   IF NOT FOUND THEN RAISE EXCEPTION 'SUPPLIER_PAYMENT_STATE_CHANGED'; END IF;
@@ -619,7 +674,9 @@ BEGIN
   IF has_function_privilege('anon','public.rpc_reset_customer_receipt_to_draft(uuid,text)','EXECUTE')
      OR has_function_privilege('anon','public.rpc_reset_supplier_payment_to_draft(uuid,text)','EXECUTE')
      OR NOT has_function_privilege('authenticated','public.rpc_reset_customer_receipt_to_draft(uuid,text)','EXECUTE')
-     OR NOT has_function_privilege('authenticated','public.rpc_reset_supplier_payment_to_draft(uuid,text)','EXECUTE') THEN
+     OR NOT has_function_privilege('authenticated','public.rpc_reset_supplier_payment_to_draft(uuid,text)','EXECUTE')
+     OR has_function_privilege('authenticated','public.wardah_has_exact_permission(uuid,uuid,text)','EXECUTE')
+     OR has_function_privilege('anon','public.wardah_has_exact_permission(uuid,uuid,text)','EXECUTE') THEN
     RAISE EXCEPTION 'VOUCHER_166_RPC_GRANT_VERIFY_FAILED';
   END IF;
 END

--- a/sql/migrations/166_voucher_reset_to_draft_workflow.sql
+++ b/sql/migrations/166_voucher_reset_to_draft_workflow.sql
@@ -1,0 +1,628 @@
+-- =====================================================================
+-- 166_voucher_reset_to_draft_workflow
+-- =====================================================================
+-- Controlled correction cycle for posted customer receipts and supplier
+-- payments without creating reversal entries:
+--
+--   posted -> draft -> corrected -> posted
+--
+-- The same GL entry identity is retained. Invoice paid/balance state, voucher
+-- state and GL state move atomically. Closed periods remain fail-closed.
+-- =====================================================================
+
+BEGIN;
+
+SET LOCAL lock_timeout = '30s';
+SET LOCAL statement_timeout = '5min';
+
+DO $preflight$
+BEGIN
+  IF to_regclass('public.customer_collections') IS NULL
+     OR to_regclass('public.customer_collection_lines') IS NULL
+     OR to_regclass('public.supplier_payments') IS NULL
+     OR to_regclass('public.supplier_payment_lines') IS NULL
+     OR to_regclass('public.sales_invoices') IS NULL
+     OR to_regclass('public.supplier_invoices') IS NULL
+     OR to_regclass('public.gl_entries') IS NULL
+     OR to_regclass('public.gl_entry_lines') IS NULL
+     OR to_regclass('public.audit_logs') IS NULL THEN
+    RAISE EXCEPTION 'VOUCHER_166_REQUIRED_OBJECT_MISSING';
+  END IF;
+END
+$preflight$;
+
+-- ---------------------------------------------------------------------
+-- 1. Sensitive permission: not automatically assigned to ordinary roles.
+-- Org admins and super admins already receive all active permissions through
+-- the existing RBAC functions; other users require an explicit role grant.
+-- ---------------------------------------------------------------------
+INSERT INTO public.permissions (
+  module_id, resource, resource_ar, action, action_ar,
+  permission_key, description, description_ar
+)
+SELECT
+  m.id,
+  'vouchers',
+  'السندات المالية',
+  'unpost',
+  'إلغاء الترحيل',
+  'accounting.vouchers.unpost',
+  'Reset a posted payment voucher and its linked GL entry to draft.',
+  'إعادة سند مالي مرحل وقيده المرتبط إلى مسودة للتصحيح.'
+FROM public.modules m
+WHERE m.name = 'accounting'
+ON CONFLICT (permission_key) DO NOTHING;
+
+-- ---------------------------------------------------------------------
+-- 2. Preserve posted-entry immutability while allowing exactly one internal
+-- transition: voucher-linked posted -> draft under a transaction-local GUC.
+-- Direct client updates remain blocked by the same trigger.
+-- ---------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.protect_posted_gl_entries()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public
+AS $function$
+DECLARE
+  v_controlled_unpost boolean :=
+    coalesce(current_setting('wardah.voucher_unpost', true), '') = 'on';
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    IF OLD.status IN ('posted', 'reversed') THEN
+      RAISE EXCEPTION 'POSTED_ENTRY_IMMUTABLE: لا يمكن حذف قيد مرحّل (%) — استخدم العكس', OLD.entry_number;
+    END IF;
+    RETURN OLD;
+  END IF;
+
+  IF OLD.status IN ('posted', 'reversed') THEN
+    IF NEW.entry_date IS DISTINCT FROM OLD.entry_date
+       OR NEW.total_debit IS DISTINCT FROM OLD.total_debit
+       OR NEW.total_credit IS DISTINCT FROM OLD.total_credit
+       OR NEW.journal_id IS DISTINCT FROM OLD.journal_id THEN
+      RAISE EXCEPTION 'POSTED_ENTRY_IMMUTABLE: لا يمكن تعديل الحقول المالية لقيد مرحّل (%) — استخدم العكس', OLD.entry_number;
+    END IF;
+
+    IF OLD.status = 'posted' AND NEW.status = 'draft' THEN
+      IF NOT v_controlled_unpost
+         OR OLD.reference_type NOT IN ('CUSTOMER_RECEIPT', 'SUPPLIER_PAYMENT')
+         OR OLD.reference_id IS NULL THEN
+        RAISE EXCEPTION 'POSTED_ENTRY_IMMUTABLE: لا يمكن إرجاع قيد مرحّل إلى مسودة (%)', OLD.entry_number;
+      END IF;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END
+$function$;
+
+-- ---------------------------------------------------------------------
+-- 3. Reuse an existing voucher GL entry when it is draft. Its lines are
+-- rebuilt from the corrected voucher and the same entry is posted again.
+-- ---------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.wardah_create_posted_voucher_gl(
+  p_org uuid,
+  p_reference_type text,
+  p_reference_id uuid,
+  p_reference_number text,
+  p_entry_date date,
+  p_description text,
+  p_debit_account_id uuid,
+  p_credit_account_id uuid,
+  p_amount numeric,
+  p_actor uuid
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_entry_id uuid;
+  v_entry_number text;
+  v_journal_id uuid;
+  v_existing_status text;
+  v_idempotency_key text := p_reference_type || ':' || p_reference_id::text;
+BEGIN
+  IF p_org IS NULL OR p_reference_id IS NULL OR p_actor IS NULL THEN
+    RAISE EXCEPTION 'VOUCHER_GL_SCOPE_REQUIRED: org, reference and actor are required';
+  END IF;
+  IF p_reference_type NOT IN ('CUSTOMER_RECEIPT', 'SUPPLIER_PAYMENT') THEN
+    RAISE EXCEPTION 'VOUCHER_GL_REFERENCE_TYPE_INVALID';
+  END IF;
+  IF p_amount IS NULL OR round(p_amount, 2) <= 0 THEN
+    RAISE EXCEPTION 'VOUCHER_AMOUNT_INVALID: amount must be positive';
+  END IF;
+  IF p_debit_account_id = p_credit_account_id THEN
+    RAISE EXCEPTION 'VOUCHER_GL_SAME_ACCOUNT_FORBIDDEN';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.gl_accounts a
+    WHERE a.id = p_debit_account_id AND a.org_id = p_org
+      AND coalesce(a.is_active, true) AND coalesce(a.allow_posting, true)
+  ) OR NOT EXISTS (
+    SELECT 1 FROM public.gl_accounts a
+    WHERE a.id = p_credit_account_id AND a.org_id = p_org
+      AND coalesce(a.is_active, true) AND coalesce(a.allow_posting, true)
+  ) THEN
+    RAISE EXCEPTION 'VOUCHER_GL_ACCOUNT_INVALID: legal posting accounts must belong to the voucher organization';
+  END IF;
+
+  PERFORM public.assert_period_open(p_org, coalesce(p_entry_date, current_date));
+
+  SELECT e.id, e.status
+  INTO v_entry_id, v_existing_status
+  FROM public.gl_entries e
+  WHERE e.org_id = p_org AND e.idempotency_key = v_idempotency_key
+  FOR UPDATE;
+
+  IF v_entry_id IS NOT NULL AND v_existing_status = 'posted' THEN
+    IF NOT EXISTS (
+      SELECT 1
+      FROM public.gl_entries e
+      WHERE e.id = v_entry_id
+        AND e.org_id = p_org
+        AND e.reference_type = p_reference_type
+        AND e.reference_id = p_reference_id
+        AND e.reference_number IS NOT DISTINCT FROM p_reference_number
+        AND e.entry_date = coalesce(p_entry_date, current_date)
+        AND round(e.total_debit, 2) = round(p_amount, 2)
+        AND round(e.total_credit, 2) = round(p_amount, 2)
+        AND (
+          SELECT count(*)
+          FROM public.gl_entry_lines l
+          WHERE l.entry_id = e.id AND l.org_id = p_org
+            AND (
+              (l.account_id = p_debit_account_id AND round(l.debit,2) = round(p_amount,2) AND l.credit = 0)
+              OR
+              (l.account_id = p_credit_account_id AND l.debit = 0 AND round(l.credit,2) = round(p_amount,2))
+            )
+        ) = 2
+    ) THEN
+      RAISE EXCEPTION 'VOUCHER_GL_IDEMPOTENCY_CONFLICT: existing posted entry does not match voucher contract';
+    END IF;
+    RETURN v_entry_id;
+  END IF;
+
+  IF v_entry_id IS NOT NULL AND v_existing_status <> 'draft' THEN
+    RAISE EXCEPTION 'VOUCHER_GL_STATE_CONFLICT: existing entry status=%', v_existing_status;
+  END IF;
+
+  IF v_entry_id IS NULL THEN
+    SELECT j.id INTO v_journal_id
+    FROM public.journals j
+    WHERE j.org_id = p_org AND coalesce(j.is_active, true)
+    ORDER BY CASE WHEN j.journal_type IN ('cash','bank') THEN 0 ELSE 1 END,
+             j.created_at NULLS LAST, j.id
+    LIMIT 1;
+    IF v_journal_id IS NULL THEN
+      RAISE EXCEPTION 'VOUCHER_JOURNAL_REQUIRED: an active journal is required';
+    END IF;
+
+    v_entry_number := 'PV-' || to_char(coalesce(p_entry_date, current_date), 'YYYYMMDD') || '-' ||
+                      substr(replace(gen_random_uuid()::text, '-', ''), 1, 12);
+
+    INSERT INTO public.gl_entries (
+      org_id, journal_id, entry_number, entry_date, entry_type,
+      reference_type, reference_id, reference_number,
+      description, description_ar, status, total_debit, total_credit,
+      idempotency_key, created_by
+    ) VALUES (
+      p_org, v_journal_id, v_entry_number, coalesce(p_entry_date, current_date), 'manual',
+      p_reference_type, p_reference_id, p_reference_number,
+      p_description, p_description, 'draft', round(p_amount,2), round(p_amount,2),
+      v_idempotency_key, p_actor
+    ) RETURNING id INTO v_entry_id;
+  ELSE
+    DELETE FROM public.gl_entry_lines
+    WHERE entry_id = v_entry_id AND org_id = p_org;
+
+    UPDATE public.gl_entries
+    SET entry_date = coalesce(p_entry_date, current_date),
+        reference_type = p_reference_type,
+        reference_id = p_reference_id,
+        reference_number = p_reference_number,
+        description = p_description,
+        description_ar = p_description,
+        total_debit = round(p_amount,2),
+        total_credit = round(p_amount,2),
+        posted_at = NULL,
+        posted_by = NULL,
+        updated_at = now()
+    WHERE id = v_entry_id AND org_id = p_org AND status = 'draft';
+    IF NOT FOUND THEN RAISE EXCEPTION 'VOUCHER_GL_DRAFT_CHANGED'; END IF;
+  END IF;
+
+  INSERT INTO public.gl_entry_lines (
+    org_id, tenant_id, entry_id, line_number, account_id,
+    debit, credit, currency_code, description, description_ar
+  ) VALUES
+    (p_org, p_org, v_entry_id, 1, p_debit_account_id,
+     round(p_amount,2), 0, 'SAR', p_description, p_description),
+    (p_org, p_org, v_entry_id, 2, p_credit_account_id,
+     0, round(p_amount,2), 'SAR', p_description, p_description);
+
+  UPDATE public.gl_entries
+  SET status = 'posted', posted_at = now(), posted_by = p_actor, updated_at = now()
+  WHERE id = v_entry_id AND org_id = p_org AND status = 'draft';
+  IF NOT FOUND THEN RAISE EXCEPTION 'VOUCHER_GL_POST_STATE_CHANGED'; END IF;
+
+  RETURN v_entry_id;
+END
+$function$;
+
+REVOKE ALL ON FUNCTION public.wardah_create_posted_voucher_gl(uuid,text,uuid,text,date,text,uuid,uuid,numeric,uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.wardah_create_posted_voucher_gl(uuid,text,uuid,text,date,text,uuid,uuid,numeric,uuid) FROM anon;
+REVOKE ALL ON FUNCTION public.wardah_create_posted_voucher_gl(uuid,text,uuid,text,date,text,uuid,uuid,numeric,uuid) FROM authenticated;
+REVOKE ALL ON FUNCTION public.wardah_create_posted_voucher_gl(uuid,text,uuid,text,date,text,uuid,uuid,numeric,uuid) FROM service_role;
+
+-- ---------------------------------------------------------------------
+-- 4. Reset customer receipt to draft.
+-- ---------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_reset_customer_receipt_to_draft(
+  p_receipt_id uuid,
+  p_reason text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_actor uuid := auth.uid();
+  v_org uuid;
+  v_receipt public.customer_collections%ROWTYPE;
+  v_entry public.gl_entries%ROWTYPE;
+  v_line record;
+  v_new_paid numeric;
+BEGIN
+  IF v_actor IS NULL THEN RAISE EXCEPTION 'AUTH_REQUIRED'; END IF;
+  IF length(trim(coalesce(p_reason,''))) < 5 THEN
+    RAISE EXCEPTION 'VOUCHER_UNPOST_REASON_REQUIRED';
+  END IF;
+
+  v_org := public.get_current_tenant_id();
+  IF v_org IS NULL OR NOT public.wardah_is_org_member(v_org) THEN
+    RAISE EXCEPTION 'TENANT_MEMBERSHIP_REQUIRED';
+  END IF;
+  IF NOT public.has_permission(v_actor, v_org, 'accounting.vouchers.unpost') THEN
+    RAISE EXCEPTION 'VOUCHER_UNPOST_PERMISSION_REQUIRED';
+  END IF;
+
+  SELECT * INTO v_receipt
+  FROM public.customer_collections
+  WHERE id = p_receipt_id AND org_id = v_org
+  FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'CUSTOMER_RECEIPT_NOT_FOUND_OR_CROSS_ORG'; END IF;
+
+  IF v_receipt.status = 'draft' THEN
+    IF v_receipt.gl_entry_id IS NULL OR NOT EXISTS (
+      SELECT 1 FROM public.gl_entries e
+      WHERE e.id=v_receipt.gl_entry_id AND e.org_id=v_org AND e.status='draft'
+    ) THEN
+      RAISE EXCEPTION 'CUSTOMER_RECEIPT_DRAFT_GL_INVALID';
+    END IF;
+    RETURN jsonb_build_object('success',true,'duplicate',true,'receipt_id',v_receipt.id,
+      'entry_id',v_receipt.gl_entry_id,'status','draft');
+  END IF;
+  IF v_receipt.status <> 'posted' OR v_receipt.gl_entry_id IS NULL THEN
+    RAISE EXCEPTION 'CUSTOMER_RECEIPT_NOT_POSTED';
+  END IF;
+
+  SELECT * INTO v_entry
+  FROM public.gl_entries
+  WHERE id=v_receipt.gl_entry_id AND org_id=v_org
+  FOR UPDATE;
+  IF NOT FOUND
+     OR v_entry.status <> 'posted'
+     OR v_entry.reference_type <> 'CUSTOMER_RECEIPT'
+     OR v_entry.reference_id <> v_receipt.id THEN
+    RAISE EXCEPTION 'CUSTOMER_RECEIPT_POSTED_GL_INVALID';
+  END IF;
+
+  PERFORM public.assert_period_open(v_org, v_entry.entry_date);
+
+  FOR v_line IN
+    SELECT l.invoice_id, round(l.allocated_amount,2) AS allocated_amount,
+           i.total_amount, coalesce(i.paid_amount,0) AS paid_amount
+    FROM public.customer_collection_lines l
+    JOIN public.sales_invoices i ON i.id=l.invoice_id
+    WHERE l.collection_id=v_receipt.id
+    ORDER BY i.id
+    FOR UPDATE OF i
+  LOOP
+    IF round(v_line.paid_amount,2) < v_line.allocated_amount THEN
+      RAISE EXCEPTION 'CUSTOMER_RECEIPT_UNPOST_INVOICE_DRIFT: invoice=% paid=% allocated=%',
+        v_line.invoice_id, v_line.paid_amount, v_line.allocated_amount;
+    END IF;
+    v_new_paid := round(v_line.paid_amount - v_line.allocated_amount,2);
+    UPDATE public.sales_invoices
+    SET paid_amount=v_new_paid,
+        balance=round(total_amount-v_new_paid,2),
+        payment_status=CASE
+          WHEN v_new_paid <= 0 THEN 'unpaid'
+          WHEN v_new_paid >= round(total_amount,2) THEN 'paid'
+          ELSE 'partially_paid'
+        END,
+        updated_at=now()
+    WHERE id=v_line.invoice_id AND org_id=v_org;
+  END LOOP;
+
+  PERFORM set_config('wardah.voucher_unpost','on',true);
+  UPDATE public.gl_entries
+  SET status='draft', posted_at=NULL, posted_by=NULL, updated_at=now()
+  WHERE id=v_entry.id AND org_id=v_org AND status='posted';
+  IF NOT FOUND THEN RAISE EXCEPTION 'CUSTOMER_RECEIPT_GL_STATE_CHANGED'; END IF;
+
+  UPDATE public.customer_collections
+  SET status='draft', posted_at=NULL, posted_by=NULL, updated_at=now()
+  WHERE id=v_receipt.id AND org_id=v_org AND status='posted';
+  IF NOT FOUND THEN RAISE EXCEPTION 'CUSTOMER_RECEIPT_STATE_CHANGED'; END IF;
+
+  INSERT INTO public.audit_logs(
+    org_id,user_id,action,entity_type,entity_id,old_data,new_data,changes,metadata
+  ) VALUES (
+    v_org,v_actor,'voucher_reset_to_draft','customer_receipt',v_receipt.id::text,
+    jsonb_build_object('status','posted','gl_status','posted','gl_entry_id',v_entry.id),
+    jsonb_build_object('status','draft','gl_status','draft','gl_entry_id',v_entry.id),
+    jsonb_build_object('reason',trim(p_reason)),
+    jsonb_build_object('source','rpc_reset_customer_receipt_to_draft')
+  );
+
+  RETURN jsonb_build_object('success',true,'duplicate',false,'receipt_id',v_receipt.id,
+    'entry_id',v_entry.id,'status','draft');
+END
+$function$;
+
+-- ---------------------------------------------------------------------
+-- 5. Reset supplier payment to draft.
+-- ---------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_reset_supplier_payment_to_draft(
+  p_payment_id uuid,
+  p_reason text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_actor uuid := auth.uid();
+  v_org uuid;
+  v_payment public.supplier_payments%ROWTYPE;
+  v_entry public.gl_entries%ROWTYPE;
+  v_line record;
+  v_new_paid numeric;
+BEGIN
+  IF v_actor IS NULL THEN RAISE EXCEPTION 'AUTH_REQUIRED'; END IF;
+  IF length(trim(coalesce(p_reason,''))) < 5 THEN
+    RAISE EXCEPTION 'VOUCHER_UNPOST_REASON_REQUIRED';
+  END IF;
+
+  v_org := public.get_current_tenant_id();
+  IF v_org IS NULL OR NOT public.wardah_is_org_member(v_org) THEN
+    RAISE EXCEPTION 'TENANT_MEMBERSHIP_REQUIRED';
+  END IF;
+  IF NOT public.has_permission(v_actor, v_org, 'accounting.vouchers.unpost') THEN
+    RAISE EXCEPTION 'VOUCHER_UNPOST_PERMISSION_REQUIRED';
+  END IF;
+
+  SELECT * INTO v_payment
+  FROM public.supplier_payments
+  WHERE id=p_payment_id AND org_id=v_org
+  FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'SUPPLIER_PAYMENT_NOT_FOUND_OR_CROSS_ORG'; END IF;
+
+  IF v_payment.status='draft' THEN
+    IF v_payment.gl_entry_id IS NULL OR NOT EXISTS (
+      SELECT 1 FROM public.gl_entries e
+      WHERE e.id=v_payment.gl_entry_id AND e.org_id=v_org AND e.status='draft'
+    ) THEN
+      RAISE EXCEPTION 'SUPPLIER_PAYMENT_DRAFT_GL_INVALID';
+    END IF;
+    RETURN jsonb_build_object('success',true,'duplicate',true,'payment_id',v_payment.id,
+      'entry_id',v_payment.gl_entry_id,'status','draft');
+  END IF;
+  IF v_payment.status <> 'posted' OR v_payment.gl_entry_id IS NULL THEN
+    RAISE EXCEPTION 'SUPPLIER_PAYMENT_NOT_POSTED';
+  END IF;
+
+  SELECT * INTO v_entry
+  FROM public.gl_entries
+  WHERE id=v_payment.gl_entry_id AND org_id=v_org
+  FOR UPDATE;
+  IF NOT FOUND
+     OR v_entry.status <> 'posted'
+     OR v_entry.reference_type <> 'SUPPLIER_PAYMENT'
+     OR v_entry.reference_id <> v_payment.id THEN
+    RAISE EXCEPTION 'SUPPLIER_PAYMENT_POSTED_GL_INVALID';
+  END IF;
+
+  PERFORM public.assert_period_open(v_org, v_entry.entry_date);
+
+  FOR v_line IN
+    SELECT l.invoice_id, round(l.allocated_amount,2) AS allocated_amount,
+           i.total_amount, coalesce(i.paid_amount,0) AS paid_amount, i.due_date
+    FROM public.supplier_payment_lines l
+    JOIN public.supplier_invoices i ON i.id=l.invoice_id
+    WHERE l.payment_id=v_payment.id
+    ORDER BY i.id
+    FOR UPDATE OF i
+  LOOP
+    IF round(v_line.paid_amount,2) < v_line.allocated_amount THEN
+      RAISE EXCEPTION 'SUPPLIER_PAYMENT_UNPOST_INVOICE_DRIFT: invoice=% paid=% allocated=%',
+        v_line.invoice_id, v_line.paid_amount, v_line.allocated_amount;
+    END IF;
+    v_new_paid := round(v_line.paid_amount-v_line.allocated_amount,2);
+    UPDATE public.supplier_invoices
+    SET paid_amount=v_new_paid,
+        balance=round(total_amount-v_new_paid,2),
+        status=CASE
+          WHEN v_new_paid >= round(total_amount,2) THEN 'paid'
+          WHEN v_new_paid > 0 THEN 'partially_paid'
+          WHEN due_date IS NOT NULL AND due_date < current_date THEN 'overdue'
+          ELSE 'approved'
+        END,
+        updated_at=now()
+    WHERE id=v_line.invoice_id AND org_id=v_org;
+  END LOOP;
+
+  PERFORM set_config('wardah.voucher_unpost','on',true);
+  UPDATE public.gl_entries
+  SET status='draft', posted_at=NULL, posted_by=NULL, updated_at=now()
+  WHERE id=v_entry.id AND org_id=v_org AND status='posted';
+  IF NOT FOUND THEN RAISE EXCEPTION 'SUPPLIER_PAYMENT_GL_STATE_CHANGED'; END IF;
+
+  UPDATE public.supplier_payments
+  SET status='draft', posted_at=NULL, posted_by=NULL, updated_at=now()
+  WHERE id=v_payment.id AND org_id=v_org AND status='posted';
+  IF NOT FOUND THEN RAISE EXCEPTION 'SUPPLIER_PAYMENT_STATE_CHANGED'; END IF;
+
+  INSERT INTO public.audit_logs(
+    org_id,user_id,action,entity_type,entity_id,old_data,new_data,changes,metadata
+  ) VALUES (
+    v_org,v_actor,'voucher_reset_to_draft','supplier_payment',v_payment.id::text,
+    jsonb_build_object('status','posted','gl_status','posted','gl_entry_id',v_entry.id),
+    jsonb_build_object('status','draft','gl_status','draft','gl_entry_id',v_entry.id),
+    jsonb_build_object('reason',trim(p_reason)),
+    jsonb_build_object('source','rpc_reset_supplier_payment_to_draft')
+  );
+
+  RETURN jsonb_build_object('success',true,'duplicate',false,'payment_id',v_payment.id,
+    'entry_id',v_entry.id,'status','draft');
+END
+$function$;
+
+REVOKE ALL ON FUNCTION public.rpc_reset_customer_receipt_to_draft(uuid,text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.rpc_reset_customer_receipt_to_draft(uuid,text) FROM anon;
+REVOKE ALL ON FUNCTION public.rpc_reset_customer_receipt_to_draft(uuid,text) FROM service_role;
+GRANT EXECUTE ON FUNCTION public.rpc_reset_customer_receipt_to_draft(uuid,text) TO authenticated;
+
+REVOKE ALL ON FUNCTION public.rpc_reset_supplier_payment_to_draft(uuid,text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.rpc_reset_supplier_payment_to_draft(uuid,text) FROM anon;
+REVOKE ALL ON FUNCTION public.rpc_reset_supplier_payment_to_draft(uuid,text) FROM service_role;
+GRANT EXECUTE ON FUNCTION public.rpc_reset_supplier_payment_to_draft(uuid,text) TO authenticated;
+
+-- ---------------------------------------------------------------------
+-- 6. Keep invoice balance synchronized during normal posting too.
+-- ---------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_post_customer_receipt(p_receipt_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_actor uuid := auth.uid(); v_org uuid;
+  v_receipt public.customer_collections%ROWTYPE;
+  v_payment_account uuid; v_ar_account uuid; v_entry_id uuid;
+  v_line record; v_allocation_total numeric:=0; v_open numeric;
+  v_new_paid numeric; v_line_count integer:=0;
+BEGIN
+  IF v_actor IS NULL THEN RAISE EXCEPTION 'AUTH_REQUIRED'; END IF;
+  v_org:=public.get_current_tenant_id();
+  IF v_org IS NULL OR NOT public.wardah_is_org_member(v_org) THEN RAISE EXCEPTION 'TENANT_MEMBERSHIP_REQUIRED'; END IF;
+  SELECT * INTO v_receipt FROM public.customer_collections WHERE id=p_receipt_id AND org_id=v_org FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'CUSTOMER_RECEIPT_NOT_FOUND_OR_CROSS_ORG'; END IF;
+  IF v_receipt.status='posted' AND v_receipt.gl_entry_id IS NOT NULL THEN
+    IF NOT EXISTS(SELECT 1 FROM public.gl_entries e WHERE e.id=v_receipt.gl_entry_id AND e.org_id=v_org AND e.status='posted') THEN RAISE EXCEPTION 'CUSTOMER_RECEIPT_POSTED_GL_INVALID'; END IF;
+    RETURN jsonb_build_object('success',true,'duplicate',true,'receipt_id',v_receipt.id,'entry_id',v_receipt.gl_entry_id,'status','posted');
+  END IF;
+  IF v_receipt.status<>'draft' THEN RAISE EXCEPTION 'CUSTOMER_RECEIPT_NOT_DRAFT: status=%',v_receipt.status; END IF;
+  v_payment_account:=v_receipt.payment_account_id;
+  IF v_payment_account IS NULL THEN SELECT a.id INTO v_payment_account FROM public.gl_accounts a WHERE a.org_id=v_org AND a.subtype=CASE WHEN v_receipt.payment_method IN ('cash','check') THEN 'CASH' ELSE 'BANK' END AND coalesce(a.is_active,true) AND coalesce(a.allow_posting,true) ORDER BY a.code,a.id LIMIT 1; END IF;
+  SELECT a.id INTO v_ar_account FROM public.gl_accounts a WHERE a.org_id=v_org AND a.subtype IN ('ACCOUNTS_RECEIVABLE','AR') AND coalesce(a.is_active,true) AND coalesce(a.allow_posting,true) ORDER BY a.code,a.id LIMIT 1;
+  IF v_payment_account IS NULL OR v_ar_account IS NULL THEN RAISE EXCEPTION 'CUSTOMER_RECEIPT_GL_ACCOUNTS_MISSING'; END IF;
+  FOR v_line IN SELECT l.invoice_id,l.allocated_amount,coalesce(l.discount_amount,0) discount_amount,i.org_id,i.customer_id,i.total_amount,coalesce(i.paid_amount,0) paid_amount FROM public.customer_collection_lines l JOIN public.sales_invoices i ON i.id=l.invoice_id WHERE l.collection_id=v_receipt.id ORDER BY i.id FOR UPDATE OF i LOOP
+    v_line_count:=v_line_count+1;
+    IF v_line.org_id<>v_org OR v_line.customer_id<>v_receipt.customer_id THEN RAISE EXCEPTION 'CUSTOMER_RECEIPT_ALLOCATION_CROSS_SCOPE'; END IF;
+    IF v_line.discount_amount<>0 THEN RAISE EXCEPTION 'VOUCHER_DISCOUNT_UNSUPPORTED: discount accounting mapping is required'; END IF;
+    v_open:=round(v_line.total_amount-v_line.paid_amount,2);
+    IF round(v_line.allocated_amount,2)>v_open THEN RAISE EXCEPTION 'CUSTOMER_RECEIPT_OVER_ALLOCATION: invoice=% open=% allocated=%',v_line.invoice_id,v_open,v_line.allocated_amount; END IF;
+    v_allocation_total:=v_allocation_total+round(v_line.allocated_amount,2);
+  END LOOP;
+  IF v_line_count>0 AND round(v_allocation_total,2)<>round(v_receipt.amount,2) THEN RAISE EXCEPTION 'CUSTOMER_RECEIPT_ALLOCATION_TOTAL_MISMATCH: allocations=% receipt=%',v_allocation_total,v_receipt.amount; END IF;
+  v_entry_id:=public.wardah_create_posted_voucher_gl(v_org,'CUSTOMER_RECEIPT',v_receipt.id,v_receipt.collection_number,v_receipt.collection_date,'سند قبض '||v_receipt.collection_number,v_payment_account,v_ar_account,v_receipt.amount,v_actor);
+  FOR v_line IN SELECT l.invoice_id,l.allocated_amount,i.total_amount,coalesce(i.paid_amount,0) paid_amount FROM public.customer_collection_lines l JOIN public.sales_invoices i ON i.id=l.invoice_id WHERE l.collection_id=v_receipt.id ORDER BY i.id FOR UPDATE OF i LOOP
+    v_new_paid:=round(v_line.paid_amount+v_line.allocated_amount,2);
+    UPDATE public.sales_invoices SET paid_amount=v_new_paid,balance=round(total_amount-v_new_paid,2),payment_status=CASE WHEN v_new_paid>=round(total_amount,2) THEN 'paid' ELSE 'partially_paid' END,updated_at=now() WHERE id=v_line.invoice_id AND org_id=v_org;
+  END LOOP;
+  UPDATE public.customer_collections SET status='posted',gl_entry_id=v_entry_id,posted_at=now(),posted_by=v_actor,updated_at=now() WHERE id=v_receipt.id AND org_id=v_org AND status='draft';
+  IF NOT FOUND THEN RAISE EXCEPTION 'CUSTOMER_RECEIPT_STATE_CHANGED'; END IF;
+  RETURN jsonb_build_object('success',true,'duplicate',false,'receipt_id',v_receipt.id,'entry_id',v_entry_id,'status','posted');
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION public.rpc_post_supplier_payment(p_payment_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_actor uuid:=auth.uid(); v_org uuid;
+  v_payment public.supplier_payments%ROWTYPE;
+  v_payment_account uuid; v_ap_account uuid; v_entry_id uuid;
+  v_line record; v_allocation_total numeric:=0; v_open numeric;
+  v_new_paid numeric; v_line_count integer:=0;
+BEGIN
+  IF v_actor IS NULL THEN RAISE EXCEPTION 'AUTH_REQUIRED'; END IF;
+  v_org:=public.get_current_tenant_id();
+  IF v_org IS NULL OR NOT public.wardah_is_org_member(v_org) THEN RAISE EXCEPTION 'TENANT_MEMBERSHIP_REQUIRED'; END IF;
+  SELECT * INTO v_payment FROM public.supplier_payments WHERE id=p_payment_id AND org_id=v_org FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'SUPPLIER_PAYMENT_NOT_FOUND_OR_CROSS_ORG'; END IF;
+  IF v_payment.status='posted' AND v_payment.gl_entry_id IS NOT NULL THEN
+    IF NOT EXISTS(SELECT 1 FROM public.gl_entries e WHERE e.id=v_payment.gl_entry_id AND e.org_id=v_org AND e.status='posted') THEN RAISE EXCEPTION 'SUPPLIER_PAYMENT_POSTED_GL_INVALID'; END IF;
+    RETURN jsonb_build_object('success',true,'duplicate',true,'payment_id',v_payment.id,'entry_id',v_payment.gl_entry_id,'status','posted');
+  END IF;
+  IF v_payment.status<>'draft' THEN RAISE EXCEPTION 'SUPPLIER_PAYMENT_NOT_DRAFT: status=%',v_payment.status; END IF;
+  v_payment_account:=v_payment.payment_account_id;
+  IF v_payment_account IS NULL THEN SELECT a.id INTO v_payment_account FROM public.gl_accounts a WHERE a.org_id=v_org AND a.subtype=CASE WHEN v_payment.payment_method='cash' THEN 'CASH' ELSE 'BANK' END AND coalesce(a.is_active,true) AND coalesce(a.allow_posting,true) ORDER BY a.code,a.id LIMIT 1; END IF;
+  SELECT a.id INTO v_ap_account FROM public.gl_accounts a WHERE a.org_id=v_org AND a.subtype IN ('ACCOUNTS_PAYABLE','AP') AND coalesce(a.is_active,true) AND coalesce(a.allow_posting,true) ORDER BY a.code,a.id LIMIT 1;
+  IF v_payment_account IS NULL OR v_ap_account IS NULL THEN RAISE EXCEPTION 'SUPPLIER_PAYMENT_GL_ACCOUNTS_MISSING'; END IF;
+  FOR v_line IN SELECT l.invoice_id,l.allocated_amount,coalesce(l.discount_amount,0) discount_amount,i.org_id,i.vendor_id,i.total_amount,coalesce(i.paid_amount,0) paid_amount,i.status FROM public.supplier_payment_lines l JOIN public.supplier_invoices i ON i.id=l.invoice_id WHERE l.payment_id=v_payment.id ORDER BY i.id FOR UPDATE OF i LOOP
+    v_line_count:=v_line_count+1;
+    IF v_line.org_id<>v_org OR v_line.vendor_id<>v_payment.vendor_id THEN RAISE EXCEPTION 'SUPPLIER_PAYMENT_ALLOCATION_CROSS_SCOPE'; END IF;
+    IF v_line.status NOT IN ('approved','partially_paid','overdue') THEN RAISE EXCEPTION 'SUPPLIER_INVOICE_NOT_PAYABLE: invoice=% status=%',v_line.invoice_id,v_line.status; END IF;
+    IF v_line.discount_amount<>0 THEN RAISE EXCEPTION 'VOUCHER_DISCOUNT_UNSUPPORTED: discount accounting mapping is required'; END IF;
+    v_open:=round(v_line.total_amount-v_line.paid_amount,2);
+    IF round(v_line.allocated_amount,2)>v_open THEN RAISE EXCEPTION 'SUPPLIER_PAYMENT_OVER_ALLOCATION: invoice=% open=% allocated=%',v_line.invoice_id,v_open,v_line.allocated_amount; END IF;
+    v_allocation_total:=v_allocation_total+round(v_line.allocated_amount,2);
+  END LOOP;
+  IF v_line_count>0 AND round(v_allocation_total,2)<>round(v_payment.amount,2) THEN RAISE EXCEPTION 'SUPPLIER_PAYMENT_ALLOCATION_TOTAL_MISMATCH: allocations=% payment=%',v_allocation_total,v_payment.amount; END IF;
+  v_entry_id:=public.wardah_create_posted_voucher_gl(v_org,'SUPPLIER_PAYMENT',v_payment.id,v_payment.payment_number,v_payment.payment_date,'سند صرف '||v_payment.payment_number,v_ap_account,v_payment_account,v_payment.amount,v_actor);
+  FOR v_line IN SELECT l.invoice_id,l.allocated_amount,i.total_amount,coalesce(i.paid_amount,0) paid_amount FROM public.supplier_payment_lines l JOIN public.supplier_invoices i ON i.id=l.invoice_id WHERE l.payment_id=v_payment.id ORDER BY i.id FOR UPDATE OF i LOOP
+    v_new_paid:=round(v_line.paid_amount+v_line.allocated_amount,2);
+    UPDATE public.supplier_invoices SET paid_amount=v_new_paid,balance=round(total_amount-v_new_paid,2),status=CASE WHEN v_new_paid>=round(total_amount,2) THEN 'paid' ELSE 'partially_paid' END,updated_at=now() WHERE id=v_line.invoice_id AND org_id=v_org;
+  END LOOP;
+  UPDATE public.supplier_payments SET status='posted',gl_entry_id=v_entry_id,posted_at=now(),posted_by=v_actor,updated_at=now() WHERE id=v_payment.id AND org_id=v_org AND status='draft';
+  IF NOT FOUND THEN RAISE EXCEPTION 'SUPPLIER_PAYMENT_STATE_CHANGED'; END IF;
+  RETURN jsonb_build_object('success',true,'duplicate',false,'payment_id',v_payment.id,'entry_id',v_entry_id,'status','posted');
+END
+$function$;
+
+REVOKE ALL ON FUNCTION public.rpc_post_customer_receipt(uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.rpc_post_customer_receipt(uuid) FROM anon;
+REVOKE ALL ON FUNCTION public.rpc_post_customer_receipt(uuid) FROM service_role;
+GRANT EXECUTE ON FUNCTION public.rpc_post_customer_receipt(uuid) TO authenticated;
+
+REVOKE ALL ON FUNCTION public.rpc_post_supplier_payment(uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.rpc_post_supplier_payment(uuid) FROM anon;
+REVOKE ALL ON FUNCTION public.rpc_post_supplier_payment(uuid) FROM service_role;
+GRANT EXECUTE ON FUNCTION public.rpc_post_supplier_payment(uuid) TO authenticated;
+
+DO $verify$
+BEGIN
+  IF NOT EXISTS(SELECT 1 FROM public.permissions WHERE permission_key='accounting.vouchers.unpost') THEN
+    RAISE EXCEPTION 'VOUCHER_166_PERMISSION_MISSING';
+  END IF;
+  IF has_function_privilege('anon','public.rpc_reset_customer_receipt_to_draft(uuid,text)','EXECUTE')
+     OR has_function_privilege('anon','public.rpc_reset_supplier_payment_to_draft(uuid,text)','EXECUTE')
+     OR NOT has_function_privilege('authenticated','public.rpc_reset_customer_receipt_to_draft(uuid,text)','EXECUTE')
+     OR NOT has_function_privilege('authenticated','public.rpc_reset_supplier_payment_to_draft(uuid,text)','EXECUTE') THEN
+    RAISE EXCEPTION 'VOUCHER_166_RPC_GRANT_VERIFY_FAILED';
+  END IF;
+END
+$verify$;
+
+COMMIT;

--- a/src/services/voucher-reset-166-contract.test.ts
+++ b/src/services/voucher-reset-166-contract.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const migration = readFileSync(
+  resolve(process.cwd(), 'sql/migrations/166_voucher_reset_to_draft_workflow.sql'),
+  'utf8',
+)
+
+function functionBody(name: string): string {
+  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const match = migration.match(
+    new RegExp(
+      `CREATE OR REPLACE FUNCTION public\\.${escapedName}\\([\\s\\S]*?AS \\$function\\$([\\s\\S]*?)\\$function\\$;`,
+    ),
+  )
+
+  expect(match, `Expected function ${name} in Migration 166`).not.toBeNull()
+  return match?.[1] ?? ''
+}
+
+describe('Migration 166 voucher reset contract', () => {
+  it('never writes generated invoice balance columns', () => {
+    expect(migration).not.toMatch(/\bSET\s+[\s\S]{0,250}?\bbalance\s*=/i)
+  })
+
+  it('requires the exact unpost permission instead of module fallback', () => {
+    const receiptReset = functionBody('rpc_reset_customer_receipt_to_draft')
+    const supplierReset = functionBody('rpc_reset_supplier_payment_to_draft')
+    const exactGuard = functionBody('wardah_has_exact_permission')
+
+    expect(receiptReset).toContain(
+      "wardah_has_exact_permission(v_actor, v_org, 'accounting.vouchers.unpost')",
+    )
+    expect(supplierReset).toContain(
+      "wardah_has_exact_permission(v_actor, v_org, 'accounting.vouchers.unpost')",
+    )
+    expect(receiptReset).not.toContain('has_permission(')
+    expect(supplierReset).not.toContain('has_permission(')
+    expect(exactGuard).toContain('p.permission_key = p_permission_key')
+    expect(exactGuard).not.toMatch(/permission_key\s+LIKE/i)
+  })
+
+  it('closes the controlled-unpost GUC immediately after each GL update', () => {
+    for (const name of [
+      'rpc_reset_customer_receipt_to_draft',
+      'rpc_reset_supplier_payment_to_draft',
+    ]) {
+      const body = functionBody(name)
+      const enabledAt = body.indexOf("set_config('wardah.voucher_unpost','on',true)")
+      const glUpdateAt = body.indexOf('UPDATE public.gl_entries', enabledAt)
+      const disabledAt = body.indexOf("set_config('wardah.voucher_unpost','off',true)", glUpdateAt)
+      const voucherUpdateAt = body.indexOf(
+        name.includes('customer')
+          ? 'UPDATE public.customer_collections'
+          : 'UPDATE public.supplier_payments',
+        glUpdateAt,
+      )
+
+      expect(enabledAt).toBeGreaterThanOrEqual(0)
+      expect(glUpdateAt).toBeGreaterThan(enabledAt)
+      expect(disabledAt).toBeGreaterThan(glUpdateAt)
+      expect(voucherUpdateAt).toBeGreaterThan(disabledAt)
+    }
+  })
+})

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -11563,6 +11563,10 @@ export type Database = {
         }
         Returns: string
       }
+      wardah_has_exact_permission: {
+        Args: { p_org_id: string; p_permission_key: string; p_user_id: string }
+        Returns: boolean
+      }
       wardah_is_org_admin: { Args: { p_org: string }; Returns: boolean }
       wardah_is_org_member: { Args: { p_org: string }; Returns: boolean }
       wardah_org_id: { Args: { p_explicit?: string }; Returns: string }

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -11093,6 +11093,14 @@ export type Database = {
         }
         Returns: string
       }
+      rpc_reset_customer_receipt_to_draft: {
+        Args: { p_reason: string; p_receipt_id: string }
+        Returns: Json
+      }
+      rpc_reset_supplier_payment_to_draft: {
+        Args: { p_payment_id: string; p_reason: string }
+        Returns: Json
+      }
       rpc_resolve_uom_backfill_issue: {
         Args: {
           p_issue_id: string


### PR DESCRIPTION
## الهدف

إضافة دورة تصحيح محاسبية كاملة لسندات القبض والصرف دون إنشاء قيد عكسي عندما تكون الفترة مفتوحة:

`posted → draft → corrected → posted`

مع الاحتفاظ بنفس `gl_entry_id` حتى لا يتشوه كشف حساب العميل أو المورد بحركة أصلية وحركة عكسية لا تمثلان عملية اقتصادية فعلية.

## Migration 166

- تضيف صلاحية حساسة مستقلة `accounting.vouchers.unpost` ولا تمنحها تلقائيًا للأدوار العادية.
- تفرض الصلاحية الحساسة بفحص دقيق `wardah_has_exact_permission` لا يمر عبر fallback العام لصلاحيات الوحدة؛ يبقى الاستثناء فقط للمشرف العام ومدير المؤسسة وفق عقد RBAC الحالي.
- تضيف:
  - `rpc_reset_customer_receipt_to_draft(uuid,text)`
  - `rpc_reset_supplier_payment_to_draft(uuid,text)`
- السبب إلزامي، والمؤسسة مشتقة من الجلسة، والعملية تتطلب عضوية وصلاحية صريحة.
- تعيد السند والقيد المرتبط نفسه إلى `draft` داخل معاملة واحدة.
- تعكس أثر التخصيصات من `paid_amount` وتعيد حالة الفاتورة؛ عمود `balance` مولّد تلقائيًا من `total_amount - paid_amount` ولا تتم الكتابة إليه.
- تسجل عملية الـReset في `audit_logs`.
- تمنع العملية في الفترة المقفلة أو عند وجود عدم اتساق في السند أو القيد أو الفاتورة.
- تحافظ على منع `posted → draft` المباشر؛ الاستثناء محصور داخل RPC عبر transaction-local GUC ولسندات القبض والصرف فقط، ويُطفأ فور تحديث القيد.
- تطور `wardah_create_posted_voucher_gl` لإعادة بناء سطور القيد المسودة نفسه وإعادة ترحيله بدل إنشاء قيد جديد.
- تحدث دوال الإقرار لتزامن `paid_amount` وحالة الفاتورة، مع ترك `balance` للعمود المولّد.
- تحافظ على aliases الفعلية `AR/AP` من Migration 164 وعلى صلاحيات RPC الحالية.

## ترتيب النشر

هذا PR خاص بقاعدة البيانات والأنواع المولدة فقط. لا توجد واجهة داخله. بعد نجاح البوابات ودمجه:

1. تطبيق Migration 166 على Production.
2. فحوص بنيوية وصلاحيات، بما فيها رفض مستخدم يحمل صلاحية محاسبية عامة فقط.
3. اختبار سلبي متراجع يثبت عدم الكتابة إلى الأعمدة المولدة وعدم تغير البيانات عند الفشل.
4. اختبار دورة Reset/Repost على بيانات اختبار مع حفظ نفس `gl_entry_id`.
5. بعدها فقط PR واجهة مستقل.

Closes جزء قاعدة البيانات من #81، وتبقى الواجهة في مرحلة مستقلة.