### PR TITLE
fix(reports-insights): exclude SPA fallback, verify content identity, correct the ACAO contract

### DIFF
--- a/.github/workflows/reports-insights-isolation-e2e.yml
+++ b/.github/workflows/reports-insights-isolation-e2e.yml
@@ -58,121 +58,26 @@ jobs:
           path: playwright-report/
           retention-days: 14
 
-  # TEMPORARY (remove once this PR is merged): runs the same isolation
-  # suite against this PR's own real Vercel Preview deployment, using
-  # Vercel's "Protection Bypass for Automation" header. This exists as a
-  # pull_request job — not the permanent workflow_dispatch job in
-  # reports-insights-vercel-preview-check.yml — specifically because a
-  # workflow_dispatch-triggered workflow cannot be dispatched via the
-  # API/UI until its file exists on the default branch; a pull_request
-  # trigger, uniquely, is evaluated from the PR branch's own version of
-  # the workflow file even before merge, which is what makes it possible
-  # to run this check pre-merge at all. Once main has the permanent job,
-  # this one has no further reason to exist.
-  #
-  # Runs only for same-repo PRs (a fork PR's pull_request run never has
-  # access to repository secrets regardless, per GitHub Actions' own
-  # default; the explicit check below just makes that scoping visible
-  # rather than relying on it silently).
-  vercel-preview-check:
-    name: Playwright — real Vercel Preview (Protection Bypass)
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.repository
-
-    steps:
-      # Explicit head SHA, not the default merge ref: the content-identity
-      # assertions in the isolation suite (dashboard.html/dashboard.js/
-      # vendor/tailwind.css/the webfont) compare the real Preview's response
-      # bytes against the checked-out files on disk, and the Preview URL
-      # resolved below is looked up for this exact head SHA via the
-      # Deployments API. actions/checkout defaults to refs/pull/<pr>/merge
-      # on a pull_request event — head merged into whatever main currently
-      # is — so a base-branch change to any of those files between the
-      # Vercel build and this job running would make the checkout diverge
-      # from what Vercel actually deployed, failing the identity check for
-      # a reason unrelated to this PR's own diff.
-      - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: '24'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Install Playwright Chromium
-        run: npx playwright install --with-deps chromium
-
-      # Vercel's GitHub integration creates a real GitHub Deployment (and
-      # deployment statuses) for every preview build — this polls the
-      # GitHub Deployments API for this PR head SHA's Vercel deployment to
-      # reach a 'success' status and reads its environment/target URL from
-      # there, rather than guessing Vercel's branch-alias URL format
-      # (which is opaquely shortened/hashed for long branch names, not
-      # something this job can derive on its own) or requiring a separate
-      # Vercel API token. Bounded to 5 minutes (20 x 15s), matching the
-      # ~1-2 minute build times observed for this project; fails the job
-      # if no successful deployment shows up in that window rather than
-      # silently skipping the check.
-      - name: Resolve the real Vercel Preview URL for this PR
-        id: resolve_preview
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        with:
-          script: |
-            const sha = context.payload.pull_request.head.sha;
-            const maxAttempts = 20;
-            const delayMs = 15000;
-            let previewUrl = null;
-
-            for (let attempt = 0; attempt < maxAttempts && !previewUrl; attempt++) {
-              if (attempt > 0) await new Promise((resolve) => setTimeout(resolve, delayMs));
-
-              const { data: deployments } = await github.rest.repos.listDeployments({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                sha,
-                per_page: 10,
-              });
-
-              for (const deployment of deployments) {
-                const { data: statuses } = await github.rest.repos.listDeploymentStatuses({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  deployment_id: deployment.id,
-                  per_page: 10,
-                });
-                const success = statuses.find((s) => s.state === 'success' && (s.environment_url || s.target_url));
-                if (success) {
-                  previewUrl = success.environment_url || success.target_url;
-                  break;
-                }
-              }
-            }
-
-            if (!previewUrl) {
-              core.setFailed(
-                `No successful Vercel deployment found for PR head SHA ${sha} within the timeout — ` +
-                `the real Preview check cannot run. Verify Vercel actually built a preview for this commit.`
-              );
-              return;
-            }
-            core.exportVariable('PLAYWRIGHT_VERCEL_PREVIEW_URL', previewUrl);
-
-      - name: Run reports-insights isolation suite against the real Preview
-        if: steps.resolve_preview.outcome == 'success'
-        env:
-          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
-        run: npx playwright test e2e/reports-insights-isolation.spec.ts --config=playwright.reports-insights.vercel-preview.config.ts --reporter=list
-
-      - name: Upload Playwright report
-        if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: reports-insights-vercel-preview-playwright-report
-          path: playwright-report/
-          retention-days: 14
+# The real-Vercel-Preview check used to live here as a TEMPORARY
+# pull_request-triggered job (removed) — it existed only because
+# reports-insights-vercel-preview-check.yml, a workflow_dispatch workflow,
+# could not be dispatched via the API/UI before its file existed on the
+# default branch. #106 merged that permanent workflow to main, so that
+# constraint no longer applies; use it directly (workflow_dispatch, with
+# required `revision` and `preview_url` inputs) instead of an automatic
+# job here.
+#
+# The automatic version was removed for a second, independent reason, not
+# just obsolescence: it resolved the Preview URL via GitHub's Deployments
+# API filtered only by SHA, which returns every deployment for that commit
+# across every connected provider (this repo has both Vercel and Netlify
+# ones) with no check on which provider produced the match. The resolved
+# URL then received VERCEL_AUTOMATION_BYPASS_SECRET via
+# x-vercel-protection-bypass regardless. Every real run happened to select
+# a genuine *.vercel.app URL, but "happened to" is not a boundary — a
+# same-SHA Netlify deployment landing earlier in an unordered API response
+# would have sent this secret to a non-Vercel host. The permanent
+# workflow's own preview_url validation step (added there) is the actual
+# boundary: it runs before any step that receives the secret and enforces
+# https:// plus an exact *.vercel.app hostname suffix, regardless of how
+# the URL was obtained.

