### PR TITLE
fix(vouchers): close direct writes and payment-state drift

### DIFF
--- a/.github/workflows/voucher-write-closure-169-red-proof.yml
+++ b/.github/workflows/voucher-write-closure-169-red-proof.yml
@@ -1,16 +1,17 @@
-name: Voucher Write Closure 169 Red Proof
+name: Voucher Write Closure 169 Acceptance
 
 on:
   pull_request:
     branches: [main]
     paths:
       - 'scripts/ci/fresh-db/acceptance_169_voucher_write_closure.sql'
+      - 'sql/migrations/169_voucher_write_closure.sql'
       - '.github/workflows/voucher-write-closure-169-red-proof.yml'
   workflow_dispatch:
 
 jobs:
-  red-proof:
-    name: Confirm 168 baseline fails the 169 contract
+  acceptance:
+    name: Confirm Migration 169 satisfies the immutable contract
     runs-on: ubuntu-latest
 
     services:
@@ -70,7 +71,7 @@ jobs:
           PGUSER: postgres
           PGPASSWORD: postgres
 
-      - name: Execute immutable 169 contract against the 168 baseline
+      - name: Execute immutable 169 contract after Migration 169
         shell: bash
         run: |
           set -Eeuo pipefail
@@ -86,7 +87,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: voucher-write-closure-169-red-${{ github.run_id }}
+          name: voucher-write-closure-169-${{ github.run_id }}
           path: |
             /tmp/voucher-write-closure-169.out
             /tmp/chain_order.txt

--- a/.github/workflows/voucher-write-closure-169-red-proof.yml
+++ b/.github/workflows/voucher-write-closure-169-red-proof.yml
@@ -71,7 +71,7 @@ jobs:
           PGUSER: postgres
           PGPASSWORD: postgres
 
-      - name: Execute immutable 169 contract after Migration 169
+      - name: Execute reviewed 169 contract after Migration 169
         shell: bash
         run: |
           set -Eeuo pipefail
@@ -83,7 +83,7 @@ jobs:
           PGUSER: postgres
           PGPASSWORD: postgres
 
-      - name: Upload red-proof evidence
+      - name: Upload voucher-closure evidence
         if: always()
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/voucher-write-closure-169-red-proof.yml
+++ b/.github/workflows/voucher-write-closure-169-red-proof.yml
@@ -1,0 +1,95 @@
+name: Voucher Write Closure 169 Red Proof
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'scripts/ci/fresh-db/acceptance_169_voucher_write_closure.sql'
+      - '.github/workflows/voucher-write-closure-169-red-proof.yml'
+  workflow_dispatch:
+
+jobs:
+  red-proof:
+    name: Confirm 168 baseline fails the 169 contract
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build fresh database through migration 168
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          PAIR=$(bash scripts/ci/fresh-db/resolve_baseline_pair.sh sql/baseline)
+          pair_field() { printf '%s\n' "$PAIR" | sed -n "s/^$1=//p"; }
+          BASELINE=$(pair_field BASELINE_PATH)
+          REFERENCE=$(pair_field REFERENCE_PATH)
+          CUTOFF=$(pair_field BASELINE_CUTOFF)
+          CUTOFF=${CUTOFF:-0}
+
+          createdb wardah_fresh
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh \
+            -f scripts/ci/fresh-db/supabase_shim.sql -q
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh -f "$BASELINE" -q
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh -f "$REFERENCE" -q
+
+          python3 scripts/ci/fresh-db/build_apply_order.py \
+            sql/migrations "$CUTOFF" > /tmp/chain_order.txt
+          REPORT=/tmp/chain_report.txt PGDATABASE=wardah_fresh \
+            bash scripts/ci/fresh-db/run_chain.sh sql/migrations /tmp/chain_order.txt
+        env:
+          PGHOST: localhost
+          PGUSER: postgres
+          PGPASSWORD: postgres
+
+      - name: Seed committed voucher lifecycle fixtures
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh \
+            -f scripts/ci/fresh-db/acceptance_168_voucher_atomic_lifecycle.sql \
+            | tee /tmp/voucher-write-closure-169.out
+        env:
+          PGHOST: localhost
+          PGUSER: postgres
+          PGPASSWORD: postgres
+
+      - name: Execute immutable 169 contract against the 168 baseline
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh \
+            -f scripts/ci/fresh-db/acceptance_169_voucher_write_closure.sql \
+            2>&1 | tee -a /tmp/voucher-write-closure-169.out
+        env:
+          PGHOST: localhost
+          PGUSER: postgres
+          PGPASSWORD: postgres
+
+      - name: Upload red-proof evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: voucher-write-closure-169-red-${{ github.run_id }}
+          path: |
+            /tmp/voucher-write-closure-169.out
+            /tmp/chain_order.txt
+            /tmp/chain_report.txt
+          if-no-files-found: warn
+          retention-days: 30

--- a/scripts/ci/fresh-db/acceptance_169_voucher_write_closure.sql
+++ b/scripts/ci/fresh-db/acceptance_169_voucher_write_closure.sql
@@ -205,14 +205,14 @@ SELECT pg_temp.expect_error($sql$
   WHERE id = '88b20000-0000-0000-0000-000000000002'
 $sql$, 'VOUCHER_DERIVED_PAYMENT_FIELDS_WRITE_FORBIDDEN');
 
-DO $
+DO $$
 BEGIN
   IF (SELECT status FROM public.supplier_invoices
       WHERE id = '88b20000-0000-0000-0000-000000000002') IS DISTINCT FROM 'paid' THEN
     RAISE EXCEPTION 'ACCEPTANCE_FAIL: rejected paid status drift changed the invoice';
   END IF;
 END;
-$;
+$$;
 
 RESET ROLE;
 UPDATE public.supplier_invoices
@@ -226,14 +226,14 @@ SELECT pg_temp.expect_error($sql$
   WHERE id = '88b20000-0000-0000-0000-000000000002'
 $sql$, 'VOUCHER_DERIVED_PAYMENT_FIELDS_WRITE_FORBIDDEN');
 
-DO $
+DO $$
 BEGIN
   IF (SELECT status FROM public.supplier_invoices
       WHERE id = '88b20000-0000-0000-0000-000000000002') IS DISTINCT FROM 'partially_paid' THEN
     RAISE EXCEPTION 'ACCEPTANCE_FAIL: rejected partially-paid status drift changed the invoice';
   END IF;
 END;
-$;
+$$;
 
 -- Normalize the 168 fixture to the start of the approval workflow, then prove
 -- the real forward path. These writes do not mutate payment state and must
@@ -259,7 +259,7 @@ RESET ROLE;
 -- A failing internal RPC must not leave any trusted write capability enabled
 -- for subsequent statements in the same outer transaction.
 SET LOCAL ROLE authenticated;
-DO $
+DO $$
 DECLARE
   v_failed boolean := false;
 BEGIN
@@ -281,7 +281,7 @@ BEGIN
     RAISE EXCEPTION 'ACCEPTANCE_FAIL: failed RPC leaked voucher write context';
   END IF;
 END;
-$;
+$$;
 RESET ROLE;
 
 -- 4. All ten RPC grants remain exactly available to authenticated and denied

--- a/scripts/ci/fresh-db/acceptance_169_voucher_write_closure.sql
+++ b/scripts/ci/fresh-db/acceptance_169_voucher_write_closure.sql
@@ -1,8 +1,8 @@
--- RED acceptance contract for Migration 169 (review revision 1.3).
+-- Acceptance contract for Migration 169 (review revision 1.4).
 --
