### PR TITLE
fix(db): Migration 172 — has_permission exact permission-key match

### DIFF
--- a/.github/workflows/has-permission-172-acceptance.yml
+++ b/.github/workflows/has-permission-172-acceptance.yml
@@ -1,0 +1,110 @@
+name: has_permission 172 Acceptance
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'scripts/ci/fresh-db/acceptance_172_has_permission_exact_key_match.sql'
+      - 'sql/migrations/172_has_permission_exact_key_match.sql'
+      - '.github/workflows/has-permission-172-acceptance.yml'
+  workflow_dispatch:
+
+jobs:
+  acceptance:
+    name: Confirm Migration 172 satisfies the exact-permission-key contract
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build fresh database through migration 172
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          PAIR=$(bash scripts/ci/fresh-db/resolve_baseline_pair.sh sql/baseline)
+          pair_field() { printf '%s\n' "$PAIR" | sed -n "s/^$1=//p"; }
+          BASELINE=$(pair_field BASELINE_PATH)
+          REFERENCE=$(pair_field REFERENCE_PATH)
+          CUTOFF=$(pair_field BASELINE_CUTOFF)
+          CUTOFF=${CUTOFF:-0}
+
+          createdb wardah_fresh
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh \
+            -f scripts/ci/fresh-db/supabase_shim.sql -q
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh -f "$BASELINE" -q
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh -f "$REFERENCE" -q
+
+          python3 scripts/ci/fresh-db/build_apply_order.py \
+            sql/migrations "$CUTOFF" > /tmp/chain_order.txt
+          REPORT=/tmp/chain_report.txt PGDATABASE=wardah_fresh \
+            bash scripts/ci/fresh-db/run_chain.sh sql/migrations /tmp/chain_order.txt
+        env:
+          PGHOST: localhost
+          PGUSER: postgres
+          PGPASSWORD: postgres
+
+      - name: Run has_permission 172 acceptance
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh \
+            -f scripts/ci/fresh-db/acceptance_172_has_permission_exact_key_match.sql \
+            2>&1 | tee /tmp/has-permission-172.out
+        env:
+          PGHOST: localhost
+          PGUSER: postgres
+          PGPASSWORD: postgres
+
+      - name: Re-run Migration 170 acceptance to confirm no regression
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh \
+            -f scripts/ci/fresh-db/acceptance_170_tenant_isolation_and_permission_hardening.sql \
+            2>&1 | tee /tmp/tenant-isolation-170-rerun.out
+        env:
+          PGHOST: localhost
+          PGUSER: postgres
+          PGPASSWORD: postgres
+
+      - name: Re-run Migration 171 acceptance to confirm no regression
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh \
+            -f scripts/ci/fresh-db/acceptance_171_ai_usage_daily.sql \
+            2>&1 | tee /tmp/ai-usage-daily-171-rerun.out
+        env:
+          PGHOST: localhost
+          PGUSER: postgres
+          PGPASSWORD: postgres
+
+      - name: Upload acceptance evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: has-permission-172-${{ github.run_id }}
+          path: |
+            /tmp/has-permission-172.out
+            /tmp/tenant-isolation-170-rerun.out
+            /tmp/ai-usage-daily-171-rerun.out
+            /tmp/chain_order.txt
+            /tmp/chain_report.txt
+          if-no-files-found: warn
+          retention-days: 30