--- a/.github/workflows/reports-insights-isolation-e2e.yml
+++ b/.github/workflows/reports-insights-isolation-e2e.yml
@@ -80,8 +80,21 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
+      # Explicit head SHA, not the default merge ref: the content-identity
+      # assertions in the isolation suite (dashboard.html/dashboard.js/
+      # vendor/tailwind.css/the webfont) compare the real Preview's response
+      # bytes against the checked-out files on disk, and the Preview URL
+      # resolved below is looked up for this exact head SHA via the
+      # Deployments API. actions/checkout defaults to refs/pull/<pr>/merge
+      # on a pull_request event — head merged into whatever main currently
+      # is — so a base-branch change to any of those files between the
+      # Vercel build and this job running would make the checkout diverge
+      # from what Vercel actually deployed, failing the identity check for
+      # a reason unrelated to this PR's own diff.
       - name: Checkout code
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/reports-insights-vercel-preview-check.yml
+++ b/.github/workflows/reports-insights-vercel-preview-check.yml
@@ -22,12 +22,12 @@ on:
   workflow_dispatch:
     inputs:
       preview_url:
-        description: 'Vercel Preview URL to check, e.g. https://<preview>.vercel.app (no trailing slash)'
+        description: 'Vercel Preview URL to check, e.g. https://<preview>.vercel.app (no trailing slash). Validated below (https:// + exact .vercel.app hostname) before any step receives VERCEL_AUTOMATION_BYPASS_SECRET — the job fails closed if this is not a genuine Vercel URL.'
         required: true
         type: string
       revision:
-        description: 'Git ref/SHA that preview_url was actually built from. The isolation suite compares response bytes for dashboard.html/dashboard.js/vendor/tailwind.css/the webfont against the checked-out files on disk, so this must match the deployed commit exactly. Leave blank to check out whichever branch is selected above in the "Use workflow from" picker — that is NOT guaranteed to match an arbitrary preview_url and will falsely fail the identity check if it does not.'
-        required: false
+        description: 'Git ref/SHA that preview_url was actually built from. The isolation suite compares response bytes for dashboard.html/dashboard.js/vendor/tailwind.css/the webfont against the checked-out files on disk, so this must match the deployed commit exactly. Required — do not guess this from the branch picker above, which is not guaranteed to match an arbitrary preview_url and will falsely fail the identity check if it does not.'
+        required: true
         type: string
 
 jobs:
@@ -39,7 +39,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
-          ref: ${{ inputs.revision || github.ref }}
+          ref: ${{ inputs.revision }}
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -53,7 +53,44 @@ jobs:
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium
 
+      # This is the actual security boundary for VERCEL_AUTOMATION_BYPASS_SECRET,
+      # not an assumption about how preview_url was obtained: preview_url is an
+      # arbitrary operator-supplied string, and the next step sends the secret
+      # to whatever host it names via x-vercel-protection-bypass. Parsing with
+      # the URL constructor (not a regex/sed match against the raw string)
+      # rejects malformed input outright and gives an exact hostname to check —
+      # required scheme https:// and a hostname ending in the literal
+      # ".vercel.app" suffix, which also rejects lookalikes such as
+      # "vercel.app.attacker.example" (fails the suffix check) or
+      # "attacker.example/.vercel.app" (the path, not the hostname). Fails
+      # closed: any parse error or mismatch stops the job here, before the
+      # step below ever runs.
+      - name: Validate preview_url before it ever reaches a step with the bypass secret
+        id: validate_preview_url
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          PREVIEW_URL: ${{ inputs.preview_url }}
+        with:
+          script: |
+            const raw = process.env.PREVIEW_URL;
+            let url;
+            try {
+              url = new URL(raw);
+            } catch {
+              core.setFailed(`preview_url is not a valid URL: ${raw}`);
+              return;
+            }
+            if (url.protocol !== 'https:') {
+              core.setFailed(`preview_url must use https://, got protocol "${url.protocol}" for: ${raw}`);
+              return;
+            }
+            if (!url.hostname.endsWith('.vercel.app')) {
+              core.setFailed(`preview_url host must end with .vercel.app exactly, got host "${url.hostname}" for: ${raw}`);
+              return;
+            }
+
       - name: Run reports-insights isolation suite against the real Preview