--- This file is intentionally red against the 168 baseline. It must be run only
--- after the 168 lifecycle acceptance has committed its fixtures. Migration 169
--- turns it green without changing the expectations below.
+-- Revision 1.4 extends the reviewed v1.3 closure contract with reverse
+-- payment-status drift checks and failed-RPC write-context restoration. It runs
+-- after the 168 lifecycle acceptance has committed its fixtures.
 \set ON_ERROR_STOP on
 
 CREATE OR REPLACE FUNCTION pg_temp.expect_error(p_sql text, p_needle text)
@@ -190,6 +190,51 @@ SELECT pg_temp.expect_error($sql$
   WHERE id = '88b20000-0000-0000-0000-000000000001'
 $sql$, 'VOUCHER_DERIVED_PAYMENT_FIELDS_WRITE_FORBIDDEN');
 
+-- Payment-derived supplier status is protected in both directions. Prepare the
+-- otherwise-unused invoice 0002 as the migration owner, then prove service_role
+-- cannot hide a paid/partially-paid state while leaving paid_amount untouched.
+RESET ROLE;
+UPDATE public.supplier_invoices
+SET status = 'paid'
+WHERE id = '88b20000-0000-0000-0000-000000000002';
+SET LOCAL ROLE service_role;
+
+SELECT pg_temp.expect_error($sql$
+  UPDATE public.supplier_invoices
+  SET status = 'approved'
+  WHERE id = '88b20000-0000-0000-0000-000000000002'
+$sql$, 'VOUCHER_DERIVED_PAYMENT_FIELDS_WRITE_FORBIDDEN');
+
+DO $
+BEGIN
+  IF (SELECT status FROM public.supplier_invoices
+      WHERE id = '88b20000-0000-0000-0000-000000000002') IS DISTINCT FROM 'paid' THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: rejected paid status drift changed the invoice';
+  END IF;
+END;
+$;
+
+RESET ROLE;
+UPDATE public.supplier_invoices
+SET status = 'partially_paid'
+WHERE id = '88b20000-0000-0000-0000-000000000002';
+SET LOCAL ROLE service_role;
+
+SELECT pg_temp.expect_error($sql$
+  UPDATE public.supplier_invoices
+  SET status = 'approved'
+  WHERE id = '88b20000-0000-0000-0000-000000000002'
+$sql$, 'VOUCHER_DERIVED_PAYMENT_FIELDS_WRITE_FORBIDDEN');
+
+DO $
+BEGIN
+  IF (SELECT status FROM public.supplier_invoices
+      WHERE id = '88b20000-0000-0000-0000-000000000002') IS DISTINCT FROM 'partially_paid' THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: rejected partially-paid status drift changed the invoice';
+  END IF;
+END;
+$;
+
 -- Normalize the 168 fixture to the start of the approval workflow, then prove
 -- the real forward path. These writes do not mutate payment state and must
 -- remain legal. Matching uses match_status and must likewise remain untouched.
@@ -209,6 +254,34 @@ SELECT set_config('wardah.voucher_header_write', 'off', true);
 SELECT set_config('wardah.voucher_lines_write', 'off', true);
 SELECT set_config('wardah.voucher_invoice_payment_write', 'off', true);
 
+RESET ROLE;
+
+-- A failing internal RPC must not leave any trusted write capability enabled
+-- for subsequent statements in the same outer transaction.
+SET LOCAL ROLE authenticated;
+DO $
+DECLARE
+  v_failed boolean := false;
+BEGIN
+  BEGIN
+    PERFORM public.rpc_update_customer_receipt_draft(
+      '00000000-0000-0000-0000-000000000169', '{}'::jsonb
+    );
+  EXCEPTION WHEN OTHERS THEN
+    v_failed := true;
+  END;
+
+  IF NOT v_failed THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: failed-RPC fixture unexpectedly succeeded';
+  END IF;
+
+  IF coalesce(current_setting('wardah.voucher_header_write', true), 'off') <> 'off'
+     OR coalesce(current_setting('wardah.voucher_lines_write', true), 'off') <> 'off'
+     OR coalesce(current_setting('wardah.voucher_invoice_payment_write', true), 'off') <> 'off' THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL: failed RPC leaked voucher write context';
+  END IF;
+END;
+$;
 RESET ROLE;
 
 -- 4. All ten RPC grants remain exactly available to authenticated and denied

