### PR TITLE
feat(db): add atomic voucher create, edit and cancel RPCs

### DIFF
--- a/.github/workflows/voucher-atomic-168-acceptance.yml
+++ b/.github/workflows/voucher-atomic-168-acceptance.yml
@@ -1,0 +1,156 @@
+name: Voucher Atomic Lifecycle 168 Acceptance
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'sql/migrations/166_voucher_reset_to_draft_workflow.sql'
+      - 'sql/migrations/167_voucher_allocation_lines_hardening.sql'
+      - 'sql/migrations/168_voucher_atomic_lifecycle_rpcs.sql'
+      - 'scripts/ci/fresh-db/acceptance_168_voucher_atomic_lifecycle.sql'
+      - 'scripts/ci/fresh-db/acceptance_168_concurrency.sh'
+      - '.github/workflows/voucher-atomic-168-acceptance.yml'
+      - 'scripts/ci/fresh-db/resolve_baseline_pair.sh'
+      - 'scripts/ci/fresh-db/build_apply_order.py'
+      - 'scripts/ci/fresh-db/run_chain.sh'
+      - 'scripts/ci/fresh-db/supabase_shim.sql'
+      - 'sql/baseline/**'
+  workflow_dispatch:
+
+jobs:
+  acceptance:
+    name: Migration 168 Atomic Voucher Lifecycle
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build fresh database through migration 168
+        run: |
+          set -Eeuo pipefail
+          set +e
+          PAIR=$(bash scripts/ci/fresh-db/resolve_baseline_pair.sh sql/baseline)
+          PAIR_STATUS=$?
+          set -e
+          test "$PAIR_STATUS" -eq 0
+
+          pair_field() { printf '%s\n' "$PAIR" | sed -n "s/^$1=//p"; }
+          BASELINE=$(pair_field BASELINE_PATH)
+          REFERENCE=$(pair_field REFERENCE_PATH)
+          CUTOFF=$(pair_field BASELINE_CUTOFF)
+          CUTOFF=${CUTOFF:-0}
+
+          createdb wardah_fresh
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh \
+            -f scripts/ci/fresh-db/supabase_shim.sql -q
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh -f "$BASELINE" -q
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh -f "$REFERENCE" -q
+
+          python3 scripts/ci/fresh-db/build_apply_order.py \
+            sql/migrations "$CUTOFF" > /tmp/chain_order.txt
+          REPORT=/tmp/chain_report.txt PGDATABASE=wardah_fresh \
+            bash scripts/ci/fresh-db/run_chain.sh sql/migrations /tmp/chain_order.txt
+
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh -tAc \
+            "SELECT to_regprocedure('public.rpc_create_customer_receipt(jsonb)') IS NOT NULL
+                    AND to_regprocedure('public.rpc_create_supplier_payment(jsonb)') IS NOT NULL
+                    AND to_regprocedure('public.rpc_update_customer_receipt_draft(uuid,jsonb)') IS NOT NULL
+                    AND to_regprocedure('public.rpc_update_supplier_payment_draft(uuid,jsonb)') IS NOT NULL
+                    AND to_regprocedure('public.rpc_cancel_customer_receipt(uuid,text)') IS NOT NULL
+                    AND to_regprocedure('public.rpc_cancel_supplier_payment(uuid,text)') IS NOT NULL" \
+            | grep -qx t
+        env:
+          PGHOST: localhost
+          PGUSER: postgres
+          PGPASSWORD: postgres
+
+      - name: Execute atomic lifecycle acceptance
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          : > /tmp/voucher-atomic-168.out
+
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh \
+            -f scripts/ci/fresh-db/acceptance_168_voucher_atomic_lifecycle.sql \
+            | tee -a /tmp/voucher-atomic-168.out
+
+          PGDATABASE=wardah_fresh \
+            bash scripts/ci/fresh-db/acceptance_168_concurrency.sh \
+            | tee -a /tmp/voucher-atomic-168.out
+        env:
+          PGHOST: localhost
+          PGUSER: postgres
+          PGPASSWORD: postgres
+
+      # Migration 168 replaces protect_posted_gl_entries, which the earlier
+      # voucher gates depend on. Re-running them here proves the replacement did
+      # not quietly change behaviour those suites already rely on.
+      - name: Re-run the dependent voucher gates against the 168 chain
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          # A separate database: the suites below seed their own tenants and
+          # must not meet the fixtures the 168 suite committed.
+          createdb wardah_regression
+          psql -v ON_ERROR_STOP=1 -d wardah_regression \
+            -f scripts/ci/fresh-db/supabase_shim.sql -q
+          PAIR=$(bash scripts/ci/fresh-db/resolve_baseline_pair.sh sql/baseline)
+          pair_field() { printf '%s\n' "$PAIR" | sed -n "s/^$1=//p"; }
+          psql -v ON_ERROR_STOP=1 -d wardah_regression -f "$(pair_field BASELINE_PATH)" -q
+          psql -v ON_ERROR_STOP=1 -d wardah_regression -f "$(pair_field REFERENCE_PATH)" -q
+          REPORT=/tmp/regression_chain.txt PGDATABASE=wardah_regression \
+            bash scripts/ci/fresh-db/run_chain.sh sql/migrations /tmp/chain_order.txt
+
+          psql -v ON_ERROR_STOP=1 -d wardah_regression \
+            -f scripts/ci/fresh-db/acceptance_166_voucher_reset.sql \
+            | tee -a /tmp/voucher-atomic-168.out
+          psql -v ON_ERROR_STOP=1 -d wardah_regression \
+            -f scripts/ci/fresh-db/acceptance_166_voucher_reset_isolation.sql \
+            | tee -a /tmp/voucher-atomic-168.out
+          psql -v ON_ERROR_STOP=1 -d wardah_regression \
+            -f scripts/ci/fresh-db/acceptance_167_voucher_allocation_hardening.sql \
+            | tee -a /tmp/voucher-atomic-168.out
+        env:
+          PGHOST: localhost
+          PGUSER: postgres
+          PGPASSWORD: postgres
+
+      # An independent completion contract. Without it a future pipeline change
+      # could stop after the first suite and still report a green job.
+      - name: Verify acceptance markers
+        run: |
+          set -Eeuo pipefail
+          grep -q 'VOUCHER_ATOMIC_168_ACCEPTANCE_PASS' /tmp/voucher-atomic-168.out
+          grep -q 'VOUCHER_ATOMIC_168_CONCURRENCY_PASS' /tmp/voucher-atomic-168.out
+          grep -q 'VOUCHER_RESET_166_ACCEPTANCE_PASS' /tmp/voucher-atomic-168.out
+          grep -q 'VOUCHER_RESET_166_ISOLATION_IDEMPOTENCY_PASS' /tmp/voucher-atomic-168.out
+          grep -q 'VOUCHER_ALLOCATION_167_ACCEPTANCE_PASS' /tmp/voucher-atomic-168.out
+
+      - name: Upload atomic lifecycle acceptance evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: voucher-atomic-168-${{ github.run_id }}
+          path: |
+            /tmp/voucher-atomic-168.out
+            /tmp/chain_order.txt
+            /tmp/chain_report.txt
+            /tmp/regression_chain.txt
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/db/VOUCHER_ATOMIC_LIFECYCLE_168_RUNBOOK.md
+++ b/docs/db/VOUCHER_ATOMIC_LIFECYCLE_168_RUNBOOK.md
@@ -1,0 +1,207 @@
+# Migration 168 — Atomic Voucher Lifecycle Runbook
+
+**Migration:** `168_voucher_atomic_lifecycle_rpcs.sql`
+**Scope:** Atomic create, edit and cancel for customer receipts and supplier payments
+**State:** Repository implementation. Do not apply to Production before the dedicated Fresh DB gate is green, and do not apply it alone — see §8.
+
+## 1. Purpose
+
+Migration 167 closed every direct write path on allocation lines and left the `corrected` step of the Migration 166 cycle without a client path. Migration 168 restores it and completes the lifecycle:
+
+```text
+create → (edit)* → post → reset → (edit)* → post
+                                 └→ cancel
+```
+
+Three RPC families, all `SECURITY DEFINER`, all owning their whole operation in one transaction:
+
+| RPC | Purpose |
+|---|---|
+| `rpc_create_customer_receipt(jsonb)` · `rpc_create_supplier_payment(jsonb)` | Header and lines in one transaction |
+| `rpc_update_customer_receipt_draft(uuid,jsonb)` · `rpc_update_supplier_payment_draft(uuid,jsonb)` | Complete allocation replacement on a draft |
+| `rpc_cancel_customer_receipt(uuid,text)` · `rpc_cancel_supplier_payment(uuid,text)` | End a voucher's cycle without deleting history |
+
+Direct client `INSERT` on allocation lines stays open here on purpose. It is withdrawn in Migration 169, after the UI moves onto these RPCs.
+
+## 2. What atomic creation fixes
+
+The browser flow inserted the header, then the lines, and on a line failure issued a compensating `DELETE` on the header. That delete checked neither its error nor its row count, and `customer_collections` exposes no client `DELETE` policy — so it matched zero rows, silently, and left an orphan header behind. Creation now succeeds or leaves nothing.
+
+Voucher numbers are also allocated server-side. The client read the current maximum and added one, which two concurrent creations resolve to the same number. `wardah_next_voucher_number` serializes allocation per organization, kind and period with a transaction-scoped advisory lock, and the unique constraint remains the final arbiter.
+
+## 3. Security contract
+
+| Role | Access |
+|---|---|
+| `anon` | none — `EXECUTE` revoked on every RPC |
+| `authenticated` | `EXECUTE` on all six RPCs; every call still re-checks active membership and the active tenant |
+| `service_role` | `EXECUTE` revoked; it bypasses RLS, so it is never given a shortcut into these paths |
+
+`wardah_next_voucher_number` is internal: `EXECUTE` is revoked from `PUBLIC`, `anon`, `authenticated` and `service_role`.
+
+Cancellation additionally requires the exact permission:
+
+```text
+accounting.vouchers.cancel
+```
+
+This is a **new key**, not derived from `accounting.vouchers.unpost`:
+
+- `unpost` returns a voucher for correction and leaves it repostable;
+- `cancel` ends the cycle.
+
+Migration 168 inserts the key into the permission catalogue and grants it to nobody; the migration's own verification fails if any role holds it at apply time. Grant it explicitly:
+
+```sql
+INSERT INTO public.role_permissions (role_id, permission_id, created_by)
+SELECT '<ROLE_ID>'::uuid, p.id, '<ADMIN_USER_ID>'::uuid
+FROM public.permissions p
+WHERE p.permission_key = 'accounting.vouchers.cancel';
+```
+
+Do not grant it to every role that already holds `unpost`. The acceptance gate proves a member holding only `unpost` is refused.
+
+## 4. The two cancel paths
+
+**A — never posted.** The voucher carries no `gl_entry_id` and no reset record. It becomes `cancelled`; no GL entry is created, touched or looked for. Allocation lines are kept as history.
+
+**B — posted, then reset for correction.** The voucher keeps `gl_entry_id`; only the linked entry's `status` moves to `cancelled`. `entry_number` and every GL line are retained — nothing is deleted, zeroed or recreated, so the entry sequence has no unexplained gap and no draft entry is left dangling. The audit record names the reset it closes through `metadata.reset_audit_id`.
+
+**Refused outright:** cancelling a `posted` voucher. It must go through `rpc_reset_*_to_draft` first, so the paid amounts and invoice states are unwound by the Migration 166 RPC rather than by a second implementation of the same reversal.
+
+A second cancel of an already-cancelled voucher returns the same result with `duplicate: true` and writes no second audit record.
+
+## 5. The GL cancel guard
+
+`protect_posted_gl_entries` refused `posted → draft` but said nothing about `posted → cancelled`, so cancelling was an unguarded way around `POSTED_ENTRY_IMMUTABLE` the moment any `UPDATE` path opened — which is exactly what this migration does. Every transition into `cancelled` on a voucher-linked entry now requires **all** of:
+
+1. the transaction-local GUC `wardah.voucher_gl_cancel = 'on'`;
+2. a voucher that exists in the same organization;
+3. a voucher whose `gl_entry_id` still points at that exact entry;
+4. a voucher still in `draft`, i.e. inside the correction cycle;
+5. a trusted Migration 166 reset record for that voucher.
+
+Condition 5 is why `gl_entry_id` alone is never taken as proof that a voucher went through reset; both the cancel and the edit RPC verify the reset record independently. Condition 4 is why `posted → cancelled` stays closed in practice: a posted voucher cannot satisfy it, with or without the GUC.
+
+Cancelling a posted entry that belongs to any other subsystem is refused outright.
+
+The GUC is opened immediately before the single `UPDATE` and closed immediately after `GET DIAGNOSTICS`, before any deliberate `RAISE`. The same discipline applies to `wardah.voucher_lines_write` in the edit RPCs. Both are `set_config(..., true)`, so they cannot outlive the transaction even if a path is missed.
+
+Note the honest limit: a GUC is a proxy for "called from the approved RPC", not a proof of it. It is not reachable from PostgREST clients, which cannot run arbitrary SQL, but anyone holding a direct connection with table privileges could set it. Conditions 2–5 are what make that insufficient on its own.
+
+## 6. Rejected states
+
+The gate proves each of these is refused:
+
+- a cross-organization invoice, customer or vendor;
+- the same invoice allocated twice in one voucher;
+- an allocation of zero or less, or any non-zero discount;
+- an allocation total that does not match the header amount;
+- an allocation above the invoice's open balance;
+- a supplier invoice that is not payable;
+- editing anything that is not a `draft`;
+- editing or cancelling a voucher that carries a GL identity without a trusted reset record;
+- changing the customer or vendor of an existing voucher;
+- an update payload with no `lines` key — replacement must be explicit, never inferred;
+- `anon`, an inactive member, and a member of another organization, on every RPC.
+
+## 7. Acceptance gate
+
+```text
+Voucher Atomic Lifecycle 168 Acceptance
+```
+
+Markers, all required:
+
+```text
+VOUCHER_ATOMIC_168_ACCEPTANCE_PASS
+VOUCHER_ATOMIC_168_CONCURRENCY_PASS
+VOUCHER_RESET_166_ACCEPTANCE_PASS
+VOUCHER_RESET_166_ISOLATION_IDEMPOTENCY_PASS
+VOUCHER_ALLOCATION_167_ACCEPTANCE_PASS
+```
+
+The chain is built `166 → 167 → 168` on PostgreSQL 17. The 166 and 167 suites are re-run on a separate database in the same job because Migration 168 replaces `protect_posted_gl_entries`, which both already depend on.
+
+The concurrency suite runs two real sessions against the same voucher and proves:
+
+- a concurrent cancel writes exactly one audit record and the loser returns the idempotent duplicate;
+- concurrent edits do not lose an update or interleave a partial replacement — the later writer's complete set survives, with exactly two audit records;
+- no internal GUC leaks into a fresh session.
+
+## 8. Deployment order
+
+Do **not** apply Migration 167 to Production on its own. Between 167 and 168 the correction step of the Migration 166 cycle has no client path, so a voucher reset in that window can be reset but not edited.
+
+The approved order:
+
+```text
+167 → 168 applied in one Production window
+    → deploy the UI that calls these RPCs
+    → 169 withdraws the direct INSERT
+```
+
+Test the full chain on Fresh DB first, then apply `167` and `168` in a single window, in that order, and run the smoke checks in §9. Migration 169 must not be prepared before this migration is applied and verified.
+
+## 9. Production smoke verification
+
+After applying both migrations, in an organization with an open period:
+
+```sql
+-- 1. The RPCs exist and only authenticated may call them.
+SELECT p.proname,
+       has_function_privilege('authenticated', p.oid, 'EXECUTE') AS auth_exec,
+       has_function_privilege('anon', p.oid, 'EXECUTE') AS anon_exec
+FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname = 'public'
+  AND p.proname IN ('rpc_create_customer_receipt','rpc_create_supplier_payment',
+                    'rpc_update_customer_receipt_draft','rpc_update_supplier_payment_draft',
+                    'rpc_cancel_customer_receipt','rpc_cancel_supplier_payment')
+ORDER BY 1;
+
+-- 2. The cancel key exists and is granted to nobody yet.
+SELECT p.permission_key, count(rp.role_id) AS granted_roles
+FROM public.permissions p
+LEFT JOIN public.role_permissions rp ON rp.permission_id = p.id
+WHERE p.permission_key = 'accounting.vouchers.cancel'
+GROUP BY 1;
+
+-- 3. The GL cancel guard is live.
+SELECT pg_get_functiondef('public.protect_posted_gl_entries()'::regprocedure)
+       LIKE '%wardah.voucher_gl_cancel%' AS cancel_guard_present;
+
+-- 4. No orphan headers and no orphan lines.
+SELECT
+  (SELECT count(*) FROM public.customer_collections c
+    WHERE c.status='draft'
+      AND NOT EXISTS (SELECT 1 FROM public.customer_collection_lines l
+                       WHERE l.collection_id = c.id)) AS receipts_without_lines,
+  (SELECT count(*) FROM public.supplier_payments p
+    WHERE p.status='draft'
+      AND NOT EXISTS (SELECT 1 FROM public.supplier_payment_lines l
+                       WHERE l.payment_id = p.id)) AS payments_without_lines;
+
+-- 5. Every cancelled voucher that kept a GL identity kept the entry too.
+SELECT c.id, c.collection_number, e.entry_number, e.status AS gl_status,
+       (SELECT count(*) FROM public.gl_entry_lines l WHERE l.entry_id = e.id) AS gl_lines
+FROM public.customer_collections c
+JOIN public.gl_entries e ON e.id = c.gl_entry_id
+WHERE c.status = 'cancelled';
+```
+
+Expected: `auth_exec` true and `anon_exec` false on all six; `granted_roles` zero until an admin grants it; `cancel_guard_present` true; both orphan counts zero; every cancelled voucher in query 5 showing `gl_status = 'cancelled'` with its line count intact.
+
+## 10. Rollback
+
+The migration is additive apart from the `protect_posted_gl_entries` replacement, which only adds refusals. To disable the new client paths without reverting schema, revoke execution:
+
+```sql
+REVOKE EXECUTE ON FUNCTION public.rpc_create_customer_receipt(jsonb) FROM authenticated;
+REVOKE EXECUTE ON FUNCTION public.rpc_create_supplier_payment(jsonb) FROM authenticated;
+REVOKE EXECUTE ON FUNCTION public.rpc_update_customer_receipt_draft(uuid,jsonb) FROM authenticated;
+REVOKE EXECUTE ON FUNCTION public.rpc_update_supplier_payment_draft(uuid,jsonb) FROM authenticated;
+REVOKE EXECUTE ON FUNCTION public.rpc_cancel_customer_receipt(uuid,text) FROM authenticated;
+REVOKE EXECUTE ON FUNCTION public.rpc_cancel_supplier_payment(uuid,text) FROM authenticated;
+```
+
+Do not restore the previous `protect_posted_gl_entries` body: that reopens `posted → cancelled` on voucher entries. Removing an applied migration is not an option under the project's golden rule — correct forward with a new numbered migration.

