### PR TITLE
test(sales): allow coverage overhead for receipt workflow

### DIFF
--- a/src/features/sales/components/__tests__/CustomerReceipts.test.tsx
+++ b/src/features/sales/components/__tests__/CustomerReceipts.test.tsx
@@ -197,5 +197,5 @@ describe('CustomerReceipts', () => {
       ],
     }))
     expect(mocks.toastSuccess).toHaveBeenCalledWith('تم إنشاء سند القبض بنجاح')
-  })
+  }, 15_000)
 })


### PR DESCRIPTION
## المشكلة

اختبار سند القبض المتكامل يتجاوز مهلة Vitest الافتراضية `5000ms` عند تشغيل V8 coverage فقط. سجل Sonar على PR #82 أثبت زمنًا `5095ms` وفشل خطوة الاختبارات قبل بدء SonarCloud Scan؛ نفس الاختبار ينجح دون تغطية.

## الإصلاح

- إضافة مهلة صريحة `15_000ms` للاختبار البطيء وحده.
- لا تغيير على `testTimeout` العام.
- لا تغيير في كود التطبيق أو Migration 166.

## السبب في الفصل

هذا PR اختبارات فقط، مستقل عن PR #82 الخاص بقاعدة البيانات. بعد اخضراره ودمجه يُزامَن PR #82 مع `main` وتُعاد بواباته على رأس بشري جديد.