### PR TITLE
fix(reports-insights): correct provider-unavailable contract, pin @supabase/supabase-js

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -2,6 +2,7 @@
   "version": "5",
   "redirects": {
     "https://esm.sh/@supabase/supabase-js@2": "https://esm.sh/@supabase/supabase-js@2.112.1",
+    "https://esm.sh/iceberg-js@^0.8.0?target=denonext": "https://esm.sh/iceberg-js@0.8.1?target=denonext",
     "https://esm.sh/iceberg-js@^0.8.1?target=denonext": "https://esm.sh/iceberg-js@0.8.1?target=denonext"
   },
   "remote": {
@@ -21,14 +22,21 @@
     "https://deno.land/std@0.168.0/testing/_format.ts": "cd11136e1797791045e639e9f0f4640d5b4166148796cad37e6ef75f7d7f3832",
     "https://deno.land/std@0.168.0/testing/asserts.ts": "51353e79437361d4b02d8e32f3fc83b22231bc8f8d4c841d86fd32b0b0afe940",
     "https://esm.sh/@supabase/auth-js@2.112.1/denonext/auth-js.mjs": "0a6548b2193536749bac8bdc311930557fc418447d7579c16a1db1ff0e17788c",
+    "https://esm.sh/@supabase/auth-js@2.86.0/denonext/auth-js.mjs": "9462cda0680690050508771f079907cb94e14f904fbcf4b07f5ae0dd3d61e345",
     "https://esm.sh/@supabase/functions-js@2.112.1/denonext/functions-js.mjs": "148a13081414a9bca1e6879d7220ae0affcd92150adc08e3eecb63fec794d9a1",
+    "https://esm.sh/@supabase/functions-js@2.86.0/denonext/functions-js.mjs": "e3c069a396ec89d9d3efc7d3bf443b5688780b13e744d110d00570c80bbeca4e",
     "https://esm.sh/@supabase/phoenix@0.4.5/denonext/phoenix.mjs": "40bd2a70829cd847848baac58e635bacd83fd62188f6624b44e2c295341004eb",
     "https://esm.sh/@supabase/postgrest-js@2.112.1/denonext/postgrest-js.mjs": "b25d2037ec88c744bbcd1ca51d21110b6d4bde16ad5d4ef7ff5d8c00183a5c78",
+    "https://esm.sh/@supabase/postgrest-js@2.86.0/denonext/postgrest-js.mjs": "a7512edf33b261a4ae269a3c6403690849408b66146b96c069aea70c4998053a",
     "https://esm.sh/@supabase/realtime-js@2.112.1/denonext/realtime-js.mjs": "71971e0bd579cb6d8c2600ba1726c7472a9d7b4fa84f8b350fd3dd1dd86e51a2",
+    "https://esm.sh/@supabase/realtime-js@2.86.0/denonext/realtime-js.mjs": "195fc54b95415cc874b56d77b369e439006bee5d7218a34293c770ae23c5ce1f",
     "https://esm.sh/@supabase/storage-js@2.112.1/denonext/storage-js.mjs": "c19d2448362f0186f92876fa53296bd43a564a48e1500a9d48fc89956ff13235",
+    "https://esm.sh/@supabase/storage-js@2.86.0/denonext/storage-js.mjs": "7112d8ea92b752e6297f98f87bb6a9a7d0cc5a2063d7e7b94f1cc42106317cc0",
     "https://esm.sh/@supabase/supabase-js@2.112.1": "497e1884f2e760ee816b6081f8e9497f453d35d0b5fb10c0bb898b0debeee58d",
     "https://esm.sh/@supabase/supabase-js@2.112.1/denonext/dist/tracingRegistry.mjs": "a5c249913461920ffde2a35911d3d0819c66aa672ce533d17ae15dbaea75a704",
     "https://esm.sh/@supabase/supabase-js@2.112.1/denonext/supabase-js.mjs": "472091d54b6ffec5b452e227d6ff0a3cfbbbd11dd61b08604fde8b3322971f35",
+    "https://esm.sh/@supabase/supabase-js@2.86.0": "03cff32ee9cd57294c4fbaef936d61d1842ebeb0e4c72c01667524c7f1e23912",
+    "https://esm.sh/@supabase/supabase-js@2.86.0/denonext/supabase-js.mjs": "b4c3a746a435ddbdcdbf5916b058f0ea40e2295e5e589529fe8e91cdd3689800",
     "https://esm.sh/iceberg-js@0.8.1/denonext/iceberg-js.mjs": "d839d81a2e3966500ca2cdd0c1cb458e9608bacfc91f7bb67a69b2e878dcdb4f",
     "https://esm.sh/iceberg-js@0.8.1?target=denonext": "58c849d7fe2bf4eca4a84eb501e83c161a7d8c34ca1bec15a962b3bec3062633",
     "https://esm.sh/tslib@2.8.1/denonext/tslib.mjs": "c38da5dd6da6281964435002ce204cd586634fe3bdfb24a0ee116f48cf3292e9"
@@ -37,6 +45,7 @@
     "packageJson": {
       "dependencies": [
         "npm:@eslint/js@^9.39.2",
+        "npm:@fortawesome/fontawesome-free@^7.3.1",
         "npm:@playwright/test@^1.55.0",
         "npm:@radix-ui/react-avatar@^1.1.3",
         "npm:@radix-ui/react-checkbox@^1.1.4",

--- a/src/features/reports/components/EnhancedInsightsDashboard.tsx
+++ b/src/features/reports/components/EnhancedInsightsDashboard.tsx
@@ -180,7 +180,22 @@ export function EnhancedInsightsDashboard() {
         return;
       }
 
-      reply({ success: true, source: data?.source, text: data?.text });
+      if (!data?.success) {
+        // The Edge Function answers a classified provider failure (missing
+        // key, timeout, rate limit, upstream 5xx) with HTTP 200 and
+        // success:false/source:'fallback' by design (see its own module
+        // comment) — supabase-js's `error` above is only set for a non-2xx
+        // status, so it stays null here exactly like a real success would.
+        // Replying success:true regardless of data.success sent the iframe
+        // a shape its own isValidInsightResponse() rejects (success:true
+        // with no text), so the reply was silently dropped and the caller
+        // sat out the full 15s local-fallback timeout instead of failing
+        // over immediately.
+        reply({ success: false, error: typeof data?.error === 'string' ? data.error : 'provider_unavailable' });
+        return;
+      }
+
+      reply({ success: true, source: data.source, text: data.text });
     } catch (err) {
       console.error('Error handling insight request:', err);
       reply({ success: false, error: 'request_failed' });

--- a/src/features/reports/components/__tests__/EnhancedInsightsDashboard.test.tsx
+++ b/src/features/reports/components/__tests__/EnhancedInsightsDashboard.test.tsx
@@ -282,6 +282,59 @@ describe('EnhancedInsightsDashboard — MessageChannel handshake and message han
     });
   });
 