--- a/scripts/ci/fresh-db/acceptance_168_concurrency.sh
+++ b/scripts/ci/fresh-db/acceptance_168_concurrency.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# Concurrency acceptance for Migration 168.
+#
+# Two sessions racing on the same voucher must not produce a lost update, a
+# second cancellation of the same GL entry, or a duplicated audit record. Runs
+# after acceptance_168_voucher_atomic_lifecycle.sql and reuses its committed
+# fixtures; the preconditions below fail loudly rather than silently passing on
+# a database where that suite never ran.
+set -Eeuo pipefail
+
+DB=${PGDATABASE:-wardah_fresh}
+PSQL=(psql -v ON_ERROR_STOP=1 -X -d "$DB")
+
+ORG=88111111-1111-1111-1111-111111111111
+ADMIN=88aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
+CANCELLER=88cccccc-cccc-cccc-cccc-cccccccccccc
+CUSTOMER=88d00000-0000-0000-0000-000000000001
+INVOICE=88b10000-0000-0000-0000-000000000001
+CASH=88a10000-0000-0000-0000-000000000001
+SESSION_A=wardah_v168_session_a
+
+fail() {
+  echo "ACCEPTANCE_168_CONCURRENCY_FAIL: $1" >&2
+  exit 1
+}
+
+"${PSQL[@]}" -tAc "
+  SELECT EXISTS (
+    SELECT 1 FROM public.user_organizations
+    WHERE user_id='$CANCELLER' AND org_id='$ORG' AND is_active
+  )" | grep -qx t \
+  || fail 'primary acceptance fixtures are missing'
+
+create_draft() {
+  local amount=$1
+  "${PSQL[@]}" -tAc "
+    SELECT set_config('request.jwt.claim.sub','$ADMIN',false);
+    SELECT set_config('request.jwt.claims','{\"org_id\":\"$ORG\"}',false);
+    SET ROLE authenticated;
+    SELECT public.rpc_create_customer_receipt(jsonb_build_object(
+      'customer_id','$CUSTOMER',
+      'amount',$amount,
+      'payment_method','cash',
+      'payment_account_id','$CASH',
+      'lines', jsonb_build_array(jsonb_build_object(
+        'invoice_id','$INVOICE','allocated_amount',$amount))
+    ))->>'receipt_id';
+  " | tail -1
+}
+
+# Wait until session A demonstrably holds its row lock on the voucher table,
+# instead of trusting the scheduler to have started it.
+wait_for_lock() {
+  local pid=$1
+  for _ in $(seq 1 100); do
+    if "${PSQL[@]}" -tAc "
+      SELECT EXISTS (
+        SELECT 1 FROM pg_locks l
+        JOIN pg_stat_activity a ON a.pid = l.pid
+        WHERE a.application_name = '$SESSION_A'
+          AND l.relation = 'public.customer_collections'::regclass
+          AND l.mode = 'RowShareLock'
+          AND l.granted
+      )" | grep -qx t; then
+      return 0
+    fi
+    if ! kill -0 "$pid" 2>/dev/null; then
+      fail 'session A exited before taking the voucher lock'
+    fi
+    sleep 0.1
+  done
+  fail 'session A never took the voucher lock'
+}
+
+# ---------------------------------------------------------------------------
+# Race 1: two cancellations of the same voucher.
+# ---------------------------------------------------------------------------
+CANCEL_TARGET=$(create_draft 90)
+[ -n "$CANCEL_TARGET" ] || fail 'could not create the cancel race fixture'
+
+cat >/tmp/v168-cancel-a.sql <<SQL
+BEGIN;
+SELECT set_config('request.jwt.claim.sub','$CANCELLER',false);
+SELECT set_config('request.jwt.claims','{"org_id":"$ORG"}',false);
+SET LOCAL ROLE authenticated;
+SELECT public.rpc_cancel_customer_receipt('$CANCEL_TARGET','concurrency session A');
+SELECT pg_sleep(2);
+COMMIT;
+SQL
+
+cat >/tmp/v168-cancel-b.sql <<SQL
+BEGIN;
+SELECT set_config('request.jwt.claim.sub','$CANCELLER',false);
+SELECT set_config('request.jwt.claims','{"org_id":"$ORG"}',false);
+SET LOCAL ROLE authenticated;
+SELECT public.rpc_cancel_customer_receipt('$CANCEL_TARGET','concurrency session B');
+COMMIT;
+SQL
+
+PGAPPNAME="$SESSION_A" "${PSQL[@]}" -f /tmp/v168-cancel-a.sql >/tmp/v168-cancel-a.out 2>&1 &
+a_pid=$!
+wait_for_lock "$a_pid"
+
+set +e
+"${PSQL[@]}" -f /tmp/v168-cancel-b.sql >/tmp/v168-cancel-b.out 2>&1
+b_status=$?
+set -e
+wait "$a_pid" || fail "session A failed: $(cat /tmp/v168-cancel-a.out)"
+[ "$b_status" -eq 0 ] || fail "session B failed: $(cat /tmp/v168-cancel-b.out)"
+
+audit_rows=$("${PSQL[@]}" -tAc "
+  SELECT count(*) FROM public.audit_logs
+  WHERE action='voucher_cancelled' AND entity_id='$CANCEL_TARGET'")
+[ "$audit_rows" = "1" ] \
+  || fail "concurrent cancel wrote $audit_rows audit records, expected exactly 1"
+
+cancel_state=$("${PSQL[@]}" -tAc "
+  SELECT status FROM public.customer_collections WHERE id='$CANCEL_TARGET'")
+[ "$cancel_state" = "cancelled" ] \
+  || fail "voucher ended in state '$cancel_state' after the cancel race"
+
+grep -q 'duplicate.*true\|"duplicate": true' /tmp/v168-cancel-b.out \
+  || fail 'the losing cancel did not return the idempotent duplicate result'
+
+# ---------------------------------------------------------------------------
+# Race 2: two edits of the same draft. The loser must wait for the winner and
+# then replace the complete allocation set, never interleave with it.
+# ---------------------------------------------------------------------------
+EDIT_TARGET=$(create_draft 80)
+[ -n "$EDIT_TARGET" ] || fail 'could not create the edit race fixture'
+
+cat >/tmp/v168-edit-a.sql <<SQL
+BEGIN;
+SELECT set_config('request.jwt.claim.sub','$ADMIN',false);
+SELECT set_config('request.jwt.claims','{"org_id":"$ORG"}',false);
+SET LOCAL ROLE authenticated;
+SELECT public.rpc_update_customer_receipt_draft('$EDIT_TARGET', jsonb_build_object(
+  'amount', 60,
+  'lines', jsonb_build_array(jsonb_build_object(
+    'invoice_id','$INVOICE','allocated_amount',60))));
+SELECT pg_sleep(2);
+COMMIT;
+SQL
+
+cat >/tmp/v168-edit-b.sql <<SQL
+BEGIN;
+SELECT set_config('request.jwt.claim.sub','$ADMIN',false);
+SELECT set_config('request.jwt.claims','{"org_id":"$ORG"}',false);
+SET LOCAL ROLE authenticated;
+SELECT public.rpc_update_customer_receipt_draft('$EDIT_TARGET', jsonb_build_object(
+  'amount', 40,
+  'lines', jsonb_build_array(jsonb_build_object(
+    'invoice_id','$INVOICE','allocated_amount',40))));
+COMMIT;
+SQL
+
+PGAPPNAME="$SESSION_A" "${PSQL[@]}" -f /tmp/v168-edit-a.sql >/tmp/v168-edit-a.out 2>&1 &
+a_pid=$!
+wait_for_lock "$a_pid"
+
+set +e
+"${PSQL[@]}" -f /tmp/v168-edit-b.sql >/tmp/v168-edit-b.out 2>&1
+b_status=$?
+set -e
+wait "$a_pid" || fail "edit session A failed: $(cat /tmp/v168-edit-a.out)"
+[ "$b_status" -eq 0 ] || fail "edit session B failed: $(cat /tmp/v168-edit-b.out)"
+
+read -r final_amount line_count total <<<"$("${PSQL[@]}" -tA -F' ' -c "
+  SELECT c.amount::numeric(18,2),
+         (SELECT count(*) FROM public.customer_collection_lines l
+           WHERE l.collection_id = c.id),
+         (SELECT coalesce(sum(l.allocated_amount),0)::numeric(18,2)
+            FROM public.customer_collection_lines l
+           WHERE l.collection_id = c.id)
+  FROM public.customer_collections c WHERE c.id='$EDIT_TARGET'")"
+
+[ "$final_amount" = "40.00" ] \
+  || fail "lost update: header amount is $final_amount, expected the later writer's 40.00"
+[ "$line_count" = "1" ] \
+  || fail "interleaved replacement left $line_count allocation lines, expected 1"
+[ "$total" = "40.00" ] \
+  || fail "allocation total is $total, expected it to match the surviving header"
+
+edit_audits=$("${PSQL[@]}" -tAc "
+  SELECT count(*) FROM public.audit_logs
+  WHERE action='voucher_draft_updated' AND entity_id='$EDIT_TARGET'")
+[ "$edit_audits" = "2" ] \
+  || fail "concurrent edits wrote $edit_audits audit records, expected exactly 2"
+
+leaked=$("${PSQL[@]}" -tAc "
+  SELECT coalesce(current_setting('wardah.voucher_lines_write', true),'')
+       || '/' || coalesce(current_setting('wardah.voucher_gl_cancel', true),'')")
+[ "$leaked" = "/" ] \
+  || fail "an internal GUC leaked into a fresh session: $leaked"
+
+echo 'VOUCHER_ATOMIC_168_CONCURRENCY_PASS'

--- a/scripts/ci/fresh-db/acceptance_168_voucher_atomic_lifecycle.sql
+++ b/scripts/ci/fresh-db/acceptance_168_voucher_atomic_lifecycle.sql
@@ -1,0 +1,766 @@
+-- Acceptance for Migration 168.
+-- Executes the real create / edit / cancel RPCs on a fresh 166 -> 167 -> 168
+-- chain and proves: atomic creation with no orphan header, the restored
+-- correction step, both cancel paths, retention of GL identity and lines,
+-- tenant isolation, the exact cancel permission, idempotency, and that the GL
+-- cancel guard cannot be reached outside the approved RPC.
+\set ON_ERROR_STOP on
+
+CREATE OR REPLACE FUNCTION pg_temp.expect_error(p_sql text, p_needle text)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_succeeded boolean := false;
+BEGIN
+  BEGIN
+    EXECUTE p_sql;
+    v_succeeded := true;
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM NOT LIKE '%' || p_needle || '%' THEN
+      RAISE EXCEPTION
+        'ACCEPTANCE_FAIL: expected [%] for [%], got [%]',
+        p_needle, p_sql, SQLERRM;
+    END IF;
+  END;
+
+  IF v_succeeded THEN
+    RAISE EXCEPTION
+      'ACCEPTANCE_FAIL: expected error [%] for [%], but it succeeded',
+      p_needle, p_sql;
+  END IF;
+END;
+$$;
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- 1. Fixtures: two organizations, four users with distinct authority, and the
+-- accounting map the voucher RPCs require.
+-- ---------------------------------------------------------------------------
+INSERT INTO auth.users (id, email) VALUES
+  ('88aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'voucher168-admin@example.test'),
+  ('88bbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'voucher168-inactive@example.test'),
+  ('88cccccc-cccc-cccc-cccc-cccccccccccc', 'voucher168-canceller@example.test'),
+  ('88dddddd-dddd-dddd-dddd-dddddddddddd', 'voucher168-plain@example.test'),
+  ('88eeeeee-eeee-eeee-eeee-eeeeeeeeeeee', 'voucher168-orgb@example.test');
+
+INSERT INTO public.organizations (id, code, name) VALUES
+  ('88111111-1111-1111-1111-111111111111', 'V168A', 'Voucher 168 Org A'),
+  ('88222222-2222-2222-2222-222222222222', 'V168B', 'Voucher 168 Org B');
+
+INSERT INTO public.user_organizations
+  (id, user_id, org_id, role, is_active, is_org_admin) VALUES
+  ('88000000-0000-0000-0000-000000000001',
+   '88aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+   '88111111-1111-1111-1111-111111111111', 'admin', true, true),
+  ('88000000-0000-0000-0000-000000000002',
+   '88bbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+   '88111111-1111-1111-1111-111111111111', 'user', false, false),
+  ('88000000-0000-0000-0000-000000000003',
+   '88cccccc-cccc-cccc-cccc-cccccccccccc',
+   '88111111-1111-1111-1111-111111111111', 'user', true, false),
+  ('88000000-0000-0000-0000-000000000004',
+   '88dddddd-dddd-dddd-dddd-dddddddddddd',
+   '88111111-1111-1111-1111-111111111111', 'user', true, false),
+  ('88000000-0000-0000-0000-000000000005',
+   '88eeeeee-eeee-eeee-eeee-eeeeeeeeeeee',
+   '88222222-2222-2222-2222-222222222222', 'admin', true, true);
+
+-- The canceller holds the exact cancel key; the plain member holds the unpost
+-- key instead, which must not be accepted as authority to cancel.
+INSERT INTO public.roles (id, org_id, name, name_ar, is_system_role, is_active) VALUES
+  ('88700000-0000-0000-0000-000000000001',
+   '88111111-1111-1111-1111-111111111111',
+   'Voucher 168 canceller', 'ملغي السندات 168', false, true),
+  ('88700000-0000-0000-0000-000000000002',
+   '88111111-1111-1111-1111-111111111111',
+   'Voucher 168 corrector', 'مصحح السندات 168', false, true);
+
+INSERT INTO public.role_permissions (role_id, permission_id)
+SELECT '88700000-0000-0000-0000-000000000001'::uuid, p.id
+FROM public.permissions p WHERE p.permission_key = 'accounting.vouchers.cancel';
+
+INSERT INTO public.role_permissions (role_id, permission_id)
+SELECT '88700000-0000-0000-0000-000000000002'::uuid, p.id
+FROM public.permissions p WHERE p.permission_key = 'accounting.vouchers.unpost';
+
+INSERT INTO public.user_roles (id, user_id, role_id, org_id) VALUES
+  ('88800000-0000-0000-0000-000000000001',
+   '88cccccc-cccc-cccc-cccc-cccccccccccc',
+   '88700000-0000-0000-0000-000000000001',
+   '88111111-1111-1111-1111-111111111111'),
+  ('88800000-0000-0000-0000-000000000002',
+   '88dddddd-dddd-dddd-dddd-dddddddddddd',
+   '88700000-0000-0000-0000-000000000002',
+   '88111111-1111-1111-1111-111111111111');
+
+INSERT INTO public.customers (id, org_id, code, name, is_active) VALUES
+  ('88d00000-0000-0000-0000-000000000001',
+   '88111111-1111-1111-1111-111111111111', 'V168-CUST-A', 'Voucher 168 Customer A', true),
+  ('88d00000-0000-0000-0000-000000000002',
+   '88222222-2222-2222-2222-222222222222', 'V168-CUST-B', 'Voucher 168 Customer B', true);
+
+INSERT INTO public.vendors (id, org_id, code, name, is_active) VALUES
+  ('88e00000-0000-0000-0000-000000000001',
+   '88111111-1111-1111-1111-111111111111', 'V168-VEND-A', 'Voucher 168 Vendor A', true),
+  ('88e00000-0000-0000-0000-000000000002',
+   '88222222-2222-2222-2222-222222222222', 'V168-VEND-B', 'Voucher 168 Vendor B', true);
+
+INSERT INTO public.gl_accounts
+  (id, org_id, code, name, category, subtype, normal_balance, allow_posting, is_active)
+VALUES
+  ('88a10000-0000-0000-0000-000000000001',
+   '88111111-1111-1111-1111-111111111111', '180101', 'Voucher 168 Cash A',
+   'ASSET', 'CASH', 'DEBIT', true, true),
+  ('88a10000-0000-0000-0000-000000000002',
+   '88111111-1111-1111-1111-111111111111', '180102', 'Voucher 168 Bank A',
+   'ASSET', 'BANK', 'DEBIT', true, true),
+  ('88a10000-0000-0000-0000-000000000003',
+   '88111111-1111-1111-1111-111111111111', '180300', 'Voucher 168 AR A',
+   'ASSET', 'AR', 'DEBIT', true, true),
+  ('88a10000-0000-0000-0000-000000000004',
+   '88111111-1111-1111-1111-111111111111', '280100', 'Voucher 168 AP A',
+   'LIABILITY', 'AP', 'CREDIT', true, true);
+
+INSERT INTO public.journals (id, org_id, code, name, journal_type, is_active) VALUES
+  ('88f00000-0000-0000-0000-000000000001',
+   '88111111-1111-1111-1111-111111111111', 'V168-JRN-A',
+   'Voucher 168 Journal A', 'cash', true);
+
+INSERT INTO public.accounting_periods
+  (id, org_id, period_code, period_name, period_type,
+   start_date, end_date, fiscal_year, status) VALUES
+  ('88d10000-0000-0000-0000-000000000001',
+   '88111111-1111-1111-1111-111111111111', 'V168-2026-08',
+   'Voucher 168 August 2026', 'month',
+   DATE '2026-08-01', DATE '2026-08-31', 2026, 'open');
+
+INSERT INTO public.sales_invoices
+  (id, org_id, invoice_number, customer_id, invoice_date,
+   subtotal, discount_amount, tax_amount, total_amount, paid_amount,
+   payment_status, status)
+VALUES
+  ('88b10000-0000-0000-0000-000000000001',
+   '88111111-1111-1111-1111-111111111111', 'V168-SI-A1',
+   '88d00000-0000-0000-0000-000000000001', DATE '2026-08-10',
+   1000, 0, 0, 1000, 0, 'unpaid', 'POSTED'),
+  ('88b10000-0000-0000-0000-000000000002',
+   '88222222-2222-2222-2222-222222222222', 'V168-SI-B1',
+   '88d00000-0000-0000-0000-000000000002', DATE '2026-08-10',
+   1000, 0, 0, 1000, 0, 'unpaid', 'POSTED');
+
+INSERT INTO public.supplier_invoices
+  (id, org_id, invoice_number, vendor_id, invoice_date, due_date,
+   subtotal, discount_amount, tax_amount, total_amount, paid_amount, status)
+VALUES
+  ('88b20000-0000-0000-0000-000000000001',
+   '88111111-1111-1111-1111-111111111111', 'V168-PI-A1',
+   '88e00000-0000-0000-0000-000000000001', DATE '2026-08-10', NULL,
+   1000, 0, 0, 1000, 0, 'approved'),
+  ('88b20000-0000-0000-0000-000000000002',
+   '88222222-2222-2222-2222-222222222222', 'V168-PI-B1',
+   '88e00000-0000-0000-0000-000000000002', DATE '2026-08-10', NULL,
+   1000, 0, 0, 1000, 0, 'approved');
+
+-- ---------------------------------------------------------------------------
+-- 2. Atomic creation through the RPCs, as an ordinary authenticated client.
+-- ---------------------------------------------------------------------------
+SELECT set_config('request.jwt.claim.sub',
+                  '88aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', false);
+SELECT set_config('request.jwt.claims',
+                  '{"org_id":"88111111-1111-1111-1111-111111111111"}', false);
+SET LOCAL ROLE authenticated;
+
+CREATE TEMP TABLE v168 AS
+SELECT
+  (public.rpc_create_customer_receipt(jsonb_build_object(
+     'customer_id','88d00000-0000-0000-0000-000000000001',
+     'receipt_date','2026-08-10',
+     'amount', 400,
+     'payment_method','cash',
+     'payment_account_id','88a10000-0000-0000-0000-000000000001',
+     'notes','created by acceptance 168',
+     'lines', jsonb_build_array(jsonb_build_object(
+        'invoice_id','88b10000-0000-0000-0000-000000000001',
+        'allocated_amount',400))
+   ))->>'receipt_id')::uuid AS receipt_id,
+  (public.rpc_create_supplier_payment(jsonb_build_object(
+     'vendor_id','88e00000-0000-0000-0000-000000000001',
+     'payment_date','2026-08-10',
+     'amount', 300,
+     'payment_method','bank_transfer',
+     'payment_account_id','88a10000-0000-0000-0000-000000000002',
+     'lines', jsonb_build_array(jsonb_build_object(
+        'invoice_id','88b20000-0000-0000-0000-000000000001',
+        'allocated_amount',300))
+   ))->>'payment_id')::uuid AS payment_id;
+
+DO $$
+DECLARE
+  v_receipt uuid;
+  v_payment uuid;
+  v_number text;
+BEGIN
+  SELECT receipt_id, payment_id INTO v_receipt, v_payment FROM v168;
+  IF v_receipt IS NULL OR v_payment IS NULL THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: atomic creation returned no identity';
+  END IF;
+
+  SELECT collection_number INTO v_number
+  FROM public.customer_collections WHERE id = v_receipt;
+  IF v_number !~ '^CR-[0-9]{6}-[0-9]{5}$' THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: server-side receipt number malformed: %', v_number;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.customer_collections
+    WHERE id = v_receipt AND status = 'draft' AND gl_entry_id IS NULL
+      AND amount = 400 AND created_by = '88aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+  ) OR (SELECT count(*) FROM public.customer_collection_lines
+        WHERE collection_id = v_receipt) <> 1 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: receipt header/lines not created atomically';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.supplier_payments
+    WHERE id = v_payment AND status = 'draft' AND gl_entry_id IS NULL AND amount = 300
+  ) OR (SELECT count(*) FROM public.supplier_payment_lines
+        WHERE payment_id = v_payment) <> 1 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: payment header/lines not created atomically';
+  END IF;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 3. Rejected creations leave nothing behind. This is the orphan-header hole
+-- the browser flow had: header inserted, line rejected, compensating delete
+-- silently matching zero rows.
+-- ---------------------------------------------------------------------------
+SELECT pg_temp.expect_error(
+  $$SELECT public.rpc_create_customer_receipt(jsonb_build_object(
+      'customer_id','88d00000-0000-0000-0000-000000000001',
+      'amount',100,'payment_method','cash',
+      'payment_account_id','88a10000-0000-0000-0000-000000000001',
+      'lines', jsonb_build_array(jsonb_build_object(
+        'invoice_id','88b10000-0000-0000-0000-000000000002','allocated_amount',100))))$$,
+  'CUSTOMER_RECEIPT_ALLOCATION_CROSS_SCOPE');
+
+SELECT pg_temp.expect_error(
+  $$SELECT public.rpc_create_customer_receipt(jsonb_build_object(
+      'customer_id','88d00000-0000-0000-0000-000000000001',
+      'amount',200,'payment_method','cash',
+      'payment_account_id','88a10000-0000-0000-0000-000000000001',
+      'lines', jsonb_build_array(
+        jsonb_build_object('invoice_id','88b10000-0000-0000-0000-000000000001','allocated_amount',100),
+        jsonb_build_object('invoice_id','88b10000-0000-0000-0000-000000000001','allocated_amount',100))))$$,
+  'CUSTOMER_RECEIPT_ALLOCATION_DUPLICATE_INVOICE');
+
+SELECT pg_temp.expect_error(
+  $$SELECT public.rpc_create_customer_receipt(jsonb_build_object(
+      'customer_id','88d00000-0000-0000-0000-000000000001',
+      'amount',150,'payment_method','cash',
+      'payment_account_id','88a10000-0000-0000-0000-000000000001',
+      'lines', jsonb_build_array(jsonb_build_object(
+        'invoice_id','88b10000-0000-0000-0000-000000000001','allocated_amount',100))))$$,
+  'CUSTOMER_RECEIPT_ALLOCATION_TOTAL_MISMATCH');
+
+SELECT pg_temp.expect_error(
+  $$SELECT public.rpc_create_customer_receipt(jsonb_build_object(
+      'customer_id','88d00000-0000-0000-0000-000000000001',
+      'amount',100,'payment_method','cash',
+      'payment_account_id','88a10000-0000-0000-0000-000000000001',
+      'lines', jsonb_build_array(jsonb_build_object(
+        'invoice_id','88b10000-0000-0000-0000-000000000001',
+        'allocated_amount',100,'discount_amount',5))))$$,
+  'VOUCHER_DISCOUNT_UNSUPPORTED');
+
+SELECT pg_temp.expect_error(
+  $$SELECT public.rpc_create_supplier_payment(jsonb_build_object(
+      'vendor_id','88e00000-0000-0000-0000-000000000001',
+      'amount',5000,'payment_method','bank_transfer',
+      'payment_account_id','88a10000-0000-0000-0000-000000000002',
+      'lines', jsonb_build_array(jsonb_build_object(
+        'invoice_id','88b20000-0000-0000-0000-000000000001','allocated_amount',5000))))$$,
+  'SUPPLIER_PAYMENT_OVER_ALLOCATION');
+
+RESET ROLE;
+
+DO $$
+BEGIN
+  IF (SELECT count(*) FROM public.customer_collections
+      WHERE org_id='88111111-1111-1111-1111-111111111111') <> 1
+     OR (SELECT count(*) FROM public.supplier_payments
+         WHERE org_id='88111111-1111-1111-1111-111111111111') <> 1 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: a rejected creation left an orphan voucher header';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM public.customer_collection_lines l
+    LEFT JOIN public.customer_collections c ON c.id = l.collection_id
+    WHERE c.id IS NULL
+  ) OR EXISTS (
+    SELECT 1 FROM public.supplier_payment_lines l
+    LEFT JOIN public.supplier_payments p ON p.id = l.payment_id
+    WHERE p.id IS NULL
+  ) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: orphan allocation lines survived a rejected creation';
+  END IF;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 4. Identity gates: anon, an inactive member, and a member of another
+-- organization are all refused on every RPC family.
+-- ---------------------------------------------------------------------------
+SELECT set_config('request.jwt.claim.sub', '', false);
+SELECT set_config('request.jwt.claims', '{}', false);
+SET LOCAL ROLE anon;
+SELECT pg_temp.expect_error(
+  $$SELECT public.rpc_create_customer_receipt('{}'::jsonb)$$, 'permission denied');
+SELECT pg_temp.expect_error(
+  $$SELECT public.rpc_cancel_customer_receipt(
+      '00000000-0000-0000-0000-000000000000','anon attempt')$$, 'permission denied');
+RESET ROLE;
+
+SELECT set_config('request.jwt.claim.sub',
+                  '88bbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', false);
+SELECT set_config('request.jwt.claims',
+                  '{"org_id":"88111111-1111-1111-1111-111111111111"}', false);
+SET LOCAL ROLE authenticated;
+SELECT pg_temp.expect_error(
+  $$SELECT public.rpc_create_customer_receipt(jsonb_build_object(
+      'customer_id','88d00000-0000-0000-0000-000000000001','amount',10,
+      'payment_method','cash',
+      'payment_account_id','88a10000-0000-0000-0000-000000000001','lines','[]'::jsonb))$$,
+  'TENANT_MEMBERSHIP_REQUIRED');
+RESET ROLE;
+
+SELECT set_config('request.jwt.claim.sub',
+                  '88eeeeee-eeee-eeee-eeee-eeeeeeeeeeee', false);
+SELECT set_config('request.jwt.claims',
+                  '{"org_id":"88222222-2222-2222-2222-222222222222"}', false);
+SET LOCAL ROLE authenticated;
+SELECT pg_temp.expect_error(
+  format($$SELECT public.rpc_update_customer_receipt_draft(%L,'{"lines":[]}'::jsonb)$$,
+         (SELECT receipt_id FROM v168)),
+  'CUSTOMER_RECEIPT_NOT_FOUND_OR_CROSS_ORG');
+-- The organization B admin clears its own permission check, so the tenant
+-- boundary — not the permission — is what must stop this call.
+SELECT pg_temp.expect_error(
+  format($$SELECT public.rpc_cancel_customer_receipt(%L,'cross org attempt')$$,
+         (SELECT receipt_id FROM v168)),
+  'CUSTOMER_RECEIPT_NOT_FOUND_OR_CROSS_ORG');
+RESET ROLE;
+
+-- ---------------------------------------------------------------------------
+-- 5. Editing a draft that was never posted.
+-- ---------------------------------------------------------------------------
+SELECT set_config('request.jwt.claim.sub',
+                  '88aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', false);
+SELECT set_config('request.jwt.claims',
+                  '{"org_id":"88111111-1111-1111-1111-111111111111"}', false);
+SET LOCAL ROLE authenticated;
+
+SELECT public.rpc_update_customer_receipt_draft(
+  (SELECT receipt_id FROM v168),
+  jsonb_build_object(
+    'amount', 350,
+    'lines', jsonb_build_array(jsonb_build_object(
+      'invoice_id','88b10000-0000-0000-0000-000000000001','allocated_amount',350)))
+);
+
+SELECT pg_temp.expect_error(
+  format($$SELECT public.rpc_update_customer_receipt_draft(%L, '{"amount":100}'::jsonb)$$,
+         (SELECT receipt_id FROM v168)),
+  'VOUCHER_UPDATE_LINES_REQUIRED');
+
+SELECT pg_temp.expect_error(
+  format($$SELECT public.rpc_update_customer_receipt_draft(%L,
+            jsonb_build_object('customer_id','88d00000-0000-0000-0000-000000000002',
+                               'lines','[]'::jsonb))$$,
+         (SELECT receipt_id FROM v168)),
+  'CUSTOMER_RECEIPT_PARTY_IMMUTABLE');
+
+DO $$
+DECLARE v_receipt uuid;
+BEGIN
+  SELECT receipt_id INTO v_receipt FROM v168;
+  IF NOT EXISTS (
+    SELECT 1 FROM public.customer_collections WHERE id = v_receipt AND amount = 350
+  ) OR (SELECT count(*) FROM public.customer_collection_lines
+        WHERE collection_id = v_receipt AND allocated_amount = 350) <> 1 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: draft edit did not replace the allocation set';
+  END IF;
+  IF coalesce(current_setting('wardah.voucher_lines_write', true), '') <> 'off' THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: voucher_lines_write GUC leaked after edit';
+  END IF;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 6. The full corrected cycle: post -> reset -> edit -> repost, with the GL
+-- identity preserved end to end.
+-- ---------------------------------------------------------------------------
+SELECT public.rpc_post_customer_receipt((SELECT receipt_id FROM v168));
+SELECT public.rpc_post_supplier_payment((SELECT payment_id FROM v168));
+
+CREATE TEMP TABLE v168_entries AS
+SELECT
+  (SELECT gl_entry_id FROM public.customer_collections
+    WHERE id = (SELECT receipt_id FROM v168)) AS receipt_entry_id,
+  (SELECT gl_entry_id FROM public.supplier_payments
+    WHERE id = (SELECT payment_id FROM v168)) AS payment_entry_id;
+
+-- The temp tables are owned by the authenticated role that created them; the
+-- service_role sections below read this one.
+GRANT SELECT ON v168_entries TO service_role;
+
+-- A posted voucher can be neither edited nor cancelled directly.
+SELECT pg_temp.expect_error(
+  format($$SELECT public.rpc_update_customer_receipt_draft(%L,'{"lines":[]}'::jsonb)$$,
+         (SELECT receipt_id FROM v168)),
+  'CUSTOMER_RECEIPT_NOT_DRAFT');
+RESET ROLE;
+
+SELECT set_config('request.jwt.claim.sub',
+                  '88cccccc-cccc-cccc-cccc-cccccccccccc', false);
+SET LOCAL ROLE authenticated;
+SELECT pg_temp.expect_error(
+  format($$SELECT public.rpc_cancel_customer_receipt(%L,'cancel a posted voucher')$$,
+         (SELECT receipt_id FROM v168)),
+  'VOUCHER_CANCEL_REQUIRES_RESET');
+RESET ROLE;
+
+SELECT set_config('request.jwt.claim.sub',
+                  '88aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', false);
+SET LOCAL ROLE authenticated;
+SELECT public.rpc_reset_customer_receipt_to_draft(
+  (SELECT receipt_id FROM v168), 'acceptance 168 correction');
+SELECT public.rpc_reset_supplier_payment_to_draft(
+  (SELECT payment_id FROM v168), 'acceptance 168 correction');
+
+SELECT public.rpc_update_customer_receipt_draft(
+  (SELECT receipt_id FROM v168),
+  jsonb_build_object(
+    'amount', 275,
+    'lines', jsonb_build_array(jsonb_build_object(
+      'invoice_id','88b10000-0000-0000-0000-000000000001','allocated_amount',275)))
+);
+
+SELECT public.rpc_post_customer_receipt((SELECT receipt_id FROM v168));
+
+DO $$
+DECLARE v_entry uuid;
+BEGIN
+  SELECT receipt_entry_id INTO v_entry FROM v168_entries;
+  IF NOT EXISTS (
+    SELECT 1 FROM public.customer_collections c, v168
+    WHERE c.id = v168.receipt_id AND c.status='posted'
+      AND c.gl_entry_id = v_entry AND c.amount = 275
+  ) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: corrected repost lost or changed the GL identity';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM public.gl_entries
+    WHERE id = v_entry AND status='posted' AND total_debit = 275 AND total_credit = 275
+  ) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: corrected repost GL header mismatch';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM public.sales_invoices
+    WHERE id='88b10000-0000-0000-0000-000000000001'
+      AND paid_amount = 275 AND balance = 725 AND payment_status='partially_paid'
+  ) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: corrected repost invoice state mismatch';
+  END IF;
+  IF (SELECT count(*) FROM public.audit_logs
+      WHERE action='voucher_draft_updated'
+        AND entity_id = (SELECT receipt_id::text FROM v168)) <> 2 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: draft edit audit trail incomplete';
+  END IF;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 7. Cancel path A: a draft that was never posted, cancelled with no GL side
+-- effect at all.
+-- ---------------------------------------------------------------------------
+CREATE TEMP TABLE v168_spare AS
+SELECT (public.rpc_create_customer_receipt(jsonb_build_object(
+    'customer_id','88d00000-0000-0000-0000-000000000001',
+    'amount',120,'payment_method','cash',
+    'payment_account_id','88a10000-0000-0000-0000-000000000001',
+    'lines', jsonb_build_array(jsonb_build_object(
+      'invoice_id','88b10000-0000-0000-0000-000000000001','allocated_amount',120))
+  ))->>'receipt_id')::uuid AS receipt_id;
+RESET ROLE;
+
+-- The plain member holds unpost, not cancel. unpost must not authorize cancel.
+SELECT set_config('request.jwt.claim.sub',
+                  '88dddddd-dddd-dddd-dddd-dddddddddddd', false);
+SET LOCAL ROLE authenticated;
+SELECT pg_temp.expect_error(
+  format($$SELECT public.rpc_cancel_customer_receipt(%L,'unpost is not cancel')$$,
+         (SELECT receipt_id FROM v168_spare)),
+  'VOUCHER_CANCEL_PERMISSION_REQUIRED');
+RESET ROLE;
+
+SELECT set_config('request.jwt.claim.sub',
+                  '88cccccc-cccc-cccc-cccc-cccccccccccc', false);
+SET LOCAL ROLE authenticated;
+SELECT pg_temp.expect_error(
+  format($$SELECT public.rpc_cancel_customer_receipt(%L,'x')$$,
+         (SELECT receipt_id FROM v168_spare)),
+  'VOUCHER_CANCEL_REASON_REQUIRED');
+SELECT public.rpc_cancel_customer_receipt(
+  (SELECT receipt_id FROM v168_spare), 'duplicate voucher entered by mistake');
+
+DO $$
+DECLARE v_spare uuid;
+BEGIN
+  SELECT receipt_id INTO v_spare FROM v168_spare;
+  IF NOT EXISTS (
+    SELECT 1 FROM public.customer_collections
+    WHERE id = v_spare AND status='cancelled' AND gl_entry_id IS NULL
+  ) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: never-posted cancel did not close the voucher';
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM public.gl_entries WHERE reference_id = v_spare
+  ) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: never-posted cancel touched the general ledger';
+  END IF;
+  IF (SELECT count(*) FROM public.customer_collection_lines
+      WHERE collection_id = v_spare) <> 1 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: cancel deleted allocation history';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM public.audit_logs
+    WHERE action='voucher_cancelled' AND entity_id = v_spare::text
+      AND changes->>'path' = 'never_posted'
+  ) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: never-posted cancel audit missing';
+  END IF;
+END;
+$$;
+
+-- Cancelling twice is idempotent and must not write a second audit record.
+SELECT public.rpc_cancel_customer_receipt(
+  (SELECT receipt_id FROM v168_spare), 'duplicate voucher entered by mistake');
+
+DO $$
+BEGIN
+  IF (SELECT count(*) FROM public.audit_logs
+      WHERE action='voucher_cancelled'
+        AND entity_id = (SELECT receipt_id::text FROM v168_spare)) <> 1 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: idempotent cancel duplicated the audit record';
+  END IF;
+END;
+$$;
+RESET ROLE;
+
+-- ---------------------------------------------------------------------------
+-- 8. Cancel path B: posted, reset, then cancelled. The entry is retained with
+-- its number and lines; only its status moves.
+-- ---------------------------------------------------------------------------
+SELECT set_config('request.jwt.claim.sub',
+                  '88aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', false);
+SET LOCAL ROLE authenticated;
+SELECT public.rpc_reset_supplier_payment_to_draft(
+  (SELECT payment_id FROM v168), 'acceptance 168 cancel path');
+RESET ROLE;
+
+CREATE TEMP TABLE v168_payment_entry AS
+SELECT e.id, e.entry_number,
+       (SELECT count(*) FROM public.gl_entry_lines l WHERE l.entry_id = e.id) AS line_count
+FROM public.gl_entries e, v168_entries x
+WHERE e.id = x.payment_entry_id;
+
+SELECT set_config('request.jwt.claim.sub',
+                  '88cccccc-cccc-cccc-cccc-cccccccccccc', false);
+SET LOCAL ROLE authenticated;
+SELECT public.rpc_cancel_supplier_payment(
+  (SELECT payment_id FROM v168), 'vendor withdrew the invoice');
+RESET ROLE;
+
+DO $$
+DECLARE
+  v_payment uuid;
+  v_entry uuid;
+  v_number text;
+  v_lines bigint;
+BEGIN
+  SELECT payment_id INTO v_payment FROM v168;
+  SELECT id, entry_number, line_count INTO v_entry, v_number, v_lines
+  FROM v168_payment_entry;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.supplier_payments
+    WHERE id = v_payment AND status='cancelled' AND gl_entry_id = v_entry
+  ) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: corrected cancel dropped the GL identity';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.gl_entries
+    WHERE id = v_entry AND status='cancelled' AND entry_number = v_number
+  ) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: linked entry was not cancelled or lost its number';
+  END IF;
+
+  IF (SELECT count(*) FROM public.gl_entry_lines WHERE entry_id = v_entry) <> v_lines
+     OR v_lines < 2 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: cancel deleted GL lines (% remaining of %)',
+      (SELECT count(*) FROM public.gl_entry_lines WHERE entry_id = v_entry), v_lines;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.audit_logs
+    WHERE action='voucher_cancelled' AND entity_id = v_payment::text
+      AND changes->>'path' = 'corrected'
+      AND (metadata->>'reset_audit_id') IS NOT NULL
+      AND old_data->>'entry_number' = v_number
+  ) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: corrected cancel audit does not name the reset it closes';
+  END IF;
+
+  IF coalesce(current_setting('wardah.voucher_gl_cancel', true), '') <> 'off' THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: voucher_gl_cancel GUC leaked after cancel';
+  END IF;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 9. The GL cancel guard is not reachable outside the approved RPC, and
+-- service_role bypasses RLS so the trigger is the only thing standing there.
+-- ---------------------------------------------------------------------------
+SELECT public.rpc_post_customer_receipt((SELECT receipt_id FROM v168));
+
+-- The receipt is posted again here, so its entry is posted too. Cancelling it
+-- is refused with the GUC closed, and still refused with the GUC opened by
+-- hand, because a posted voucher can never satisfy the eligibility conjunction.
+-- That is what keeps posted -> cancelled closed in practice.
+SET LOCAL ROLE service_role;
+SELECT pg_temp.expect_error(
+  format($$UPDATE public.gl_entries SET status='cancelled' WHERE id=%L$$,
+         (SELECT receipt_entry_id FROM v168_entries)),
+  'VOUCHER_GL_CANCEL_FORBIDDEN');
+
+SELECT set_config('wardah.voucher_gl_cancel', 'on', true);
+SELECT pg_temp.expect_error(
+  format($$UPDATE public.gl_entries SET status='cancelled' WHERE id=%L$$,
+         (SELECT receipt_entry_id FROM v168_entries)),
+  'VOUCHER_GL_CANCEL_SCOPE_INVALID');
+SELECT set_config('wardah.voucher_gl_cancel', 'off', true);
+RESET ROLE;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM public.gl_entries e, v168_entries x
+    WHERE e.id = x.receipt_entry_id AND e.status = 'posted'
+  ) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: a refused cancel still changed the posted entry';
+  END IF;
+END;
+$$;
+
+-- A voucher-linked draft entry whose voucher never went through reset is not
+-- eligible, even with the GUC opened by hand.
+INSERT INTO public.gl_entries
+  (id, org_id, journal_id, entry_number, entry_date, entry_type,
+   reference_type, reference_id, description, status, total_debit, total_credit)
+VALUES
+  ('88c90000-0000-0000-0000-000000000001',
+   '88111111-1111-1111-1111-111111111111',
+   '88f00000-0000-0000-0000-000000000001',
+   'V168-UNPROVEN', DATE '2026-08-12', 'manual',
+   'CUSTOMER_RECEIPT', (SELECT receipt_id FROM v168),
+   'entry not reachable through the reset path', 'draft', 10, 10);
+
+SET LOCAL ROLE service_role;
+SELECT set_config('wardah.voucher_gl_cancel', 'on', true);
+SELECT pg_temp.expect_error(
+  $$UPDATE public.gl_entries SET status='cancelled'
+    WHERE id='88c90000-0000-0000-0000-000000000001'$$,
+  'VOUCHER_GL_CANCEL_SCOPE_INVALID');
+SELECT set_config('wardah.voucher_gl_cancel', 'off', true);
+SELECT pg_temp.expect_error(
+  $$UPDATE public.gl_entries SET status='cancelled'
+    WHERE id='88c90000-0000-0000-0000-000000000001'$$,
+  'VOUCHER_GL_CANCEL_FORBIDDEN');
+RESET ROLE;
+
+-- A posted entry belonging to no voucher cannot be cancelled at all.
+INSERT INTO public.gl_entries
+  (id, org_id, journal_id, entry_number, entry_date, entry_type,
+   description, status, total_debit, total_credit)
+VALUES
+  ('88c90000-0000-0000-0000-000000000002',
+   '88111111-1111-1111-1111-111111111111',
+   '88f00000-0000-0000-0000-000000000001',
+   'V168-FOREIGN', DATE '2026-08-12', 'manual',
+   'entry owned by another subsystem', 'draft', 20, 20);
+UPDATE public.gl_entries SET status='posted'
+WHERE id='88c90000-0000-0000-0000-000000000002';
+
+SET LOCAL ROLE service_role;
+SELECT set_config('wardah.voucher_gl_cancel', 'on', true);
+SELECT pg_temp.expect_error(
+  $$UPDATE public.gl_entries SET status='cancelled'
+    WHERE id='88c90000-0000-0000-0000-000000000002'$$,
+  'POSTED_ENTRY_IMMUTABLE');
+SELECT set_config('wardah.voucher_gl_cancel', 'off', true);
+RESET ROLE;
+
+-- ---------------------------------------------------------------------------
+-- 10. A voucher carrying a GL identity without a trusted reset record is
+-- refused by both the edit and the cancel path. gl_entry_id alone is never
+-- accepted as proof that a voucher reached the correction phase.
+-- ---------------------------------------------------------------------------
+CREATE TEMP TABLE v168_forged AS
+SELECT gen_random_uuid() AS receipt_id;
+GRANT SELECT ON v168_forged TO authenticated;
+
+INSERT INTO public.customer_collections
+  (id, org_id, collection_number, customer_id, collection_date, amount,
+   payment_method, payment_account_id, status, gl_entry_id, created_by)
+SELECT receipt_id, '88111111-1111-1111-1111-111111111111', 'V168-FORGED',
+       '88d00000-0000-0000-0000-000000000001', DATE '2026-08-12', 50,
+       'cash', '88a10000-0000-0000-0000-000000000001', 'draft',
+       '88c90000-0000-0000-0000-000000000001',
+       '88aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+FROM v168_forged;
+
+SELECT set_config('request.jwt.claim.sub',
+                  '88cccccc-cccc-cccc-cccc-cccccccccccc', false);
+SET LOCAL ROLE authenticated;
+SELECT pg_temp.expect_error(
+  format($$SELECT public.rpc_cancel_customer_receipt(%L,'forged correction state')$$,
+         (SELECT receipt_id FROM v168_forged)),
+  'CUSTOMER_RECEIPT_CANCEL_UNPROVEN');
+RESET ROLE;
+
+SELECT set_config('request.jwt.claim.sub',
+                  '88aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', false);
+SET LOCAL ROLE authenticated;
+SELECT pg_temp.expect_error(
+  format($$SELECT public.rpc_update_customer_receipt_draft(%L,'{"lines":[]}'::jsonb)$$,
+         (SELECT receipt_id FROM v168_forged)),
+  'CUSTOMER_RECEIPT_CORRECTION_UNPROVEN');
+RESET ROLE;
+
+DO $$
+BEGIN
+  IF coalesce(current_setting('wardah.voucher_lines_write', true), '') <> 'off'
+     OR coalesce(current_setting('wardah.voucher_gl_cancel', true), '') <> 'off'
+     OR coalesce(current_setting('wardah.voucher_unpost', true), '') <> 'off' THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: an internal GUC was left open at the end of the suite';
+  END IF;
+END;
+$$;
+
+COMMIT;
+
+SELECT 'VOUCHER_ATOMIC_168_ACCEPTANCE_PASS' AS result;