--- a/scripts/ci/fresh-db/acceptance_169_voucher_write_closure.sql
+++ b/scripts/ci/fresh-db/acceptance_169_voucher_write_closure.sql
@@ -1,0 +1,245 @@
+-- RED acceptance contract for Migration 169 (review revision 1.3).
+--
+-- This file is intentionally red against the 168 baseline. It must be run only
+-- after the 168 lifecycle acceptance has committed its fixtures. Migration 169
+-- turns it green without changing the expectations below.
+\set ON_ERROR_STOP on
+
+CREATE OR REPLACE FUNCTION pg_temp.expect_error(p_sql text, p_needle text)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_succeeded boolean := false;
+BEGIN
+  BEGIN
+    EXECUTE p_sql;
+    v_succeeded := true;
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM NOT LIKE '%' || p_needle || '%' THEN
+      RAISE EXCEPTION
+        'ACCEPTANCE_FAIL: expected [%] for [%], got [%]',
+        p_needle, p_sql, SQLERRM;
+    END IF;
+  END;
+
+  IF v_succeeded THEN
+    RAISE EXCEPTION
+      'ACCEPTANCE_FAIL: expected error [%] for [%], but it succeeded',
+      p_needle, p_sql;
+  END IF;
+END;
+$$;
+
+BEGIN;
+
+-- 1. Catalog closure: authenticated keeps SELECT, loses every direct write,
+-- and the four temporary INSERT policies cease to exist.
+DO $$
+DECLARE
+  v_table text;
+  v_policy text;
+BEGIN
+  FOREACH v_table IN ARRAY ARRAY[
+    'customer_collections', 'customer_collection_lines',
+    'supplier_payments', 'supplier_payment_lines'
+  ] LOOP
+    IF has_table_privilege('authenticated', 'public.' || v_table, 'INSERT')
+       OR has_table_privilege('authenticated', 'public.' || v_table, 'UPDATE')
+       OR has_table_privilege('authenticated', 'public.' || v_table, 'DELETE') THEN
+      RAISE EXCEPTION 'ACCEPTANCE_FAIL: authenticated retains direct write on %', v_table;
+    END IF;
+    IF NOT has_table_privilege('authenticated', 'public.' || v_table, 'SELECT') THEN
+      RAISE EXCEPTION 'ACCEPTANCE_FAIL: authenticated lost required SELECT on %', v_table;
+    END IF;
+  END LOOP;
+
+  FOREACH v_policy IN ARRAY ARRAY[
+    'customer_collections_org_insert_draft',
+    'supplier_payments_org_insert_draft',
+    'customer_collection_lines_org_insert_new_draft',
+    'supplier_payment_lines_org_insert_new_draft'
+  ] LOOP
+    IF EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND policyname=v_policy) THEN
+      RAISE EXCEPTION 'ACCEPTANCE_FAIL: obsolete policy remains: %', v_policy;
+    END IF;
+  END LOOP;
+END;
+$$;
+
+-- 2. The ordinary client cannot reconstruct either voucher path directly.
+SELECT set_config('request.jwt.claim.sub',
+                  '88aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', false);
+SELECT set_config('request.jwt.claims',
+                  '{"org_id":"88111111-1111-1111-1111-111111111111"}', false);
+SET LOCAL ROLE authenticated;
+
+SELECT pg_temp.expect_error($sql$
+  INSERT INTO public.customer_collections
+    (org_id, collection_number, customer_id, collection_date, amount,
+     payment_method, payment_account_id, status, created_by)
+  VALUES
+    ('88111111-1111-1111-1111-111111111111', 'CR-169-DIRECT',
+     '88d00000-0000-0000-0000-000000000001', DATE '2026-08-10', 1,
+     'cash', '88a10000-0000-0000-0000-000000000001', 'draft',
+     '88aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+$sql$, 'permission denied');
+
+SELECT pg_temp.expect_error($sql$
+  INSERT INTO public.supplier_payments
+    (org_id, payment_number, vendor_id, payment_date, amount,
+     payment_method, payment_account_id, status, created_by)
+  VALUES
+    ('88111111-1111-1111-1111-111111111111', 'SP-169-DIRECT',
+     '88e00000-0000-0000-0000-000000000001', DATE '2026-08-10', 1,
+     'cash', '88a10000-0000-0000-0000-000000000001', 'draft',
+     '88aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+$sql$, 'permission denied');
+
+RESET ROLE;
+
+-- 3. RLS-bypassing application authority still cannot mutate derived invoice
+-- payment state directly. The guard error is a stable machine contract.
+SET LOCAL ROLE service_role;
+
+-- A capability GUC is deliberately client-settable. The guards must also
+-- verify the trusted SECURITY DEFINER owner, so spoofing every capability as
+-- service_role cannot authorize any protected write.
+SELECT set_config('wardah.voucher_header_write', 'on', true);
+SELECT set_config('wardah.voucher_lines_write', 'on', true);
+SELECT set_config('wardah.voucher_invoice_payment_write', 'on', true);
+
+-- Resolve real voucher headers committed by acceptance 168. Missing fixtures
+-- are a setup failure, never a valid red proof for the allocation guards.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM public.customer_collections
+    WHERE org_id = '88111111-1111-1111-1111-111111111111'
+      AND customer_id = '88d00000-0000-0000-0000-000000000001'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM public.supplier_payments
+    WHERE org_id = '88111111-1111-1111-1111-111111111111'
+      AND vendor_id = '88e00000-0000-0000-0000-000000000001'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM public.sales_invoices
+    WHERE id = '88b10000-0000-0000-0000-000000000002'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM public.supplier_invoices
+    WHERE id = '88b20000-0000-0000-0000-000000000002'
+  ) THEN
+    RAISE EXCEPTION
+      'ACCEPTANCE_FIXTURE_MISSING: acceptance 168 voucher headers are required';
+  END IF;
+END;
+$$;
+
+SELECT pg_temp.expect_error($sql$
+  INSERT INTO public.customer_collections
+    (org_id, collection_number, customer_id, collection_date, amount,
+     payment_method, payment_account_id, status, created_by)
+  VALUES
+    ('88111111-1111-1111-1111-111111111111', 'CR-169-SERVICE-BYPASS',
+     '88d00000-0000-0000-0000-000000000001', DATE '2026-08-10', 1,
+     'cash', '88a10000-0000-0000-0000-000000000001', 'draft',
+     '88aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+$sql$, 'VOUCHER_HEADER_WRITE_FORBIDDEN');
+
+SELECT pg_temp.expect_error($sql$
+  INSERT INTO public.supplier_payments
+    (org_id, payment_number, vendor_id, payment_date, amount,
+     payment_method, payment_account_id, status, created_by)
+  VALUES
+    ('88111111-1111-1111-1111-111111111111', 'SP-169-SERVICE-BYPASS',
+     '88e00000-0000-0000-0000-000000000001', DATE '2026-08-10', 1,
+     'cash', '88a10000-0000-0000-0000-000000000001', 'draft',
+     '88aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+$sql$, 'VOUCHER_HEADER_WRITE_FORBIDDEN');
+
+SELECT pg_temp.expect_error($sql$
+  INSERT INTO public.customer_collection_lines
+    (collection_id, invoice_id, allocated_amount)
+  VALUES
+    ((SELECT id FROM public.customer_collections
+      WHERE org_id = '88111111-1111-1111-1111-111111111111'
+        AND customer_id = '88d00000-0000-0000-0000-000000000001'
+      ORDER BY id LIMIT 1),
+     '88b10000-0000-0000-0000-000000000002', 1)
+$sql$, 'VOUCHER_ALLOCATION_DIRECT_MUTATION_FORBIDDEN');
+
+SELECT pg_temp.expect_error($sql$
+  INSERT INTO public.supplier_payment_lines
+    (payment_id, invoice_id, allocated_amount)
+  VALUES
+    ((SELECT id FROM public.supplier_payments
+      WHERE org_id = '88111111-1111-1111-1111-111111111111'
+        AND vendor_id = '88e00000-0000-0000-0000-000000000001'
+      ORDER BY id LIMIT 1),
+     '88b20000-0000-0000-0000-000000000002', 1)
+$sql$, 'VOUCHER_ALLOCATION_DIRECT_MUTATION_FORBIDDEN');
+
+SELECT pg_temp.expect_error($sql$
+  UPDATE public.sales_invoices
+  SET paid_amount = paid_amount + 1, payment_status = 'partially_paid'
+  WHERE id = '88b10000-0000-0000-0000-000000000001'
+$sql$, 'VOUCHER_DERIVED_PAYMENT_FIELDS_WRITE_FORBIDDEN');
+
+SELECT pg_temp.expect_error($sql$
+  UPDATE public.supplier_invoices
+  SET paid_amount = paid_amount + 1, status = 'partially_paid'
+  WHERE id = '88b20000-0000-0000-0000-000000000001'
+$sql$, 'VOUCHER_DERIVED_PAYMENT_FIELDS_WRITE_FORBIDDEN');
+
+-- Normalize the 168 fixture to the start of the approval workflow, then prove
+-- the real forward path. These writes do not mutate payment state and must
+-- remain legal. Matching uses match_status and must likewise remain untouched.
+UPDATE public.supplier_invoices
+SET status = 'draft', match_status = NULL
+WHERE id = '88b20000-0000-0000-0000-000000000001';
+
+UPDATE public.supplier_invoices
+SET status = 'submitted'
+WHERE id = '88b20000-0000-0000-0000-000000000001';
+
+UPDATE public.supplier_invoices
+SET status = 'approved', match_status = 'matched'
+WHERE id = '88b20000-0000-0000-0000-000000000001';
+
+SELECT set_config('wardah.voucher_header_write', 'off', true);
+SELECT set_config('wardah.voucher_lines_write', 'off', true);
+SELECT set_config('wardah.voucher_invoice_payment_write', 'off', true);
+
+RESET ROLE;
+
+-- 4. All ten RPC grants remain exactly available to authenticated and denied
+-- to anon/service_role. Existing 166/168 behavioral suites prove execution.
+DO $$
+DECLARE
+  v_signature text;
+BEGIN
+  FOREACH v_signature IN ARRAY ARRAY[
+    'public.rpc_create_customer_receipt(jsonb)',
+    'public.rpc_create_supplier_payment(jsonb)',
+    'public.rpc_update_customer_receipt_draft(uuid,jsonb)',
+    'public.rpc_update_supplier_payment_draft(uuid,jsonb)',
+    'public.rpc_cancel_customer_receipt(uuid,text)',
+    'public.rpc_cancel_supplier_payment(uuid,text)',
+    'public.rpc_post_customer_receipt(uuid)',
+    'public.rpc_post_supplier_payment(uuid)',
+    'public.rpc_reset_customer_receipt_to_draft(uuid,text)',
+    'public.rpc_reset_supplier_payment_to_draft(uuid,text)'
+  ] LOOP
+    IF NOT has_function_privilege('authenticated', v_signature, 'EXECUTE') THEN
+      RAISE EXCEPTION 'ACCEPTANCE_FAIL: authenticated lost EXECUTE on %', v_signature;
+    END IF;
+    IF has_function_privilege('anon', v_signature, 'EXECUTE')
+       OR has_function_privilege('service_role', v_signature, 'EXECUTE') THEN
+      RAISE EXCEPTION 'ACCEPTANCE_FAIL: forbidden role can EXECUTE %', v_signature;
+    END IF;
+  END LOOP;
+END;
+$$;
+
+ROLLBACK;
+
+SELECT 'VOUCHER_WRITE_CLOSURE_169_ACCEPTANCE_PASS';

--- a/sql/migrations/169_voucher_write_closure.sql
+++ b/sql/migrations/169_voucher_write_closure.sql
@@ -1,0 +1,373 @@
+-- =====================================================================
+-- 169_voucher_write_closure
+-- =====================================================================
+-- Withdraw the temporary browser write surface left open while the voucher
+-- UI moved to the atomic lifecycle RPCs.  Protected writes now require both
+-- a transaction-local capability and the trusted SECURITY DEFINER owner.
+-- A client-set GUC alone is never authority.
+-- =====================================================================
+
+BEGIN;
+
+SET LOCAL lock_timeout = '30s';
+SET LOCAL statement_timeout = '5min';
+
+LOCK TABLE public.customer_collections,
+           public.customer_collection_lines,
+           public.supplier_payments,
+           public.supplier_payment_lines,
+           public.sales_invoices,
+           public.supplier_invoices
+IN SHARE ROW EXCLUSIVE MODE;
+
+DO $preflight$
+DECLARE
+  v_signature text;
+BEGIN
+  FOREACH v_signature IN ARRAY ARRAY[
+    'public.rpc_create_customer_receipt(jsonb)',
+    'public.rpc_create_supplier_payment(jsonb)',
+    'public.rpc_update_customer_receipt_draft(uuid,jsonb)',
+    'public.rpc_update_supplier_payment_draft(uuid,jsonb)',
+    'public.rpc_cancel_customer_receipt(uuid,text)',
+    'public.rpc_cancel_supplier_payment(uuid,text)',
+    'public.rpc_post_customer_receipt(uuid)',
+    'public.rpc_post_supplier_payment(uuid)',
+    'public.rpc_reset_customer_receipt_to_draft(uuid,text)',
+    'public.rpc_reset_supplier_payment_to_draft(uuid,text)'
+  ] LOOP
+    IF to_regprocedure(v_signature) IS NULL THEN
+      RAISE EXCEPTION 'VOUCHER_169_REQUIRED_RPC_MISSING: %', v_signature;
+    END IF;
+  END LOOP;
+
+  IF to_regprocedure('public.wardah_protect_voucher_allocation_lines()') IS NULL THEN
+    RAISE EXCEPTION 'VOUCHER_169_ALLOCATION_GUARD_MISSING';
+  END IF;
+END
+$preflight$;
+
+-- Keep the original implementations private.  Stable public wrappers below
+-- establish the dual-factor write context and preserve every RPC signature.
+ALTER FUNCTION public.rpc_create_customer_receipt(jsonb)
+  RENAME TO wardah_169_internal_create_customer_receipt;
+ALTER FUNCTION public.rpc_create_supplier_payment(jsonb)
+  RENAME TO wardah_169_internal_create_supplier_payment;
+ALTER FUNCTION public.rpc_update_customer_receipt_draft(uuid,jsonb)
+  RENAME TO wardah_169_internal_update_customer_receipt_draft;
+ALTER FUNCTION public.rpc_update_supplier_payment_draft(uuid,jsonb)
+  RENAME TO wardah_169_internal_update_supplier_payment_draft;
+ALTER FUNCTION public.rpc_cancel_customer_receipt(uuid,text)
+  RENAME TO wardah_169_internal_cancel_customer_receipt;
+ALTER FUNCTION public.rpc_cancel_supplier_payment(uuid,text)
+  RENAME TO wardah_169_internal_cancel_supplier_payment;
+ALTER FUNCTION public.rpc_post_customer_receipt(uuid)
+  RENAME TO wardah_169_internal_post_customer_receipt;
+ALTER FUNCTION public.rpc_post_supplier_payment(uuid)
+  RENAME TO wardah_169_internal_post_supplier_payment;
+ALTER FUNCTION public.rpc_reset_customer_receipt_to_draft(uuid,text)
+  RENAME TO wardah_169_internal_reset_customer_receipt_to_draft;
+ALTER FUNCTION public.rpc_reset_supplier_payment_to_draft(uuid,text)
+  RENAME TO wardah_169_internal_reset_supplier_payment_to_draft;
+
+REVOKE ALL ON FUNCTION public.wardah_169_internal_create_customer_receipt(jsonb) FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.wardah_169_internal_create_supplier_payment(jsonb) FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.wardah_169_internal_update_customer_receipt_draft(uuid,jsonb) FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.wardah_169_internal_update_supplier_payment_draft(uuid,jsonb) FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.wardah_169_internal_cancel_customer_receipt(uuid,text) FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.wardah_169_internal_cancel_supplier_payment(uuid,text) FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.wardah_169_internal_post_customer_receipt(uuid) FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.wardah_169_internal_post_supplier_payment(uuid) FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.wardah_169_internal_reset_customer_receipt_to_draft(uuid,text) FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.wardah_169_internal_reset_supplier_payment_to_draft(uuid,text) FROM PUBLIC, anon, authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION public.wardah_voucher_write_is_trusted(p_capability text)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SET search_path = pg_catalog
+AS $function$
+  SELECT current_user = pg_get_userbyid(
+       (SELECT p.proowner
+        FROM pg_proc p
+        WHERE p.oid = 'public.wardah_voucher_write_is_trusted(text)'::regprocedure)
+     )
+     AND (
+       coalesce(current_setting(p_capability, true), '') = 'on'
+       OR session_user = current_user
+     );
+$function$;
+
+REVOKE ALL ON FUNCTION public.wardah_voucher_write_is_trusted(text) FROM PUBLIC, anon, authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION public.wardah_169_enter_write_context()
+RETURNS void
+LANGUAGE plpgsql
+SET search_path = pg_catalog
+AS $function$
+BEGIN
+  PERFORM set_config('wardah.voucher_header_write', 'on', true);
+  PERFORM set_config('wardah.voucher_lines_write', 'on', true);
+  PERFORM set_config('wardah.voucher_invoice_payment_write', 'on', true);
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION public.wardah_169_leave_write_context()
+RETURNS void
+LANGUAGE plpgsql
+SET search_path = pg_catalog
+AS $function$
+BEGIN
+  PERFORM set_config('wardah.voucher_header_write', 'off', true);
+  PERFORM set_config('wardah.voucher_lines_write', 'off', true);
+  PERFORM set_config('wardah.voucher_invoice_payment_write', 'off', true);
+END
+$function$;
+
+REVOKE ALL ON FUNCTION public.wardah_169_enter_write_context() FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.wardah_169_leave_write_context() FROM PUBLIC, anon, authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION public.rpc_create_customer_receipt(p_payload jsonb)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp AS $function$
+DECLARE v_result jsonb;
+BEGIN
+  PERFORM public.wardah_169_enter_write_context();
+  v_result := public.wardah_169_internal_create_customer_receipt(p_payload);
+  PERFORM public.wardah_169_leave_write_context();
+  RETURN v_result;
+END $function$;
+
+CREATE OR REPLACE FUNCTION public.rpc_create_supplier_payment(p_payload jsonb)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp AS $function$
+DECLARE v_result jsonb;
+BEGIN
+  PERFORM public.wardah_169_enter_write_context();
+  v_result := public.wardah_169_internal_create_supplier_payment(p_payload);
+  PERFORM public.wardah_169_leave_write_context();
+  RETURN v_result;
+END $function$;
+
+CREATE OR REPLACE FUNCTION public.rpc_update_customer_receipt_draft(p_receipt_id uuid, p_payload jsonb)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp AS $function$
+DECLARE v_result jsonb;
+BEGIN
+  PERFORM public.wardah_169_enter_write_context();
+  v_result := public.wardah_169_internal_update_customer_receipt_draft(p_receipt_id, p_payload);
+  PERFORM public.wardah_169_leave_write_context();
+  RETURN v_result;
+END $function$;
+
+CREATE OR REPLACE FUNCTION public.rpc_update_supplier_payment_draft(p_payment_id uuid, p_payload jsonb)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp AS $function$
+DECLARE v_result jsonb;
+BEGIN
+  PERFORM public.wardah_169_enter_write_context();
+  v_result := public.wardah_169_internal_update_supplier_payment_draft(p_payment_id, p_payload);
+  PERFORM public.wardah_169_leave_write_context();
+  RETURN v_result;
+END $function$;
+
+CREATE OR REPLACE FUNCTION public.rpc_cancel_customer_receipt(p_receipt_id uuid, p_reason text)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp AS $function$
+DECLARE v_result jsonb;
+BEGIN
+  PERFORM public.wardah_169_enter_write_context();
+  v_result := public.wardah_169_internal_cancel_customer_receipt(p_receipt_id, p_reason);
+  PERFORM public.wardah_169_leave_write_context();
+  RETURN v_result;
+END $function$;
+
+CREATE OR REPLACE FUNCTION public.rpc_cancel_supplier_payment(p_payment_id uuid, p_reason text)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp AS $function$
+DECLARE v_result jsonb;
+BEGIN
+  PERFORM public.wardah_169_enter_write_context();
+  v_result := public.wardah_169_internal_cancel_supplier_payment(p_payment_id, p_reason);
+  PERFORM public.wardah_169_leave_write_context();
+  RETURN v_result;
+END $function$;
+
+CREATE OR REPLACE FUNCTION public.rpc_post_customer_receipt(p_receipt_id uuid)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp AS $function$
+DECLARE v_result jsonb;
+BEGIN
+  PERFORM public.wardah_169_enter_write_context();
+  v_result := public.wardah_169_internal_post_customer_receipt(p_receipt_id);
+  PERFORM public.wardah_169_leave_write_context();
+  RETURN v_result;
+END $function$;
+
+CREATE OR REPLACE FUNCTION public.rpc_post_supplier_payment(p_payment_id uuid)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp AS $function$
+DECLARE v_result jsonb;
+BEGIN
+  PERFORM public.wardah_169_enter_write_context();
+  v_result := public.wardah_169_internal_post_supplier_payment(p_payment_id);
+  PERFORM public.wardah_169_leave_write_context();
+  RETURN v_result;
+END $function$;
+
+CREATE OR REPLACE FUNCTION public.rpc_reset_customer_receipt_to_draft(p_receipt_id uuid, p_reason text)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp AS $function$
+DECLARE v_result jsonb;
+BEGIN
+  PERFORM public.wardah_169_enter_write_context();
+  v_result := public.wardah_169_internal_reset_customer_receipt_to_draft(p_receipt_id, p_reason);
+  PERFORM public.wardah_169_leave_write_context();
+  RETURN v_result;
+END $function$;
+
+CREATE OR REPLACE FUNCTION public.rpc_reset_supplier_payment_to_draft(p_payment_id uuid, p_reason text)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp AS $function$
+DECLARE v_result jsonb;
+BEGIN
+  PERFORM public.wardah_169_enter_write_context();
+  v_result := public.wardah_169_internal_reset_supplier_payment_to_draft(p_payment_id, p_reason);
+  PERFORM public.wardah_169_leave_write_context();
+  RETURN v_result;
+END $function$;
+
+-- Header and allocation ownership are now RPC-only, including for
+-- service_role.  The trigger is defense in depth beyond table grants/RLS.
+CREATE OR REPLACE FUNCTION public.wardah_protect_voucher_headers()
+RETURNS trigger LANGUAGE plpgsql SET search_path = public, pg_temp AS $function$
+BEGIN
+  IF NOT public.wardah_voucher_write_is_trusted('wardah.voucher_header_write') THEN
+    RAISE EXCEPTION 'VOUCHER_HEADER_WRITE_FORBIDDEN: operation=% table=%', TG_OP, TG_TABLE_NAME;
+  END IF;
+  RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
+END $function$;
+
+DROP TRIGGER IF EXISTS trg_protect_customer_collections ON public.customer_collections;
+CREATE TRIGGER trg_protect_customer_collections
+BEFORE INSERT OR UPDATE OR DELETE ON public.customer_collections
+FOR EACH ROW EXECUTE FUNCTION public.wardah_protect_voucher_headers();
+
+DROP TRIGGER IF EXISTS trg_protect_supplier_payments ON public.supplier_payments;
+CREATE TRIGGER trg_protect_supplier_payments
+BEFORE INSERT OR UPDATE OR DELETE ON public.supplier_payments
+FOR EACH ROW EXECUTE FUNCTION public.wardah_protect_voucher_headers();
+
+CREATE OR REPLACE FUNCTION public.wardah_protect_voucher_allocation_lines()
+RETURNS trigger LANGUAGE plpgsql SET search_path = public, pg_temp AS $function$
+BEGIN
+  IF NOT public.wardah_voucher_write_is_trusted('wardah.voucher_lines_write') THEN
+    RAISE EXCEPTION 'VOUCHER_ALLOCATION_DIRECT_MUTATION_FORBIDDEN: operation=% table=%',
+      TG_OP, TG_TABLE_NAME;
+  END IF;
+  RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
+END $function$;
+
+CREATE OR REPLACE FUNCTION public.wardah_protect_invoice_payment_fields()
+RETURNS trigger LANGUAGE plpgsql SET search_path = public, pg_temp AS $function$
+DECLARE v_payment_change boolean;
+BEGIN
+  IF TG_TABLE_NAME = 'sales_invoices' THEN
+    v_payment_change := NEW.paid_amount IS DISTINCT FROM OLD.paid_amount
+      OR NEW.payment_status IS DISTINCT FROM OLD.payment_status;
+  ELSE
+    v_payment_change := NEW.paid_amount IS DISTINCT FROM OLD.paid_amount
+      OR (NEW.status IS DISTINCT FROM OLD.status AND NEW.status IN ('partially_paid', 'paid'));
+  END IF;
+
+  IF v_payment_change
+     AND NOT public.wardah_voucher_write_is_trusted('wardah.voucher_invoice_payment_write') THEN
+    RAISE EXCEPTION 'VOUCHER_DERIVED_PAYMENT_FIELDS_WRITE_FORBIDDEN: table=%', TG_TABLE_NAME;
+  END IF;
+  RETURN NEW;
+END $function$;
+
+DROP TRIGGER IF EXISTS trg_protect_sales_invoice_payment_fields ON public.sales_invoices;
+CREATE TRIGGER trg_protect_sales_invoice_payment_fields
+BEFORE UPDATE ON public.sales_invoices
+FOR EACH ROW EXECUTE FUNCTION public.wardah_protect_invoice_payment_fields();
+
+DROP TRIGGER IF EXISTS trg_protect_supplier_invoice_payment_fields ON public.supplier_invoices;
+CREATE TRIGGER trg_protect_supplier_invoice_payment_fields
+BEFORE UPDATE ON public.supplier_invoices
+FOR EACH ROW EXECUTE FUNCTION public.wardah_protect_invoice_payment_fields();
+
+DROP POLICY IF EXISTS customer_collections_org_insert_draft ON public.customer_collections;
+DROP POLICY IF EXISTS supplier_payments_org_insert_draft ON public.supplier_payments;
+DROP POLICY IF EXISTS customer_collection_lines_org_insert_new_draft ON public.customer_collection_lines;
+DROP POLICY IF EXISTS supplier_payment_lines_org_insert_new_draft ON public.supplier_payment_lines;
+
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.customer_collections FROM authenticated;
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.customer_collection_lines FROM authenticated;
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.supplier_payments FROM authenticated;
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.supplier_payment_lines FROM authenticated;
+
+GRANT SELECT ON TABLE public.customer_collections, public.customer_collection_lines,
+  public.supplier_payments, public.supplier_payment_lines TO authenticated;
+
+DO $grants$
+DECLARE v_signature text;
+BEGIN
+  FOREACH v_signature IN ARRAY ARRAY[
+    'public.rpc_create_customer_receipt(jsonb)',
+    'public.rpc_create_supplier_payment(jsonb)',
+    'public.rpc_update_customer_receipt_draft(uuid,jsonb)',
+    'public.rpc_update_supplier_payment_draft(uuid,jsonb)',
+    'public.rpc_cancel_customer_receipt(uuid,text)',
+    'public.rpc_cancel_supplier_payment(uuid,text)',
+    'public.rpc_post_customer_receipt(uuid)',
+    'public.rpc_post_supplier_payment(uuid)',
+    'public.rpc_reset_customer_receipt_to_draft(uuid,text)',
+    'public.rpc_reset_supplier_payment_to_draft(uuid,text)'
+  ] LOOP
+    EXECUTE format('REVOKE ALL ON FUNCTION %s FROM PUBLIC, anon, service_role', v_signature);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION %s TO authenticated', v_signature);
+  END LOOP;
+END
+$grants$;
+
+DO $verify$
+DECLARE
+  v_table text;
+  v_signature text;
+BEGIN
+  FOREACH v_table IN ARRAY ARRAY[
+    'customer_collections', 'customer_collection_lines',
+    'supplier_payments', 'supplier_payment_lines'
+  ] LOOP
+    IF has_table_privilege('authenticated', 'public.' || v_table, 'INSERT')
+       OR has_table_privilege('authenticated', 'public.' || v_table, 'UPDATE')
+       OR has_table_privilege('authenticated', 'public.' || v_table, 'DELETE')
+       OR NOT has_table_privilege('authenticated', 'public.' || v_table, 'SELECT') THEN
+      RAISE EXCEPTION 'VOUCHER_169_TABLE_GRANT_VERIFY_FAILED: %', v_table;
+    END IF;
+  END LOOP;
+
+  FOREACH v_signature IN ARRAY ARRAY[
+    'public.rpc_create_customer_receipt(jsonb)',
+    'public.rpc_create_supplier_payment(jsonb)',
+    'public.rpc_update_customer_receipt_draft(uuid,jsonb)',
+    'public.rpc_update_supplier_payment_draft(uuid,jsonb)',
+    'public.rpc_cancel_customer_receipt(uuid,text)',
+    'public.rpc_cancel_supplier_payment(uuid,text)',
+    'public.rpc_post_customer_receipt(uuid)',
+    'public.rpc_post_supplier_payment(uuid)',
+    'public.rpc_reset_customer_receipt_to_draft(uuid,text)',
+    'public.rpc_reset_supplier_payment_to_draft(uuid,text)'
+  ] LOOP
+    IF NOT has_function_privilege('authenticated', v_signature, 'EXECUTE')
+       OR has_function_privilege('anon', v_signature, 'EXECUTE')
+       OR has_function_privilege('service_role', v_signature, 'EXECUTE') THEN
+      RAISE EXCEPTION 'VOUCHER_169_RPC_GRANT_VERIFY_FAILED: %', v_signature;
+    END IF;
+  END LOOP;
+
+  IF (SELECT count(*) FROM pg_trigger
+      WHERE tgname IN ('trg_protect_customer_collections',
+                       'trg_protect_supplier_payments',
+                       'trg_protect_customer_collection_lines',
+                       'trg_protect_supplier_payment_lines',
+                       'trg_protect_sales_invoice_payment_fields',
+                       'trg_protect_supplier_invoice_payment_fields')
+        AND NOT tgisinternal) <> 6 THEN
+    RAISE EXCEPTION 'VOUCHER_169_TRIGGER_VERIFY_FAILED';
+  END IF;
+END
+$verify$;
+
+COMMIT;

--- a/sql/migrations/169_voucher_write_closure.sql
+++ b/sql/migrations/169_voucher_write_closure.sql
@@ -138,7 +138,12 @@ BEGIN
     RAISE EXCEPTION 'TENANT_MEMBERSHIP_REQUIRED';
   END IF;
   PERFORM public.wardah_169_enter_write_context();
-  v_result := public.wardah_169_internal_create_customer_receipt(p_payload);
+  BEGIN
+    v_result := public.wardah_169_internal_create_customer_receipt(p_payload);
+  EXCEPTION WHEN OTHERS THEN
+    PERFORM public.wardah_169_leave_write_context();
+    RAISE;
+  END;
   PERFORM public.wardah_169_leave_write_context();
   RETURN v_result;
 END $function$;
@@ -153,7 +158,12 @@ BEGIN
     RAISE EXCEPTION 'TENANT_MEMBERSHIP_REQUIRED';
   END IF;
   PERFORM public.wardah_169_enter_write_context();
-  v_result := public.wardah_169_internal_create_supplier_payment(p_payload);
+  BEGIN
+    v_result := public.wardah_169_internal_create_supplier_payment(p_payload);
+  EXCEPTION WHEN OTHERS THEN
+    PERFORM public.wardah_169_leave_write_context();
+    RAISE;
+  END;
   PERFORM public.wardah_169_leave_write_context();
   RETURN v_result;
 END $function$;
@@ -168,7 +178,12 @@ BEGIN
     RAISE EXCEPTION 'TENANT_MEMBERSHIP_REQUIRED';
   END IF;
   PERFORM public.wardah_169_enter_write_context();
-  v_result := public.wardah_169_internal_update_customer_receipt_draft(p_receipt_id, p_payload);
+  BEGIN
+    v_result := public.wardah_169_internal_update_customer_receipt_draft(p_receipt_id, p_payload);
+  EXCEPTION WHEN OTHERS THEN
+    PERFORM public.wardah_169_leave_write_context();
+    RAISE;
+  END;
   PERFORM public.wardah_169_leave_write_context();
   RETURN v_result;
 END $function$;
@@ -183,7 +198,12 @@ BEGIN
     RAISE EXCEPTION 'TENANT_MEMBERSHIP_REQUIRED';
   END IF;
   PERFORM public.wardah_169_enter_write_context();
-  v_result := public.wardah_169_internal_update_supplier_payment_draft(p_payment_id, p_payload);
+  BEGIN
+    v_result := public.wardah_169_internal_update_supplier_payment_draft(p_payment_id, p_payload);
+  EXCEPTION WHEN OTHERS THEN
+    PERFORM public.wardah_169_leave_write_context();
+    RAISE;
+  END;
   PERFORM public.wardah_169_leave_write_context();
   RETURN v_result;
 END $function$;
@@ -198,7 +218,12 @@ BEGIN
     RAISE EXCEPTION 'TENANT_MEMBERSHIP_REQUIRED';
   END IF;
   PERFORM public.wardah_169_enter_write_context();
-  v_result := public.wardah_169_internal_cancel_customer_receipt(p_receipt_id, p_reason);
+  BEGIN
+    v_result := public.wardah_169_internal_cancel_customer_receipt(p_receipt_id, p_reason);
+  EXCEPTION WHEN OTHERS THEN
+    PERFORM public.wardah_169_leave_write_context();
+    RAISE;
+  END;
   PERFORM public.wardah_169_leave_write_context();
   RETURN v_result;
 END $function$;
@@ -213,7 +238,12 @@ BEGIN
     RAISE EXCEPTION 'TENANT_MEMBERSHIP_REQUIRED';
   END IF;
   PERFORM public.wardah_169_enter_write_context();
-  v_result := public.wardah_169_internal_cancel_supplier_payment(p_payment_id, p_reason);
+  BEGIN
+    v_result := public.wardah_169_internal_cancel_supplier_payment(p_payment_id, p_reason);
+  EXCEPTION WHEN OTHERS THEN
+    PERFORM public.wardah_169_leave_write_context();
+    RAISE;
+  END;
   PERFORM public.wardah_169_leave_write_context();
   RETURN v_result;
 END $function$;
@@ -228,7 +258,12 @@ BEGIN
     RAISE EXCEPTION 'TENANT_MEMBERSHIP_REQUIRED';
   END IF;
   PERFORM public.wardah_169_enter_write_context();
-  v_result := public.wardah_169_internal_post_customer_receipt(p_receipt_id);
+  BEGIN
+    v_result := public.wardah_169_internal_post_customer_receipt(p_receipt_id);
+  EXCEPTION WHEN OTHERS THEN
+    PERFORM public.wardah_169_leave_write_context();
+    RAISE;
+  END;
   PERFORM public.wardah_169_leave_write_context();
   RETURN v_result;
 END $function$;
@@ -243,7 +278,12 @@ BEGIN
     RAISE EXCEPTION 'TENANT_MEMBERSHIP_REQUIRED';
   END IF;
   PERFORM public.wardah_169_enter_write_context();
-  v_result := public.wardah_169_internal_post_supplier_payment(p_payment_id);
+  BEGIN
+    v_result := public.wardah_169_internal_post_supplier_payment(p_payment_id);
+  EXCEPTION WHEN OTHERS THEN
+    PERFORM public.wardah_169_leave_write_context();
+    RAISE;
+  END;
   PERFORM public.wardah_169_leave_write_context();
   RETURN v_result;
 END $function$;
@@ -258,7 +298,12 @@ BEGIN
     RAISE EXCEPTION 'TENANT_MEMBERSHIP_REQUIRED';
   END IF;
   PERFORM public.wardah_169_enter_write_context();
-  v_result := public.wardah_169_internal_reset_customer_receipt_to_draft(p_receipt_id, p_reason);
+  BEGIN
+    v_result := public.wardah_169_internal_reset_customer_receipt_to_draft(p_receipt_id, p_reason);
+  EXCEPTION WHEN OTHERS THEN
+    PERFORM public.wardah_169_leave_write_context();
+    RAISE;
+  END;
   PERFORM public.wardah_169_leave_write_context();
   RETURN v_result;
 END $function$;
@@ -273,7 +318,12 @@ BEGIN
     RAISE EXCEPTION 'TENANT_MEMBERSHIP_REQUIRED';
   END IF;
   PERFORM public.wardah_169_enter_write_context();
-  v_result := public.wardah_169_internal_reset_supplier_payment_to_draft(p_payment_id, p_reason);
+  BEGIN
+    v_result := public.wardah_169_internal_reset_supplier_payment_to_draft(p_payment_id, p_reason);
+  EXCEPTION WHEN OTHERS THEN
+    PERFORM public.wardah_169_leave_write_context();
+    RAISE;
+  END;
   PERFORM public.wardah_169_leave_write_context();
   RETURN v_result;
 END $function$;
@@ -318,7 +368,13 @@ BEGIN
       OR NEW.payment_status IS DISTINCT FROM OLD.payment_status;
   ELSE
     v_payment_change := NEW.paid_amount IS DISTINCT FROM OLD.paid_amount
-      OR (NEW.status IS DISTINCT FROM OLD.status AND NEW.status IN ('partially_paid', 'paid'));
+      OR (
+        NEW.status IS DISTINCT FROM OLD.status
+        AND (
+          OLD.status IN ('partially_paid', 'paid')
+          OR NEW.status IN ('partially_paid', 'paid')
+        )
+      );
   END IF;
 
   IF v_payment_change

--- a/sql/migrations/169_voucher_write_closure.sql
+++ b/sql/migrations/169_voucher_write_closure.sql
@@ -99,6 +99,7 @@ AS $function$
 $function$;
 
 REVOKE ALL ON FUNCTION public.wardah_voucher_write_is_trusted(text) FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.wardah_voucher_write_is_trusted(text) TO service_role;
 
 CREATE OR REPLACE FUNCTION public.wardah_169_enter_write_context()
 RETURNS void
@@ -131,6 +132,11 @@ CREATE OR REPLACE FUNCTION public.rpc_create_customer_receipt(p_payload jsonb)
 RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp AS $function$
 DECLARE v_result jsonb;
 BEGIN
+  IF auth.uid() IS NULL THEN RAISE EXCEPTION 'AUTH_REQUIRED'; END IF;
+  IF public.get_current_tenant_id() IS NULL
+     OR NOT public.wardah_is_org_member(public.get_current_tenant_id()) THEN
+    RAISE EXCEPTION 'TENANT_MEMBERSHIP_REQUIRED';
+  END IF;
   PERFORM public.wardah_169_enter_write_context();
   v_result := public.wardah_169_internal_create_customer_receipt(p_payload);
   PERFORM public.wardah_169_leave_write_context();
@@ -141,6 +147,11 @@ CREATE OR REPLACE FUNCTION public.rpc_create_supplier_payment(p_payload jsonb)
 RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp AS $function$
 DECLARE v_result jsonb;
 BEGIN
+  IF auth.uid() IS NULL THEN RAISE EXCEPTION 'AUTH_REQUIRED'; END IF;
+  IF public.get_current_tenant_id() IS NULL
+     OR NOT public.wardah_is_org_member(public.get_current_tenant_id()) THEN
+    RAISE EXCEPTION 'TENANT_MEMBERSHIP_REQUIRED';
+  END IF;
   PERFORM public.wardah_169_enter_write_context();
   v_result := public.wardah_169_internal_create_supplier_payment(p_payload);
   PERFORM public.wardah_169_leave_write_context();
@@ -151,6 +162,11 @@ CREATE OR REPLACE FUNCTION public.rpc_update_customer_receipt_draft(p_receipt_id
 RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp AS $function$
 DECLARE v_result jsonb;
 BEGIN
+  IF auth.uid() IS NULL THEN RAISE EXCEPTION 'AUTH_REQUIRED'; END IF;
+  IF public.get_current_tenant_id() IS NULL
+     OR NOT public.wardah_is_org_member(public.get_current_tenant_id()) THEN
+    RAISE EXCEPTION 'TENANT_MEMBERSHIP_REQUIRED';
+  END IF;
   PERFORM public.wardah_169_enter_write_context();
   v_result := public.wardah_169_internal_update_customer_receipt_draft(p_receipt_id, p_payload);
   PERFORM public.wardah_169_leave_write_context();
@@ -161,6 +177,11 @@ CREATE OR REPLACE FUNCTION public.rpc_update_supplier_payment_draft(p_payment_id
 RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp AS $function$
 DECLARE v_result jsonb;
 BEGIN
+  IF auth.uid() IS NULL THEN RAISE EXCEPTION 'AUTH_REQUIRED'; END IF;
+  IF public.get_current_tenant_id() IS NULL
+     OR NOT public.wardah_is_org_member(public.get_current_tenant_id()) THEN
+    RAISE EXCEPTION 'TENANT_MEMBERSHIP_REQUIRED';
+  END IF;
   PERFORM public.wardah_169_enter_write_context();
   v_result := public.wardah_169_internal_update_supplier_payment_draft(p_payment_id, p_payload);
   PERFORM public.wardah_169_leave_write_context();
@@ -171,6 +192,11 @@ CREATE OR REPLACE FUNCTION public.rpc_cancel_customer_receipt(p_receipt_id uuid,
 RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp AS $function$
 DECLARE v_result jsonb;
 BEGIN
+  IF auth.uid() IS NULL THEN RAISE EXCEPTION 'AUTH_REQUIRED'; END IF;
+  IF public.get_current_tenant_id() IS NULL
+     OR NOT public.wardah_is_org_member(public.get_current_tenant_id()) THEN
+    RAISE EXCEPTION 'TENANT_MEMBERSHIP_REQUIRED';
+  END IF;
   PERFORM public.wardah_169_enter_write_context();
   v_result := public.wardah_169_internal_cancel_customer_receipt(p_receipt_id, p_reason);
   PERFORM public.wardah_169_leave_write_context();
@@ -181,6 +207,11 @@ CREATE OR REPLACE FUNCTION public.rpc_cancel_supplier_payment(p_payment_id uuid,
 RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp AS $function$
 DECLARE v_result jsonb;
 BEGIN
+  IF auth.uid() IS NULL THEN RAISE EXCEPTION 'AUTH_REQUIRED'; END IF;
+  IF public.get_current_tenant_id() IS NULL
+     OR NOT public.wardah_is_org_member(public.get_current_tenant_id()) THEN
+    RAISE EXCEPTION 'TENANT_MEMBERSHIP_REQUIRED';
+  END IF;
   PERFORM public.wardah_169_enter_write_context();
   v_result := public.wardah_169_internal_cancel_supplier_payment(p_payment_id, p_reason);
   PERFORM public.wardah_169_leave_write_context();
@@ -191,6 +222,11 @@ CREATE OR REPLACE FUNCTION public.rpc_post_customer_receipt(p_receipt_id uuid)
 RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp AS $function$
 DECLARE v_result jsonb;
 BEGIN
+  IF auth.uid() IS NULL THEN RAISE EXCEPTION 'AUTH_REQUIRED'; END IF;
+  IF public.get_current_tenant_id() IS NULL
+     OR NOT public.wardah_is_org_member(public.get_current_tenant_id()) THEN
+    RAISE EXCEPTION 'TENANT_MEMBERSHIP_REQUIRED';
+  END IF;
   PERFORM public.wardah_169_enter_write_context();
   v_result := public.wardah_169_internal_post_customer_receipt(p_receipt_id);
   PERFORM public.wardah_169_leave_write_context();
@@ -201,6 +237,11 @@ CREATE OR REPLACE FUNCTION public.rpc_post_supplier_payment(p_payment_id uuid)
 RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp AS $function$
 DECLARE v_result jsonb;
 BEGIN
+  IF auth.uid() IS NULL THEN RAISE EXCEPTION 'AUTH_REQUIRED'; END IF;
+  IF public.get_current_tenant_id() IS NULL
+     OR NOT public.wardah_is_org_member(public.get_current_tenant_id()) THEN
+    RAISE EXCEPTION 'TENANT_MEMBERSHIP_REQUIRED';
+  END IF;
   PERFORM public.wardah_169_enter_write_context();
   v_result := public.wardah_169_internal_post_supplier_payment(p_payment_id);
   PERFORM public.wardah_169_leave_write_context();
@@ -211,6 +252,11 @@ CREATE OR REPLACE FUNCTION public.rpc_reset_customer_receipt_to_draft(p_receipt_
 RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp AS $function$
 DECLARE v_result jsonb;
 BEGIN
+  IF auth.uid() IS NULL THEN RAISE EXCEPTION 'AUTH_REQUIRED'; END IF;
+  IF public.get_current_tenant_id() IS NULL
+     OR NOT public.wardah_is_org_member(public.get_current_tenant_id()) THEN
+    RAISE EXCEPTION 'TENANT_MEMBERSHIP_REQUIRED';
+  END IF;
   PERFORM public.wardah_169_enter_write_context();
   v_result := public.wardah_169_internal_reset_customer_receipt_to_draft(p_receipt_id, p_reason);
   PERFORM public.wardah_169_leave_write_context();
@@ -221,6 +267,11 @@ CREATE OR REPLACE FUNCTION public.rpc_reset_supplier_payment_to_draft(p_payment_
 RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp AS $function$
 DECLARE v_result jsonb;
 BEGIN
+  IF auth.uid() IS NULL THEN RAISE EXCEPTION 'AUTH_REQUIRED'; END IF;
+  IF public.get_current_tenant_id() IS NULL
+     OR NOT public.wardah_is_org_member(public.get_current_tenant_id()) THEN
+    RAISE EXCEPTION 'TENANT_MEMBERSHIP_REQUIRED';
+  END IF;
   PERFORM public.wardah_169_enter_write_context();
   v_result := public.wardah_169_internal_reset_supplier_payment_to_draft(p_payment_id, p_reason);
   PERFORM public.wardah_169_leave_write_context();

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -11537,6 +11537,48 @@ export type Database = {
           is_valid: boolean
         }[]
       }
+      wardah_169_enter_write_context: { Args: never; Returns: undefined }
+      wardah_169_internal_cancel_customer_receipt: {
+        Args: { p_reason: string; p_receipt_id: string }
+        Returns: Json
+      }
+      wardah_169_internal_cancel_supplier_payment: {
+        Args: { p_payment_id: string; p_reason: string }
+        Returns: Json
+      }
+      wardah_169_internal_create_customer_receipt: {
+        Args: { p_payload: Json }
+        Returns: Json
+      }
+      wardah_169_internal_create_supplier_payment: {
+        Args: { p_payload: Json }
+        Returns: Json
+      }
+      wardah_169_internal_post_customer_receipt: {
+        Args: { p_receipt_id: string }
+        Returns: Json
+      }
+      wardah_169_internal_post_supplier_payment: {
+        Args: { p_payment_id: string }
+        Returns: Json
+      }
+      wardah_169_internal_reset_customer_receipt_to_draft: {
+        Args: { p_reason: string; p_receipt_id: string }
+        Returns: Json
+      }
+      wardah_169_internal_reset_supplier_payment_to_draft: {
+        Args: { p_payment_id: string; p_reason: string }
+        Returns: Json
+      }
+      wardah_169_internal_update_customer_receipt_draft: {
+        Args: { p_payload: Json; p_receipt_id: string }
+        Returns: Json
+      }
+      wardah_169_internal_update_supplier_payment_draft: {
+        Args: { p_payload: Json; p_payment_id: string }
+        Returns: Json
+      }
+      wardah_169_leave_write_context: { Args: never; Returns: undefined }
       wardah_apply_stock_incoming: {
         Args: {
           p_org: string
@@ -11632,6 +11674,10 @@ export type Database = {
           p_uom: string
         }
         Returns: number
+      }
+      wardah_voucher_write_is_trusted: {
+        Args: { p_capability: string }
+        Returns: boolean
       }
     }
     Enums: {


### PR DESCRIPTION
## What changed

- adds Migration 169 to close direct voucher header/allocation writes
- protects supplier invoice payment-derived status transitions in both directions
- wraps all ten public voucher RPCs with explicit write-context restoration on success and error
- extends Acceptance 169 to cover `paid → approved`, `partially_paid → approved`, state preservation after rejection, and failed-RPC context cleanup
- retains the Fresh PostgreSQL 17 evidence workflow and the 168/AP 149/Financial GL 153 regression gates

## Root cause

The first implementation guarded transitions into `paid` and `partially_paid`, but not transitions out of them when `paid_amount` stayed unchanged. That allowed payment-state drift outside the legal voucher reset/cancel lifecycle. The wrappers also relied on transaction rollback to clear local capability flags after an internal error instead of restoring them explicitly.

## Validation gate

Keep this PR as draft and do not merge or apply Migration 169 to production until every required check is green on the same final head commit:

- Voucher Write Closure 169 Acceptance
- Acceptance 168 lifecycle baseline
- AP 149 Fresh DB
- Financial GL 153 Fresh DB
- Migration Governance
- CI/CD Pipeline
- SonarQube

The generated `src/types/database.generated.ts` commit remains bot-authored and is not part of the security logic.