### PR TITLE
chore: sync receipt coverage fix into voucher reset branch

### DIFF
--- a/src/features/sales/components/__tests__/CustomerReceipts.test.tsx
+++ b/src/features/sales/components/__tests__/CustomerReceipts.test.tsx
@@ -197,5 +197,5 @@ describe('CustomerReceipts', () => {
       ],
     }))
     expect(mocks.toastSuccess).toHaveBeenCalledWith('تم إنشاء سند القبض بنجاح')
-  })
+  }, 15_000)
 })


### PR DESCRIPTION
Technical synchronization only: merge the approved test-only timeout fix from `main` into `feat/voucher-reset-to-draft-db` so PR #82 reruns from a human-authored merge head. No changes to Migration 166 or generated database types.