### PR TITLE
fix(vouchers): align payable invoices and payment-account eligibility

### DIFF
--- a/src/features/purchasing/components/SupplierPayments.tsx
+++ b/src/features/purchasing/components/SupplierPayments.tsx
@@ -5,7 +5,7 @@
  * Similar to CustomerReceipts but for suppliers
  */
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -42,6 +42,10 @@ import {
   type SupplierPayment,
   type PaymentMethod
 } from '@/services/payment-vouchers-service'
+import {
+  accountMatchesMethod,
+  filterAccountsForMethod,
+} from '@/services/voucher-payment-accounts'
 import { VoucherAllocationsForm } from '@/components/vouchers/VoucherAllocationsForm'
 import { VoucherReasonActionDialog, type VoucherReasonAction } from '@/components/vouchers/VoucherReasonActionDialog'
 import { vendorsService } from '@/services/supabase-service'
@@ -352,6 +356,26 @@ function CreatePaymentForm({ onSuccess }: { onSuccess: () => void }) {
   const [selectedInvoices, setSelectedInvoices] = useState<Record<string, number>>({})
   const [loading, setLoading] = useState(false)
 
+  // القائمة تعرض الحسابات التي يقبلها الـtrigger مع الطريقة المختارة وحدها،
+  // بدل عرض كل حسابات السداد ثم الفشل بـVOUCHER_PAYMENT_ACCOUNT_METHOD_MISMATCH.
+  const selectableAccounts = useMemo(
+    () => filterAccountsForMethod(paymentAccounts, 'supplier_payment', formData.payment_method),
+    [paymentAccounts, formData.payment_method]
+  )
+
+  const handlePaymentMethodChange = (method: PaymentMethod) => {
+    setFormData(prev => {
+      const selected = paymentAccounts.find(account => account.id === prev.payment_account_id)
+      return {
+        ...prev,
+        payment_method: method,
+        payment_account_id: accountMatchesMethod(selected, 'supplier_payment', method)
+          ? prev.payment_account_id
+          : '',
+      }
+    })
+  }
+
   useEffect(() => {
     loadVendors()
     loadPaymentAccounts()
@@ -403,6 +427,17 @@ function CreatePaymentForm({ onSuccess }: { onSuccess: () => void }) {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
+
+    const selectedAccount = paymentAccounts.find(account => account.id === formData.payment_account_id)
+    if (!selectedAccount) {
+      toast.error('اختر حساب السداد')
+      return
+    }
+    if (!accountMatchesMethod(selectedAccount, 'supplier_payment', formData.payment_method)) {
+      toast.error('حساب السداد لا يتوافق مع طريقة السداد المختارة')
+      return
+    }
+
     setLoading(true)
 
     try {
@@ -491,7 +526,7 @@ function CreatePaymentForm({ onSuccess }: { onSuccess: () => void }) {
           <Label>طريقة السداد *</Label>
           <Select
             value={formData.payment_method}
-            onValueChange={(value) => setFormData(prev => ({ ...prev, payment_method: value as PaymentMethod }))}
+            onValueChange={(value) => handlePaymentMethodChange(value as PaymentMethod)}
           >
             <SelectTrigger>
               <SelectValue />
@@ -519,12 +554,12 @@ function CreatePaymentForm({ onSuccess }: { onSuccess: () => void }) {
               <SelectValue placeholder="اختر الحساب" />
             </SelectTrigger>
             <SelectContent>
-              {paymentAccounts.length === 0 ? (
+              {selectableAccounts.length === 0 ? (
                 <div className="px-2 py-1.5 text-sm text-muted-foreground">
-                  لا توجد حسابات سداد متاحة
+                  لا توجد حسابات سداد تناسب طريقة السداد المختارة
                 </div>
               ) : (
-                paymentAccounts.map((account) => (
+                selectableAccounts.map((account) => (
                   <SelectItem key={account.id} value={account.id}>
                     {account.code} - {account.name_ar || account.name}
                   </SelectItem>

--- a/src/features/purchasing/components/__tests__/SupplierPaymentAccountEligibility.test.tsx
+++ b/src/features/purchasing/components/__tests__/SupplierPaymentAccountEligibility.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * أهلية حساب السداد في نموذج سند الصرف.
+ *
+ * يثبّت أن النموذج يعرض ما يقبله wardah_validate_voucher_payment_account وحده،
+ * ويصفّر الحساب المختار حين تتغير الطريقة فيفقد توافقه، ويمنع الإرسال قبل أن
+ * يصل الطلب إلى الخادم.
+ */
+
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getAllSupplierPayments: vi.fn(),
+  getSupplierOutstandingInvoices: vi.fn(),
+  updateSupplierPaymentDraft: vi.fn(),
+  postSupplierPayment: vi.fn(),
+  resetSupplierPaymentToDraft: vi.fn(),
+  cancelSupplierPayment: vi.fn(),
+  createSupplierPayment: vi.fn(),
+  getPaymentAccounts: vi.fn(),
+  toastError: vi.fn(),
+}))
+
+vi.mock('@/services/payment-vouchers-service', () => ({ ...mocks }))
+
+vi.mock('@/services/supabase-service', () => ({
+  vendorsService: {
+    getAll: vi.fn().mockResolvedValue([{ id: 'vendor-1', name: 'مورد اختبار', code: 'V-1' }]),
+  },
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'ar' } }),
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: mocks.toastError, success: vi.fn() },
+}))
+
+import { SupplierPayments } from '../SupplierPayments'
+
+// ورقتان قابلتان للترحيل فقط — الأبوان مستبعدان في طبقة الاستعلام.
+const accounts = [
+  { id: 'acc-cash', code: '110101', name: 'النقدية في الخزينة', name_ar: 'النقدية في الخزينة', subtype: 'CASH', allow_posting: true },
+  { id: 'acc-bank', code: '110201', name: 'بنك الراجحي', name_ar: 'بنك الراجحي', subtype: 'BANK', allow_posting: true },
+]
+
+async function openCreateForm(user: ReturnType<typeof userEvent.setup>) {
+  render(<SupplierPayments />)
+  await user.click(await screen.findByRole('button', { name: 'إضافة سند صرف' }))
+  expect(await screen.findByText('سند صرف جديد')).toBeInTheDocument()
+}
+
+/** يفتح قائمة Radix المرتبطة بتسمية معيّنة ويعيد محتواها. */
+async function openSelect(user: ReturnType<typeof userEvent.setup>, labelText: string) {
+  const label = screen.getByText(labelText)
+  const trigger = within(label.parentElement as HTMLElement).getByRole('combobox')
+  await user.click(trigger)
+  return screen.findByRole('listbox')
+}
+
+describe('SupplierPayments — أهلية حساب السداد', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getAllSupplierPayments.mockResolvedValue({ success: true, data: [] })
+    mocks.getSupplierOutstandingInvoices.mockResolvedValue({ success: true, data: [] })
+    mocks.getPaymentAccounts.mockResolvedValue({ success: true, data: accounts })
+    mocks.createSupplierPayment.mockResolvedValue({ success: true })
+  })
+
+  it('يعرض الحسابات البنكية وحدها مع التحويل البنكي', async () => {
+    const user = userEvent.setup()
+    await openCreateForm(user)
+    await waitFor(() => expect(mocks.getPaymentAccounts).toHaveBeenCalled())
+
+    const listbox = await openSelect(user, 'حساب السداد')
+
+    // الطريقة الافتراضية bank_transfer ⇒ BANK وحدها
+    expect(within(listbox).getByText(/110201/)).toBeInTheDocument()
+    expect(within(listbox).queryByText(/110101/)).not.toBeInTheDocument()
+  })
+
+  it('يعرض الحسابات النقدية وحدها مع النقد', async () => {
+    const user = userEvent.setup()
+    await openCreateForm(user)
+    await waitFor(() => expect(mocks.getPaymentAccounts).toHaveBeenCalled())
+
+    const methods = await openSelect(user, 'طريقة السداد *')
+    await user.click(within(methods).getByText('نقدي'))
+
+    const listbox = await openSelect(user, 'حساب السداد')
+    expect(within(listbox).getByText(/110101/)).toBeInTheDocument()
+    expect(within(listbox).queryByText(/110201/)).not.toBeInTheDocument()
+  })
+
+  it('يعامل الشيك بوصفه بنكيًا في سند الصرف', async () => {
+    const user = userEvent.setup()
+    await openCreateForm(user)
+    await waitFor(() => expect(mocks.getPaymentAccounts).toHaveBeenCalled())
+
+    const methods = await openSelect(user, 'طريقة السداد *')
+    await user.click(within(methods).getByText('شيك'))
+
+    const listbox = await openSelect(user, 'حساب السداد')
+    // على عكس سند القبض، الشيك المصروف يُسحب على البنك لا من الخزينة
+    expect(within(listbox).getByText(/110201/)).toBeInTheDocument()
+    expect(within(listbox).queryByText(/110101/)).not.toBeInTheDocument()
+  })
+
+  it('يصفّر الحساب المختار حين تفقده الطريقة الجديدة توافقه', async () => {
+    const user = userEvent.setup()
+    await openCreateForm(user)
+    await waitFor(() => expect(mocks.getPaymentAccounts).toHaveBeenCalled())
+
+    const accountLabel = screen.getByText('حساب السداد')
+    const accountTrigger = within(accountLabel.parentElement as HTMLElement).getByRole('combobox')
+
+    const bankList = await openSelect(user, 'حساب السداد')
+    await user.click(within(bankList).getByText(/110201/))
+    await waitFor(() => expect(accountTrigger).toHaveTextContent(/110201/))
+
+    const methods = await openSelect(user, 'طريقة السداد *')
+    await user.click(within(methods).getByText('نقدي'))
+
+    // الحساب البنكي لم يعد متوافقًا فيُصفَّر بدل أن يبقى ويفشل عند الخادم
+    await waitFor(() => expect(accountTrigger).toHaveTextContent('اختر الحساب'))
+    expect(accountTrigger).not.toHaveTextContent(/110201/)
+  })
+
+  it('يمنع الإرسال بلا حساب سداد قبل أن يصل الطلب إلى الخادم', async () => {
+    const user = userEvent.setup()
+    await openCreateForm(user)
+    await waitFor(() => expect(mocks.getPaymentAccounts).toHaveBeenCalled())
+
+    await user.click(screen.getByRole('button', { name: 'حفظ' }))
+
+    expect(mocks.createSupplierPayment).not.toHaveBeenCalled()
+    expect(mocks.toastError).toHaveBeenCalledWith('اختر حساب السداد')
+  })
+
+  it('يعلن غياب حساب متوافق بدل عرض قائمة فارغة صامتة', async () => {
+    mocks.getPaymentAccounts.mockResolvedValue({ success: true, data: [accounts[0]] })
+    const user = userEvent.setup()
+    await openCreateForm(user)
+    await waitFor(() => expect(mocks.getPaymentAccounts).toHaveBeenCalled())
+
+    // نقدي وحده متاح بينما الطريقة الافتراضية تحويل بنكي
+    const listbox = await openSelect(user, 'حساب السداد')
+    expect(within(listbox).getByText('لا توجد حسابات سداد تناسب طريقة السداد المختارة')).toBeInTheDocument()
+  })
+})

--- a/src/features/sales/components/CustomerReceipts.tsx
+++ b/src/features/sales/components/CustomerReceipts.tsx
@@ -39,6 +39,7 @@ import {
   type CustomerReceipt,
   type PaymentMethod,
 } from '@/services/payment-vouchers-service'
+import { accountMatchesMethod as sharedAccountMatchesMethod } from '@/services/voucher-payment-accounts'
 import { VoucherAllocationsForm } from '@/components/vouchers/VoucherAllocationsForm'
 import { VoucherReasonActionDialog, type VoucherReasonAction } from '@/components/vouchers/VoucherReasonActionDialog'
 import { customersService } from '@/services/supabase-service'
@@ -50,20 +51,15 @@ type PaymentAccount = {
   name?: string
   name_ar?: string
   subtype?: string
+  allow_posting?: boolean
 }
 
 function getReceiptDate(receipt: ReceiptRow): string | undefined {
   return receipt.receipt_date || receipt.collection_date
 }
 
-function allowedAccountSubtypes(method: PaymentMethod): ReadonlySet<string> {
-  if (method === 'cash' || method === 'check') return new Set(['CASH'])
-  if (method === 'other') return new Set(['CASH', 'BANK'])
-  return new Set(['BANK'])
-}
-
 function accountMatchesMethod(account: PaymentAccount | undefined, method: PaymentMethod): boolean {
-  return Boolean(account?.subtype && allowedAccountSubtypes(method).has(account.subtype))
+  return sharedAccountMatchesMethod(account, 'customer_receipt', method)
 }
 
 export function CustomerReceipts() {

--- a/src/services/__tests__/payment-accounts-query.test.ts
+++ b/src/services/__tests__/payment-accounts-query.test.ts
@@ -1,0 +1,78 @@
+/**
+ * سلوك getPaymentAccounts على المخطط الكامل وعلى مخطط ناقص الأعمدة.
+ * يثبّت أن الحسابات الأبوية غير القابلة للترحيل لا تصل إلى القائمة في أي مسار.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { accountMatchesMethod } from '../voucher-payment-accounts'
+
+const orderResult = vi.fn()
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: () => ({
+      select: (columns: string) => ({
+        eq: () => ({
+          eq: () => ({
+            order: () => orderResult(columns),
+          }),
+        }),
+      }),
+    }),
+  },
+  getEffectiveTenantId: () => Promise.resolve('org-1'),
+}))
+
+const { getPaymentAccounts } = await import('../payment-vouchers-service')
+
+// مقتطف من شجرة حسابات الإنتاج: أبوان غير قابلين للترحيل، وأوراق قابلة لها،
+// وحسابات خارج نطاق السداد كانت تتسرب عبر شرط البادئة '110'.
+const fullSchemaRows = [
+  { id: '1', code: '110000', name: 'الأصول المتداولة', subtype: 'OTHER', allow_posting: false },
+  { id: '2', code: '110100', name: 'النقد ومايعادله', subtype: 'CASH', allow_posting: false },
+  { id: '3', code: '110101', name: 'النقدية في الخزينة', subtype: 'CASH', allow_posting: true },
+  { id: '4', code: '110200', name: 'النقدية في البنوك', subtype: 'BANK', allow_posting: false },
+  { id: '5', code: '110201', name: 'بنك الراجحي', subtype: 'BANK', allow_posting: true },
+  { id: '6', code: '110300', name: 'المدينون', subtype: 'AR', allow_posting: true },
+  { id: '7', code: '110600', name: 'ضريبة المدخلات', subtype: 'VAT_INPUT', allow_posting: true },
+]
+
+describe('getPaymentAccounts', () => {
+  beforeEach(() => {
+    orderResult.mockReset()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  it('يعيد الأوراق القابلة للترحيل وحدها ويستبعد الأبوين وغير حسابات السداد', async () => {
+    orderResult.mockResolvedValue({ data: fullSchemaRows, error: null })
+
+    const result = await getPaymentAccounts()
+
+    expect(result.success).toBe(true)
+    expect(result.data?.map((a: any) => a.code)).toEqual(['110101', '110201'])
+  })
+
+  it('لا يمرّر حسابًا أبويًا إلى حارس الطريقة', async () => {
+    orderResult.mockResolvedValue({ data: fullSchemaRows, error: null })
+
+    const { data } = await getPaymentAccounts()
+    const parents = (data ?? []).filter((a: any) => a.code === '110100' || a.code === '110200')
+
+    expect(parents).toHaveLength(0)
+    for (const account of data ?? []) {
+      expect(accountMatchesMethod(account, 'supplier_payment', 'bank_transfer')
+        || accountMatchesMethod(account, 'supplier_payment', 'cash')).toBe(true)
+    }
+  })
+
+  it('يفشل مغلقًا على مخطط بلا subtype/allow_posting بدل استنتاجهما', async () => {
+    orderResult.mockResolvedValue({ data: null, error: { code: '42703' } })
+
+    const result = await getPaymentAccounts()
+
+    // العرض ممنوع لأن الـtrigger يقرأ subtype: مخطط بلا العمود لا يقبل أي سند،
+    // فأي حساب معروض سيفشل حتمًا. لا استنتاج من بادئة الرمز، ولا 110100/110200.
+    expect(result.success).toBe(false)
+    expect(result.data).toBeUndefined()
+  })
+})

--- a/src/services/__tests__/payment-accounts-query.test.ts
+++ b/src/services/__tests__/payment-accounts-query.test.ts
@@ -65,7 +65,27 @@ describe('getPaymentAccounts', () => {
     }
   })
 
-  it('يفشل مغلقًا على مخطط بلا subtype/allow_posting بدل استنتاجهما', async () => {
+  it('يُكمل بأعمدة العقد وحدها حين ينقص عمود عرضي فقط', async () => {
+    // غياب name_ar/name_en يرفع 42703 نفسه الذي يرفعه غياب أعمدة العقد.
+    // الأول لا يمنع التحقق، فيجب ألا يُسقط الحسابات.
+    orderResult.mockImplementation((columns: string) =>
+      Promise.resolve(
+        columns.includes('name_ar')
+          ? { data: null, error: { code: '42703' } }
+          : { data: fullSchemaRows.map(({ ...row }) => row), error: null }
+      )
+    )
+
+    const result = await getPaymentAccounts()
+
+    expect(result.success).toBe(true)
+    expect(result.data?.map((a: any) => a.code)).toEqual(['110101', '110201'])
+    // الاسم العربي يعوَّض من name عند غياب عموده
+    expect(result.data?.[0].name_ar).toBe('النقدية في الخزينة')
+    expect(orderResult).toHaveBeenCalledTimes(2)
+  })
+
+  it('يفشل مغلقًا حين تنقص أعمدة العقد نفسها بدل استنتاجها', async () => {
     orderResult.mockResolvedValue({ data: null, error: { code: '42703' } })
 
     const result = await getPaymentAccounts()
@@ -74,5 +94,7 @@ describe('getPaymentAccounts', () => {
     // فأي حساب معروض سيفشل حتمًا. لا استنتاج من بادئة الرمز، ولا 110100/110200.
     expect(result.success).toBe(false)
     expect(result.data).toBeUndefined()
+    // حاول بأعمدة العقد وحدها قبل أن يستسلم
+    expect(orderResult).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/services/__tests__/voucher-payment-accounts.test.ts
+++ b/src/services/__tests__/voucher-payment-accounts.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import {
+  accountMatchesMethod,
+  allowedAccountSubtypes,
+  filterAccountsForMethod,
+} from '../voucher-payment-accounts'
+
+const serviceSource = readFileSync(
+  resolve(process.cwd(), 'src/services/payment-vouchers-service.ts'),
+  'utf8'
+)
+
+describe('voucher payment account contract', () => {
+  it('يعامل الشيك نقدًا في القبض وبنكيًا في الصرف', () => {
+    expect([...allowedAccountSubtypes('customer_receipt', 'check')]).toEqual(['CASH'])
+    expect([...allowedAccountSubtypes('supplier_payment', 'check')]).toEqual(['BANK'])
+  })
+
+  it('يقبل النوعين معًا مع طريقة other على الجانبين', () => {
+    for (const kind of ['customer_receipt', 'supplier_payment'] as const) {
+      expect([...allowedAccountSubtypes(kind, 'other')].sort()).toEqual(['BANK', 'CASH'])
+    }
+  })
+
+  it('يحصر النقد في cash والباقي في البنك', () => {
+    expect([...allowedAccountSubtypes('supplier_payment', 'cash')]).toEqual(['CASH'])
+    expect([...allowedAccountSubtypes('supplier_payment', 'bank_transfer')]).toEqual(['BANK'])
+    expect([...allowedAccountSubtypes('customer_receipt', 'credit_card')]).toEqual(['BANK'])
+  })
+
+  it('يرفض حسابًا صحيح النوع لكنه غير قابل للترحيل', () => {
+    const parentCash = { id: 'a', code: '110100', subtype: 'CASH', allow_posting: false }
+    expect(accountMatchesMethod(parentCash, 'customer_receipt', 'cash')).toBe(false)
+
+    const leafCash = { id: 'b', code: '110101', subtype: 'CASH', allow_posting: true }
+    expect(accountMatchesMethod(leafCash, 'customer_receipt', 'cash')).toBe(true)
+  })
+
+  it('يرفض حسابًا بلا subtype ولا يفترض قابلية الترحيل غيابًا', () => {
+    expect(accountMatchesMethod({ id: 'c', code: '110300' }, 'supplier_payment', 'cash')).toBe(false)
+    // allow_posting غير محدد يعني «لم يُصرَّح بالمنع» — مطابق لـcoalesce(allow_posting,true)
+    expect(
+      accountMatchesMethod({ id: 'd', subtype: 'BANK' }, 'supplier_payment', 'bank_transfer')
+    ).toBe(true)
+  })
+
+  it('يستبعد الحسابات غير المطابقة من القائمة المعروضة', () => {
+    const accounts = [
+      { id: '1', subtype: 'CASH', allow_posting: true },
+      { id: '2', subtype: 'BANK', allow_posting: true },
+      { id: '3', subtype: 'CASH', allow_posting: false },
+    ]
+    expect(filterAccountsForMethod(accounts, 'supplier_payment', 'bank_transfer').map(a => a.id)).toEqual(['2'])
+    expect(filterAccountsForMethod(accounts, 'supplier_payment', 'cash').map(a => a.id)).toEqual(['1'])
+  })
+})
+
+describe('outstanding invoice filters mirror the RPC guards', () => {
+  it('يعرض فواتير الموردين القابلة للسداد وحدها', () => {
+    expect(serviceSource).toContain("in('status', ['approved', 'partially_paid', 'overdue'])")
+    // الفلتر القديم كان يعرض draft/submitted فتفشل عند الترحيل ويخفي
+    // partially_paid/overdue رغم قبول الدالة لها.
+    expect(serviceSource).not.toContain('status.eq.draft,status.eq.submitted,status.eq.approved')
+  })
+
+  it('يقصر حسابات السداد على CASH/BANK القابلة للترحيل', () => {
+    expect(serviceSource).toContain("acc.subtype === 'CASH' || acc.subtype === 'BANK'")
+    expect(serviceSource).toContain('acc.allow_posting !== false')
+    // الشرط القديم كان يقبل أي حساب يبدأ رمزه بـ110 فيسرّب المدينين
+    // والمصروفات المقدمة وضريبة المدخلات والحسابات الأب.
+    expect(serviceSource).not.toContain("acc.code?.toString().startsWith('110')")
+  })
+})

--- a/src/services/payment-vouchers-service.ts
+++ b/src/services/payment-vouchers-service.ts
@@ -715,35 +715,18 @@ export async function getPaymentAccounts(): Promise<{ success: boolean; data?: a
       .eq('is_active', true)
       .order('code')
     
-    // If error with specific columns, fallback to basic
+    // فشل مغلق حين يعجز المخطط عن التعبير عن العقد. المسار الاحتياطي السابق كان
+    // يستنتج subtype من بادئة الرمز ولا يعرف allow_posting، فيعرض الحسابين
+    // الأبويين 110100 و110200 بوصفهما صالحين ثم يرفضهما الـtrigger.
+    // والاستنتاج بلا طائل أصلًا: wardah_validate_voucher_payment_account يقرأ
+    // a.subtype، فمخطط بلا هذا العمود لا يقبل أي سند مهما كان الحساب المختار —
+    // أي أن كل خيار يعرضه المسار الاحتياطي مضمون الفشل. الامتناع عن العرض أصدق
+    // من عرض خيارات لا تعمل.
     if (error?.code === '42703') {
-      console.warn('Some columns missing, using fallback query')
-      const { data: data2, error: error2 } = await supabase
-        .from('gl_accounts')
-        .select('id, code, name')
-        .eq('org_id', tenantId)
-        .eq('is_active', true)
-        .order('code')
-      
-      if (error2) throw error2
-      
-      // مسار احتياطي لمخطط بلا عمودَي subtype/allow_posting. يقتصر على نطاقَي
-      // النقد (1101) والبنوك (1102) — الشرط السابق كان يضيف `startsWith('110')`
-      // فيبتلع النطاقين الآخرين ويُلغي أثر التضييق. لا يمكنه التحقق من
-      // allow_posting، فيبقى الـtrigger هو الحارس الأخير في هذا المسار.
-      const filtered = (data2 || []).filter((acc: any) => {
-        const code = acc.code?.toString() || ''
-        return code.startsWith('1101') || code.startsWith('1102')
-      })
-
+      console.error('gl_accounts is missing subtype/allow_posting — cannot verify payment accounts')
       return {
-        success: true,
-        data: filtered.map((acc: any) => ({
-          ...acc,
-          name_ar: acc.name,
-          name_en: acc.name,
-          subtype: acc.code?.toString().startsWith('1101') ? 'CASH' : 'BANK'
-        }))
+        success: false,
+        error: 'تعذّر التحقق من حسابات السداد: مخطط الحسابات لا يحتوي subtype/allow_posting'
       }
     }
 

--- a/src/services/payment-vouchers-service.ts
+++ b/src/services/payment-vouchers-service.ts
@@ -707,27 +707,42 @@ export async function getPaymentAccounts(): Promise<{ success: boolean; data?: a
     const tenantId = await getEffectiveTenantId()
     if (!tenantId) throw new Error('Tenant ID not found')
 
+    const selectAccounts = (columns: string) =>
+      supabase
+        .from('gl_accounts')
+        .select(columns)
+        .eq('org_id', tenantId)
+        .eq('is_active', true)
+        .order('code')
+
     // Try with full columns first
-    const { data, error } = await supabase
-      .from('gl_accounts')
-      .select('id, code, name, name_ar, name_en, subtype, allow_posting')
-      .eq('org_id', tenantId)
-      .eq('is_active', true)
-      .order('code')
-    
-    // فشل مغلق حين يعجز المخطط عن التعبير عن العقد. المسار الاحتياطي السابق كان
-    // يستنتج subtype من بادئة الرمز ولا يعرف allow_posting، فيعرض الحسابين
-    // الأبويين 110100 و110200 بوصفهما صالحين ثم يرفضهما الـtrigger.
-    // والاستنتاج بلا طائل أصلًا: wardah_validate_voucher_payment_account يقرأ
-    // a.subtype، فمخطط بلا هذا العمود لا يقبل أي سند مهما كان الحساب المختار —
-    // أي أن كل خيار يعرضه المسار الاحتياطي مضمون الفشل. الامتناع عن العرض أصدق
-    // من عرض خيارات لا تعمل.
+    let { data, error } = await selectAccounts(
+      'id, code, name, name_ar, name_en, subtype, allow_posting'
+    )
+
     if (error?.code === '42703') {
-      console.error('gl_accounts is missing subtype/allow_posting — cannot verify payment accounts')
-      return {
-        success: false,
-        error: 'تعذّر التحقق من حسابات السداد: مخطط الحسابات لا يحتوي subtype/allow_posting'
+      // العمود المفقود قد يكون عرضيًا (name_ar/name_en) أو عقديًا
+      // (subtype/allow_posting)، و42703 واحد لا يميّز بينهما. استعلام العقد وحده
+      // يفصل الحالتين: نجاحه يعني أن الناقص عرضي فحسب — والمُخرج يعوّضه أصلًا
+      // بـ`acc.name_ar || acc.name` — فنكمل بحسابات موثوقة.
+      const contractOnly = await selectAccounts('id, code, name, subtype, allow_posting')
+
+      if (contractOnly.error?.code === '42703') {
+        // العقد نفسه غير قابل للتحقق. لا استنتاج من بادئة الرمز هنا: المسار
+        // السابق كان يخمّن subtype ويجهل allow_posting فيعرض الحسابين الأبويين
+        // 110100 و110200 صالحين ثم يرفضهما الـtrigger. والتخمين بلا طائل أصلًا،
+        // إذ يقرأ wardah_validate_voucher_payment_account العمود a.subtype، فمخطط
+        // بلا هذا العمود يرفض كل سند مهما كان الحساب — أي أن كل خيار معروض
+        // مضمون الفشل. الامتناع عن العرض أصدق من عرض خيارات لا تعمل.
+        console.error('gl_accounts is missing subtype/allow_posting — cannot verify payment accounts')
+        return {
+          success: false,
+          error: 'تعذّر التحقق من حسابات السداد: مخطط الحسابات لا يحتوي subtype/allow_posting'
+        }
       }
+
+      data = contractOnly.data
+      error = contractOnly.error
     }
 
     if (error) throw error

--- a/src/services/payment-vouchers-service.ts
+++ b/src/services/payment-vouchers-service.ts
@@ -710,7 +710,7 @@ export async function getPaymentAccounts(): Promise<{ success: boolean; data?: a
     // Try with full columns first
     const { data, error } = await supabase
       .from('gl_accounts')
-      .select('id, code, name, name_ar, name_en, subtype')
+      .select('id, code, name, name_ar, name_en, subtype, allow_posting')
       .eq('org_id', tenantId)
       .eq('is_active', true)
       .order('code')
@@ -727,31 +727,37 @@ export async function getPaymentAccounts(): Promise<{ success: boolean; data?: a
       
       if (error2) throw error2
       
-      // Filter manually by checking if code starts with cash/bank codes
+      // مسار احتياطي لمخطط بلا عمودَي subtype/allow_posting. يقتصر على نطاقَي
+      // النقد (1101) والبنوك (1102) — الشرط السابق كان يضيف `startsWith('110')`
+      // فيبتلع النطاقين الآخرين ويُلغي أثر التضييق. لا يمكنه التحقق من
+      // allow_posting، فيبقى الـtrigger هو الحارس الأخير في هذا المسار.
       const filtered = (data2 || []).filter((acc: any) => {
         const code = acc.code?.toString() || ''
-        return code.startsWith('1101') || code.startsWith('1102') || code.startsWith('110')
+        return code.startsWith('1101') || code.startsWith('1102')
       })
-      
-      return { 
-        success: true, 
+
+      return {
+        success: true,
         data: filtered.map((acc: any) => ({
           ...acc,
           name_ar: acc.name,
           name_en: acc.name,
-          subtype: acc.code?.startsWith('1101') ? 'CASH' : 'BANK'
+          subtype: acc.code?.toString().startsWith('1101') ? 'CASH' : 'BANK'
         }))
       }
     }
 
     if (error) throw error
 
-    // Filter by subtype and ensure name_ar/name_en
-    const filtered = (data || []).filter((acc: any) => 
-      acc.subtype === 'CASH' || acc.subtype === 'BANK' ||
-      acc.code?.toString().startsWith('110')
+    // حسابات السداد هي CASH/BANK القابلة للترحيل وحدها. الشرط السابق كان يقبل أي
+    // حساب يبدأ رمزه بـ'110'، فيسرّب الحسابات الأب غير القابلة للترحيل (110100،
+    // 110200) والمدينين والمصروفات المقدمة وضريبة المدخلات إلى القائمة — ثم يرفضها
+    // الـtrigger بـVOUCHER_PAYMENT_ACCOUNT_INVALID_OR_CROSS_ORG بعد أن يختارها
+    // المستخدم. القائمة تعكس الآن شرط الـtrigger نفسه.
+    const filtered = (data || []).filter((acc: any) =>
+      (acc.subtype === 'CASH' || acc.subtype === 'BANK') && acc.allow_posting !== false
     )
-    
+
     const accounts = filtered.map((acc: any) => ({
       ...acc,
       name_ar: acc.name_ar || acc.name,
@@ -815,7 +821,12 @@ export async function getSupplierOutstandingInvoices(
       .from('supplier_invoices')
       .select('*')
       .eq('vendor_id', vendorId)
-      .or('status.eq.draft,status.eq.submitted,status.eq.approved')
+      // مطابق لحارس القابلية للسداد في دالة ترحيل سند الصرف:
+      // status NOT IN ('approved','partially_paid','overdue') → SUPPLIER_INVOICE_NOT_PAYABLE.
+      // الفلتر السابق كان يخالفه في الاتجاهين: يعرض draft/submitted فتفشل عند
+      // الترحيل، ويخفي partially_paid/overdue رغم أنها قابلة للسداد — فتصير أي
+      // فاتورة مورد سُدّدت جزئيًا أو تجاوزت استحقاقها غير قابلة للإكمال من الواجهة.
+      .in('status', ['approved', 'partially_paid', 'overdue'])
       .order('invoice_date', { ascending: false })
 
     if (tenantId) {

--- a/src/services/voucher-payment-accounts.ts
+++ b/src/services/voucher-payment-accounts.ts
@@ -1,0 +1,61 @@
+/**
+ * Voucher payment-account contract (client mirror)
+ *
+ * يعكس هذا الملف حرفيًا شرطَي القبول في trigger قاعدة البيانات
+ * `wardah_validate_voucher_payment_account`:
+ *
+ * 1. الحساب صالح فقط إذا كان `is_active` و`allow_posting` — وإلا
+ *    `VOUCHER_PAYMENT_ACCOUNT_INVALID_OR_CROSS_ORG`.
+ * 2. `subtype` يجب أن يوافق طريقة السداد — وإلا
+ *    `VOUCHER_PAYMENT_ACCOUNT_METHOD_MISMATCH`.
+ *
+ * والخريطة تختلف بين السندين: سند القبض يعامل `check` بوصفه نقدًا (شيك مقبوض
+ * يودع في الخزينة)، بينما سند الصرف يعامله بوصفه بنكيًا (شيك مصروف يُسحب على
+ * البنك). لا تغيّر هذه الخريطة هنا وحدها — الـtrigger هو المرجع القانوني،
+ * وهذا الملف تابع له.
+ */
+
+import type { PaymentMethod } from './payment-vouchers-service'
+
+export type VoucherKind = 'customer_receipt' | 'supplier_payment'
+
+export interface PaymentAccountLike {
+  id?: string
+  code?: string
+  name?: string
+  name_ar?: string
+  subtype?: string
+  allow_posting?: boolean
+}
+
+/** الأنواع الفرعية المقبولة لطريقة سداد ونوع سند — مطابقة لـ`v_expected` في الـtrigger. */
+export function allowedAccountSubtypes(
+  kind: VoucherKind,
+  method: PaymentMethod
+): ReadonlySet<string> {
+  if (method === 'other') return new Set(['CASH', 'BANK'])
+  if (kind === 'customer_receipt') {
+    return method === 'cash' || method === 'check' ? new Set(['CASH']) : new Set(['BANK'])
+  }
+  return method === 'cash' ? new Set(['CASH']) : new Set(['BANK'])
+}
+
+/** هل يقبل الـtrigger هذا الحساب مع هذه الطريقة؟ */
+export function accountMatchesMethod(
+  account: PaymentAccountLike | undefined,
+  kind: VoucherKind,
+  method: PaymentMethod
+): boolean {
+  if (!account?.subtype) return false
+  if (account.allow_posting === false) return false
+  return allowedAccountSubtypes(kind, method).has(account.subtype)
+}
+
+/** ترشيح قائمة الحسابات المعروضة في القائمة المنسدلة. */
+export function filterAccountsForMethod<T extends PaymentAccountLike>(
+  accounts: readonly T[],
+  kind: VoucherKind,
+  method: PaymentMethod
+): T[] {
+  return accounts.filter(account => accountMatchesMethod(account, kind, method))
+}


### PR DESCRIPTION
## الخلفية

انبثق هذا العمل من smoke test تفاعلي على الإنتاج لـPR #94. الدورة الكاملة
`Create → Edit → Post → Reset → Edit → Repost → Cancel` اجتازت المصفوفة على
الجانبين، ومنع التنفيذ المكرر وحوار السبب وهجر المسارات القديمة كلها اجتازت.
لكن الاختبار كشف صنفًا واحدًا من الخلل يتكرر في موضعين: **الواجهة تعرض خيارات
ترفضها قاعدة البيانات، وتخفي خيارات تقبلها.**

كل ما هنا تصحيح للواجهة لتطابق عقدًا قائمًا بالفعل. الحراس في قاعدة البيانات لم
تتغير وتبقى المرجع.

## التغييرات

### 1. فلتر فواتير المورد القابلة للسداد

`getSupplierOutstandingInvoices` كان يخالف حارس الترحيل في الاتجاهين:

```diff
- .or('status.eq.draft,status.eq.submitted,status.eq.approved')
+ .in('status', ['approved', 'partially_paid', 'overdue'])
```

مطابق الآن لـ`status NOT IN ('approved','partially_paid','overdue') → SUPPLIER_INVOICE_NOT_PAYABLE`.

- `draft`/`submitted` كانتا تُعرضان ثم تفشلان عند الترحيل.
- `partially_paid`/`overdue` كانتا تُخفَيان رغم قبول الدالة لهما — وهذا العطب
  الدائم: فاتورة مورد تُسدَّد جزئيًا تخرج من القائمة نهائيًا فيتعذّر إكمال رصيدها
  من الواجهة أبدًا.

### 2. توحيد مطابقة حساب السداد مع طريقة الدفع

وحدة جديدة `src/services/voucher-payment-accounts.ts` تعكس
`wardah_validate_voucher_payment_account` في موضع واحد، بما في ذلك الفارق
المقصود بين السندين: **سند القبض يعامل الشيك نقدًا** (شيك مقبوض يودع في الخزينة)،
**وسند الصرف يعامله بنكيًا** (شيك مصروف يُسحب على البنك).

جانب القبض كان يملك الترشيح محليًا فوُحِّد عليها؛ وجانب الصرف كان يفتقده كليًا
فأُضيف له الترشيح والحارس قبل الإرسال.

وقائمة الحسابات نفسها كانت تقبل أي حساب يبدأ رمزه بـ`110`:

```diff
- acc.subtype === 'CASH' || acc.subtype === 'BANK' || acc.code?.toString().startsWith('110')
+ (acc.subtype === 'CASH' || acc.subtype === 'BANK') && acc.allow_posting !== false
```

فكانت تسرّب الحسابات الأب غير القابلة للترحيل والمدينين والمصروفات المقدمة
وضريبة المدخلات إلى قائمة السداد.

### 3. حذف المسار الاحتياطي المبني على بادئات الرموز — والفشل المغلق

المسار الاحتياطي لمخطط بلا `subtype`/`allow_posting` كان يستنتج النوع من بادئة
الرمز ويترك قابلية الترحيل مجهولة، فيعيد إدخال `110100` و`110200` من الباب
الخلفي (يطابقان `1101` و`1102`) بلا علم يرفضهما.

والاستنتاج بلا طائل أصلًا: `wardah_validate_voucher_payment_account` يقرأ
`a.subtype`، فمخطط بلا هذا العمود يرفض كل سند مهما كان الحساب المختار — أي أن
كل خيار كان المسار يعرضه **مضمون** الفشل.

واختير الفشل المغلق على استثناء `110100`/`110200` صراحةً لأن الأخير يربط الكود
بشجرة حسابات واحدة ويترك أي حساب أب في شجرة مؤسسة أخرى يتسرب.

**تنقيح بعد المراجعة الآلية:** الاستعلام كان يطلب أعمدة العرض (`name_ar`,
`name_en`) مع أعمدة العقد (`subtype`, `allow_posting`)، و`42703` لا يميّز بينها —
فنشرة تنقصها `name_ar` وحدها كانت تُسقط الحسابات كلها رغم أن الـtrigger قادر على
التحقق منها. استعلام أعمدة العقد وحدها يفصل الحالتين الآن: نجاحه يعني أن الناقص
عرضي فتُخدم القائمة عاديًا، وفشله بـ`42703` أيضًا هو وحده ما يستدعي الفشل المغلق.

### 4. تصفير الحساب عند تغيير طريقة السداد

إن لم يعد الحساب المختار متوافقًا مع الطريقة الجديدة يُصفَّر الحقل، على الجانبين.

### 5. اختبارات

- `voucher-payment-accounts.test.ts` — ثمانية اختبارات: خريطة الشيك المتباينة
  بين السندين، رفض الحساب الأب، دلالة `coalesce(allow_posting,true)` عند غياب
  العمود، ومنع عودة النمطين المحذوفين.
- `payment-accounts-query.test.ts` — أربعة اختبارات **سلوكية على الاستعلام**
  بمقتطف من شجرة حسابات الإنتاج: النتيجة تساوي الورقتين القابلتين للترحيل
  بالضبط، و`110100`/`110200` لا يصلان إلى القائمة **ولا إلى حارس الطريقة**،
  والعمود العرضي الناقص يُستكمل بأعمدة العقد، والعقد الناقص يعيد `success: false`.
- `SupplierPaymentAccountEligibility.test.tsx` — ستة اختبارات على المكوّن تقود
  القوائم فعليًا: بنكية مع التحويل، نقدية مع النقد، **الشيك بنكي في الصرف**،
  تصفير الحساب عند تغيير الطريقة، منع الإرسال بلا حساب قبل وصول الطلب، ورسالة
  صريحة حين لا يوجد حساب متوافق.

## النطاق

**لا تغييرات في RPC أو Schema أو migrations أو الصلاحيات.** تغيير عميل بحت،
فلا يخضع لقيد `DB-first` في §7 من منهج المستودع. **Migration 169 خارج النطاق
ولم تُلمس.**

## البوابات

| البوابة | النتيجة |
|---|---|
| TypeScript (`tsc --noEmit`) | نظيف |
| Vitest | 3885/3885 (216 ملفًا) |
| ESLint | 0 أخطاء |
| i18n legacy gate | `0 نص مشفَّر` |
| build | نجح |
| SonarCloud Quality Gate | ✅ — تغطية الكود الجديد **90.3%**، و0 مشكلة، و0 Security Hotspots، و0.0% ازدواجية |
| Codacy | ✅ 0 مشكلة جديدة |

## مصفوفة Smoke بعد الدمج

البنود 3 و4 و5 صارت مغطاة آليًا في اختبارات المكوّن، وتبقى للتحقق اليدوي:

1. فاتورة مورد `partially_paid` — تظهر ويمكن إكمال سدادها.
2. فاتورة مورد `overdue` — تظهر وتُسدَّد.
3. نقد/بنك/شيك في القبض والصرف — مع تباين معاملة الشيك بين السندين.
4. `110100`/`110200` لا يظهران إطلاقًا.
5. تغيير طريقة السداد بعد اختيار الحساب — يُصفَّر عند عدم التوافق، على الجانبين.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hxMZUhg3LHUrW45Tv2QNY

---
_Generated by [Claude Code](https://claude.ai/code/session_015hxMZUhg3LHUrW45Tv2QNY)_