### PR TITLE
chore: sync CI baseline fix into voucher reset branch

### DIFF
--- a/.github/workflows/regenerate-uom-types.yml
+++ b/.github/workflows/regenerate-uom-types.yml
@@ -104,17 +104,28 @@ jobs:
           mkdir -p reports
           set +e
           bash -Eeuo pipefail <<'SCRIPT' > reports/uom-fresh-db.log 2>&1
-          BASELINE=$(ls sql/baseline/000_schema_baseline_*.sql 2>/dev/null | sort | tail -1)
-          test -n "$BASELINE"
+          set +e
+          PAIR=$(bash scripts/ci/fresh-db/resolve_baseline_pair.sh sql/baseline)
+          PAIR_STATUS=$?
+          set -e
+          if [ "$PAIR_STATUS" -ne 0 ]; then
+            echo "❌ تعذر حل زوج الـbaseline المقترن (status=$PAIR_STATUS)"
+            exit 1
+          fi
 
-          CUTOFF=$(grep -oE '^-- migration_cutoff: ([0-9]+)' "$BASELINE" \
-            | grep -oE '[0-9]+$' | head -1)
+          pair_field() { printf '%s\n' "$PAIR" | sed -n "s/^$1=//p"; }
+          BASELINE=$(pair_field BASELINE_PATH)
+          REFERENCE=$(pair_field REFERENCE_PATH)
+          CUTOFF=$(pair_field BASELINE_CUTOFF)
           CUTOFF=${CUTOFF:-0}
+          test -n "$BASELINE"
+          test -n "$REFERENCE"
 
           createdb wardah_fresh
           psql -v ON_ERROR_STOP=1 -d wardah_fresh \
             -f scripts/ci/fresh-db/supabase_shim.sql -q
           psql -v ON_ERROR_STOP=1 -d wardah_fresh -f "$BASELINE" -q
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh -f "$REFERENCE" -q
 
           python3 scripts/ci/fresh-db/build_apply_order.py sql/migrations "$CUTOFF" \
             > reports/uom-chain-order.txt

--- a/.github/workflows/uom-master-data-hardening.yml
+++ b/.github/workflows/uom-master-data-hardening.yml
@@ -10,6 +10,8 @@ on:
       - scripts/ci/fresh-db/acceptance_146_uom_master_data_hardening.sql
       - scripts/ci/fresh-db/acceptance_146_trusted_product_insert_guard.sql
       - .github/workflows/uom-master-data-hardening.yml