--- a/docs/db/HAS_PERMISSION_172_RUNBOOK.md
+++ b/docs/db/HAS_PERMISSION_172_RUNBOOK.md
@@ -53,20 +53,22 @@ The `OR LIKE` clause predates any tenant-scoping work in this codebase (`sql/mig
 scripts/ci/fresh-db/acceptance_172_has_permission_exact_key_match.sql
 ```
 
-Seeds two organizations and six fixture users covering every case in scope, then calls `has_permission()` as each (via `request.jwt.claim.sub`, matching the function's own `auth.uid()` self-check):
+Seeds two organizations and **seven** fixture users covering every case in scope, then calls `has_permission()` as each (via `request.jwt.claim.sub`, matching the function's own `auth.uid()` self-check):
 
 1. **The bug scenario itself**: a user whose only role grants `reports.financial.read` (same module, different permission) — `has_permission(..., 'reports.ai_insights.use')` must return `false`. Before the fix, this returned `true`; confirmed empirically by reverting the function to the pre-172 text on the same fixtures and observing this exact assertion fail (`ACCEPTANCE_FAIL[172-1]`) before restoring the fix and re-confirming a clean pass.
 2. An explicit, exact grant of `reports.ai_insights.use` itself still returns `true`.
 3. Org-admin override (`is_org_admin = true`, no explicit grant) still returns `true`.
 4. Super-admin override (`super_admins` row, no explicit grant, not an org admin) still returns `true`.
 5. Cross-user: a caller cannot query a different user's permission state (Migration 170 behavior, unchanged).
-6. Cross-org: a real member of org B evaluated against org A's id returns `false`, even for the exact permission key.
+6. **Cross-org**: the `CrossOrg` user holds the *exact* `reports.ai_insights.use` key via a real `user_roles` row scoped to org B — first checked against org B itself (must return `true`, proving the grant is real, not a broken fixture), then checked against org A (must return `false`). This fixture shape is deliberate: an earlier draft used a `CrossOrg` user with *no* grant anywhere, which made the org-A assertion pass regardless of whether `ur.org_id = p_org_id` was even present in the function — indistinguishable from case 8 (ungranted) and not a real proof of org scoping. Granting the exact key in the *wrong* org is the only shape that isolates the org predicate specifically. **Mutation-tested**: temporarily removed `AND ur.org_id = p_org_id` from `has_permission` on the same fixtures and confirmed the org-A assertion failed exactly as expected (`ACCEPTANCE_FAIL[172-6]: ... evaluated true against org A`), then restored the predicate and re-confirmed a clean pass.
 7. Expired role: an exact-key grant via a `user_roles` row whose `expires_at` is in the past returns `false`.
-8. Ungranted: a real, active org member with zero role/permission rows returns `false`, not an error.
+8. Ungranted: a **separate, distinct** user (`Ungranted`, not `CrossOrg` — which now genuinely holds a grant) with zero role/permission rows anywhere returns `false`, not an error.
 
 Final marker: `HAS_PERMISSION_172_ACCEPTANCE_PASS`.
 
-**Confirmed green locally on real PostgreSQL 17** (installed from the PGDG apt repository in this session's sandbox, since Docker was unavailable here): Fresh DB built from `000_schema_baseline_20260729_210941.sql` + `001_system_reference_data_20260729_210941.sql` through the full chain (`153` → `172`) via `run_chain.sh`, `11/11 PASS`; `acceptance_172_has_permission_exact_key_match.sql` → `HAS_PERMISSION_172_ACCEPTANCE_PASS`; `acceptance_170_tenant_isolation_and_permission_hardening.sql` → `TENANT_ISOLATION_170_ACCEPTANCE_PASS` (re-run after 172, confirming no regression); `acceptance_171_ai_usage_daily.sql` → `AI_USAGE_DAILY_171_ACCEPTANCE_PASS` (same). The dedicated `has-permission-172-acceptance.yml` workflow mirrors this exactly for CI.
+Migration 172's own postflight `$verify$` block also asserts `has_permission`'s `prosrc` still contains the `ur\.org_id\s*=\s*p_org_id` predicate text, independent of the acceptance suite's behavioral proof — a static, in-migration check that the org-scoping join condition specifically was not dropped.
+
+**Confirmed green locally on real PostgreSQL 17** (installed from the PGDG apt repository in this session's sandbox, since Docker was unavailable here): Fresh DB built from `000_schema_baseline_20260729_210941.sql` + `001_system_reference_data_20260729_210941.sql` through the full chain (`153` → `172`) via `run_chain.sh`, `11/11 PASS`; `acceptance_172_has_permission_exact_key_match.sql` → `HAS_PERMISSION_172_ACCEPTANCE_PASS` (9 assertions, including the cross-org setup check); `acceptance_170_tenant_isolation_and_permission_hardening.sql` → `TENANT_ISOLATION_170_ACCEPTANCE_PASS` (re-run after 172, confirming no regression); `acceptance_171_ai_usage_daily.sql` → `AI_USAGE_DAILY_171_ACCEPTANCE_PASS` (same). Both the same-module mutation (case 1) and the org-scoping mutation (case 6) were independently confirmed to fail acceptance when reverted, then pass cleanly when restored. The dedicated `has-permission-172-acceptance.yml` workflow mirrors this exactly for CI.
 
 ## 5. Production apply
 
@@ -96,7 +98,8 @@ SELECT
   prosrc ~ 'p_user_id IS DISTINCT FROM auth\.uid\(\)' AS identity_guard_present,
   prosrc ~ 'super_admins' AS super_admin_override_present,
   prosrc ~ 'is_org_admin' AS org_admin_override_present,
-  prosrc ~ 'expires_at' AS role_expiry_present
+  prosrc ~ 'expires_at' AS role_expiry_present,
+  prosrc ~ 'ur\.org_id\s*=\s*p_org_id' AS org_scoping_present
 FROM pg_proc WHERE proname = 'has_permission';
 -- Expect every column true.
 
@@ -108,7 +111,7 @@ SELECT version, name FROM supabase_migrations.schema_migrations
 WHERE name = '172_has_permission_exact_key_match';
 ```
 
-Expected: `like_removed`, `exact_match_present`, `identity_guard_present`, `super_admin_override_present`, `org_admin_override_present`, and `role_expiry_present` all `true`; `has_function_privilege` `true`; exactly one ledger row for 172.
+Expected: `like_removed`, `exact_match_present`, `identity_guard_present`, `super_admin_override_present`, `org_admin_override_present`, `role_expiry_present`, and `org_scoping_present` all `true`; `has_function_privilege` `true`; exactly one ledger row for 172.
 
 ## 6. Rollback
 

--- a/docs/db/HAS_PERMISSION_172_RUNBOOK.md
+++ b/docs/db/HAS_PERMISSION_172_RUNBOOK.md
@@ -1,0 +1,121 @@
+# Migration 172 — `has_permission` Exact Permission-Key Match Runbook
+
+**Migration:** `172_has_permission_exact_key_match.sql`
+**Scope:** Close a same-module authorization-scope bug in `has_permission()`, inherited unchanged through Migration 170, that let any granted permission in a module implicitly satisfy every other permission key in that same module.
+**State:** Repository implementation, not yet applied to Production. Do not apply before the paired Fresh DB acceptance gate is green and this runbook's preflight/postflight queries have been reviewed.
+
+## 1. Purpose
+
+Pre-deployment verification of the (still undeployed) `reports-insights` Edge Function found that `has_permission(p_user_id, p_org_id, p_permission_key)`'s "ordinary role" branch — unchanged by Migration 170, which only added the caller-identity guard around it — matches not only an exact `permission_key`, but any `permission_key` sharing the same first dot-segment:
+
+```sql
+p.permission_key = p_permission_key
+OR p.permission_key LIKE REPLACE(
+     SPLIT_PART(p_permission_key, '.', 1) || '.%', '*', '%'
+   )
+```
+
+For `p_permission_key = 'reports.ai_insights.use'`, `SPLIT_PART(p_permission_key, '.', 1)` is `'reports'`, so the pattern reduces to `p.permission_key LIKE 'reports.%'` — `REPLACE(...,'*','%')` is a no-op here since the pattern never contains a literal `*`. Any role holding **any** `reports.*` permission (e.g. `reports.financial.read`, `reports.exports.export`) therefore implicitly satisfied `reports.ai_insights.use`, defeating the dedicated permission Migration 171 introduced specifically to gate the `reports-insights` Edge Function's AI usage quota. This is a general same-module authorization-scope bug affecting every permission key in the catalog, not just this one.
+
+## 2. Root cause and caller audit
+
+The `OR LIKE` clause predates any tenant-scoping work in this codebase (`sql/migrations/41_multi_tenant_rls_policies.sql`) and survived Migration 170's `has_permission` rewrite untouched — 170 only added the `p_user_id IS DISTINCT FROM auth.uid()` self-check as the function's first statement; it did not touch the ordinary-role predicate.
+
+**Live-data confirmation (read-only, before writing this migration):** queried Production (`uutfztmqvajmsxnrqeiv`) directly — `has_permission`'s `prosrc` matches the buggy text above verbatim, and the live `permissions` catalog holds **169 rows, 0 of which contain a literal `*`**. No `permission_key` in actual use depends on wildcard/prefix matching; the `REPLACE(...,'*','%')` call was always a no-op against real data, and the `LIKE` clause never did anything except accidentally broaden every same-module check.
+
+**Caller audit — does any caller rely on the broad match?**
+
+| Caller | Permission key(s) passed | Exact vs. broadened | Affected? |
+|---|---|---|---|
+| `149_ap_three_way_match_allocations.sql` (RPC, `rpc_post_ap_matched_invoice`-family) | `'purchasing.purchase_invoices.approve'` (literal, exact) | Exact — a literal match was always intended and always worked without the `LIKE` clause | No |
+| `150_ap_matched_invoice_idempotency_and_grn_gate.sql` (same RPC family) | `'purchasing.purchase_invoices.approve'` (literal, exact) | Same as above | No |
+| Baseline copies of the same two RPCs (`sql/baseline/000_schema_baseline_20260729_210941.sql`) | Same literal | Same as above | No |
+| `supabase/functions/reports-insights/index.ts` (`authorize()`) | `PERMISSION_KEY = 'reports.ai_insights.use'` (exact, via `authorize()` → `userClient.rpc('has_permission', ...)`) | Exact intent — this is the caller the bug actually defeats | No (this caller needed the fix, not the broad match) |
+| `src/hooks/usePermissions.ts` — exported `checkPermission(userId, orgId, moduleCode, action)` utility, constructs `p_permission_key: \`${moduleCode}.${action}\`` (a 2-segment key against a 3-segment `module.resource.action` catalog) | Rarely if ever exactly equal to a real key — this is the one place in the codebase that would actually have depended on the broad match to return `true` at all | **Zero importers anywhere in `src/`** (confirmed via `grep -rln`) — dead code, not a live dependency | No — unreachable |
+| `src/hooks/usePermissions.ts` — the actual `usePermissions()` hook used by `ModuleGuard`, `ProtectedComponent`, `sidebar.tsx`, `withPermission.tsx` | N/A | Never calls the `has_permission` RPC at all — fetches permission rows directly and does its own exact `module_code`+`action` comparison client-side | No — independent code path |
+
+**Conclusion: no live caller anywhere in this codebase (SQL or application) relies on the broad same-module match.** The only caller that structurally could have depended on it is dead code with zero importers.
+
+## 3. What the migration changes
+
+| Change | Detail |
+|---|---|
+| `has_permission` | `CREATE OR REPLACE`. Ordinary-role predicate: `p.permission_key = p_permission_key` only — the `OR p.permission_key LIKE ...` clause is removed entirely. `auth.uid()` self-check (170), super-admin override, org-admin override, `ur.org_id = p_org_id` scoping, and `(ur.expires_at IS NULL OR ur.expires_at > NOW())` role-expiry behavior are byte-identical to Migration 170 — untouched. |
+| Grants | Unchanged (`authenticated`, `service_role` retain `EXECUTE`) — this migration narrows the predicate only, not the execution boundary. |
+| `scripts/ci/check_definer_guards.py` | No change needed — `has_permission` was already added to `KNOWN_EXEMPT` by Migration 170 (guarded by a direct `auth.uid()` comparison, not an org-membership helper). |
+| Preflight | Fails closed (`PERMISSION_172_HAS_PERMISSION_MISSING`, `PERMISSION_172_REQUIRED_TABLE_MISSING`) if the schema has drifted from what this migration assumes, before touching anything. |
+| Postflight | In-transaction `$verify$` block: `has_permission`'s `prosrc` no longer contains `LIKE` (`FAIL[172]`); still contains the exact-equality predicate (`FAIL[172]`); and still contains the `auth.uid()` self-check, `super_admins` override, `is_org_admin` override, and `expires_at` role-expiry text from Migration 170 (each a distinct `FAIL[172]` check) — proving the fix narrowed only the intended predicate, not the surrounding contract. Raises before `COMMIT` on any failure. |
+| Locking | Function-only change — no `LOCK TABLE` (matches the convention already used for function-only migrations such as 121); `SET LOCAL lock_timeout = '30s'`, `statement_timeout = '5min'`. |
+
+## 4. Acceptance gate
+
+```text
+scripts/ci/fresh-db/acceptance_172_has_permission_exact_key_match.sql
+```
+
+Seeds two organizations and six fixture users covering every case in scope, then calls `has_permission()` as each (via `request.jwt.claim.sub`, matching the function's own `auth.uid()` self-check):
+
+1. **The bug scenario itself**: a user whose only role grants `reports.financial.read` (same module, different permission) — `has_permission(..., 'reports.ai_insights.use')` must return `false`. Before the fix, this returned `true`; confirmed empirically by reverting the function to the pre-172 text on the same fixtures and observing this exact assertion fail (`ACCEPTANCE_FAIL[172-1]`) before restoring the fix and re-confirming a clean pass.
+2. An explicit, exact grant of `reports.ai_insights.use` itself still returns `true`.
+3. Org-admin override (`is_org_admin = true`, no explicit grant) still returns `true`.
+4. Super-admin override (`super_admins` row, no explicit grant, not an org admin) still returns `true`.
+5. Cross-user: a caller cannot query a different user's permission state (Migration 170 behavior, unchanged).
+6. Cross-org: a real member of org B evaluated against org A's id returns `false`, even for the exact permission key.
+7. Expired role: an exact-key grant via a `user_roles` row whose `expires_at` is in the past returns `false`.
+8. Ungranted: a real, active org member with zero role/permission rows returns `false`, not an error.
+
+Final marker: `HAS_PERMISSION_172_ACCEPTANCE_PASS`.
+
+**Confirmed green locally on real PostgreSQL 17** (installed from the PGDG apt repository in this session's sandbox, since Docker was unavailable here): Fresh DB built from `000_schema_baseline_20260729_210941.sql` + `001_system_reference_data_20260729_210941.sql` through the full chain (`153` → `172`) via `run_chain.sh`, `11/11 PASS`; `acceptance_172_has_permission_exact_key_match.sql` → `HAS_PERMISSION_172_ACCEPTANCE_PASS`; `acceptance_170_tenant_isolation_and_permission_hardening.sql` → `TENANT_ISOLATION_170_ACCEPTANCE_PASS` (re-run after 172, confirming no regression); `acceptance_171_ai_usage_daily.sql` → `AI_USAGE_DAILY_171_ACCEPTANCE_PASS` (same). The dedicated `has-permission-172-acceptance.yml` workflow mirrors this exactly for CI.
+
+## 5. Production apply
+
+Target project: Supabase `uutfztmqvajmsxnrqeiv` ("Manufacturing Process") — **not** `Wardah-Prod` (`rytzljjlthouptdqeuxh`), which is `INACTIVE`.
+
+**Preflight (read-only, before applying):**
+```sql
+-- Confirm the exact current (broken) predicate text, for the record.
+SELECT prosrc FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname = 'public' AND p.proname = 'has_permission';
+-- Expect the OR-LIKE clause to still be present.
+
+-- Confirm the live permission catalog has no wildcard keys (sanity check
+-- this migration's premise still holds at apply time).
+SELECT count(*) AS total, count(*) FILTER (WHERE permission_key LIKE '%*%') AS wildcard_count
+FROM public.permissions;
+-- Expect wildcard_count = 0.
+```
+
+**Postflight (read-only, after applying):**
+```sql
+-- has_permission must no longer contain LIKE, must contain the exact
+-- equality predicate, and must retain every Migration 170 behavior.
+SELECT
+  prosrc !~ 'LIKE' AS like_removed,
+  prosrc ~ 'p\.permission_key\s*=\s*p_permission_key' AS exact_match_present,
+  prosrc ~ 'p_user_id IS DISTINCT FROM auth\.uid\(\)' AS identity_guard_present,
+  prosrc ~ 'super_admins' AS super_admin_override_present,
+  prosrc ~ 'is_org_admin' AS org_admin_override_present,
+  prosrc ~ 'expires_at' AS role_expiry_present
+FROM pg_proc WHERE proname = 'has_permission';
+-- Expect every column true.
+
+SELECT has_function_privilege('authenticated', 'has_permission(uuid,uuid,varchar)', 'EXECUTE');
+-- Expect true (unchanged, still callable).
+
+-- Ledger row landed exactly once.
+SELECT version, name FROM supabase_migrations.schema_migrations
+WHERE name = '172_has_permission_exact_key_match';
+```
+
+Expected: `like_removed`, `exact_match_present`, `identity_guard_present`, `super_admin_override_present`, `org_admin_override_present`, and `role_expiry_present` all `true`; `has_function_privilege` `true`; exactly one ledger row for 172.
+
+## 6. Rollback
+
+Additive apart from replacing `has_permission()`'s ordinary-role predicate — a single `CREATE OR REPLACE FUNCTION`. Before any Production traffic depends on the tightened contract, the reviewed recovery is to correct forward with a new numbered migration rather than hand-edit 172 in place, per the project's golden rule. Do not restore the `OR LIKE` same-module match under any circumstance — it is the exact vulnerability this migration closes, and the caller audit in §2 confirms no legitimate caller needs it. If a legitimate workflow is found broken by the tightened match (a caller genuinely needs a same-module or hierarchical permission check), the correct response is a forward-fix migration that adds an explicit, narrow mechanism for that (e.g. a dedicated parent-permission table, not a `LIKE` pattern reconstructed from string-splitting the key), not reverting to the broad match.
+
+Never edit `supabase_migrations.schema_migrations` to remove this row, and never apply SQL that is not the exact file merged to `main`.
+
+## 7. Relationship to `reports-insights` deployment
+
+This migration is a **prerequisite** for deploying the `reports-insights` Edge Function (`verify_jwt=true`), per the repository's `repository-first` migration / `DB-first` interface ordering rule (`CLAUDE.md`). The Edge Function calls `has_permission(auth.uid(), org_id, 'reports.ai_insights.use')` to gate access before ever reaching the AI provider or the daily-quota RPC; without this fix, any role holding an unrelated `reports.*` permission would bypass that gate entirely. The function remains undeployed until: this migration is merged to `main`, applied to Production, and verified via the postflight queries in §5 above — after which the Edge Function deployment and its own agreed Production checks (401 without JWT, 403 without permission, 200 for an authorized user, immediate fallback on provider failure, 429 on quota) proceed as a separate, later step.

--- a/scripts/ci/fresh-db/acceptance_172_has_permission_exact_key_match.sql
+++ b/scripts/ci/fresh-db/acceptance_172_has_permission_exact_key_match.sql
@@ -1,0 +1,245 @@
+-- Acceptance for Migration 172.
+-- Proves the exact bug scenario and every behavior Migration 172 must
+-- preserve unchanged from Migration 170:
+-- (1) a role holding a DIFFERENT permission in the SAME module
+--     (reports.financial.read) does NOT grant reports.ai_insights.use —
+--     the specific defeat of Migration 171's dedicated permission that
+--     motivated this fix;
+-- (2) an explicit, exact grant of reports.ai_insights.use itself still
+--     returns true;
+-- (3) org-admin and super-admin overrides still return true regardless of
+--     any specific grant;
+-- (4) cross-user, cross-org, expired-role, and ungranted checks all still
+--     return false.
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- 1. Fixtures.
+--
+-- Org A / Org B, disjoint.
+-- User SameModule: org A member, role grants ONLY reports.financial.read.
+-- User Exact: org A member, role grants ONLY reports.ai_insights.use.
+-- User OrgAdmin: org A member, is_org_admin = true, no explicit grants.
+-- User Super: super_admins row, is_active = true, no explicit grants.
+-- User Expired: org A member, role grants reports.ai_insights.use but
+--   user_roles.expires_at is in the past.
+-- User CrossOrg: org B member, no grants at all in org A.
+-- ---------------------------------------------------------------------------
+INSERT INTO auth.users (id, email) VALUES
+  ('99172172-0001-0001-0001-000000000001', 'perm172-samemodule@example.test'),
+  ('99172172-0002-0002-0002-000000000002', 'perm172-exact@example.test'),
+  ('99172172-0003-0003-0003-000000000003', 'perm172-orgadmin@example.test'),
+  ('99172172-0004-0004-0004-000000000004', 'perm172-super@example.test'),
+  ('99172172-0005-0005-0005-000000000005', 'perm172-expired@example.test'),
+  ('99172172-0006-0006-0006-000000000006', 'perm172-crossorg@example.test');
+
+INSERT INTO public.organizations (id, name, code) VALUES
+  ('99172172-a000-a000-a000-00000000000a', 'Perm172 Org A', 'P172-A'),
+  ('99172172-b000-b000-b000-00000000000b', 'Perm172 Org B', 'P172-B');
+
+INSERT INTO public.user_organizations (user_id, org_id, is_active, is_org_admin) VALUES
+  ('99172172-0001-0001-0001-000000000001', '99172172-a000-a000-a000-00000000000a', true, false),
+  ('99172172-0002-0002-0002-000000000002', '99172172-a000-a000-a000-00000000000a', true, false),
+  ('99172172-0003-0003-0003-000000000003', '99172172-a000-a000-a000-00000000000a', true, true),
+  ('99172172-0004-0004-0004-000000000004', '99172172-a000-a000-a000-00000000000a', true, false),
+  ('99172172-0005-0005-0005-000000000005', '99172172-a000-a000-a000-00000000000a', true, false),
+  ('99172172-0006-0006-0006-000000000006', '99172172-b000-b000-b000-00000000000b', true, false);
+
+INSERT INTO public.super_admins (user_id, email, is_active) VALUES
+  ('99172172-0004-0004-0004-000000000004', 'perm172-super@example.test', true);
+
+-- Two permissions in the SAME module ('reports'): the pre-fix defeat and
+-- the permission actually being tested for.
+INSERT INTO public.permissions (id, module_id, resource, resource_ar, action, action_ar, permission_key)
+SELECT '99172172-0000-0000-0000-000000000010', id, 'financial', 'مالي', 'read', 'قراءة', 'reports.financial.read'
+FROM public.modules WHERE name = 'reports'
+ON CONFLICT (permission_key) DO NOTHING;
+
+INSERT INTO public.permissions (id, module_id, resource, resource_ar, action, action_ar, permission_key)
+SELECT '99172172-0000-0000-0000-000000000011', id, 'ai_insights', 'الرؤى الذكية', 'use', 'استخدام', 'reports.ai_insights.use'
+FROM public.modules WHERE name = 'reports'
+ON CONFLICT (permission_key) DO NOTHING;
+
+-- Roles: one per test user that needs a specific grant.
+INSERT INTO public.roles (id, org_id, name, name_ar) VALUES
+  ('99172172-0000-0000-0000-000000000020', '99172172-a000-a000-a000-00000000000a', 'Perm172 SameModule Role', 'دور نفس-الوحدة'),
+  ('99172172-0000-0000-0000-000000000021', '99172172-a000-a000-a000-00000000000a', 'Perm172 Exact Role', 'دور مطابقة تامة'),
+  ('99172172-0000-0000-0000-000000000022', '99172172-a000-a000-a000-00000000000a', 'Perm172 Expired Role', 'دور منتهي');
+
+INSERT INTO public.role_permissions (role_id, permission_id) VALUES
+  ('99172172-0000-0000-0000-000000000020',
+   (SELECT id FROM public.permissions WHERE permission_key = 'reports.financial.read')),
+  ('99172172-0000-0000-0000-000000000021',
+   (SELECT id FROM public.permissions WHERE permission_key = 'reports.ai_insights.use')),
+  ('99172172-0000-0000-0000-000000000022',
+   (SELECT id FROM public.permissions WHERE permission_key = 'reports.ai_insights.use'));
+
+INSERT INTO public.user_roles (user_id, role_id, org_id, expires_at) VALUES
+  ('99172172-0001-0001-0001-000000000001', '99172172-0000-0000-0000-000000000020',
+   '99172172-a000-a000-a000-00000000000a', NULL),
+  ('99172172-0002-0002-0002-000000000002', '99172172-0000-0000-0000-000000000021',
+   '99172172-a000-a000-a000-00000000000a', NULL),
+  ('99172172-0005-0005-0005-000000000005', '99172172-0000-0000-0000-000000000022',
+   '99172172-a000-a000-a000-00000000000a', '2020-01-01T00:00:00Z');
+
+-- ---------------------------------------------------------------------------
+-- 2. As each fixture user (JWT-scoped, matching has_permission's own
+-- auth.uid() self-check), call has_permission for 'reports.ai_insights.use'.
+-- ---------------------------------------------------------------------------
+
+-- 2a. THE bug scenario: a role granting only reports.financial.read (same
+-- module, different permission) must NOT satisfy reports.ai_insights.use.
+SELECT set_config('request.jwt.claim.sub', '99172172-0001-0001-0001-000000000001', false);
+SET LOCAL ROLE authenticated;
+DO $$
+DECLARE v_result boolean;
+BEGIN
+  SELECT public.has_permission(
+    '99172172-0001-0001-0001-000000000001',
+    '99172172-a000-a000-a000-00000000000a',
+    'reports.ai_insights.use'
+  ) INTO v_result;
+  IF v_result IS DISTINCT FROM false THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[172-1]: reports.financial.read implicitly granted reports.ai_insights.use (same-module wildcard regression): %', v_result;
+  END IF;
+END;
+$$;
+RESET ROLE;
+
+-- 2b. Explicit exact grant must still return true.
+SELECT set_config('request.jwt.claim.sub', '99172172-0002-0002-0002-000000000002', false);
+SET LOCAL ROLE authenticated;
+DO $$
+DECLARE v_result boolean;
+BEGIN
+  SELECT public.has_permission(
+    '99172172-0002-0002-0002-000000000002',
+    '99172172-a000-a000-a000-00000000000a',
+    'reports.ai_insights.use'
+  ) INTO v_result;
+  IF v_result IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[172-2]: exact reports.ai_insights.use grant did not return true: %', v_result;
+  END IF;
+END;
+$$;
+RESET ROLE;
+
+-- 2c. Org admin override still returns true with no explicit grant at all.
+SELECT set_config('request.jwt.claim.sub', '99172172-0003-0003-0003-000000000003', false);
+SET LOCAL ROLE authenticated;
+DO $$
+DECLARE v_result boolean;
+BEGIN
+  SELECT public.has_permission(
+    '99172172-0003-0003-0003-000000000003',
+    '99172172-a000-a000-a000-00000000000a',
+    'reports.ai_insights.use'
+  ) INTO v_result;
+  IF v_result IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[172-3]: org-admin override did not return true: %', v_result;
+  END IF;
+END;
+$$;
+RESET ROLE;
+
+-- 2d. Super admin override still returns true with no explicit grant and no
+-- org-admin flag.
+SELECT set_config('request.jwt.claim.sub', '99172172-0004-0004-0004-000000000004', false);
+SET LOCAL ROLE authenticated;
+DO $$
+DECLARE v_result boolean;
+BEGIN
+  SELECT public.has_permission(
+    '99172172-0004-0004-0004-000000000004',
+    '99172172-a000-a000-a000-00000000000a',
+    'reports.ai_insights.use'
+  ) INTO v_result;
+  IF v_result IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[172-4]: super-admin override did not return true: %', v_result;
+  END IF;
+END;
+$$;
+RESET ROLE;
+
+-- 2e. Cross-user: a caller cannot query a different user's permission
+-- state (Migration 170 behavior, must survive unchanged).
+SELECT set_config('request.jwt.claim.sub', '99172172-0001-0001-0001-000000000001', false);
+SET LOCAL ROLE authenticated;
+DO $$
+DECLARE v_result boolean;
+BEGIN
+  SELECT public.has_permission(
+    '99172172-0002-0002-0002-000000000002',
+    '99172172-a000-a000-a000-00000000000a',
+    'reports.ai_insights.use'
+  ) INTO v_result;
+  IF v_result IS DISTINCT FROM false THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[172-5]: has_permission answered for a different caller: %', v_result;
+  END IF;
+END;
+$$;
+RESET ROLE;
+
+-- 2f. Cross-org: a real member of org B, checked against org A's id, must
+-- return false even for the exact permission key (no membership in org A
+-- at all).
+SELECT set_config('request.jwt.claim.sub', '99172172-0006-0006-0006-000000000006', false);
+SET LOCAL ROLE authenticated;
+DO $$
+DECLARE v_result boolean;
+BEGIN
+  SELECT public.has_permission(
+    '99172172-0006-0006-0006-000000000006',
+    '99172172-a000-a000-a000-00000000000a',
+    'reports.ai_insights.use'
+  ) INTO v_result;
+  IF v_result IS DISTINCT FROM false THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[172-6]: org B member evaluated true against org A: %', v_result;
+  END IF;
+END;
+$$;
+RESET ROLE;
+
+-- 2g. Expired role: a grant of the exact permission key via a role whose
+-- user_roles.expires_at is in the past must return false.
+SELECT set_config('request.jwt.claim.sub', '99172172-0005-0005-0005-000000000005', false);
+SET LOCAL ROLE authenticated;
+DO $$
+DECLARE v_result boolean;
+BEGIN
+  SELECT public.has_permission(
+    '99172172-0005-0005-0005-000000000005',
+    '99172172-a000-a000-a000-00000000000a',
+    'reports.ai_insights.use'
+  ) INTO v_result;
+  IF v_result IS DISTINCT FROM false THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[172-7]: expired user_roles grant still evaluated true: %', v_result;
+  END IF;
+END;
+$$;
+RESET ROLE;
+
+-- 2h. Ungranted: a real org member with zero role/permission rows at all
+-- must return false, not error.
+SELECT set_config('request.jwt.claim.sub', '99172172-0006-0006-0006-000000000006', false);
+SET LOCAL ROLE authenticated;
+DO $$
+DECLARE v_result boolean;
+BEGIN
+  SELECT public.has_permission(
+    '99172172-0006-0006-0006-000000000006',
+    '99172172-b000-b000-b000-00000000000b',
+    'reports.ai_insights.use'
+  ) INTO v_result;
+  IF v_result IS DISTINCT FROM false THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[172-8]: ungranted same-org check did not return false: %', v_result;
+  END IF;
+END;
+$$;
+RESET ROLE;
+
+ROLLBACK;
+
+SELECT 'HAS_PERMISSION_172_ACCEPTANCE_PASS';

--- a/scripts/ci/fresh-db/acceptance_172_has_permission_exact_key_match.sql
+++ b/scripts/ci/fresh-db/acceptance_172_has_permission_exact_key_match.sql
@@ -11,6 +11,19 @@
 --     any specific grant;
 -- (4) cross-user, cross-org, expired-role, and ungranted checks all still
 --     return false.
+--
+-- Cross-org test design note: assertion 172-6 grants the CrossOrg user the
+-- EXACT permission key in org B (via a real role/user_roles row with
+-- user_roles.org_id = org B), then calls has_permission() against org A.
+-- This is deliberate, not incidental: a fixture user with no grant at all
+-- would make 172-6 pass even if `AND ur.org_id = p_org_id` were removed
+-- from has_permission entirely, since the query would already return no
+-- rows for an unrelated reason (no grant anywhere) — indistinguishable
+-- from assertion 172-8 (ungranted) and proving nothing about org scoping
+-- specifically. Granting the exact key in the WRONG org is the only
+-- fixture shape that makes 172-6 a real regression guard for the org
+-- predicate; see the mutation-test note in
+-- docs/db/HAS_PERMISSION_172_RUNBOOK.md for the empirical confirmation.
 \set ON_ERROR_STOP on
 
 BEGIN;
@@ -25,7 +38,13 @@ BEGIN;
 -- User Super: super_admins row, is_active = true, no explicit grants.
 -- User Expired: org A member, role grants reports.ai_insights.use but
 --   user_roles.expires_at is in the past.
--- User CrossOrg: org B member, no grants at all in org A.
+-- User CrossOrg: org B member, role grants the EXACT reports.ai_insights.use
+--   key with user_roles.org_id = org B — a real grant in the wrong org, not
+--   an absence of any grant (see the header note above on why this shape is
+--   required for 172-6 to be a genuine org-scoping regression guard).
+-- User Ungranted: org B member, zero role/permission rows anywhere — a
+--   distinct user from CrossOrg so 172-8 (ungranted) and 172-6 (cross-org,
+--   with a real grant in the wrong org) cannot collapse into the same case.
 -- ---------------------------------------------------------------------------
 INSERT INTO auth.users (id, email) VALUES
   ('99172172-0001-0001-0001-000000000001', 'perm172-samemodule@example.test'),
@@ -33,7 +52,8 @@ INSERT INTO auth.users (id, email) VALUES
   ('99172172-0003-0003-0003-000000000003', 'perm172-orgadmin@example.test'),
   ('99172172-0004-0004-0004-000000000004', 'perm172-super@example.test'),
   ('99172172-0005-0005-0005-000000000005', 'perm172-expired@example.test'),
-  ('99172172-0006-0006-0006-000000000006', 'perm172-crossorg@example.test');
+  ('99172172-0006-0006-0006-000000000006', 'perm172-crossorg@example.test'),
+  ('99172172-0007-0007-0007-000000000007', 'perm172-ungranted@example.test');
 
 INSERT INTO public.organizations (id, name, code) VALUES
   ('99172172-a000-a000-a000-00000000000a', 'Perm172 Org A', 'P172-A'),
@@ -45,7 +65,8 @@ INSERT INTO public.user_organizations (user_id, org_id, is_active, is_org_admin)
   ('99172172-0003-0003-0003-000000000003', '99172172-a000-a000-a000-00000000000a', true, true),
   ('99172172-0004-0004-0004-000000000004', '99172172-a000-a000-a000-00000000000a', true, false),
   ('99172172-0005-0005-0005-000000000005', '99172172-a000-a000-a000-00000000000a', true, false),
-  ('99172172-0006-0006-0006-000000000006', '99172172-b000-b000-b000-00000000000b', true, false);
+  ('99172172-0006-0006-0006-000000000006', '99172172-b000-b000-b000-00000000000b', true, false),
+  ('99172172-0007-0007-0007-000000000007', '99172172-b000-b000-b000-00000000000b', true, false);
 
 INSERT INTO public.super_admins (user_id, email, is_active) VALUES
   ('99172172-0004-0004-0004-000000000004', 'perm172-super@example.test', true);
@@ -62,11 +83,14 @@ SELECT '99172172-0000-0000-0000-000000000011', id, 'ai_insights', 'الرؤى ا
 FROM public.modules WHERE name = 'reports'
 ON CONFLICT (permission_key) DO NOTHING;
 
--- Roles: one per test user that needs a specific grant.
+-- Roles: one per test user that needs a specific grant. The org B role
+-- grants CrossOrg the EXACT reports.ai_insights.use key — the fixture that
+-- makes 172-6 a genuine org-scoping proof (see header note).
 INSERT INTO public.roles (id, org_id, name, name_ar) VALUES
   ('99172172-0000-0000-0000-000000000020', '99172172-a000-a000-a000-00000000000a', 'Perm172 SameModule Role', 'دور نفس-الوحدة'),
   ('99172172-0000-0000-0000-000000000021', '99172172-a000-a000-a000-00000000000a', 'Perm172 Exact Role', 'دور مطابقة تامة'),
-  ('99172172-0000-0000-0000-000000000022', '99172172-a000-a000-a000-00000000000a', 'Perm172 Expired Role', 'دور منتهي');
+  ('99172172-0000-0000-0000-000000000022', '99172172-a000-a000-a000-00000000000a', 'Perm172 Expired Role', 'دور منتهي'),
+  ('99172172-0000-0000-0000-000000000023', '99172172-b000-b000-b000-00000000000b', 'Perm172 Org B Exact Role', 'دور مطابقة تامة (منظمة ب)');
 
 INSERT INTO public.role_permissions (role_id, permission_id) VALUES
   ('99172172-0000-0000-0000-000000000020',
@@ -74,6 +98,8 @@ INSERT INTO public.role_permissions (role_id, permission_id) VALUES
   ('99172172-0000-0000-0000-000000000021',
    (SELECT id FROM public.permissions WHERE permission_key = 'reports.ai_insights.use')),
   ('99172172-0000-0000-0000-000000000022',
+   (SELECT id FROM public.permissions WHERE permission_key = 'reports.ai_insights.use')),
+  ('99172172-0000-0000-0000-000000000023',
    (SELECT id FROM public.permissions WHERE permission_key = 'reports.ai_insights.use'));
 
 INSERT INTO public.user_roles (user_id, role_id, org_id, expires_at) VALUES
@@ -82,7 +108,9 @@ INSERT INTO public.user_roles (user_id, role_id, org_id, expires_at) VALUES
   ('99172172-0002-0002-0002-000000000002', '99172172-0000-0000-0000-000000000021',
    '99172172-a000-a000-a000-00000000000a', NULL),
   ('99172172-0005-0005-0005-000000000005', '99172172-0000-0000-0000-000000000022',
-   '99172172-a000-a000-a000-00000000000a', '2020-01-01T00:00:00Z');
+   '99172172-a000-a000-a000-00000000000a', '2020-01-01T00:00:00Z'),
+  ('99172172-0006-0006-0006-000000000006', '99172172-0000-0000-0000-000000000023',
+   '99172172-b000-b000-b000-00000000000b', NULL);
 
 -- ---------------------------------------------------------------------------
 -- 2. As each fixture user (JWT-scoped, matching has_permission's own
@@ -182,21 +210,37 @@ END;
 $$;
 RESET ROLE;
 
--- 2f. Cross-org: a real member of org B, checked against org A's id, must
--- return false even for the exact permission key (no membership in org A
--- at all).
+-- 2f. Cross-org: CrossOrg holds the EXACT reports.ai_insights.use key, but
+-- only via a user_roles row scoped to org B (ur.org_id = org B). First
+-- prove the grant is real by checking it against org B (must be true) —
+-- otherwise a mistake in the fixture wiring could make the org A check
+-- below pass for the wrong reason (no real grant anywhere, same as 172-8)
+-- rather than because org scoping actually rejected it. Then check against
+-- org A: must return false, and — unlike the old fixture shape — this can
+-- ONLY be false because of `ur.org_id = p_org_id`, since the exact key and
+-- an active org B membership both exist.
 SELECT set_config('request.jwt.claim.sub', '99172172-0006-0006-0006-000000000006', false);
 SET LOCAL ROLE authenticated;
 DO $$
-DECLARE v_result boolean;
+DECLARE v_org_b_result boolean;
+DECLARE v_org_a_result boolean;
 BEGIN
+  SELECT public.has_permission(
+    '99172172-0006-0006-0006-000000000006',
+    '99172172-b000-b000-b000-00000000000b',
+    'reports.ai_insights.use'
+  ) INTO v_org_b_result;
+  IF v_org_b_result IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[172-6-setup]: CrossOrg fixture grant did not evaluate true in its own org B (fixture wiring is broken, 172-6 below would be meaningless): %', v_org_b_result;
+  END IF;
+
   SELECT public.has_permission(
     '99172172-0006-0006-0006-000000000006',
     '99172172-a000-a000-a000-00000000000a',
     'reports.ai_insights.use'
-  ) INTO v_result;
-  IF v_result IS DISTINCT FROM false THEN
-    RAISE EXCEPTION 'ACCEPTANCE_FAIL[172-6]: org B member evaluated true against org A: %', v_result;
+  ) INTO v_org_a_result;
+  IF v_org_a_result IS DISTINCT FROM false THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[172-6]: org B member holding the exact key evaluated true against org A (org-scoping regression): %', v_org_a_result;
   END IF;
 END;
 $$;
@@ -221,15 +265,17 @@ END;
 $$;
 RESET ROLE;
 
--- 2h. Ungranted: a real org member with zero role/permission rows at all
--- must return false, not error.
-SELECT set_config('request.jwt.claim.sub', '99172172-0006-0006-0006-000000000006', false);
+-- 2h. Ungranted: a real org member with zero role/permission rows anywhere
+-- must return false, not error. Uses the distinct Ungranted user (not
+-- CrossOrg, which now genuinely holds the exact key in org B) so this case
+-- cannot collapse into 172-6.
+SELECT set_config('request.jwt.claim.sub', '99172172-0007-0007-0007-000000000007', false);
 SET LOCAL ROLE authenticated;
 DO $$
 DECLARE v_result boolean;
 BEGIN
   SELECT public.has_permission(
-    '99172172-0006-0006-0006-000000000006',
+    '99172172-0007-0007-0007-000000000007',
     '99172172-b000-b000-b000-00000000000b',
     'reports.ai_insights.use'
   ) INTO v_result;

--- a/sql/migrations/172_has_permission_exact_key_match.sql
+++ b/sql/migrations/172_has_permission_exact_key_match.sql
@@ -169,6 +169,14 @@ BEGIN
   IF v_src !~ 'expires_at' THEN
     RAISE EXCEPTION 'FAIL[172] has_permission lost role-expiry enforcement';
   END IF;
+  -- The org-scoping predicate itself: without this, the exact-equality fix
+  -- above would still let a grant in ANY org satisfy a check against a
+  -- DIFFERENT org, as long as the permission_key matched exactly. This is
+  -- the predicate acceptance_172's cross-org assertion (172-6) is built to
+  -- regression-guard.
+  IF v_src !~ 'ur\.org_id\s*=\s*p_org_id' THEN
+    RAISE EXCEPTION 'FAIL[172] has_permission lost the ur.org_id = p_org_id scoping predicate';
+  END IF;
 
   RAISE NOTICE 'PASS[172] has_permission now requires exact permission_key equality; same-module wildcard match removed';
 END

--- a/sql/migrations/172_has_permission_exact_key_match.sql
+++ b/sql/migrations/172_has_permission_exact_key_match.sql
@@ -1,0 +1,177 @@
+-- =====================================================================
+-- 172_has_permission_exact_key_match
+-- =====================================================================
+-- Closes an authorization-scope bug in has_permission(p_user_id, p_org_id,
+-- p_permission_key), inherited unchanged through Migration 170: the
+-- "ordinary role" branch matched not only an exact permission_key, but
+-- also any other permission_key sharing the same first dot-segment
+-- ("module"):
+--
+--   p.permission_key = p_permission_key
+--   OR p.permission_key LIKE REPLACE(
+--        SPLIT_PART(p_permission_key, '.', 1) || '.%', '*', '%'
+--      )
+--
+-- For p_permission_key = 'reports.ai_insights.use', SPLIT_PART(...,'.',1)
+-- is 'reports', so the pattern reduces to `p.permission_key LIKE
+-- 'reports.%'` — REPLACE(...,'*','%') is a no-op here since the pattern
+-- never contains a literal '*'. Any role holding ANY 'reports.*'
+-- permission (e.g. reports.financial.read, reports.exports.export)
+-- therefore implicitly satisfied reports.ai_insights.use, defeating the
+-- dedicated permission Migration 171 introduced specifically to gate the
+-- reports-insights Edge Function's AI usage quota. The same shape applies
+-- to every other permission_key in the catalog, not just this one — it is
+-- a general same-module authorization-scope bug, found during pre-deploy
+-- verification of reports-insights on 2026-08-08, before that function was
+-- ever deployed (verify_jwt) or given production traffic.
+--
+-- Confirmed live in Production (project uutfztmqvajmsxnrqeiv) before this
+-- migration was written: `has_permission`'s prosrc matches the buggy text
+-- above verbatim, and the live `permissions` catalog holds 169 rows, 0 of
+-- which contain a literal '*' — i.e. no permission_key in actual use
+-- depends on wildcard/prefix matching. The REPLACE(...,'*','%') call was
+-- therefore always a no-op against real data; the LIKE clause never did
+-- anything except accidentally broaden every same-module check.
+--
+-- Fix: ordinary role authorization now requires exact permission_key
+-- equality only. auth.uid() self-check (170), super-admin override,
+-- org-admin override, org scoping, and role-expiry behavior are all
+-- unchanged — only the ordinary-role predicate's OR-LIKE clause is
+-- removed.
+--
+-- Caller audit (see docs/db/HAS_PERMISSION_172_RUNBOOK.md §2 for detail):
+-- every SQL caller (149, 150, and their baseline copies) already passes an
+-- exact, real permission_key it expects to match exactly — neither relies
+-- on or is affected by the broad match. The one application-code RPC
+-- caller that constructed a differently-shaped key
+-- (`checkPermission()` in src/hooks/usePermissions.ts, a `${moduleCode}.
+-- ${action}` 2-segment key against a 3-segment `module.resource.action`
+-- catalog) has zero importers anywhere in `src/` — dead code, not a live
+-- dependency on the broad match. The live `usePermissions()` hook actually
+-- used by the app (ModuleGuard, ProtectedComponent, sidebar, withPermission)
+-- never calls this RPC at all; it does its own exact client-side
+-- module_code+action comparison against permission rows fetched directly.
+-- =====================================================================
+
+BEGIN;
+
+SET LOCAL lock_timeout = '30s';
+SET LOCAL statement_timeout = '5min';
+
+-- ---------------------------------------------------------------------------
+-- Preflight: fail closed if the schema has already drifted from what this
+-- migration assumes, before touching anything.
+-- ---------------------------------------------------------------------------
+DO $preflight$
+BEGIN
+  IF to_regprocedure('public.has_permission(uuid,uuid,character varying)') IS NULL THEN
+    RAISE EXCEPTION 'PERMISSION_172_HAS_PERMISSION_MISSING';
+  END IF;
+
+  IF to_regclass('public.permissions') IS NULL
+     OR to_regclass('public.role_permissions') IS NULL
+     OR to_regclass('public.user_roles') IS NULL THEN
+    RAISE EXCEPTION 'PERMISSION_172_REQUIRED_TABLE_MISSING';
+  END IF;
+END
+$preflight$;
+
+-- ---------------------------------------------------------------------------
+-- has_permission — exact permission_key match only. auth.uid() self-check,
+-- super-admin override, org-admin override, org scoping, and role-expiry
+-- behavior are byte-identical to Migration 170; only the ordinary-role
+-- predicate changes.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.has_permission(p_user_id uuid, p_org_id uuid, p_permission_key character varying) RETURNS boolean
+    LANGUAGE plpgsql STABLE SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+DECLARE
+    v_has_permission BOOLEAN;
+BEGIN
+    IF p_user_id IS DISTINCT FROM auth.uid() THEN
+        RETURN false;
+    END IF;
+
+    -- Super Admin: كل الصلاحيات
+    IF EXISTS (
+        SELECT 1 FROM super_admins
+        WHERE user_id = p_user_id AND is_active = true
+    ) THEN
+        RETURN true;
+    END IF;
+
+    -- Org Admin: كل صلاحيات منظمته
+    IF EXISTS (
+        SELECT 1 FROM user_organizations
+        WHERE user_id = p_user_id
+        AND org_id = p_org_id
+        AND is_active = true
+        AND is_org_admin = true
+    ) THEN
+        RETURN true;
+    END IF;
+
+    -- التحقق من الصلاحيات العادية: مطابقة تامة لمفتاح الصلاحية فقط — لا
+    -- توسيع لأي صلاحية أخرى تشارك نفس الوحدة (module).
+    SELECT EXISTS (
+        SELECT 1
+        FROM user_roles ur
+        INNER JOIN role_permissions rp ON ur.role_id = rp.role_id
+        INNER JOIN permissions p ON rp.permission_id = p.id
+        WHERE ur.user_id = p_user_id
+        AND ur.org_id = p_org_id
+        AND p.permission_key = p_permission_key
+        AND (ur.expires_at IS NULL OR ur.expires_at > NOW())
+    ) INTO v_has_permission;
+
+    RETURN COALESCE(v_has_permission, false);
+END;
+$$;
+
+-- Grants unchanged: authenticated and service_role retain EXECUTE (see
+-- Migration 170) — this migration narrows the predicate only, not the
+-- execution boundary.
+
+-- ---------------------------------------------------------------------------
+-- Postflight: fail closed before COMMIT if the fix did not take.
+-- ---------------------------------------------------------------------------
+DO $verify$
+DECLARE
+  v_src text;
+BEGIN
+  SELECT prosrc INTO v_src FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public' AND p.proname = 'has_permission';
+
+  IF v_src IS NULL THEN
+    RAISE EXCEPTION 'FAIL[172] has_permission not found after CREATE OR REPLACE';
+  END IF;
+
+  IF v_src ~ 'LIKE' THEN
+    RAISE EXCEPTION 'FAIL[172] has_permission still contains a LIKE-based same-module match: %', v_src;
+  END IF;
+
+  IF v_src !~ 'p\.permission_key\s*=\s*p_permission_key' THEN
+    RAISE EXCEPTION 'FAIL[172] has_permission is missing the exact permission_key equality predicate';
+  END IF;
+
+  -- The auth.uid() self-check, super-admin, and org-admin branches from
+  -- Migration 170 must survive untouched.
+  IF v_src !~ 'p_user_id IS DISTINCT FROM auth\.uid\(\)' THEN
+    RAISE EXCEPTION 'FAIL[172] has_permission lost the caller-identity guard from Migration 170';
+  END IF;
+  IF v_src !~ 'super_admins' THEN
+    RAISE EXCEPTION 'FAIL[172] has_permission lost the super-admin override';
+  END IF;
+  IF v_src !~ 'is_org_admin' THEN
+    RAISE EXCEPTION 'FAIL[172] has_permission lost the org-admin override';
+  END IF;
+  IF v_src !~ 'expires_at' THEN
+    RAISE EXCEPTION 'FAIL[172] has_permission lost role-expiry enforcement';
+  END IF;
+
+  RAISE NOTICE 'PASS[172] has_permission now requires exact permission_key equality; same-module wildcard match removed';
+END
+$verify$;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Pre-deployment verification of the (still undeployed) `reports-insights` Edge Function found a real authorization-scope bug in `has_permission()`, inherited unchanged through Migration 170.

`has_permission(p_user_id, p_org_id, p_permission_key)`'s ordinary-role predicate matched not only an exact `permission_key`, but any `permission_key` sharing the same first dot-segment ("module"):

```sql
p.permission_key = p_permission_key
OR p.permission_key LIKE REPLACE(
     SPLIT_PART(p_permission_key, '.', 1) || '.%', '*', '%'
   )
```

For `p_permission_key = 'reports.ai_insights.use'`, this reduces to `p.permission_key LIKE 'reports.%'` — `REPLACE(...,'*','%')` is a no-op since the pattern never contains a literal `*`. Any role holding **any** `reports.*` permission (e.g. `reports.financial.read`, `reports.exports.export`) therefore implicitly satisfied `reports.ai_insights.use`, defeating the dedicated permission Migration 171 introduced specifically to gate the `reports-insights` Edge Function's AI usage quota.

**Confirmed live in Production (`uutfztmqvajmsxnrqeiv`) before writing this migration**: `has_permission`'s `prosrc` matches the buggy text verbatim, and the live `permissions` catalog holds **169 rows, 0 containing a literal `*`** — no real `permission_key` depends on wildcard matching.

## What changed

- `sql/migrations/172_has_permission_exact_key_match.sql`: `CREATE OR REPLACE FUNCTION has_permission` — ordinary-role predicate is now `p.permission_key = p_permission_key` only, the `OR LIKE` clause removed entirely. The `auth.uid()` self-check (Migration 170), super-admin override, org-admin override, org scoping, and role-expiry behavior are all byte-identical to Migration 170 — preflight/postflight explicitly assert each survives, **including a dedicated assertion that `ur.org_id = p_org_id` remains present** (added in this PR's second commit, see below).
- `scripts/ci/fresh-db/acceptance_172_has_permission_exact_key_match.sql`: 8 behavioral cases across 9 assertions — the exact bug scenario (`reports.financial.read` must NOT grant `reports.ai_insights.use`), an explicit exact grant returning `true`, org-admin/super-admin overrides, cross-user/cross-org/expired-role/ungranted checks all returning `false`.
- `.github/workflows/has-permission-172-acceptance.yml`: Fresh DB (PostgreSQL 17) acceptance gate, also re-runs the 170 and 171 acceptance suites on the same DB to prove no regression.
- `docs/db/HAS_PERMISSION_172_RUNBOOK.md`: full root cause, a table auditing every `has_permission` caller in the codebase (SQL and application) for reliance on the broad match, Production apply/rollback procedure.

## Revision: the cross-org acceptance proof was strengthened after review

The first version of `acceptance_172`'s cross-org case (172-6) used a `CrossOrg` fixture user with **no grant anywhere** — so the assertion (`has_permission` against org A returns `false`) would have passed even if `AND ur.org_id = p_org_id` were accidentally removed from `has_permission` entirely, since the query would already return no rows for an unrelated reason. It was indistinguishable from the ungranted case (172-8) and proved nothing about org scoping specifically.

Fixed in the second commit:
- `CrossOrg` now holds the **exact** `reports.ai_insights.use` key via a real `role`/`user_roles` row scoped to org B.
- The assertion first checks `has_permission(CrossOrg, org B, key)` returns `true` (proves the grant is real, not a broken fixture), *then* checks `has_permission(CrossOrg, org A, key)` returns `false` — which can now **only** be false because of the org-scoping predicate, since the exact key and an active org B membership both genuinely exist.
- A new, separate `Ungranted` user (distinct from `CrossOrg`) now covers the ungranted case (172-8), so it can't collapse into the same scenario as 172-6.
- Migration 172 gained a new postflight assertion: `has_permission`'s `prosrc` must still contain `ur\.org_id\s*=\s*p_org_id`.
- **Mutation-tested**: temporarily removed `AND ur.org_id = p_org_id` from `has_permission` on the same fixtures and confirmed 172-6 failed exactly as expected (`ACCEPTANCE_FAIL[172-6]: ... evaluated true against org A`), then restored the predicate and re-confirmed a clean pass — the same proof pattern already used for the same-module case (172-1).

No production logic changed in this revision beyond the migration's own new postflight assertion — `has_permission`'s fixed predicate itself is unchanged from the first commit.

## Caller audit (full detail in the runbook §2)

Every SQL caller (`149`, `150`, and their baseline copies) already passes an exact, literal key — unaffected by this change. The one application-code RPC caller that constructed a differently-shaped key (`checkPermission()` in `src/hooks/usePermissions.ts`, a `${moduleCode}.${action}` 2-segment key against a 3-segment catalog) has **zero importers anywhere in `src/`** — dead code, not a live dependency. The live `usePermissions()` hook actually used by the app (`ModuleGuard`, `ProtectedComponent`, `sidebar`, `withPermission`) never calls this RPC at all — it does its own exact client-side comparison against permission rows fetched directly.

## Verification

All run locally on **real PostgreSQL 17** (installed via the PGDG apt repository in this session's sandbox, Docker unavailable there), re-run in full after the acceptance-proof revision:

- Fresh DB built from the current baseline through the full migration chain (`153` → `172`) via `run_chain.sh` — **11/11 PASS**.
- `acceptance_172_has_permission_exact_key_match.sql` → `HAS_PERMISSION_172_ACCEPTANCE_PASS`.
- **Regression-guard proof, same-module case**: temporarily reverted `has_permission` to the pre-172 (buggy) text — assertion 172-1 failed exactly as expected, then restored and re-confirmed clean.
- **Regression-guard proof, org-scoping case**: temporarily removed `ur.org_id = p_org_id` — assertion 172-6 failed exactly as expected, then restored and re-confirmed clean.
- `acceptance_170_tenant_isolation_and_permission_hardening.sql` re-run on the post-172 DB → `TENANT_ISOLATION_170_ACCEPTANCE_PASS` (no regression).
- `acceptance_171_ai_usage_daily.sql` re-run on the post-172 DB → `AI_USAGE_DAILY_171_ACCEPTANCE_PASS` (no regression).
- `python3 scripts/ci/check_migration_syntax.py` (pglast) — clean, 200 files.
- `python3 scripts/ci/check_definer_guards.py` — clean (`has_permission` already exempt since Migration 170).
- `python3 scripts/ci/validate_migration_ledger.py` — `status: ok`, `repo_max: 172`.
- `python3 scripts/ci/test_validate_migration_ledger.py` — 5/5 unit tests pass.
- `npm run build` — clean (DB-only change, no frontend files touched).

## Not in scope

- Deploying `reports-insights` (`verify_jwt=true`) — this migration is a **prerequisite**, applied and verified on Production first, per the repo's `repository-first`/`DB-first` ordering rule in `CLAUDE.md`. Deployment and its own agreed Production checks (401/403/200/fallback/429) proceed as a separate, later step.
- Confirming `GROQ_API_KEY` exists in Supabase secrets — separate mandatory pre-deploy check, no MCP tool exposes secret listing; will be confirmed via `supabase secrets list --project-ref uutfztmqvajmsxnrqeiv` before deploy, value never printed.