+        if: steps.validate_preview_url.outcome == 'success'
         env:
           PLAYWRIGHT_VERCEL_PREVIEW_URL: ${{ inputs.preview_url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}

--- a/.github/workflows/reports-insights-vercel-preview-check.yml
+++ b/.github/workflows/reports-insights-vercel-preview-check.yml
@@ -25,6 +25,10 @@ on:
         description: 'Vercel Preview URL to check, e.g. https://<preview>.vercel.app (no trailing slash)'
         required: true
         type: string
+      revision:
+        description: 'Git ref/SHA that preview_url was actually built from. The isolation suite compares response bytes for dashboard.html/dashboard.js/vendor/tailwind.css/the webfont against the checked-out files on disk, so this must match the deployed commit exactly. Leave blank to check out whichever branch is selected above in the "Use workflow from" picker — that is NOT guaranteed to match an arbitrary preview_url and will falsely fail the identity check if it does not.'
+        required: false
+        type: string
 
 jobs:
   test:
@@ -34,6 +38,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          ref: ${{ inputs.revision || github.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/e2e/fixtures/local-vercel-headers-server.ts
+++ b/e2e/fixtures/local-vercel-headers-server.ts
@@ -1,10 +1,9 @@
 /**
- * Minimal static file server for e2e tests that reproduces the response
- * headers vercel.json actually configures for the isolated
- * /reports-insights/* route vs. the rest of the app — the Vite dev server
- * used for the rest of the e2e suite does not send production headers at
- * all, so a test asserting on CSP/X-Frame-Options against it would prove
- * nothing.
+ * Minimal static file server for e2e tests that reproduces vercel.json's
+ * actual header AND rewrite behavior for the isolated /reports-insights/*
+ * route vs. the rest of the app — the Vite dev server used for the rest of
+ * the e2e suite does not send production headers or apply the SPA rewrite
+ * at all, so a test asserting on either against it would prove nothing.
  *
  * This intentionally does NOT reimplement Vercel's full path-to-regexp
  * router — each vercel.json rule's `source` is compiled to a real RegExp
@@ -12,8 +11,14 @@
  * and every rule whose source matches the request path contributes its
  * headers, matching Vercel's own documented behavior for multiple
  * matching rules (e.g. their own `/service-worker.js` + `/(.*)` example).
- * Rule *values* always come straight from vercel.json, never a
- * hand-copied duplicate, so an edit there is what the test sees.
+ * Rewrites are applied the same way Vercel's static hosting does: a
+ * request first tries to resolve to a real file, and only falls through to
+ * a matching rewrite's destination when no file exists — so a route
+ * deliberately excluded from the SPA rewrite genuinely 404s here too,
+ * instead of this fixture 404ing regardless of the rewrite config and
+ * silently passing a rewrite regression either way. Rule *values* always
+ * come straight from vercel.json, never a hand-copied duplicate, so an
+ * edit there is what the test sees.
  */
 import { createServer, type Server } from 'node:http';
 import { readFile } from 'node:fs/promises';
@@ -30,10 +35,19 @@ interface VercelHeaderRule {
   headers: { key: string; value: string }[];
 }
 
-async function loadHeaderRules(): Promise<VercelHeaderRule[]> {
+interface VercelRewriteRule {
+  source: string;
+  destination: string;
+}
+
+interface VercelConfig {
+  headers?: VercelHeaderRule[];
+  rewrites?: VercelRewriteRule[];
+}
+
+async function loadVercelConfig(): Promise<VercelConfig> {
   const raw = await readFile(path.join(REPO_ROOT, 'vercel.json'), 'utf8');
-  const config = JSON.parse(raw) as { headers?: VercelHeaderRule[] };
-  return config.headers ?? [];
+  return JSON.parse(raw) as VercelConfig;
 }
 
 const CONTENT_TYPES: Record<string, string> = {
@@ -44,24 +58,47 @@ const CONTENT_TYPES: Record<string, string> = {
   '.json': 'application/json; charset=utf-8',
 };
 
+// A requested path can resolve against either public/ (static assets
+// Vercel copies into the build output as-is) or the repo root (index.html
+// lives there pre-build for a Vite project, not under public/) — checked
+// in that order, matching where each actually lives in this repo.
+function resolveExistingFile(urlPath: string): string | null {
+  for (const base of [PUBLIC_DIR, REPO_ROOT]) {
+    const filePath = path.join(base, decodeURIComponent(urlPath));
+    if (filePath.startsWith(base) && existsSync(filePath)) return filePath;
+  }
+  return null;
+}
+
 export async function startLocalVercelHeadersServer(port: number): Promise<Server> {
-  const rules = await loadHeaderRules();
-  if (rules.length === 0) {
+  const config = await loadVercelConfig();
+  const headerRules = config.headers ?? [];
+  const rewriteRules = config.rewrites ?? [];
+  if (headerRules.length === 0) {
     throw new Error('local-vercel-headers-server: vercel.json has no header rules — update this test helper');
   }
-  const compiledRules = rules.map((r) => ({ ...r, regex: new RegExp(`^${r.source}$`) }));
+  const compiledHeaderRules = headerRules.map((r) => ({ ...r, regex: new RegExp(`^${r.source}$`) }));
+  const compiledRewriteRules = rewriteRules.map((r) => ({ ...r, regex: new RegExp(`^${r.source}$`) }));
 
   const server = createServer(async (req, res) => {
     const urlPath = (req.url ?? '/').split('?')[0];
-    for (const rule of compiledRules) {
+    for (const rule of compiledHeaderRules) {
       if (!rule.regex.test(urlPath)) continue;
       for (const h of rule.headers) {
         res.setHeader(h.key, h.value);
       }
     }
 
-    const filePath = path.join(PUBLIC_DIR, decodeURIComponent(urlPath));
-    if (!filePath.startsWith(PUBLIC_DIR) || !existsSync(filePath)) {
+    let filePath = resolveExistingFile(urlPath);
+    if (!filePath) {
+      for (const rule of compiledRewriteRules) {
+        if (!rule.regex.test(urlPath)) continue;
+        filePath = resolveExistingFile(rule.destination);
+        break;
+      }
+    }
+
+    if (!filePath) {
       res.statusCode = 404;
       res.end('Not found');
       return;

--- a/e2e/reports-insights-isolation.spec.ts
+++ b/e2e/reports-insights-isolation.spec.ts
@@ -13,12 +13,18 @@
 import { test, expect, type Page } from '@playwright/test';
 import type { Server } from 'node:http';
 import { readFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { startLocalVercelHeadersServer } from './fixtures/local-vercel-headers-server';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..');
 const PORT = 4174;
+
+function sha256(buffer: Buffer): string {
+  return createHash('sha256').update(buffer).digest('hex');
+}
 
 // Two modes, selected by PLAYWRIGHT_VERCEL_PREVIEW_URL:
 //  - Default (unset): starts the local static server that reproduces
@@ -110,60 +116,80 @@ test.describe('reports-insights response headers (vercel.json)', () => {
     expect(res.headers()['x-frame-options']).toBe('SAMEORIGIN');
   });
 
+  test('reports-insights static assets are the real checked-out files, not a silently substituted SPA-fallback response', async ({ request }) => {
+    // A missing/renamed file under /reports-insights/ used to still answer
+    // 200 with the SPA shell's index.html (vercel.json's single catch-all
+    // rewrite matched everything, this route included) — same ETag, same
+    // byte count, on every path tried, confirmed live on a real deployment.
+    // A 200 status and a plausible content-type both survive that
+    // substitution, so neither is sufficient on its own; only a body-identity
+    // check against the actual checked-out file can catch it. This runs
+    // before any header assertion in this file, deliberately: asserting on
+    // headers of a response that turns out to be the wrong file proves
+    // nothing about the route this suite is actually testing.
+    const assets = [
+      { url: `${ORIGIN}/reports-insights/dashboard.html`, localPath: 'public/reports-insights/dashboard.html', mimeFamily: /^text\/html/ },
+      { url: `${ORIGIN}/reports-insights/dashboard.js`, localPath: 'public/reports-insights/dashboard.js', mimeFamily: /^(text|application)\/javascript/ },
+      { url: `${ORIGIN}/reports-insights/vendor/tailwind.css`, localPath: 'public/reports-insights/vendor/tailwind.css', mimeFamily: /^text\/css/ },
+      { url: `${ORIGIN}/reports-insights/vendor/fontawesome/webfonts/fa-solid-900.woff2`, localPath: 'public/reports-insights/vendor/fontawesome/webfonts/fa-solid-900.woff2', mimeFamily: /^font\/woff2/ },
+    ] as const;
+
+    const responses = await Promise.all(assets.map((a) => request.get(a.url)));
+
+    for (let i = 0; i < assets.length; i++) {
+      const { localPath, mimeFamily } = assets[i];
+      const res = responses[i];
+      expect(res.status(), `${localPath}: expected a real 200`).toBe(200);
+
+      const body = await res.body();
+      const expectedHash = sha256(await readFile(path.join(REPO_ROOT, localPath)));
+      expect(sha256(body), `${localPath}: response body must byte-match the checked-out file (a mismatch means this URL is serving something else)`).toBe(expectedHash);
+
+      const contentType = res.headers()['content-type'] ?? '';
+      expect(contentType, `${localPath}: content-type must match its real MIME family`).toMatch(mimeFamily);
+    }
+  });
+
   test('Access-Control-Allow-Origin is scoped to the Font Awesome webfont files only, not the whole isolated route', async ({ request }) => {
     const fontRes = await request.get(`${ORIGIN}/reports-insights/vendor/fontawesome/webfonts/fa-solid-900.woff2`);
     expect(fontRes.headers()['access-control-allow-origin']).toBe('*');
     expect(fontRes.headers()['access-control-allow-credentials']).toBeUndefined();
 
-    // dashboard.js/dashboard.html/the vendored CSS still get the isolated
-    // route's CSP/X-Frame-Options (asserted above) but must NOT also get
-    // a blanket CORS header they have no reason to need — only actual
-    // cross-origin @font-face fetches from inside the opaque-origin
-    // sandbox require it (see the branch history for why this was
-    // narrowed from the whole /reports-insights/* route).
     const nonFontAssets = [
       await request.get(`${ORIGIN}/reports-insights/dashboard.js`),
       await request.get(`${ORIGIN}/reports-insights/dashboard.html`),
       await request.get(`${ORIGIN}/reports-insights/vendor/tailwind.css`),
     ];
 
-    // Real Vercel Preview deployments are protected; this suite only ever
-    // reaches one through Vercel's Protection Bypass for Automation
-    // (x-vercel-protection-bypass / x-vercel-set-bypass-cookie — see
-    // playwright.reports-insights.vercel-preview.config.ts). On that
-    // authenticated path, non-font static assets have been observed
-    // carrying Access-Control-Allow-Origin: "*" that vercel.json does not
-    // configure — its two /reports-insights/* header blocks are mutually
-    // exclusive (see the negative lookahead in vercel.json), and
-    // e2e/fixtures/local-vercel-headers-server.ts, which compiles those
-    // same source patterns to real anchored RegExps, never reproduces it
-    // (see the local-lane branch below, which stays strict). A direct,
-    // unauthenticated curl to a protected Preview URL gets a 302 to
-    // vercel.com/sso-api with no ACAO at all and never reaches the origin,
-    // so the "*" is only correlated with the bypass-authenticated request,
-    // not proven to be caused by it — Vercel's public docs for Protection
-    // Bypass for Automation describe what it bypasses but document no
-    // header side effect.
+    // Two separate, deliberately distinct contracts here — config-intent
+    // and live-platform — because they were confirmed to genuinely differ,
+    // not because of any bypass, cache, or per-file artifact (all three
+    // were investigated and falsified; see git history on this file for
+    // that investigation if it matters later).
     //
-    // This is NOT scoped to dashboard.js specifically: across two separate
-    // Preview deployments in this branch's own CI history, the "*" showed
-    // up on a *different* one of these three assets each time — dashboard.js
-    // on one run, dashboard.html on the next, both reproducible 3/3 within
-    // their own run. That rules out a per-file cause and points at
-    // something environment-wide on the bypass-authenticated path (a
-    // leading hypothesis is edge-cache state at request time, but that is
-    // not confirmed either — recorded here as variable behavior observed
-    // across bypass-authenticated Preview deployments, not as proven
-    // edge-cache behavior or a documented bypass side effect). So the
-    // exception is scoped to the *lane*, not to any one filename: every
-    // inspected non-font asset may be absent-or-"*" only when running
-    // against a real Preview through the bypass; the local-server lane,
-    // which never goes through Vercel's protection layer at all, keeps the
-    // original strict contract for all three. Real end users never carry
-    // the bypass secret, so real production/preview traffic is unaffected
-    // regardless of which file the artifact lands on in a given CI run — a
-    // strict no-bypass check against the public production deployment is
-    // required after merge to confirm that directly.
+    // Config-intent (local-server lane, PLAYWRIGHT_VERCEL_PREVIEW_URL
+    // unset): e2e/fixtures/local-vercel-headers-server.ts compiles
+    // vercel.json's own header rules to real anchored RegExps and applies
+    // only what they declare — vercel.json declares Access-Control-Allow-Origin
+    // for exactly one rule, the webfonts path, and nothing else does. This
+    // lane proves that intent: strictly no ACAO on any non-font asset.
+    //
+    // Live-platform (real Preview or production, PLAYWRIGHT_VERCEL_PREVIEW_URL
+    // set): confirmed directly — both on this project's own pre-#106
+    // production deployment (real JS/SVG assets on a fresh cache MISS) and
+    // independently on Vercel's own official zero-config Vite example
+    // deployment — that Vercel serves ACAO: "*" on public static assets as
+    // a platform-level default, unrelated to vercel.json, Protection
+    // Bypass, or caching. It is not configured by this repo and cannot be
+    // unconfigured by vercel.json's headers array (there is no "unset a
+    // header" directive), so a real deployment's non-font assets may
+    // legitimately answer with ACAO absent or "*" — either is correct
+    // platform behavior. What must still hold, and does: the font path
+    // always gets "*" (this repo's own explicit grant, needed for the
+    // sandboxed iframe's cross-origin @font-face fetches), and
+    // Access-Control-Allow-Credentials — which would actually be
+    // dangerous paired with a wildcard origin — stays absent everywhere,
+    // on every asset, in both lanes, no exception.
     for (const res of nonFontAssets) {
       if (process.env.PLAYWRIGHT_VERCEL_PREVIEW_URL) {
         const acao = res.headers()['access-control-allow-origin'];
@@ -186,6 +212,22 @@ test.describe('reports-insights response headers (vercel.json)', () => {
     // lanes, real Preview or not.
     expect(fontRes.headers()['x-frame-options']).toBeUndefined();
     expect(fontRes.headers()['content-security-policy']).toBeUndefined();
+  });
+
+  test('a missing /reports-insights/* asset returns a real 404, never the SPA-fallback app shell', async ({ request }) => {
+    // vercel.json's single rewrite used to catch every unmatched path,
+    // /reports-insights/* included, and answer 200 with index.html — same
+    // ETag and byte count for a typo'd filename as for the real index
+    // route. The rewrite now explicitly excludes /reports-insights/, so a
+    // missing file falls through to Vercel's ordinary static 404 instead.
+    const res = await request.get(`${ORIGIN}/reports-insights/this-file-does-not-exist-e2e-probe.js`);
+    expect(res.status()).toBe(404);
+    const body = await res.text();
+    // Belt and suspenders on top of the status code: the SPA shell's root
+    // mount point must not appear in a 404 body either, so a future rewrite
+    // regression that returns 404 with the app shell's HTML (a plausible
+    // half-fix) still fails this test.
+    expect(body).not.toContain('<div id="root">');
   });
 
   test('every other route keeps X-Frame-Options: DENY and no conflicting header is ever sent for the same path', async ({ request }) => {

--- a/e2e/reports-insights-isolation.spec.ts
+++ b/e2e/reports-insights-isolation.spec.ts
@@ -84,6 +84,41 @@ async function getChildFrame(page: Page) {
 }
 
 test.describe('reports-insights response headers (vercel.json)', () => {
+  // Deliberately the first test in this file, not just commented as such:
+  // a missing/renamed file under /reports-insights/ used to still answer
+  // 200 with the SPA shell's index.html (vercel.json's single catch-all
+  // rewrite matched everything, this route included) — same ETag, same
+  // byte count, on every path tried, confirmed live on a real deployment.
+  // A 200 status and a plausible content-type both survive that
+  // substitution, so neither is sufficient on its own; only a body-identity
+  // check against the actual checked-out file can catch it. Every other
+  // test in this file asserts on response headers for these same routes,
+  // so this one runs before all of them — a header assertion on a response
+  // that turns out to be the wrong file would prove nothing.
+  test('reports-insights static assets are the real checked-out files, not a silently substituted SPA-fallback response', async ({ request }) => {
+    const assets = [
+      { url: `${ORIGIN}/reports-insights/dashboard.html`, localPath: 'public/reports-insights/dashboard.html', mimeFamily: /^text\/html/ },
+      { url: `${ORIGIN}/reports-insights/dashboard.js`, localPath: 'public/reports-insights/dashboard.js', mimeFamily: /^(text|application)\/javascript/ },
+      { url: `${ORIGIN}/reports-insights/vendor/tailwind.css`, localPath: 'public/reports-insights/vendor/tailwind.css', mimeFamily: /^text\/css/ },
+      { url: `${ORIGIN}/reports-insights/vendor/fontawesome/webfonts/fa-solid-900.woff2`, localPath: 'public/reports-insights/vendor/fontawesome/webfonts/fa-solid-900.woff2', mimeFamily: /^font\/woff2/ },
+    ] as const;
+
+    const responses = await Promise.all(assets.map((a) => request.get(a.url)));
+
+    for (let i = 0; i < assets.length; i++) {
+      const { localPath, mimeFamily } = assets[i];
+      const res = responses[i];
+      expect(res.status(), `${localPath}: expected a real 200`).toBe(200);
+
+      const body = await res.body();
+      const expectedHash = sha256(await readFile(path.join(REPO_ROOT, localPath)));
+      expect(sha256(body), `${localPath}: response body must byte-match the checked-out file (a mismatch means this URL is serving something else)`).toBe(expectedHash);
+
+      const contentType = res.headers()['content-type'] ?? '';
+      expect(contentType, `${localPath}: content-type must match its real MIME family`).toMatch(mimeFamily);
+    }
+  });
+
   test('the isolated dashboard route sends an enforcing CSP — script-src stays strict, style-src allows unsafe-inline only (ApexCharts compatibility), X-Frame-Options: SAMEORIGIN', async ({ request }) => {
     const res = await request.get(`${ORIGIN}/reports-insights/dashboard.html`);
     expect(res.status()).toBe(200);
@@ -114,40 +149,6 @@ test.describe('reports-insights response headers (vercel.json)', () => {
 
     expect(csp).toContain("frame-ancestors 'self'");
     expect(res.headers()['x-frame-options']).toBe('SAMEORIGIN');
-  });
-
-  test('reports-insights static assets are the real checked-out files, not a silently substituted SPA-fallback response', async ({ request }) => {
-    // A missing/renamed file under /reports-insights/ used to still answer
-    // 200 with the SPA shell's index.html (vercel.json's single catch-all
-    // rewrite matched everything, this route included) — same ETag, same
-    // byte count, on every path tried, confirmed live on a real deployment.
-    // A 200 status and a plausible content-type both survive that
-    // substitution, so neither is sufficient on its own; only a body-identity
-    // check against the actual checked-out file can catch it. This runs
-    // before any header assertion in this file, deliberately: asserting on
-    // headers of a response that turns out to be the wrong file proves
-    // nothing about the route this suite is actually testing.
-    const assets = [
-      { url: `${ORIGIN}/reports-insights/dashboard.html`, localPath: 'public/reports-insights/dashboard.html', mimeFamily: /^text\/html/ },
-      { url: `${ORIGIN}/reports-insights/dashboard.js`, localPath: 'public/reports-insights/dashboard.js', mimeFamily: /^(text|application)\/javascript/ },
-      { url: `${ORIGIN}/reports-insights/vendor/tailwind.css`, localPath: 'public/reports-insights/vendor/tailwind.css', mimeFamily: /^text\/css/ },
-      { url: `${ORIGIN}/reports-insights/vendor/fontawesome/webfonts/fa-solid-900.woff2`, localPath: 'public/reports-insights/vendor/fontawesome/webfonts/fa-solid-900.woff2', mimeFamily: /^font\/woff2/ },
-    ] as const;
-
-    const responses = await Promise.all(assets.map((a) => request.get(a.url)));
-
-    for (let i = 0; i < assets.length; i++) {
-      const { localPath, mimeFamily } = assets[i];
-      const res = responses[i];
-      expect(res.status(), `${localPath}: expected a real 200`).toBe(200);
-
-      const body = await res.body();
-      const expectedHash = sha256(await readFile(path.join(REPO_ROOT, localPath)));
-      expect(sha256(body), `${localPath}: response body must byte-match the checked-out file (a mismatch means this URL is serving something else)`).toBe(expectedHash);
-
-      const contentType = res.headers()['content-type'] ?? '';
-      expect(contentType, `${localPath}: content-type must match its real MIME family`).toMatch(mimeFamily);
-    }
   });
 
   test('Access-Control-Allow-Origin is scoped to the Font Awesome webfont files only, not the whole isolated route', async ({ request }) => {

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "rewrites": [
-    { "source": "/(.*)", "destination": "/index.html" }
+    { "source": "/((?!reports-insights/).*)", "destination": "/index.html" }
   ],
   "headers": [
     {


### PR DESCRIPTION
## Summary

Follow-up to #106, opened after the Instant Rollback of that PR's production deployment. This branches from `main@bcc1a3c` (the already-merged #106).

**Root cause, independently confirmed by the reviewer** on Vercel's own zero-config Vite example deployment, and on this project's own pre-#106 production JS/SVG assets under a fresh cache `MISS`: `Access-Control-Allow-Origin: *` on public static assets is **Vercel's platform-level static-serving default** — unrelated to `vercel.json`, Protection Bypass for Automation, or caching. All three explanations recorded in #106's history (bypass-authenticated-lane artifact, per-file artifact, edge-cache state) are falsified by this direct evidence.

Two findings, treated separately per the reviewer's explicit direction:

1. **`ACAO: *` on public static assets, with no `Access-Control-Allow-Credentials` and no sensitive response body, is not an authentication/data-exposure bug.** No site-wide response-header deletion transform is added. `vercel.json` still explicitly declares `ACAO: *` only for the webfonts rule — that stays the config's own intent, verified strictly in the local-server lane. On a real Vercel deployment, non-font public static assets may legitimately return either absent or `"*"` — both are correct platform behavior now that the cause is understood, and there is no `vercel.json` directive to "unset" a header.
2. **A missing `/reports-insights/*` asset silently becoming a 200 `index.html` response was a real routing bug and a real test gap.** The rollback investigation exposed it directly: `/reports-insights/dashboard.html`, `/reports-insights/dashboard.js`, `/index.html`, `/`, and a made-up nonexistent path all returned the *identical* SPA-shell body (same ETag, same 786 bytes) on the pre-#106 production deployment, because `vercel.json`'s single catch-all rewrite (`/(.*)` → `/index.html`) matched `/reports-insights/*` too.

## Changes

- **`vercel.json`**: the rewrite rule now excludes `/reports-insights/` (`/((?!reports-insights/).*)`). A missing file under that route now falls through to Vercel's real static 404 instead of the SPA shell.
- **`e2e/reports-insights-isolation.spec.ts`**: content-identity test (SHA-256 body match + MIME family, for `dashboard.html`/`dashboard.js`/`vendor/tailwind.css`/the webfont, against the checked-out files) is now genuinely the **first** test declared in the file, not just documented as such — a prior version claimed this ordering while actually being declared second, after the pre-existing CSP test. A new 404 test proves a missing file gets a real 404, with a belt-and-suspenders check that the body isn't the SPA shell either. The ACAO test's config-intent (local-server, strict) vs. live-platform (real Preview, non-font assets may be absent-or-`"*"`) split is documented with the real, confirmed cause — no remaining reference to the bypass mechanism or caching as an explanation, both falsified.
- **Security fix — removed a cross-provider secret-leak risk**: the automatic `vercel-preview-check` job resolved a Preview URL via GitHub's Deployments API filtered only by head SHA, which returns every deployment for that commit across every connected provider (this repo has both Vercel and Netlify) with no check on which provider produced the match, then sent `VERCEL_AUTOMATION_BYPASS_SECRET` to whatever URL it picked regardless. Every actual CI run happened to select a genuine `*.vercel.app` URL, but that ordering was never a security boundary. **Removed the job entirely** — it was already documented `TEMPORARY`, existing only because the permanent `workflow_dispatch` workflow couldn't be dispatched before its file existed on the default branch, a constraint #106 already resolved by merging that file to `main`. The permanent workflow (`reports-insights-vercel-preview-check.yml`) now requires **both** `revision` and `preview_url` (previously `revision` was optional) and runs a dedicated validation step — using the `URL` constructor for real parsing, not a regex/sed match against the raw string — enforcing `https://` and an exact `.vercel.app` hostname suffix **before any step receives the secret**. That validation is the actual boundary now, independent of how the URL was obtained.
- Also includes the two Codex-review fixes from the prior push: checkout pinned to the PR's exact head SHA (not the default merge ref) for the content-identity comparison to be meaningful, and `e2e/fixtures/local-vercel-headers-server.ts` now implements real rewrite matching so the local "missing file → 404" test can't stay green through a full revert of the actual fix (verified directly).

## Test plan

All figures below are from CI on head `0fdc2ae` — the current, unchanged, final head.

- [x] `npm run type-check` — clean
- [x] `npm run lint` — 0 errors, no new warnings on changed files
- [x] `npx vitest run` — 3922/3922 passing
- [x] `e2e/reports-insights-isolation.spec.ts`, local-server lane — 29/29 passing
- [x] **`e2e/reports-insights-isolation.spec.ts` against the real, protected Vercel Preview deployment — 29/29 passing, zero retries**, run via the hardened permanent workflow (`reports-insights-vercel-preview-check.yml`, manually dispatched from this PR's branch since the automatic job is now removed): checkout pinned to `revision=0fdc2ae`, `preview_url` resolved independently via Vercel's own project-scoped deployments API (never GitHub's cross-provider one), and the workflow's own `https://` + exact `.vercel.app`-hostname validation step passed before the bypass secret was used in any step. [Run](https://github.com/6thd/wardah-process-costing/actions/runs/31242877118).
- [x] SonarCloud — Quality Gate passed, 0 new issues
- [ ] Codacy — 2 critical findings, both `Semgrep_javascript_dos_rule-non-literal-regexp` on `e2e/fixtures/local-vercel-headers-server.ts` (dynamically compiling regexes from `vercel.json`'s own repo-controlled `source` field, not attacker-controlled input — the same pattern accepted in #106, now duplicated across two lines instead of one). Reviewer has confirmed both as approved false positives; dismissal and reanalysis to happen now that the workflow fix is on this final head.

**Context**: PR #106 was merged, then its production deployment was Instant-Rolled-Back after this same investigation showed the ACAO artifact was not scoped to the bypass lane as originally believed. Production is currently rolled back to `2e16f16`, and the `reports-insights` Edge Function has not been deployed. **This PR does not change that** — no merge, no re-promotion to production, and no Edge Function deploy until the reviewer signs off.
