### PR TITLE
docs(db): record migration 170 as applied to Production

### DIFF
--- a/docs/db/TENANT_ISOLATION_170_RUNBOOK.md
+++ b/docs/db/TENANT_ISOLATION_170_RUNBOOK.md
@@ -2,7 +2,9 @@
 
 **Migration:** `170_tenant_isolation_and_permission_hardening.sql`
 **Scope:** Fix a real cross-tenant RLS bypass, remove a default-organization fallback reachable by `anon`, and close a cross-user permission-disclosure path.
-**State:** Repository implementation, not yet applied to Production. Do not apply before the paired Fresh DB acceptance gate is green and this runbook's preflight/postflight queries have been reviewed.
+**State:** Applied to Production (`uutfztmqvajmsxnrqeiv`) on 2026-08-06, verified via the postflight queries below run directly against the live database. Ledger row: `170_tenant_isolation_and_permission_hardening`, version `20260806043140`.
+
+**Note on the gap between merge and apply:** this migration was merged to `main` in PR #98 well before it was actually applied to Production — the ledger had stalled at 169 with 170 sitting unapplied. Independent verification against the live database on 2026-08-06 confirmed all three original vulnerabilities were still fully live in Production for that entire window (self-referencing `physical_count_*` policies, `anon` holding SELECT+INSERT on the three manufacturing tables via the default-org fallback, `has_permission` with no caller-identity guard). A migration landing on `main` closes the gap in the repository, not in Production — the apply step is not optional follow-up, it is the fix. Do not treat a merged migration as resolved until this section (or the ledger itself) says otherwise.
 
 ## 1. Purpose
 


### PR DESCRIPTION
## Summary

Migration 170 was merged in #98 but sat unapplied on Production — the ledger had stalled at 169. Independent verification against `uutfztmqvajmsxnrqeiv` on 2026-08-06 confirmed all three original vulnerabilities were still fully live (self-referencing `physical_count_*` policies, `anon` holding SELECT+INSERT on the three manufacturing tables, `has_permission` with no caller-identity guard). Applied the exact file from `main` via `apply_migration` and re-verified against the live database:

- All 8 `physical_count_*` policies rewritten with `user_organizations.org_id` + `is_active` guard
- `anon`: `sel=false, ins=false` on all 3 manufacturing tables
- `get_effective_org_id()`: `delegates_correctly=true, no_dead_guc=true`
- `has_permission()`: `has_guard=true`
- Ledger: exactly one row, `170_tenant_isolation_and_permission_hardening` / `20260806043140`

This PR only updates the runbook to record that state — no schema change (already applied directly, per the standard runbook process).

## Test plan

- [x] Verification queries run directly against Production, results pasted above

---
_Generated by [Claude Code](https://claude.ai/code/session_018cutU8CHzP246sWciqbGNT)_