--- a/sql/migrations/168_voucher_atomic_lifecycle_rpcs.sql
+++ b/sql/migrations/168_voucher_atomic_lifecycle_rpcs.sql
@@ -1,0 +1,1198 @@
+-- =====================================================================
+-- 168_voucher_atomic_lifecycle_rpcs
+-- =====================================================================
+-- Atomic create, edit and cancel for customer receipts and supplier payments.
+--
+-- Migration 167 closed the direct write paths on allocation lines and left the
+-- `corrected` step of the Migration 166 cycle without any client path. This
+-- migration restores it through SECURITY DEFINER RPCs that own the whole
+-- operation in one transaction, and adds the cancel path that ends a voucher's
+-- life without deleting accounting history.
+--
+-- Cancel is a different accounting event from reset, so it gets its own
+-- permission (accounting.vouchers.cancel), its own transaction-local GUC
+-- (wardah.voucher_gl_cancel), and its own guard inside
+-- protect_posted_gl_entries. Neither is derived from the unpost contract.
+--
+-- Direct client INSERT on allocation lines stays open here on purpose. It is
+-- withdrawn in Migration 169, after the UI moves onto these RPCs.
+-- =====================================================================
+
+BEGIN;
+
+SET LOCAL lock_timeout = '30s';
+SET LOCAL statement_timeout = '5min';
+
+DO $preflight$
+BEGIN
+  IF to_regclass('public.customer_collections') IS NULL
+     OR to_regclass('public.customer_collection_lines') IS NULL
+     OR to_regclass('public.supplier_payments') IS NULL
+     OR to_regclass('public.supplier_payment_lines') IS NULL
+     OR to_regclass('public.sales_invoices') IS NULL
+     OR to_regclass('public.supplier_invoices') IS NULL
+     OR to_regclass('public.gl_entries') IS NULL
+     OR to_regclass('public.audit_logs') IS NULL
+     OR to_regclass('public.permissions') IS NULL THEN
+    RAISE EXCEPTION 'VOUCHER_168_REQUIRED_OBJECT_MISSING';
+  END IF;
+
+  IF to_regprocedure('public.wardah_has_exact_permission(uuid,uuid,text)') IS NULL
+     OR to_regprocedure('public.wardah_is_org_member(uuid)') IS NULL
+     OR to_regprocedure('public.get_current_tenant_id()') IS NULL
+     OR to_regprocedure('public.wardah_protect_voucher_allocation_lines()') IS NULL
+     OR to_regprocedure('public.rpc_reset_customer_receipt_to_draft(uuid,text)') IS NULL
+     OR to_regprocedure('public.rpc_reset_supplier_payment_to_draft(uuid,text)') IS NULL THEN
+    RAISE EXCEPTION 'VOUCHER_168_REQUIRED_FUNCTION_MISSING';
+  END IF;
+END
+$preflight$;
+
+-- ---------------------------------------------------------------------
+-- 1. Cancel is its own sensitive permission. unpost returns a voucher for
+-- correction and keeps it repostable; cancel ends its cycle. Neither implies
+-- the other, and this key is not granted to any role by this migration.
+-- ---------------------------------------------------------------------
+INSERT INTO public.permissions (
+  module_id, resource, resource_ar, action, action_ar,
+  permission_key, description, description_ar
+)
+SELECT
+  m.id,
+  'vouchers',
+  'السندات المالية',
+  'cancel',
+  'إلغاء',
+  'accounting.vouchers.cancel',
+  'Cancel a payment voucher and, for a corrected voucher, its retained GL entry.',
+  'إلغاء سند مالي، ومعه قيده المحفوظ إن كان السند قد أُعيد للتصحيح.'
+FROM public.modules m
+WHERE m.name = 'accounting'
+ON CONFLICT (permission_key) DO NOTHING;
+
+-- ---------------------------------------------------------------------
+-- 2. Close the cancel path on GL entries.
+--
+-- protect_posted_gl_entries refused posted -> draft but said nothing about
+-- posted -> cancelled, so cancelling was an unguarded way around
+-- POSTED_ENTRY_IMMUTABLE the moment any UPDATE path opened. Every transition
+-- into 'cancelled' on a voucher-linked entry now requires all of:
+--
+--   * the dedicated transaction-local GUC;
+--   * a voucher that exists in the same organization;
+--   * a voucher whose gl_entry_id still points at this exact entry;
+--   * a voucher still in draft, i.e. inside the correction cycle;
+--   * a trusted Migration 166 reset record for that voucher.
+--
+-- The last condition is the reason gl_entry_id alone is never taken as proof
+-- that a voucher went through reset. A posted voucher cannot satisfy the draft
+-- condition, so posted -> cancelled stays closed in practice.
+--
+-- Cancelling a posted entry that belongs to any other subsystem is refused
+-- outright; no such path exists today and none may appear by accident.
+-- ---------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.protect_posted_gl_entries()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public
+AS $function$
+DECLARE
+  v_controlled_unpost boolean :=
+    coalesce(current_setting('wardah.voucher_unpost', true), '') = 'on';
+  v_controlled_cancel boolean :=
+    coalesce(current_setting('wardah.voucher_gl_cancel', true), '') = 'on';
+  v_voucher_eligible boolean := false;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    IF OLD.status IN ('posted', 'reversed') THEN
+      RAISE EXCEPTION 'POSTED_ENTRY_IMMUTABLE: لا يمكن حذف قيد مرحّل (%) — استخدم العكس', OLD.entry_number;
+    END IF;
+    RETURN OLD;
+  END IF;
+
+  IF NEW.status = 'cancelled' AND OLD.status IS DISTINCT FROM 'cancelled' THEN
+    IF OLD.reference_type IN ('CUSTOMER_RECEIPT', 'SUPPLIER_PAYMENT')
+       AND OLD.reference_id IS NOT NULL THEN
+      IF NOT v_controlled_cancel THEN
+        RAISE EXCEPTION
+          'VOUCHER_GL_CANCEL_FORBIDDEN: لا يمكن إلغاء قيد سند (%) خارج RPC الإلغاء المعتمد',
+          OLD.entry_number;
+      END IF;
+
+      IF OLD.reference_type = 'CUSTOMER_RECEIPT' THEN
+        SELECT EXISTS (
+          SELECT 1
+          FROM public.customer_collections c
+          WHERE c.id = OLD.reference_id
+            AND c.org_id = OLD.org_id
+            AND c.gl_entry_id = OLD.id
+            AND c.status = 'draft'
+            AND EXISTS (
+              SELECT 1
+              FROM public.audit_logs a
+              WHERE a.org_id = OLD.org_id
+                AND a.action = 'voucher_reset_to_draft'
+                AND a.entity_type = 'customer_receipt'
+                AND a.entity_id = c.id::text
+            )
+        ) INTO v_voucher_eligible;
+      ELSE
+        SELECT EXISTS (
+          SELECT 1
+          FROM public.supplier_payments p
+          WHERE p.id = OLD.reference_id
+            AND p.org_id = OLD.org_id
+            AND p.gl_entry_id = OLD.id
+            AND p.status = 'draft'
+            AND EXISTS (
+              SELECT 1
+              FROM public.audit_logs a
+              WHERE a.org_id = OLD.org_id
+                AND a.action = 'voucher_reset_to_draft'
+                AND a.entity_type = 'supplier_payment'
+                AND a.entity_id = p.id::text
+            )
+        ) INTO v_voucher_eligible;
+      END IF;
+
+      IF NOT v_voucher_eligible THEN
+        RAISE EXCEPTION
+          'VOUCHER_GL_CANCEL_SCOPE_INVALID: القيد (%) لا يطابق سندًا مؤهلًا لمسار الإلغاء',
+          OLD.entry_number;
+      END IF;
+    ELSIF OLD.status = 'posted' THEN
+      RAISE EXCEPTION
+        'POSTED_ENTRY_IMMUTABLE: لا يمكن إلغاء قيد مرحّل (%) — استخدم العكس', OLD.entry_number;
+    END IF;
+  END IF;
+
+  IF OLD.status IN ('posted', 'reversed') THEN
+    IF NEW.entry_date IS DISTINCT FROM OLD.entry_date
+       OR NEW.total_debit IS DISTINCT FROM OLD.total_debit
+       OR NEW.total_credit IS DISTINCT FROM OLD.total_credit
+       OR NEW.journal_id IS DISTINCT FROM OLD.journal_id THEN
+      RAISE EXCEPTION 'POSTED_ENTRY_IMMUTABLE: لا يمكن تعديل الحقول المالية لقيد مرحّل (%) — استخدم العكس', OLD.entry_number;
+    END IF;
+
+    IF OLD.status = 'posted' AND NEW.status = 'draft' THEN
+      IF NOT v_controlled_unpost
+         OR OLD.reference_type NOT IN ('CUSTOMER_RECEIPT', 'SUPPLIER_PAYMENT')
+         OR OLD.reference_id IS NULL THEN
+        RAISE EXCEPTION 'POSTED_ENTRY_IMMUTABLE: لا يمكن إرجاع قيد مرحّل إلى مسودة (%)', OLD.entry_number;
+      END IF;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END
+$function$;
+
+-- ---------------------------------------------------------------------
+-- 3. Voucher numbering. The browser used to read the current maximum and add
+-- one, which two concurrent creations resolve to the same number. The
+-- allocation is serialized per organization, kind and period for the rest of
+-- the transaction, and the unique constraint remains the final arbiter.
+-- ---------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.wardah_next_voucher_number(
+  p_org uuid,
+  p_kind text
+)
+RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_prefix text;
+  v_period text := to_char(current_date, 'YYYYMM');
+  v_stem text;
+  v_seq integer;
+BEGIN
+  IF p_org IS NULL THEN
+    RAISE EXCEPTION 'VOUCHER_NUMBER_SCOPE_REQUIRED';
+  END IF;
+
+  IF p_kind = 'CUSTOMER_RECEIPT' THEN
+    v_prefix := 'CR-';
+  ELSIF p_kind = 'SUPPLIER_PAYMENT' THEN
+    v_prefix := 'SP-';
+  ELSE
+    RAISE EXCEPTION 'VOUCHER_NUMBER_KIND_INVALID: %', p_kind;
+  END IF;
+
+  v_stem := v_prefix || v_period || '-';
+  PERFORM pg_advisory_xact_lock(hashtext(p_org::text || ':' || p_kind || ':' || v_period));
+
+  IF p_kind = 'CUSTOMER_RECEIPT' THEN
+    SELECT coalesce(max(substr(c.collection_number, length(v_stem) + 1)::integer), 0)
+    INTO v_seq
+    FROM public.customer_collections c
+    WHERE c.org_id = p_org
+      AND c.collection_number ~ ('^' || v_stem || '[0-9]+$');
+  ELSE
+    SELECT coalesce(max(substr(p.payment_number, length(v_stem) + 1)::integer), 0)
+    INTO v_seq
+    FROM public.supplier_payments p
+    WHERE p.org_id = p_org
+      AND p.payment_number ~ ('^' || v_stem || '[0-9]+$');
+  END IF;
+
+  RETURN v_stem || lpad((v_seq + 1)::text, 5, '0');
+END
+$function$;
+
+REVOKE ALL ON FUNCTION public.wardah_next_voucher_number(uuid,text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.wardah_next_voucher_number(uuid,text) FROM anon;
+REVOKE ALL ON FUNCTION public.wardah_next_voucher_number(uuid,text) FROM authenticated;
+REVOKE ALL ON FUNCTION public.wardah_next_voucher_number(uuid,text) FROM service_role;
+
+-- ---------------------------------------------------------------------
+-- 4. Atomic creation. Header and lines land in one transaction, so a rejected
+-- line can no longer leave an orphan header behind a silent compensating
+-- delete.
+-- ---------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_create_customer_receipt(p_payload jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_actor uuid := auth.uid();
+  v_org uuid;
+  v_receipt_id uuid := gen_random_uuid();
+  v_number text;
+  v_customer uuid;
+  v_date date;
+  v_amount numeric;
+  v_method text;
+  v_account uuid;
+  v_line jsonb;
+  v_invoice_id uuid;
+  v_allocated numeric;
+  v_discount numeric;
+  v_seen uuid[] := ARRAY[]::uuid[];
+  v_total numeric := 0;
+  v_count integer := 0;
+  v_open numeric;
+  v_invoice record;
+BEGIN
+  IF v_actor IS NULL THEN RAISE EXCEPTION 'AUTH_REQUIRED'; END IF;
+  v_org := public.get_current_tenant_id();
+  IF v_org IS NULL OR NOT public.wardah_is_org_member(v_org) THEN
+    RAISE EXCEPTION 'TENANT_MEMBERSHIP_REQUIRED';
+  END IF;
+
+  v_customer := nullif(p_payload->>'customer_id', '')::uuid;
+  v_date := coalesce(nullif(p_payload->>'receipt_date', '')::date, current_date);
+  v_amount := round(coalesce(nullif(p_payload->>'amount', '')::numeric, 0), 2);
+  v_method := coalesce(nullif(p_payload->>'payment_method', ''), 'cash');
+  v_account := nullif(p_payload->>'payment_account_id', '')::uuid;
+
+  IF v_customer IS NULL THEN RAISE EXCEPTION 'CUSTOMER_RECEIPT_CUSTOMER_REQUIRED'; END IF;
+  IF v_amount <= 0 THEN RAISE EXCEPTION 'VOUCHER_AMOUNT_INVALID: amount must be positive'; END IF;
+  IF v_account IS NULL THEN RAISE EXCEPTION 'VOUCHER_PAYMENT_ACCOUNT_REQUIRED'; END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM public.customers c WHERE c.id = v_customer AND c.org_id = v_org
+  ) THEN
+    RAISE EXCEPTION 'CUSTOMER_RECEIPT_CUSTOMER_CROSS_ORG';
+  END IF;
+
+  v_number := public.wardah_next_voucher_number(v_org, 'CUSTOMER_RECEIPT');
+
+  INSERT INTO public.customer_collections (
+    id, org_id, collection_number, customer_id, collection_date, amount,
+    payment_method, payment_account_id, check_number, check_date,
+    reference_number, notes, status, created_by
+  ) VALUES (
+    v_receipt_id, v_org, v_number, v_customer, v_date, v_amount,
+    v_method, v_account,
+    nullif(p_payload->>'check_number', ''),
+    nullif(p_payload->>'check_date', '')::date,
+    nullif(p_payload->>'reference_number', ''),
+    nullif(p_payload->>'notes', ''),
+    'draft', v_actor
+  );
+
+  FOR v_line IN
+    SELECT value FROM jsonb_array_elements(coalesce(p_payload->'lines', '[]'::jsonb))
+  LOOP
+    v_invoice_id := nullif(v_line->>'invoice_id', '')::uuid;
+    v_allocated := round(coalesce(nullif(v_line->>'allocated_amount', '')::numeric, 0), 2);
+    v_discount := round(coalesce(nullif(v_line->>'discount_amount', '')::numeric, 0), 2);
+
+    IF v_invoice_id IS NULL THEN
+      RAISE EXCEPTION 'CUSTOMER_RECEIPT_ALLOCATION_INVOICE_REQUIRED';
+    END IF;
+    IF v_allocated <= 0 THEN
+      RAISE EXCEPTION 'CUSTOMER_RECEIPT_ALLOCATION_AMOUNT_INVALID: invoice=%', v_invoice_id;
+    END IF;
+    IF v_discount <> 0 THEN
+      RAISE EXCEPTION 'VOUCHER_DISCOUNT_UNSUPPORTED: discount accounting mapping is required';
+    END IF;
+    IF v_invoice_id = ANY (v_seen) THEN
+      RAISE EXCEPTION 'CUSTOMER_RECEIPT_ALLOCATION_DUPLICATE_INVOICE: invoice=%', v_invoice_id;
+    END IF;
+    v_seen := v_seen || v_invoice_id;
+
+    SELECT i.total_amount, coalesce(i.paid_amount, 0) AS paid_amount
+    INTO v_invoice
+    FROM public.sales_invoices i
+    WHERE i.id = v_invoice_id AND i.org_id = v_org AND i.customer_id = v_customer
+    FOR UPDATE;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'CUSTOMER_RECEIPT_ALLOCATION_CROSS_SCOPE: invoice=%', v_invoice_id;
+    END IF;
+
+    v_open := round(v_invoice.total_amount - v_invoice.paid_amount, 2);
+    IF v_allocated > v_open THEN
+      RAISE EXCEPTION 'CUSTOMER_RECEIPT_OVER_ALLOCATION: invoice=% open=% allocated=%',
+        v_invoice_id, v_open, v_allocated;
+    END IF;
+
+    INSERT INTO public.customer_collection_lines (
+      collection_id, invoice_id, allocated_amount, discount_amount, notes
+    ) VALUES (
+      v_receipt_id, v_invoice_id, v_allocated, 0, nullif(v_line->>'notes', '')
+    );
+
+    v_total := v_total + v_allocated;
+    v_count := v_count + 1;
+  END LOOP;
+
+  IF v_count > 0 AND round(v_total, 2) <> v_amount THEN
+    RAISE EXCEPTION 'CUSTOMER_RECEIPT_ALLOCATION_TOTAL_MISMATCH: allocations=% receipt=%',
+      v_total, v_amount;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true, 'receipt_id', v_receipt_id, 'receipt_number', v_number,
+    'status', 'draft', 'line_count', v_count
+  );
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION public.rpc_create_supplier_payment(p_payload jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_actor uuid := auth.uid();
+  v_org uuid;
+  v_payment_id uuid := gen_random_uuid();
+  v_number text;
+  v_vendor uuid;
+  v_date date;
+  v_amount numeric;
+  v_method text;
+  v_account uuid;
+  v_line jsonb;
+  v_invoice_id uuid;
+  v_allocated numeric;
+  v_discount numeric;
+  v_seen uuid[] := ARRAY[]::uuid[];
+  v_total numeric := 0;
+  v_count integer := 0;
+  v_open numeric;
+  v_invoice record;
+BEGIN
+  IF v_actor IS NULL THEN RAISE EXCEPTION 'AUTH_REQUIRED'; END IF;
+  v_org := public.get_current_tenant_id();
+  IF v_org IS NULL OR NOT public.wardah_is_org_member(v_org) THEN
+    RAISE EXCEPTION 'TENANT_MEMBERSHIP_REQUIRED';
+  END IF;
+
+  v_vendor := nullif(p_payload->>'vendor_id', '')::uuid;
+  v_date := coalesce(nullif(p_payload->>'payment_date', '')::date, current_date);
+  v_amount := round(coalesce(nullif(p_payload->>'amount', '')::numeric, 0), 2);
+  v_method := coalesce(nullif(p_payload->>'payment_method', ''), 'bank_transfer');
+  v_account := nullif(p_payload->>'payment_account_id', '')::uuid;
+
+  IF v_vendor IS NULL THEN RAISE EXCEPTION 'SUPPLIER_PAYMENT_VENDOR_REQUIRED'; END IF;
+  IF v_amount <= 0 THEN RAISE EXCEPTION 'VOUCHER_AMOUNT_INVALID: amount must be positive'; END IF;
+  IF v_account IS NULL THEN RAISE EXCEPTION 'VOUCHER_PAYMENT_ACCOUNT_REQUIRED'; END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM public.vendors v WHERE v.id = v_vendor AND v.org_id = v_org
+  ) THEN
+    RAISE EXCEPTION 'SUPPLIER_PAYMENT_VENDOR_CROSS_ORG';
+  END IF;
+
+  v_number := public.wardah_next_voucher_number(v_org, 'SUPPLIER_PAYMENT');
+
+  INSERT INTO public.supplier_payments (
+    id, org_id, payment_number, vendor_id, payment_date, amount,
+    payment_method, payment_account_id, check_number, check_date, check_bank,
+    reference_number, notes, status, created_by
+  ) VALUES (
+    v_payment_id, v_org, v_number, v_vendor, v_date, v_amount,
+    v_method, v_account,
+    nullif(p_payload->>'check_number', ''),
+    nullif(p_payload->>'check_date', '')::date,
+    nullif(p_payload->>'check_bank', ''),
+    nullif(p_payload->>'reference_number', ''),
+    nullif(p_payload->>'notes', ''),
+    'draft', v_actor
+  );
+
+  FOR v_line IN
+    SELECT value FROM jsonb_array_elements(coalesce(p_payload->'lines', '[]'::jsonb))
+  LOOP
+    v_invoice_id := nullif(v_line->>'invoice_id', '')::uuid;
+    v_allocated := round(coalesce(nullif(v_line->>'allocated_amount', '')::numeric, 0), 2);
+    v_discount := round(coalesce(nullif(v_line->>'discount_amount', '')::numeric, 0), 2);
+
+    IF v_invoice_id IS NULL THEN
+      RAISE EXCEPTION 'SUPPLIER_PAYMENT_ALLOCATION_INVOICE_REQUIRED';
+    END IF;
+    IF v_allocated <= 0 THEN
+      RAISE EXCEPTION 'SUPPLIER_PAYMENT_ALLOCATION_AMOUNT_INVALID: invoice=%', v_invoice_id;
+    END IF;
+    IF v_discount <> 0 THEN
+      RAISE EXCEPTION 'VOUCHER_DISCOUNT_UNSUPPORTED: discount accounting mapping is required';
+    END IF;
+    IF v_invoice_id = ANY (v_seen) THEN
+      RAISE EXCEPTION 'SUPPLIER_PAYMENT_ALLOCATION_DUPLICATE_INVOICE: invoice=%', v_invoice_id;
+    END IF;
+    v_seen := v_seen || v_invoice_id;
+
+    SELECT i.total_amount, coalesce(i.paid_amount, 0) AS paid_amount, i.status
+    INTO v_invoice
+    FROM public.supplier_invoices i
+    WHERE i.id = v_invoice_id AND i.org_id = v_org AND i.vendor_id = v_vendor
+    FOR UPDATE;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'SUPPLIER_PAYMENT_ALLOCATION_CROSS_SCOPE: invoice=%', v_invoice_id;
+    END IF;
+    IF v_invoice.status NOT IN ('approved', 'partially_paid', 'overdue') THEN
+      RAISE EXCEPTION 'SUPPLIER_INVOICE_NOT_PAYABLE: invoice=% status=%',
+        v_invoice_id, v_invoice.status;
+    END IF;
+
+    v_open := round(v_invoice.total_amount - v_invoice.paid_amount, 2);
+    IF v_allocated > v_open THEN
+      RAISE EXCEPTION 'SUPPLIER_PAYMENT_OVER_ALLOCATION: invoice=% open=% allocated=%',
+        v_invoice_id, v_open, v_allocated;
+    END IF;
+
+    INSERT INTO public.supplier_payment_lines (
+      payment_id, invoice_id, allocated_amount, discount_amount, notes
+    ) VALUES (
+      v_payment_id, v_invoice_id, v_allocated, 0, nullif(v_line->>'notes', '')
+    );
+
+    v_total := v_total + v_allocated;
+    v_count := v_count + 1;
+  END LOOP;
+
+  IF v_count > 0 AND round(v_total, 2) <> v_amount THEN
+    RAISE EXCEPTION 'SUPPLIER_PAYMENT_ALLOCATION_TOTAL_MISMATCH: allocations=% payment=%',
+      v_total, v_amount;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true, 'payment_id', v_payment_id, 'payment_number', v_number,
+    'status', 'draft', 'line_count', v_count
+  );
+END
+$function$;
+
+-- ---------------------------------------------------------------------
+-- 5. Atomic edit of a draft voucher — the `corrected` step Migration 167 left
+-- without a client path. Lines are replaced wholesale inside the Migration 167
+-- internal contract, which is closed again before any deliberate error.
+--
+-- A voucher that carries a GL identity is only editable when a trusted reset
+-- record proves it reached the correction phase legally.
+-- ---------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_update_customer_receipt_draft(
+  p_receipt_id uuid,
+  p_payload jsonb
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_actor uuid := auth.uid();
+  v_org uuid;
+  v_receipt public.customer_collections%ROWTYPE;
+  v_amount numeric;
+  v_date date;
+  v_method text;
+  v_account uuid;
+  v_line jsonb;
+  v_invoice_id uuid;
+  v_allocated numeric;
+  v_discount numeric;
+  v_seen uuid[] := ARRAY[]::uuid[];
+  v_total numeric := 0;
+  v_count integer := 0;
+  v_deleted integer;
+  v_stored integer;
+  v_open numeric;
+  v_invoice record;
+BEGIN
+  IF v_actor IS NULL THEN RAISE EXCEPTION 'AUTH_REQUIRED'; END IF;
+  v_org := public.get_current_tenant_id();
+  IF v_org IS NULL OR NOT public.wardah_is_org_member(v_org) THEN
+    RAISE EXCEPTION 'TENANT_MEMBERSHIP_REQUIRED';
+  END IF;
+  IF NOT (p_payload ? 'lines') THEN
+    RAISE EXCEPTION 'VOUCHER_UPDATE_LINES_REQUIRED: send the complete allocation set';
+  END IF;
+
+  SELECT * INTO v_receipt
+  FROM public.customer_collections
+  WHERE id = p_receipt_id AND org_id = v_org
+  FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'CUSTOMER_RECEIPT_NOT_FOUND_OR_CROSS_ORG'; END IF;
+  IF v_receipt.status <> 'draft' THEN
+    RAISE EXCEPTION 'CUSTOMER_RECEIPT_NOT_DRAFT: status=%', v_receipt.status;
+  END IF;
+
+  IF v_receipt.gl_entry_id IS NOT NULL THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM public.gl_entries e
+      WHERE e.id = v_receipt.gl_entry_id AND e.org_id = v_org AND e.status = 'draft'
+      FOR UPDATE
+    ) THEN
+      RAISE EXCEPTION 'CUSTOMER_RECEIPT_DRAFT_GL_INVALID';
+    END IF;
+    IF NOT EXISTS (
+      SELECT 1 FROM public.audit_logs a
+      WHERE a.org_id = v_org
+        AND a.action = 'voucher_reset_to_draft'
+        AND a.entity_type = 'customer_receipt'
+        AND a.entity_id = v_receipt.id::text
+    ) THEN
+      RAISE EXCEPTION 'CUSTOMER_RECEIPT_CORRECTION_UNPROVEN: no trusted reset record';
+    END IF;
+  END IF;
+
+  IF nullif(p_payload->>'customer_id', '') IS NOT NULL
+     AND (p_payload->>'customer_id')::uuid <> v_receipt.customer_id THEN
+    RAISE EXCEPTION 'CUSTOMER_RECEIPT_PARTY_IMMUTABLE: cancel and create a new voucher';
+  END IF;
+
+  v_amount := round(coalesce(nullif(p_payload->>'amount', '')::numeric, v_receipt.amount), 2);
+  v_date := coalesce(nullif(p_payload->>'receipt_date', '')::date, v_receipt.collection_date);
+  v_method := coalesce(nullif(p_payload->>'payment_method', ''), v_receipt.payment_method);
+  v_account := coalesce(nullif(p_payload->>'payment_account_id', '')::uuid,
+                        v_receipt.payment_account_id);
+  IF v_amount <= 0 THEN RAISE EXCEPTION 'VOUCHER_AMOUNT_INVALID: amount must be positive'; END IF;
+
+  UPDATE public.customer_collections
+  SET amount = v_amount,
+      collection_date = v_date,
+      payment_method = v_method,
+      payment_account_id = v_account,
+      check_number = coalesce(nullif(p_payload->>'check_number', ''), check_number),
+      check_date = coalesce(nullif(p_payload->>'check_date', '')::date, check_date),
+      reference_number = coalesce(nullif(p_payload->>'reference_number', ''), reference_number),
+      notes = coalesce(nullif(p_payload->>'notes', ''), notes),
+      updated_at = now()
+  WHERE id = v_receipt.id AND org_id = v_org AND status = 'draft';
+  IF NOT FOUND THEN RAISE EXCEPTION 'CUSTOMER_RECEIPT_STATE_CHANGED'; END IF;
+
+  PERFORM set_config('wardah.voucher_lines_write', 'on', true);
+
+  DELETE FROM public.customer_collection_lines WHERE collection_id = v_receipt.id;
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+
+  FOR v_line IN
+    SELECT value FROM jsonb_array_elements(p_payload->'lines')
+  LOOP
+    v_invoice_id := nullif(v_line->>'invoice_id', '')::uuid;
+    v_allocated := round(coalesce(nullif(v_line->>'allocated_amount', '')::numeric, 0), 2);
+    v_discount := round(coalesce(nullif(v_line->>'discount_amount', '')::numeric, 0), 2);
+
+    IF v_invoice_id IS NULL
+       OR v_allocated <= 0
+       OR v_discount <> 0
+       OR v_invoice_id = ANY (v_seen) THEN
+      PERFORM set_config('wardah.voucher_lines_write', 'off', true);
+      RAISE EXCEPTION 'CUSTOMER_RECEIPT_ALLOCATION_INVALID: invoice=% allocated=% discount=%',
+        v_invoice_id, v_allocated, v_discount;
+    END IF;
+    v_seen := v_seen || v_invoice_id;
+
+    SELECT i.total_amount, coalesce(i.paid_amount, 0) AS paid_amount
+    INTO v_invoice
+    FROM public.sales_invoices i
+    WHERE i.id = v_invoice_id AND i.org_id = v_org AND i.customer_id = v_receipt.customer_id
+    FOR UPDATE;
+    IF NOT FOUND THEN
+      PERFORM set_config('wardah.voucher_lines_write', 'off', true);
+      RAISE EXCEPTION 'CUSTOMER_RECEIPT_ALLOCATION_CROSS_SCOPE: invoice=%', v_invoice_id;
+    END IF;
+
+    v_open := round(v_invoice.total_amount - v_invoice.paid_amount, 2);
+    IF v_allocated > v_open THEN
+      PERFORM set_config('wardah.voucher_lines_write', 'off', true);
+      RAISE EXCEPTION 'CUSTOMER_RECEIPT_OVER_ALLOCATION: invoice=% open=% allocated=%',
+        v_invoice_id, v_open, v_allocated;
+    END IF;
+
+    INSERT INTO public.customer_collection_lines (
+      collection_id, invoice_id, allocated_amount, discount_amount, notes
+    ) VALUES (
+      v_receipt.id, v_invoice_id, v_allocated, 0, nullif(v_line->>'notes', '')
+    );
+
+    v_total := v_total + v_allocated;
+    v_count := v_count + 1;
+  END LOOP;
+
+  PERFORM set_config('wardah.voucher_lines_write', 'off', true);
+
+  SELECT count(*) INTO v_stored
+  FROM public.customer_collection_lines WHERE collection_id = v_receipt.id;
+  IF v_stored <> v_count THEN
+    RAISE EXCEPTION 'CUSTOMER_RECEIPT_LINE_REPLACEMENT_MISMATCH: stored=% expected=%',
+      v_stored, v_count;
+  END IF;
+  IF v_count > 0 AND round(v_total, 2) <> v_amount THEN
+    RAISE EXCEPTION 'CUSTOMER_RECEIPT_ALLOCATION_TOTAL_MISMATCH: allocations=% receipt=%',
+      v_total, v_amount;
+  END IF;
+
+  INSERT INTO public.audit_logs(
+    org_id, user_id, action, entity_type, entity_id, old_data, new_data, changes, metadata
+  ) VALUES (
+    v_org, v_actor, 'voucher_draft_updated', 'customer_receipt', v_receipt.id::text,
+    jsonb_build_object('amount', v_receipt.amount, 'collection_date', v_receipt.collection_date,
+                       'payment_method', v_receipt.payment_method,
+                       'payment_account_id', v_receipt.payment_account_id,
+                       'line_count', v_deleted),
+    jsonb_build_object('amount', v_amount, 'collection_date', v_date,
+                       'payment_method', v_method, 'payment_account_id', v_account,
+                       'line_count', v_count),
+    jsonb_build_object('lines_replaced', v_deleted || ' -> ' || v_count),
+    jsonb_build_object('source', 'rpc_update_customer_receipt_draft',
+                       'gl_entry_id', v_receipt.gl_entry_id)
+  );
+
+  RETURN jsonb_build_object(
+    'success', true, 'receipt_id', v_receipt.id, 'status', 'draft',
+    'line_count', v_count, 'lines_removed', v_deleted
+  );
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION public.rpc_update_supplier_payment_draft(
+  p_payment_id uuid,
+  p_payload jsonb
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_actor uuid := auth.uid();
+  v_org uuid;
+  v_payment public.supplier_payments%ROWTYPE;
+  v_amount numeric;
+  v_date date;
+  v_method text;
+  v_account uuid;
+  v_line jsonb;
+  v_invoice_id uuid;
+  v_allocated numeric;
+  v_discount numeric;
+  v_seen uuid[] := ARRAY[]::uuid[];
+  v_total numeric := 0;
+  v_count integer := 0;
+  v_deleted integer;
+  v_stored integer;
+  v_open numeric;
+  v_invoice record;
+BEGIN
+  IF v_actor IS NULL THEN RAISE EXCEPTION 'AUTH_REQUIRED'; END IF;
+  v_org := public.get_current_tenant_id();
+  IF v_org IS NULL OR NOT public.wardah_is_org_member(v_org) THEN
+    RAISE EXCEPTION 'TENANT_MEMBERSHIP_REQUIRED';
+  END IF;
+  IF NOT (p_payload ? 'lines') THEN
+    RAISE EXCEPTION 'VOUCHER_UPDATE_LINES_REQUIRED: send the complete allocation set';
+  END IF;
+
+  SELECT * INTO v_payment
+  FROM public.supplier_payments
+  WHERE id = p_payment_id AND org_id = v_org
+  FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'SUPPLIER_PAYMENT_NOT_FOUND_OR_CROSS_ORG'; END IF;
+  IF v_payment.status <> 'draft' THEN
+    RAISE EXCEPTION 'SUPPLIER_PAYMENT_NOT_DRAFT: status=%', v_payment.status;
+  END IF;
+
+  IF v_payment.gl_entry_id IS NOT NULL THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM public.gl_entries e
+      WHERE e.id = v_payment.gl_entry_id AND e.org_id = v_org AND e.status = 'draft'
+      FOR UPDATE
+    ) THEN
+      RAISE EXCEPTION 'SUPPLIER_PAYMENT_DRAFT_GL_INVALID';
+    END IF;
+    IF NOT EXISTS (
+      SELECT 1 FROM public.audit_logs a
+      WHERE a.org_id = v_org
+        AND a.action = 'voucher_reset_to_draft'
+        AND a.entity_type = 'supplier_payment'
+        AND a.entity_id = v_payment.id::text
+    ) THEN
+      RAISE EXCEPTION 'SUPPLIER_PAYMENT_CORRECTION_UNPROVEN: no trusted reset record';
+    END IF;
+  END IF;
+
+  IF nullif(p_payload->>'vendor_id', '') IS NOT NULL
+     AND (p_payload->>'vendor_id')::uuid <> v_payment.vendor_id THEN
+    RAISE EXCEPTION 'SUPPLIER_PAYMENT_PARTY_IMMUTABLE: cancel and create a new voucher';
+  END IF;
+
+  v_amount := round(coalesce(nullif(p_payload->>'amount', '')::numeric, v_payment.amount), 2);
+  v_date := coalesce(nullif(p_payload->>'payment_date', '')::date, v_payment.payment_date);
+  v_method := coalesce(nullif(p_payload->>'payment_method', ''), v_payment.payment_method);
+  v_account := coalesce(nullif(p_payload->>'payment_account_id', '')::uuid,
+                        v_payment.payment_account_id);
+  IF v_amount <= 0 THEN RAISE EXCEPTION 'VOUCHER_AMOUNT_INVALID: amount must be positive'; END IF;
+
+  UPDATE public.supplier_payments
+  SET amount = v_amount,
+      payment_date = v_date,
+      payment_method = v_method,
+      payment_account_id = v_account,
+      check_number = coalesce(nullif(p_payload->>'check_number', ''), check_number),
+      check_date = coalesce(nullif(p_payload->>'check_date', '')::date, check_date),
+      check_bank = coalesce(nullif(p_payload->>'check_bank', ''), check_bank),
+      reference_number = coalesce(nullif(p_payload->>'reference_number', ''), reference_number),
+      notes = coalesce(nullif(p_payload->>'notes', ''), notes),
+      updated_at = now()
+  WHERE id = v_payment.id AND org_id = v_org AND status = 'draft';
+  IF NOT FOUND THEN RAISE EXCEPTION 'SUPPLIER_PAYMENT_STATE_CHANGED'; END IF;
+
+  PERFORM set_config('wardah.voucher_lines_write', 'on', true);
+
+  DELETE FROM public.supplier_payment_lines WHERE payment_id = v_payment.id;
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+
+  FOR v_line IN
+    SELECT value FROM jsonb_array_elements(p_payload->'lines')
+  LOOP
+    v_invoice_id := nullif(v_line->>'invoice_id', '')::uuid;
+    v_allocated := round(coalesce(nullif(v_line->>'allocated_amount', '')::numeric, 0), 2);
+    v_discount := round(coalesce(nullif(v_line->>'discount_amount', '')::numeric, 0), 2);
+
+    IF v_invoice_id IS NULL
+       OR v_allocated <= 0
+       OR v_discount <> 0
+       OR v_invoice_id = ANY (v_seen) THEN
+      PERFORM set_config('wardah.voucher_lines_write', 'off', true);
+      RAISE EXCEPTION 'SUPPLIER_PAYMENT_ALLOCATION_INVALID: invoice=% allocated=% discount=%',
+        v_invoice_id, v_allocated, v_discount;
+    END IF;
+    v_seen := v_seen || v_invoice_id;
+
+    SELECT i.total_amount, coalesce(i.paid_amount, 0) AS paid_amount, i.status
+    INTO v_invoice
+    FROM public.supplier_invoices i
+    WHERE i.id = v_invoice_id AND i.org_id = v_org AND i.vendor_id = v_payment.vendor_id
+    FOR UPDATE;
+    IF NOT FOUND THEN
+      PERFORM set_config('wardah.voucher_lines_write', 'off', true);
+      RAISE EXCEPTION 'SUPPLIER_PAYMENT_ALLOCATION_CROSS_SCOPE: invoice=%', v_invoice_id;
+    END IF;
+    IF v_invoice.status NOT IN ('approved', 'partially_paid', 'overdue') THEN
+      PERFORM set_config('wardah.voucher_lines_write', 'off', true);
+      RAISE EXCEPTION 'SUPPLIER_INVOICE_NOT_PAYABLE: invoice=% status=%',
+        v_invoice_id, v_invoice.status;
+    END IF;
+
+    v_open := round(v_invoice.total_amount - v_invoice.paid_amount, 2);
+    IF v_allocated > v_open THEN
+      PERFORM set_config('wardah.voucher_lines_write', 'off', true);
+      RAISE EXCEPTION 'SUPPLIER_PAYMENT_OVER_ALLOCATION: invoice=% open=% allocated=%',
+        v_invoice_id, v_open, v_allocated;
+    END IF;
+
+    INSERT INTO public.supplier_payment_lines (
+      payment_id, invoice_id, allocated_amount, discount_amount, notes
+    ) VALUES (
+      v_payment.id, v_invoice_id, v_allocated, 0, nullif(v_line->>'notes', '')
+    );
+
+    v_total := v_total + v_allocated;
+    v_count := v_count + 1;
+  END LOOP;
+
+  PERFORM set_config('wardah.voucher_lines_write', 'off', true);
+
+  SELECT count(*) INTO v_stored
+  FROM public.supplier_payment_lines WHERE payment_id = v_payment.id;
+  IF v_stored <> v_count THEN
+    RAISE EXCEPTION 'SUPPLIER_PAYMENT_LINE_REPLACEMENT_MISMATCH: stored=% expected=%',
+      v_stored, v_count;
+  END IF;
+  IF v_count > 0 AND round(v_total, 2) <> v_amount THEN
+    RAISE EXCEPTION 'SUPPLIER_PAYMENT_ALLOCATION_TOTAL_MISMATCH: allocations=% payment=%',
+      v_total, v_amount;
+  END IF;
+
+  INSERT INTO public.audit_logs(
+    org_id, user_id, action, entity_type, entity_id, old_data, new_data, changes, metadata
+  ) VALUES (
+    v_org, v_actor, 'voucher_draft_updated', 'supplier_payment', v_payment.id::text,
+    jsonb_build_object('amount', v_payment.amount, 'payment_date', v_payment.payment_date,
+                       'payment_method', v_payment.payment_method,
+                       'payment_account_id', v_payment.payment_account_id,
+                       'line_count', v_deleted),
+    jsonb_build_object('amount', v_amount, 'payment_date', v_date,
+                       'payment_method', v_method, 'payment_account_id', v_account,
+                       'line_count', v_count),
+    jsonb_build_object('lines_replaced', v_deleted || ' -> ' || v_count),
+    jsonb_build_object('source', 'rpc_update_supplier_payment_draft',
+                       'gl_entry_id', v_payment.gl_entry_id)
+  );
+
+  RETURN jsonb_build_object(
+    'success', true, 'payment_id', v_payment.id, 'status', 'draft',
+    'line_count', v_count, 'lines_removed', v_deleted
+  );
+END
+$function$;
+
+-- ---------------------------------------------------------------------
+-- 6. Cancellation. Two paths, deliberately separated:
+--
+--   * a draft that was never posted carries no GL identity and no reset
+--     record, so it is cancelled on its own and no GL entry is touched;
+--   * a voucher that was posted and then reset for correction keeps its
+--     gl_entry_id, entry_number and every GL line. Only the entry's status
+--     moves to cancelled, and the audit record names the reset it closes.
+--
+-- Cancelling a posted voucher is refused: it must go through reset first, so
+-- the paid amounts and invoice states are unwound by the Migration 166 RPC
+-- rather than by a second implementation of the same reversal here.
+-- ---------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_cancel_customer_receipt(
+  p_receipt_id uuid,
+  p_reason text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_actor uuid := auth.uid();
+  v_org uuid;
+  v_receipt public.customer_collections%ROWTYPE;
+  v_entry public.gl_entries%ROWTYPE;
+  v_reset_id uuid;
+  v_gl_rows integer;
+  v_path text;
+BEGIN
+  IF v_actor IS NULL THEN RAISE EXCEPTION 'AUTH_REQUIRED'; END IF;
+  IF length(trim(coalesce(p_reason, ''))) < 5 THEN
+    RAISE EXCEPTION 'VOUCHER_CANCEL_REASON_REQUIRED';
+  END IF;
+
+  v_org := public.get_current_tenant_id();
+  IF v_org IS NULL OR NOT public.wardah_is_org_member(v_org) THEN
+    RAISE EXCEPTION 'TENANT_MEMBERSHIP_REQUIRED';
+  END IF;
+  IF NOT public.wardah_has_exact_permission(v_actor, v_org, 'accounting.vouchers.cancel') THEN
+    RAISE EXCEPTION 'VOUCHER_CANCEL_PERMISSION_REQUIRED';
+  END IF;
+
+  SELECT * INTO v_receipt
+  FROM public.customer_collections
+  WHERE id = p_receipt_id AND org_id = v_org
+  FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'CUSTOMER_RECEIPT_NOT_FOUND_OR_CROSS_ORG'; END IF;
+
+  IF v_receipt.status = 'cancelled' THEN
+    RETURN jsonb_build_object('success', true, 'duplicate', true,
+      'receipt_id', v_receipt.id, 'status', 'cancelled',
+      'entry_id', v_receipt.gl_entry_id);
+  END IF;
+  IF v_receipt.status = 'posted' THEN
+    RAISE EXCEPTION 'VOUCHER_CANCEL_REQUIRES_RESET: reset the receipt before cancelling it';
+  END IF;
+  IF v_receipt.status <> 'draft' THEN
+    RAISE EXCEPTION 'CUSTOMER_RECEIPT_NOT_CANCELLABLE: status=%', v_receipt.status;
+  END IF;
+
+  SELECT a.id INTO v_reset_id
+  FROM public.audit_logs a
+  WHERE a.org_id = v_org
+    AND a.action = 'voucher_reset_to_draft'
+    AND a.entity_type = 'customer_receipt'
+    AND a.entity_id = v_receipt.id::text
+  ORDER BY a.created_at DESC NULLS LAST, a.id DESC
+  LIMIT 1;
+
+  IF v_receipt.gl_entry_id IS NULL THEN
+    IF v_reset_id IS NOT NULL THEN
+      RAISE EXCEPTION 'CUSTOMER_RECEIPT_CANCEL_STATE_INCONSISTENT: reset record without GL identity';
+    END IF;
+    v_path := 'never_posted';
+  ELSE
+    IF v_reset_id IS NULL THEN
+      RAISE EXCEPTION 'CUSTOMER_RECEIPT_CANCEL_UNPROVEN: GL identity without a trusted reset record';
+    END IF;
+    v_path := 'corrected';
+
+    SELECT * INTO v_entry
+    FROM public.gl_entries
+    WHERE id = v_receipt.gl_entry_id AND org_id = v_org
+    FOR UPDATE;
+    IF NOT FOUND
+       OR v_entry.status <> 'draft'
+       OR v_entry.reference_type <> 'CUSTOMER_RECEIPT'
+       OR v_entry.reference_id <> v_receipt.id THEN
+      RAISE EXCEPTION 'CUSTOMER_RECEIPT_CANCEL_GL_INVALID';
+    END IF;
+
+    PERFORM set_config('wardah.voucher_gl_cancel', 'on', true);
+    UPDATE public.gl_entries
+    SET status = 'cancelled', updated_at = now()
+    WHERE id = v_entry.id AND org_id = v_org AND status = 'draft';
+    GET DIAGNOSTICS v_gl_rows = ROW_COUNT;
+    PERFORM set_config('wardah.voucher_gl_cancel', 'off', true);
+    IF v_gl_rows <> 1 THEN RAISE EXCEPTION 'CUSTOMER_RECEIPT_CANCEL_GL_STATE_CHANGED'; END IF;
+  END IF;
+
+  UPDATE public.customer_collections
+  SET status = 'cancelled', updated_at = now()
+  WHERE id = v_receipt.id AND org_id = v_org AND status = 'draft';
+  IF NOT FOUND THEN RAISE EXCEPTION 'CUSTOMER_RECEIPT_STATE_CHANGED'; END IF;
+
+  INSERT INTO public.audit_logs(
+    org_id, user_id, action, entity_type, entity_id, old_data, new_data, changes, metadata
+  ) VALUES (
+    v_org, v_actor, 'voucher_cancelled', 'customer_receipt', v_receipt.id::text,
+    jsonb_build_object('status', 'draft', 'gl_entry_id', v_receipt.gl_entry_id,
+                       'gl_status', CASE WHEN v_path = 'corrected' THEN v_entry.status ELSE NULL END,
+                       'entry_number', CASE WHEN v_path = 'corrected' THEN v_entry.entry_number ELSE NULL END),
+    jsonb_build_object('status', 'cancelled', 'gl_entry_id', v_receipt.gl_entry_id,
+                       'gl_status', CASE WHEN v_path = 'corrected' THEN 'cancelled' ELSE NULL END,
+                       'entry_number', CASE WHEN v_path = 'corrected' THEN v_entry.entry_number ELSE NULL END),
+    jsonb_build_object('reason', trim(p_reason), 'path', v_path),
+    jsonb_build_object('source', 'rpc_cancel_customer_receipt',
+                       'reset_audit_id', v_reset_id)
+  );
+
+  RETURN jsonb_build_object('success', true, 'duplicate', false,
+    'receipt_id', v_receipt.id, 'status', 'cancelled',
+    'entry_id', v_receipt.gl_entry_id, 'path', v_path);
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION public.rpc_cancel_supplier_payment(
+  p_payment_id uuid,
+  p_reason text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_actor uuid := auth.uid();
+  v_org uuid;
+  v_payment public.supplier_payments%ROWTYPE;
+  v_entry public.gl_entries%ROWTYPE;
+  v_reset_id uuid;
+  v_gl_rows integer;
+  v_path text;
+BEGIN
+  IF v_actor IS NULL THEN RAISE EXCEPTION 'AUTH_REQUIRED'; END IF;
+  IF length(trim(coalesce(p_reason, ''))) < 5 THEN
+    RAISE EXCEPTION 'VOUCHER_CANCEL_REASON_REQUIRED';
+  END IF;
+
+  v_org := public.get_current_tenant_id();
+  IF v_org IS NULL OR NOT public.wardah_is_org_member(v_org) THEN
+    RAISE EXCEPTION 'TENANT_MEMBERSHIP_REQUIRED';
+  END IF;
+  IF NOT public.wardah_has_exact_permission(v_actor, v_org, 'accounting.vouchers.cancel') THEN
+    RAISE EXCEPTION 'VOUCHER_CANCEL_PERMISSION_REQUIRED';
+  END IF;
+
+  SELECT * INTO v_payment
+  FROM public.supplier_payments
+  WHERE id = p_payment_id AND org_id = v_org
+  FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'SUPPLIER_PAYMENT_NOT_FOUND_OR_CROSS_ORG'; END IF;
+
+  IF v_payment.status = 'cancelled' THEN
+    RETURN jsonb_build_object('success', true, 'duplicate', true,
+      'payment_id', v_payment.id, 'status', 'cancelled',
+      'entry_id', v_payment.gl_entry_id);
+  END IF;
+  IF v_payment.status = 'posted' THEN
+    RAISE EXCEPTION 'VOUCHER_CANCEL_REQUIRES_RESET: reset the payment before cancelling it';
+  END IF;
+  IF v_payment.status <> 'draft' THEN
+    RAISE EXCEPTION 'SUPPLIER_PAYMENT_NOT_CANCELLABLE: status=%', v_payment.status;
+  END IF;
+
+  SELECT a.id INTO v_reset_id
+  FROM public.audit_logs a
+  WHERE a.org_id = v_org
+    AND a.action = 'voucher_reset_to_draft'
+    AND a.entity_type = 'supplier_payment'
+    AND a.entity_id = v_payment.id::text
+  ORDER BY a.created_at DESC NULLS LAST, a.id DESC
+  LIMIT 1;
+
+  IF v_payment.gl_entry_id IS NULL THEN
+    IF v_reset_id IS NOT NULL THEN
+      RAISE EXCEPTION 'SUPPLIER_PAYMENT_CANCEL_STATE_INCONSISTENT: reset record without GL identity';
+    END IF;
+    v_path := 'never_posted';
+  ELSE
+    IF v_reset_id IS NULL THEN
+      RAISE EXCEPTION 'SUPPLIER_PAYMENT_CANCEL_UNPROVEN: GL identity without a trusted reset record';
+    END IF;
+    v_path := 'corrected';
+
+    SELECT * INTO v_entry
+    FROM public.gl_entries
+    WHERE id = v_payment.gl_entry_id AND org_id = v_org
+    FOR UPDATE;
+    IF NOT FOUND
+       OR v_entry.status <> 'draft'
+       OR v_entry.reference_type <> 'SUPPLIER_PAYMENT'
+       OR v_entry.reference_id <> v_payment.id THEN
+      RAISE EXCEPTION 'SUPPLIER_PAYMENT_CANCEL_GL_INVALID';
+    END IF;
+
+    PERFORM set_config('wardah.voucher_gl_cancel', 'on', true);
+    UPDATE public.gl_entries
+    SET status = 'cancelled', updated_at = now()
+    WHERE id = v_entry.id AND org_id = v_org AND status = 'draft';
+    GET DIAGNOSTICS v_gl_rows = ROW_COUNT;
+    PERFORM set_config('wardah.voucher_gl_cancel', 'off', true);
+    IF v_gl_rows <> 1 THEN RAISE EXCEPTION 'SUPPLIER_PAYMENT_CANCEL_GL_STATE_CHANGED'; END IF;
+  END IF;
+
+  UPDATE public.supplier_payments
+  SET status = 'cancelled', updated_at = now()
+  WHERE id = v_payment.id AND org_id = v_org AND status = 'draft';
+  IF NOT FOUND THEN RAISE EXCEPTION 'SUPPLIER_PAYMENT_STATE_CHANGED'; END IF;
+
+  INSERT INTO public.audit_logs(
+    org_id, user_id, action, entity_type, entity_id, old_data, new_data, changes, metadata
+  ) VALUES (
+    v_org, v_actor, 'voucher_cancelled', 'supplier_payment', v_payment.id::text,
+    jsonb_build_object('status', 'draft', 'gl_entry_id', v_payment.gl_entry_id,
+                       'gl_status', CASE WHEN v_path = 'corrected' THEN v_entry.status ELSE NULL END,
+                       'entry_number', CASE WHEN v_path = 'corrected' THEN v_entry.entry_number ELSE NULL END),
+    jsonb_build_object('status', 'cancelled', 'gl_entry_id', v_payment.gl_entry_id,
+                       'gl_status', CASE WHEN v_path = 'corrected' THEN 'cancelled' ELSE NULL END,
+                       'entry_number', CASE WHEN v_path = 'corrected' THEN v_entry.entry_number ELSE NULL END),
+    jsonb_build_object('reason', trim(p_reason), 'path', v_path),
+    jsonb_build_object('source', 'rpc_cancel_supplier_payment',
+                       'reset_audit_id', v_reset_id)
+  );
+
+  RETURN jsonb_build_object('success', true, 'duplicate', false,
+    'payment_id', v_payment.id, 'status', 'cancelled',
+    'entry_id', v_payment.gl_entry_id, 'path', v_path);
+END
+$function$;
+
+-- ---------------------------------------------------------------------
+-- 7. Client execution contract. Nothing is inherited from PUBLIC.
+-- ---------------------------------------------------------------------
+REVOKE ALL ON FUNCTION public.rpc_create_customer_receipt(jsonb) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.rpc_create_customer_receipt(jsonb) FROM anon;
+REVOKE ALL ON FUNCTION public.rpc_create_customer_receipt(jsonb) FROM service_role;
+GRANT EXECUTE ON FUNCTION public.rpc_create_customer_receipt(jsonb) TO authenticated;
+
+REVOKE ALL ON FUNCTION public.rpc_create_supplier_payment(jsonb) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.rpc_create_supplier_payment(jsonb) FROM anon;
+REVOKE ALL ON FUNCTION public.rpc_create_supplier_payment(jsonb) FROM service_role;
+GRANT EXECUTE ON FUNCTION public.rpc_create_supplier_payment(jsonb) TO authenticated;
+
+REVOKE ALL ON FUNCTION public.rpc_update_customer_receipt_draft(uuid,jsonb) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.rpc_update_customer_receipt_draft(uuid,jsonb) FROM anon;
+REVOKE ALL ON FUNCTION public.rpc_update_customer_receipt_draft(uuid,jsonb) FROM service_role;
+GRANT EXECUTE ON FUNCTION public.rpc_update_customer_receipt_draft(uuid,jsonb) TO authenticated;
+
+REVOKE ALL ON FUNCTION public.rpc_update_supplier_payment_draft(uuid,jsonb) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.rpc_update_supplier_payment_draft(uuid,jsonb) FROM anon;
+REVOKE ALL ON FUNCTION public.rpc_update_supplier_payment_draft(uuid,jsonb) FROM service_role;
+GRANT EXECUTE ON FUNCTION public.rpc_update_supplier_payment_draft(uuid,jsonb) TO authenticated;
+
+REVOKE ALL ON FUNCTION public.rpc_cancel_customer_receipt(uuid,text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.rpc_cancel_customer_receipt(uuid,text) FROM anon;
+REVOKE ALL ON FUNCTION public.rpc_cancel_customer_receipt(uuid,text) FROM service_role;
+GRANT EXECUTE ON FUNCTION public.rpc_cancel_customer_receipt(uuid,text) TO authenticated;
+
+REVOKE ALL ON FUNCTION public.rpc_cancel_supplier_payment(uuid,text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.rpc_cancel_supplier_payment(uuid,text) FROM anon;
+REVOKE ALL ON FUNCTION public.rpc_cancel_supplier_payment(uuid,text) FROM service_role;
+GRANT EXECUTE ON FUNCTION public.rpc_cancel_supplier_payment(uuid,text) TO authenticated;
+
+DO $verify$
+DECLARE
+  v_definition text;
+  v_fn text;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM public.permissions WHERE permission_key = 'accounting.vouchers.cancel'
+  ) THEN
+    RAISE EXCEPTION 'VOUCHER_168_PERMISSION_MISSING';
+  END IF;
+
+  -- The cancel key must not be handed out by this migration; granting it is an
+  -- explicit RBAC decision.
+  IF EXISTS (
+    SELECT 1
+    FROM public.role_permissions rp
+    JOIN public.permissions p ON p.id = rp.permission_id
+    WHERE p.permission_key = 'accounting.vouchers.cancel'
+  ) THEN
+    RAISE EXCEPTION 'VOUCHER_168_CANCEL_PERMISSION_AUTOGRANTED';
+  END IF;
+
+  FOREACH v_fn IN ARRAY ARRAY[
+    'public.rpc_create_customer_receipt(jsonb)',
+    'public.rpc_create_supplier_payment(jsonb)',
+    'public.rpc_update_customer_receipt_draft(uuid,jsonb)',
+    'public.rpc_update_supplier_payment_draft(uuid,jsonb)',
+    'public.rpc_cancel_customer_receipt(uuid,text)',
+    'public.rpc_cancel_supplier_payment(uuid,text)'
+  ] LOOP
+    IF to_regprocedure(v_fn) IS NULL THEN
+      RAISE EXCEPTION 'VOUCHER_168_RPC_MISSING: %', v_fn;
+    END IF;
+    IF has_function_privilege('anon', v_fn, 'EXECUTE')
+       OR NOT has_function_privilege('authenticated', v_fn, 'EXECUTE') THEN
+      RAISE EXCEPTION 'VOUCHER_168_RPC_GRANT_VERIFY_FAILED: %', v_fn;
+    END IF;
+  END LOOP;
+
+  IF has_function_privilege('anon', 'public.wardah_next_voucher_number(uuid,text)', 'EXECUTE')
+     OR has_function_privilege('authenticated', 'public.wardah_next_voucher_number(uuid,text)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'VOUCHER_168_NUMBER_HELPER_EXPOSED';
+  END IF;
+
+  SELECT pg_get_functiondef('public.protect_posted_gl_entries()'::regprocedure)
+  INTO v_definition;
+  IF v_definition NOT LIKE '%wardah.voucher_gl_cancel%'
+     OR v_definition NOT LIKE '%VOUCHER_GL_CANCEL_FORBIDDEN%'
+     OR v_definition NOT LIKE '%VOUCHER_GL_CANCEL_SCOPE_INVALID%'
+     OR v_definition NOT LIKE '%voucher_reset_to_draft%' THEN
+    RAISE EXCEPTION 'VOUCHER_168_GL_CANCEL_GUARD_VERIFY_FAILED';
+  END IF;
+END
+$verify$;
+
+COMMIT;

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -10919,8 +10919,16 @@ export type Database = {
         Args: { p_org_id: string; p_product_id: string; p_uom_id: string }
         Returns: Json
       }
+      rpc_cancel_customer_receipt: {
+        Args: { p_reason: string; p_receipt_id: string }
+        Returns: Json
+      }
       rpc_cancel_stock_adjustment: {
         Args: { p_adjustment_id: string; p_reason: string }
+        Returns: Json
+      }
+      rpc_cancel_supplier_payment: {
+        Args: { p_payment_id: string; p_reason: string }
         Returns: Json
       }
       rpc_complete_manufacturing_order: {
@@ -10948,6 +10956,7 @@ export type Database = {
         Args: { p_mo_id: string; p_stage_no?: number; p_tenant?: string }
         Returns: Json
       }
+      rpc_create_customer_receipt: { Args: { p_payload: Json }; Returns: Json }
       rpc_create_journal_entry: { Args: { p_payload: Json }; Returns: Json }
       rpc_create_matched_supplier_invoice: {
         Args: { p_payload: Json }
@@ -10977,6 +10986,7 @@ export type Database = {
         Returns: Json
       }
       rpc_create_stock_adjustment: { Args: { p_payload: Json }; Returns: Json }
+      rpc_create_supplier_payment: { Args: { p_payload: Json }; Returns: Json }
       rpc_create_uom_purchase_order: {
         Args: { p_payload: Json }
         Returns: Json
@@ -11166,6 +11176,14 @@ export type Database = {
           p_status: string
           p_tenant?: string
         }
+        Returns: Json
+      }
+      rpc_update_customer_receipt_draft: {
+        Args: { p_payload: Json; p_receipt_id: string }
+        Returns: Json
+      }
+      rpc_update_supplier_payment_draft: {
+        Args: { p_payload: Json; p_payment_id: string }
         Returns: Json
       }
       rpc_upsert_event_mapping: {
@@ -11569,6 +11587,10 @@ export type Database = {
       }
       wardah_is_org_admin: { Args: { p_org: string }; Returns: boolean }
       wardah_is_org_member: { Args: { p_org: string }; Returns: boolean }
+      wardah_next_voucher_number: {
+        Args: { p_kind: string; p_org: string }
+        Returns: string
+      }
       wardah_org_id: { Args: { p_explicit?: string }; Returns: string }
       wardah_periods_org_col: { Args: never; Returns: string }
       wardah_receipt_line_uninvoiced_base: {


### PR DESCRIPTION
> **Draft — للمراجعة وتشغيل CI فقط.** لا دمج، ولا تطبيق على Production.

## الحالة

| | |
|---|---|
| الفرع | `fix/voucher-atomic-rpcs-168` |
| الرأس | `a6bf992` |
| القاعدة | `main` (`8434b43`) |
| Migration 167 | **في المستودع، غير مطبقة على Production** — سجل Production عند 166 |
| Migration 168 | للمراجعة والاختبار فقط |
| سحب `INSERT` المباشر | مؤجَّل إلى Migration 169 |
| الترتيب التشغيلي المستهدف | `167 → 168` في نافذة واحدة ← الواجهة ← `169` |

تسلسل الرأس: `c6f296b` (العمل) → `1430fc8` (commit آلي من `github-actions[bot]`: `Regenerate UoM Database Types` أضاف تواقيع الدوال الست و`wardah_next_voucher_number` إلى `src/types/database.generated.ts`، 22 إضافة وصفر حذف، بلا مساس بالـSQL) → `a6bf992` (تغطية إضافية في بوابة القبول، بلا مساس بالـmigration).

## الهدف

Migration 167 أغلق كل مسارات الكتابة المباشرة على سطور التخصيص، فبقيت خطوة `corrected` من دورة Migration 166 بلا مسار قانوني لأي عميل. هذه الـmigration تعيدها وتُكمل دورة حياة السند:

```text
create → (edit)* → post → reset → (edit)* → post
                                 └→ cancel
```

| RPC | الوظيفة |
|---|---|
| `rpc_create_customer_receipt(jsonb)` · `rpc_create_supplier_payment(jsonb)` | الرأس والسطور في معاملة واحدة |
| `rpc_update_customer_receipt_draft(uuid,jsonb)` · `rpc_update_supplier_payment_draft(uuid,jsonb)` | استبدال كامل للتخصيصات على مسودة |
| `rpc_cancel_customer_receipt(uuid,text)` · `rpc_cancel_supplier_payment(uuid,text)` | إنهاء دورة السند دون حذف تاريخ |

الإنشاء الذري يُنهي ثقب «الرأس اليتيم»: الواجهة كانت تُدرج الرأس ثم السطور، وعند فشل السطر تُصدر حذفًا تعويضيًا لا يفحص خطأه ولا عدد صفوفه — و`customer_collections` بلا سياسة `DELETE` للعميل، فيمرّ الحذف بصفر صفوف بصمت. والترقيم صار من الخادم تحت قفل استشاري بدل «اقرأ الأقصى وأضف واحدًا» الذي يعطي رقمين متطابقين عند إنشاءين متزامنين.

## قرارات معتمدة

**الإلغاء بـGUC مستقل:** `wardah.voucher_gl_cancel`، ولا إعادة استخدام لـ`voucher_unpost` — الإلغاء حدث محاسبي مختلف عن إعادة السند للتصحيح.

**`accounting.vouchers.cancel` مفتاح مستقل:** أُضيف إلى الكتالوج ولم يُمنح لأي دور، وكتلة التحقق داخل الـmigration **تفشل** إن وجدت أي دور يحمله وقت التطبيق.

**مساران للإلغاء:**

- مسودة لم تُرحّل قط: تصبح `cancelled`، ولا يُنشأ ولا يُمسّ أي قيد، وتبقى سطور التخصيص كتاريخ.
- سند رُحّل ثم أُعيد للتصحيح: يبقى `gl_entry_id`، ويتحول القيد المرتبط فقط إلى `cancelled` مع الاحتفاظ بـ`entry_number` وكل سطور القيد — لا حذف ولا تصفير ولا إعادة إنشاء. والـAudit يسمّي سجل الـReset الذي يُغلقه عبر `metadata.reset_audit_id`.
- إلغاء سند **مرحّل** مرفوض: يجب أن يمر بـ`rpc_reset_*_to_draft` أولًا، فيبقى فكّ الترحيل مملوكًا لدالة 166 بدل تنفيذ ثانٍ للمنطق نفسه.

## حارس إلغاء القيد

`protect_posted_gl_entries` كان يرفض `posted → draft` ولا يقول شيئًا عن `posted → cancelled`، فكان الإلغاء سيصبح التفافًا غير محروس حول `POSTED_ENTRY_IMMUTABLE` لحظة فتح أي مسار `UPDATE` — وهو ما تفعله هذه الـmigration. كل انتقال إلى `cancelled` على قيد مرتبط بسند يتطلب **اجتماع**:

1. `wardah.voucher_gl_cancel = 'on'`؛
2. سند موجود في المؤسسة نفسها؛
3. `gl_entry_id` ما زال يشير إلى هذا القيد بعينه؛
4. السند ما زال `draft` — أي داخل دورة التصحيح؛
5. سجل Reset موثوق من Migration 166.

الشرط الخامس هو سبب عدم قبول `gl_entry_id` وحده دليلًا على المرور بالـReset؛ ودالتا الإلغاء والتعديل تتحققان منه استقلالًا. والشرط الرابع هو ما يُبقي `posted → cancelled` مغلقًا عمليًا. وقيد مرحّل لا يتبع سندًا يُرفض إلغاؤه مطلقًا.

**ترتيب الأقفال والتحديثات:** قفل الرأس بـ`FOR UPDATE` → قراءة سجل الـReset لتحديد المسار قبل أي كتابة → قفل القيد بـ`FOR UPDATE` والتحقق من `draft` و`reference_type`/`reference_id` → **إلغاء القيد والسند ما زال `draft`** فيستوفي الـtrigger شرطه الرابع → `GET DIAGNOSTICS` ثم إغلاق الـGUC ثم اشتراط صف واحد → وبعدها فقط تحويل السند إلى `cancelled`. الترتيب المعكوس يرفضه الـtrigger بـ`VOUCHER_GL_CANCEL_SCOPE_INVALID`، أي أن الترتيب جزء من العقد لا تفصيل أسلوبي.

## نتائج البوابة

بُنيت السلسلة `166 → 167 → 168` وشُغّلت الملفات كما هي:

```text
سلسلة 153→168 ......................... 7 PASS / 0 FAIL
acceptance_168 ........................ VOUCHER_ATOMIC_168_ACCEPTANCE_PASS
acceptance_168_concurrency ............ VOUCHER_ATOMIC_168_CONCURRENCY_PASS
acceptance_166 / _isolation ........... PASS / PASS
acceptance_167 ........................ PASS
acceptance_148 / 149 / 149_closure .... PASS / PASS / PASS
check_definer_guards.py ............... لا دالة DEFINER بلا حارس
validate_migration_ledger.py .......... repo_max = 168
```

**التزامن بجلسات PostgreSQL حقيقية** (`acceptance_168_concurrency.sh`)، بانتظار القفل عبر `pg_locks` لا بالاعتماد على المجدول:

- إلغاءان متزامنان للسند نفسه → **سجل Audit واحد بالضبط**، والخاسر يعيد `duplicate: true`.
- تعديلان متزامنان → **لا lost update**: مجموعة الكاتب الأخير كاملة، سطر واحد، سجلّا Audit — أي لا استبدال متداخل.
- **لا تسرّب GUC** إلى جلسة جديدة.

**دورة تصحيح ثانية على السند نفسه:** بعد `reset → edit → repost` يُعاد الـReset ثم يُلغى السند، ويُثبَت أن `reset_audit_id` المذكور في سجل الإلغاء هو **سجل Reset لهذا السند في هذه المؤسسة** — إثبات نسب لا مجرد قيمة غير فارغة — مع بقاء رقم القيد وسطوره، وعدم مساس الإلغاء بحالة الفاتورة التي سوّاها الـReset.

ترتيب سجلات الـReset موثَّق بلا مبالغة: في Production كل Reset معاملة مستقلة فيفصلها `created_at` بدقة؛ وداخل معاملة واحدة لا يفصلها شيء لأن `created_at` هو طابع المعاملة و`audit_logs.id` عشوائي — ولا شيء في عقد الإلغاء يتوقف على أيّها يُذكر، فالبوابة تثبّت المضمون فعلًا لا ترتيبًا غير موجود.

**إعادة تشغيل بوابتي 166 و167** على قاعدة ثانية داخل الوظيفة نفسها، لأن 168 يستبدل `protect_posted_gl_entries` الذي تعتمدان عليه.

**رفض الهوية:** `anon` (لا `EXECUTE` أصلًا)، وعضو غير نشط (`TENANT_MEMBERSHIP_REQUIRED`)، وعضو من مؤسسة أخرى (السند غير مرئي عبر حدود المؤسسة).

**`unpost` وحدها لا تسمح بالإلغاء:** عضو يحمل `accounting.vouchers.unpost` فقط يُرفض بـ`VOUCHER_CANCEL_PERMISSION_REQUIRED`.

**قيد لا يتبع سندًا لا يُلغى حتى مع فتح الـGUC:** `service_role` — الذي يتجاوز RLS، فالـtrigger هو الحارس الوحيد عليه — يُرفض بـ`POSTED_ENTRY_IMMUTABLE`. وقيد سند مرحّل يُرفض بـ`VOUCHER_GL_CANCEL_FORBIDDEN` مع إغلاق الـGUC، وبـ`VOUCHER_GL_CANCEL_SCOPE_INVALID` مع فتحه يدويًا.

## حالة CI

على `c6f296b` عملت البوابات تلقائيًا ونجحت جميعًا عدا واحدة:

| البوابة | النتيجة |
|---|---|
| **Voucher Atomic Lifecycle 168 Acceptance** | ✅ |
| Financial GL 153 · AP 149 | ✅ · ✅ |
| Migration Governance | ✅ |
| SonarQube Analysis | ✅ |
| Regenerate UoM Database Types | ✅ (ودفعت `1430fc8`) |
| CI/CD Pipeline | ❌ **عطل بنية تحتية** |

```text
Error response from daemon: Get "https://registry-1.docker.io/v2/":
net/http: request canceled while waiting for connection
##[error]Docker pull failed with exit code 1
```

`docker pull postgres:17` انتهت مهلته ثلاث مرات، فلم تبدأ حاوية الخدمة ولم يُشغَّل أي اختبار — إعادة تشغيل تكفي.

على الرأس الحالي تنتظر **ثماني** workflows موافقة يدوية (`action_required`): Voucher Atomic Lifecycle 168 · Financial GL 153 · AP 149 · UoM Partial Receipt Atomic · Migration Governance · SonarQube Analysis · Regenerate UoM Database Types · CI/CD Pipeline. زرّ **Approve and run** من حساب له صلاحية الكتابة يُشغّلها جميعًا.

## حالات مرفوضة يثبتها القبول

فاتورة/عميل/مورد من مؤسسة أخرى · تخصيص الفاتورة نفسها مرتين · تخصيص صفري أو سالب أو بخصم غير صفري · إجمالي لا يطابق مبلغ الرأس · تخصيص يتجاوز الرصيد المفتوح · فاتورة مورد غير قابلة للسداد · تعديل ما ليس `draft` · تعديل أو إلغاء سند يحمل `gl_entry_id` بلا سجل Reset · تغيير العميل أو المورد · حمولة تعديل بلا مفتاح `lines` (الاستبدال صريح لا مستنتج).

## قيد بيئي

`pglast` تعذّر تنزيله في بيئة التطوير (انقطاع شبكة)، فبوابة الصياغة تعمل في CI. الملف حُلِّل ونُفِّذ على خادم PostgreSQL فعلي، وهو أقوى دليلًا من فحص المحلِّل وحده.

## خارج النطاق

- سحب `INSERT` المباشر على سطور التخصيص: Migration 169، بعد نشر الواجهة.
- واجهة Create/Edit/Repost/Cancel.
- Reset الفواتير.