+  it('replies success:false immediately (not a fabricated success) when the Edge Function classifies the provider as unavailable', async () => {
+    mockGetSession.mockResolvedValue({ data: { session: { access_token: 'fake' } } });
+    // The Edge Function's own contract (supabase/functions/reports-insights/index.ts):
+    // a classified provider failure is HTTP 200 with success:false/source:'fallback'.
+    // supabase-js's `error` is only set for a non-2xx status, so it is null here
+    // exactly like a real success — the component must branch on data.success,
+    // not on the absence of `error`, to avoid relaying a fabricated success.
+    mockInvoke.mockResolvedValue({
+      data: { success: false, error: 'provider_unavailable', source: 'fallback', requestId: 'req-3' },
+      error: null,
+    });
+
+    const { iframe } = renderDashboard();
+
+    let capturedChannel: FakeMessageChannel | undefined;
+    class CapturingFakeMessageChannel extends FakeMessageChannel {
+      constructor() {
+        super();
+        capturedChannel = this;
+      }
+    }
+    vi.stubGlobal('MessageChannel', CapturingFakeMessageChannel);
+
+    iframe.dispatchEvent(new Event('load'));
+    const responses: unknown[] = [];
+    capturedChannel!.port2.onmessage = (event) => responses.push(event.data);
+
+    capturedChannel!.port2.postMessage({
+      type: 'WARDHAH_INSIGHT_REQUEST',
+      requestId: 'req-3',
+      operation: 'summary',
+      locale: 'en',
+      data: {},
+    });
+
+    await waitFor(() =>
+      expect(responses.some((r: any) => r.type === 'WARDHAH_INSIGHT_RESPONSE' && r.requestId === 'req-3')).toBe(true)
+    );
+    const insightResponse = responses.find((r: any) => r.type === 'WARDHAH_INSIGHT_RESPONSE') as any;
+    // success:false so the iframe's own isValidInsightResponse() (which
+    // requires a non-empty string `text` whenever success:true) accepts the
+    // message and its resolver fires right away — never a fabricated
+    // success, and never a silently dropped reply that stalls until the
+    // iframe's own 15s local-fallback timeout.
+    expect(insightResponse).toMatchObject({
+      type: 'WARDHAH_INSIGHT_RESPONSE',
+      requestId: 'req-3',
+      success: false,
+      error: 'provider_unavailable',
+    });
+    expect(insightResponse.text).toBeUndefined();
+  });
+
   it('ignores a message with an invalid/unrecognized shape instead of replying to it', async () => {
     mockGetSession.mockResolvedValue({ data: { session: { access_token: 'fake' } } });
     const { iframe } = renderDashboard();

--- a/supabase/functions/reports-insights/index.test.ts
+++ b/supabase/functions/reports-insights/index.test.ts
@@ -16,19 +16,23 @@
 // nothing concurrent to exercise at this layer, since each Edge Function
 // invocation is an independent request that defers all shared-state
 // arbitration to that single RPC call.
-import { assertEquals, assertNotEquals } from 'https://deno.land/std@0.168.0/testing/asserts.ts'
+import { assertEquals, assertNotEquals, assertRejects } from 'https://deno.land/std@0.168.0/testing/asserts.ts'
 import {
   handleRequest,
   validateBody,
   buildSystemPrompt,
   buildUserPrompt,
+  createProvider,
   INSIGHT_OPERATIONS,
   MAX_QUESTION_LENGTH,
   PERMISSION_KEY,
+  GROQ_URL,
+  GROQ_MODEL,
   type AuthUserClient,
   type AdminClient,
   type HandleRequestDeps,
   type ProviderCaller,
+  type FetchImpl,
 } from './index.ts'
 
 const ORG_ID = '11111111-1111-1111-1111-111111111111'
@@ -145,6 +149,80 @@ Deno.test('buildUserPrompt includes financial context in an ask prompt when prov
 Deno.test('buildSystemPrompt never mentions any operation-specific data', () => {
   const sys = buildSystemPrompt('en')
   assertEquals(sys.includes('totalSales'), false)
+})
+
+// --- createProvider() direct coverage --------------------------------------
+//
+// handleRequest()'s own tests above drive callProvider through the injected
+// ProviderCaller fake, which never exercises createProvider()'s actual HTTP
+// request/response handling. These tests call createProvider() itself with
+// an injected fake fetch (matching the real `fetch` signature) so the
+// request Groq actually receives, and every one of its response-status
+// branches, is proven directly rather than only through hand-written
+// ProviderResult stand-ins.
+
+function fakeFetch(handler: (input: RequestInfo | URL, init?: RequestInit) => Response): FetchImpl {
+  return ((input: RequestInfo | URL, init?: RequestInit) => Promise.resolve(handler(input, init))) as FetchImpl
+}
+
+Deno.test('createProvider with no API key returns unavailable without ever calling fetch', async () => {
+  let fetchCalled = false
+  const provider = createProvider('', fakeFetch(() => {
+    fetchCalled = true
+    return new Response('should not be reached', { status: 200 })
+  }))
+  const result = await provider('sys', 'user')
+  assertEquals(result, { kind: 'unavailable', reason: 'provider_not_configured' })
+  assertEquals(fetchCalled, false)
+})
+
+Deno.test('createProvider sends the exact URL, model, messages, max_tokens, and temperature Groq expects', async () => {
+  let capturedUrl: string | undefined
+  let capturedInit: RequestInit | undefined
+  const provider = createProvider('real-key', fakeFetch((input, init) => {
+    capturedUrl = String(input)
+    capturedInit = init
+    return new Response(JSON.stringify({ choices: [{ message: { content: 'ok' } }] }), { status: 200 })
+  }))
+
+  await provider('system prompt', 'user prompt')
+
+  assertEquals(capturedUrl, GROQ_URL)
+  assertEquals(capturedInit?.method, 'POST')
+  assertEquals(capturedInit?.headers, { 'Content-Type': 'application/json', Authorization: 'Bearer real-key' })
+  const body = JSON.parse(capturedInit?.body as string)
+  assertEquals(body.model, GROQ_MODEL)
+  assertEquals(body.messages, [
+    { role: 'system', content: 'system prompt' },
+    { role: 'user', content: 'user prompt' },
+  ])
+  assertEquals(body.max_tokens, 500)
+  assertEquals(body.temperature, 0.3)
+})
+
+Deno.test('createProvider parses a successful Groq response into kind:ok with the model text', async () => {
+  const provider = createProvider('real-key', fakeFetch(() =>
+    new Response(JSON.stringify({ choices: [{ message: { content: 'Real model answer' } }] }), { status: 200 })
+  ))
+  const result = await provider('sys', 'user')
+  assertEquals(result, { kind: 'ok', text: 'Real model answer' })
+})
+
+Deno.test('createProvider classifies a 429 response as unavailable, not a thrown error', async () => {
+  const provider = createProvider('real-key', fakeFetch(() => new Response('rate limited', { status: 429 })))
+  const result = await provider('sys', 'user')
+  assertEquals(result, { kind: 'unavailable', reason: 'provider_status_429' })
+})
+
+Deno.test('createProvider classifies a 5xx response as unavailable, not a thrown error', async () => {
+  const provider = createProvider('real-key', fakeFetch(() => new Response('upstream error', { status: 503 })))
+  const result = await provider('sys', 'user')
+  assertEquals(result, { kind: 'unavailable', reason: 'provider_status_503' })
+})
+
+Deno.test('createProvider treats a non-429 4xx as our own request bug, not a classified provider failure — it throws instead of returning unavailable', async () => {
+  const provider = createProvider('real-key', fakeFetch(() => new Response('bad request', { status: 400 })))
+  await assertRejects(() => provider('sys', 'user'), Error, 'provider_request_error_400')
 })
 
 // --- HTTP-level behavior -----------------------------------------------------

--- a/supabase/functions/reports-insights/index.ts
+++ b/supabase/functions/reports-insights/index.ts
@@ -28,7 +28,14 @@
 // — auth, org resolution, permission, quota, provider success/failure —
 // without a live database or network call.
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+// Pinned to the exact version resolved in package-lock.json (the npm side
+// of this same client) rather than the floating "@2" tag: this function
+// runs with the service_role key, so an unreviewed transitive upgrade
+// landing between deploys is not an acceptable way to pick up a new
+// @supabase/supabase-js release. Bump deliberately, alongside the npm
+// dependency, and regenerate supabase/functions/deno.lock in the same
+// change.
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.86.0'
 import { corsHeaders } from '../_shared/cors.ts'
 
 const SUPABASE_URL = Deno.env.get('SUPABASE_URL') ?? ''

--- a/supabase/functions/reports-insights/index.ts
+++ b/supabase/functions/reports-insights/index.ts
@@ -33,8 +33,11 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 // runs with the service_role key, so an unreviewed transitive upgrade
 // landing between deploys is not an acceptable way to pick up a new
 // @supabase/supabase-js release. Bump deliberately, alongside the npm
-// dependency, and regenerate supabase/functions/deno.lock in the same
-// change.
+// dependency, and regenerate the repo's root-level deno.lock in the same
+// change — every `deno check`/`lint`/`test` invocation here (CI included)
+// runs from the repo root, so that root deno.lock is the one that's
+// actually consulted, not a per-function lock next to
+// supabase/functions/deno.json.
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.86.0'
 import { corsHeaders } from '../_shared/cors.ts'
 
@@ -53,8 +56,14 @@ export const MAX_BODY_BYTES = 16 * 1024
 export const MAX_QUESTION_LENGTH = 500
 export const MAX_OUTPUT_CHARS = 4000
 export const PROVIDER_TIMEOUT_MS = 10000
-const GROQ_URL = 'https://api.groq.com/openai/v1/chat/completions'
-const GROQ_MODEL = 'qwen/qwen3.6-27b'
+export const GROQ_URL = 'https://api.groq.com/openai/v1/chat/completions'
+// openai/gpt-oss-120b, not qwen/qwen3.6-27b: Groq classifies Qwen 3.6 27B as
+// Preview ("evaluation purposes only," may be discontinued without notice),
+// while GPT-OSS 120B is Production-tier, lists the same ~500 t/s speed, and
+// is materially cheaper — no reason to run this function's real traffic on
+// an eval-only model when a Production one matches or beats it on every
+// axis that matters here.
+export const GROQ_MODEL = 'openai/gpt-oss-120b'
 
 export const INSIGHT_OPERATIONS = ['summary', 'predictions', 'optimization', 'risk', 'strategy', 'ask'] as const
 export type InsightOperation = (typeof INSIGHT_OPERATIONS)[number]


### PR DESCRIPTION
## Summary

Pre-deployment review of the (still undeployed) `reports-insights` Edge Function found real gaps before it can safely go live:

- **Contract mismatch, provider unavailable → fabricated success.** `supabase/functions/reports-insights/index.ts` answers a classified provider failure (missing `GROQ_API_KEY`, timeout, rate limit, upstream 5xx) with **HTTP 200** and `{success:false, error:'provider_unavailable', source:'fallback'}` by design — that's the documented contract in the function's own header comment. But `EnhancedInsightsDashboard.tsx`'s `handleIframeMessage` only branched on supabase-js's `error` (set only for a non-2xx status), so this 200 always fell into the happy path and relayed `{success:true, text: undefined}` to the sandboxed iframe. The iframe's own `isValidInsightResponse()` (in `dashboard.js`) correctly rejects that malformed shape (`success:true` requires a non-empty `text`) and silently drops it — so the caller sat out the full **15s local-fallback timeout** instead of failing over immediately, even though the real answer was known instantly. Fixed by branching on `data.success` before replying; added a unit test (`EnhancedInsightsDashboard.test.tsx`) that drives this exact branch and asserts the iframe-bound message is honestly `success:false`.
- **Floating `@supabase/supabase-js@2` import with a service_role-keyed function.** The Edge Function imported `https://esm.sh/@supabase/supabase-js@2` (floating major-version tag) despite calling `rpc_check_and_record_ai_usage` through a service_role client. Pinned to `@2.86.0` — the exact version already resolved on the npm side per `package-lock.json` — and regenerated the repo's root-level `deno.lock` so the integrity hash is captured for that exact specifier (every `deno check`/`lint`/`test` invocation here, CI included, runs from the repo root, so that's the lock file actually consulted — not a separate one next to `supabase/functions/deno.json`).
- **Model swapped off Preview tier.** `GROQ_MODEL` was `qwen/qwen3.6-27b`, which Groq's own docs classify as **Preview** — "evaluation purposes only," may be discontinued without notice. Swapped to `openai/gpt-oss-120b`: Production-tier, same listed ~500 t/s speed, materially cheaper. `GROQ_MODEL`/`GROQ_URL` are now exported so tests assert against the real constants instead of a duplicated literal.
- **Direct `createProvider()` test coverage.** Previously only exercised indirectly through `handleRequest()`'s injected `ProviderCaller` fake, which never touched the actual HTTP request-building or response-status handling. Added 6 tests driving `createProvider()` itself with an injected fake `fetch`: outgoing URL/model/messages/`max_tokens`/`temperature` are captured and asserted, a missing API key never calls `fetch`, a successful response parses into `kind:'ok'` with the model text, `429`/`5xx` classify as `unavailable` (not thrown), and a non-429 `4xx` throws (our own bug, not a classified provider failure) — matching the existing `runProvider()` contract that a thrown error becomes a real 500, never a disguised fallback.

## Verification

- `deno check supabase/functions/reports-insights/index.ts` — clean
- `deno lint supabase/functions/reports-insights/index.ts supabase/functions/reports-insights/index.test.ts` — clean
- `deno test --no-check --allow-env supabase/functions/reports-insights/index.test.ts` — **34/34** passing (28 previous + 6 new `createProvider()` tests)
- `npx vitest run src/features/reports/components/__tests__/EnhancedInsightsDashboard.test.tsx` — 8/8 passing
- `npx tsc --noEmit` — clean
- `npx eslint` on changed frontend files — 0 errors (pre-existing `no-explicit-any` warnings only, unrelated to this diff)

## Not in scope

- Deploying the function (`verify_jwt=true`) — stays undeployed until this merges, per the repo's `repository-first` migration/interface-deploy ordering rule in `CLAUDE.md`.
- Confirming `GROQ_API_KEY` exists in the Supabase project's secrets — separate mandatory pre-deploy check, not verifiable from this repo (no MCP tool exposes secret listing, by design). Must be confirmed via `supabase secrets list --project-ref uutfztmqvajmsxnrqeiv` or the dashboard before deploy; never print its value.
- `translate-text`'s own floating `@supabase/supabase-js@2` import — unrelated function, out of scope here.