+      - scripts/ci/fresh-db/resolve_baseline_pair.sh
+      - sql/baseline/**
   push:
     branches:
       - claude/complete-master-data-uom-hn893k
@@ -20,6 +22,8 @@ on:
       - scripts/ci/fresh-db/acceptance_146_uom_master_data_hardening.sql
       - scripts/ci/fresh-db/acceptance_146_trusted_product_insert_guard.sql
       - .github/workflows/uom-master-data-hardening.yml
+      - scripts/ci/fresh-db/resolve_baseline_pair.sh
+      - sql/baseline/**
   workflow_dispatch:
 
 permissions:
@@ -48,17 +52,22 @@ jobs:
       - name: Build canonical Fresh DB through latest migration
         run: |
           set -Eeuo pipefail
-          BASELINE=$(ls sql/baseline/000_schema_baseline_*.sql 2>/dev/null | sort | tail -1)
-          test -n "$BASELINE"
-
-          CUTOFF=$(grep -oE '^-- migration_cutoff: ([0-9]+)' "$BASELINE" \
-            | grep -oE '[0-9]+$' | head -1)
+          set +e
+          PAIR=$(bash scripts/ci/fresh-db/resolve_baseline_pair.sh sql/baseline)
+          PAIR_STATUS=$?
+          set -e
+          test "$PAIR_STATUS" -eq 0
+          pair_field() { printf '%s\n' "$PAIR" | sed -n "s/^$1=//p"; }
+          BASELINE=$(pair_field BASELINE_PATH)
+          REFERENCE=$(pair_field REFERENCE_PATH)
+          CUTOFF=$(pair_field BASELINE_CUTOFF)
           CUTOFF=${CUTOFF:-0}
 
           createdb wardah_fresh
           psql -v ON_ERROR_STOP=1 -d wardah_fresh \
             -f scripts/ci/fresh-db/supabase_shim.sql -q
           psql -v ON_ERROR_STOP=1 -d wardah_fresh -f "$BASELINE" -q
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh -f "$REFERENCE" -q
 
           python3 scripts/ci/fresh-db/build_apply_order.py \
             sql/migrations "$CUTOFF" > /tmp/chain_order.txt

--- a/.github/workflows/uom-partial-receipt-atomic.yml
+++ b/.github/workflows/uom-partial-receipt-atomic.yml
@@ -11,13 +11,14 @@ on:
       - 'src/features/purchasing/index.tsx'
       - 'src/services/uom-goods-receipt-service.ts'
       - 'src/services/purchasing-service.ts'
-      # ملفات الاختبار نفسها ضمن المسارات: تعديل الحارس وحده يجب أن يشغّل البوابة.
       - 'src/components/forms/__tests__/goods-receipt-legacy-contract.test.tsx'
       - 'src/features/purchasing/__tests__/goods-receipt-rollout-gate.test.tsx'
       - 'src/services/__tests__/uom-goods-receipt-service.test.ts'
       - 'src/services/__tests__/goods-receipt-atomic.test.ts'
       - 'src/types/database.generated.ts'
       - '.github/workflows/uom-partial-receipt-atomic.yml'
+      - 'scripts/ci/fresh-db/resolve_baseline_pair.sh'
+      - 'sql/baseline/**'
   workflow_dispatch:
 
 jobs:
@@ -47,16 +48,22 @@ jobs:
       - name: Build fresh database through migration 148
         run: |
           set -Eeuo pipefail
-          BASELINE=$(ls sql/baseline/000_schema_baseline_*.sql 2>/dev/null | sort | tail -1)
-          test -n "$BASELINE"
-          CUTOFF=$(grep -oE '^-- migration_cutoff: ([0-9]+)' "$BASELINE" \
-            | grep -oE '[0-9]+$' | head -1)
+          set +e
+          PAIR=$(bash scripts/ci/fresh-db/resolve_baseline_pair.sh sql/baseline)
+          PAIR_STATUS=$?
+          set -e
+          test "$PAIR_STATUS" -eq 0
+          pair_field() { printf '%s\n' "$PAIR" | sed -n "s/^$1=//p"; }
+          BASELINE=$(pair_field BASELINE_PATH)
+          REFERENCE=$(pair_field REFERENCE_PATH)
+          CUTOFF=$(pair_field BASELINE_CUTOFF)
           CUTOFF=${CUTOFF:-0}
 
           createdb wardah_fresh
           psql -v ON_ERROR_STOP=1 -d wardah_fresh \
             -f scripts/ci/fresh-db/supabase_shim.sql -q
           psql -v ON_ERROR_STOP=1 -d wardah_fresh -f "$BASELINE" -q
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh -f "$REFERENCE" -q
 
           python3 scripts/ci/fresh-db/build_apply_order.py \
             sql/migrations "$CUTOFF" > /tmp/chain_order.txt
@@ -110,8 +117,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # العلم مطفأ في كل المؤسسات اليوم؛ هذه البوابة تمنع أن يتحول العلم من
-      # بوابة للمسار الجديد إلى قاطع للمسار التشغيلي القائم.
       - name: Prove the rollout flag never breaks the legacy receipt path
         run: >-
           npm run test -- --run --coverage.enabled=false

--- a/.github/workflows/uom-purchase-order-atomic.yml
+++ b/.github/workflows/uom-purchase-order-atomic.yml
@@ -7,6 +7,8 @@ on:
       - 'sql/migrations/147_atomic_uom_purchase_order_creation.sql'
       - 'scripts/ci/fresh-db/acceptance_147_atomic_uom_purchase_order.sql'
       - '.github/workflows/uom-purchase-order-atomic.yml'
+      - 'scripts/ci/fresh-db/resolve_baseline_pair.sh'
+      - 'sql/baseline/**'
   workflow_dispatch:
 
 jobs:
@@ -36,16 +38,22 @@ jobs:
       - name: Build fresh database through migration 147
         run: |
           set -Eeuo pipefail
-          BASELINE=$(ls sql/baseline/000_schema_baseline_*.sql 2>/dev/null | sort | tail -1)
-          test -n "$BASELINE"
-          CUTOFF=$(grep -oE '^-- migration_cutoff: ([0-9]+)' "$BASELINE" \
-            | grep -oE '[0-9]+$' | head -1)
+          set +e
+          PAIR=$(bash scripts/ci/fresh-db/resolve_baseline_pair.sh sql/baseline)
+          PAIR_STATUS=$?
+          set -e
+          test "$PAIR_STATUS" -eq 0
+          pair_field() { printf '%s\n' "$PAIR" | sed -n "s/^$1=//p"; }
+          BASELINE=$(pair_field BASELINE_PATH)
+          REFERENCE=$(pair_field REFERENCE_PATH)
+          CUTOFF=$(pair_field BASELINE_CUTOFF)
           CUTOFF=${CUTOFF:-0}
 
           createdb wardah_fresh
           psql -v ON_ERROR_STOP=1 -d wardah_fresh \
             -f scripts/ci/fresh-db/supabase_shim.sql -q
           psql -v ON_ERROR_STOP=1 -d wardah_fresh -f "$BASELINE" -q
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh -f "$REFERENCE" -q
 
           python3 scripts/ci/fresh-db/build_apply_order.py \
             sql/migrations "$CUTOFF" > /tmp/chain_order.txt


### PR DESCRIPTION
Technical synchronization only: merge the approved paired-baseline workflow fix from `main` into `feat/voucher-reset-to-draft-db` so PR #82 reruns against the corrected Fresh DB contract. No additional product or migration changes.