### PR TITLE
fix(db): Migration 173 — has_permission active-role check

### DIFF
--- a/.github/workflows/has-permission-173-acceptance.yml
+++ b/.github/workflows/has-permission-173-acceptance.yml
@@ -1,0 +1,123 @@
+name: has_permission 173 Acceptance
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'scripts/ci/fresh-db/acceptance_173_has_permission_active_role_check.sql'
+      - 'sql/migrations/173_has_permission_active_role_check.sql'
+      - '.github/workflows/has-permission-173-acceptance.yml'
+  workflow_dispatch:
+
+jobs:
+  acceptance:
+    name: Confirm Migration 173 satisfies the active-role contract
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build fresh database through migration 173
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          PAIR=$(bash scripts/ci/fresh-db/resolve_baseline_pair.sh sql/baseline)
+          pair_field() { printf '%s\n' "$PAIR" | sed -n "s/^$1=//p"; }
+          BASELINE=$(pair_field BASELINE_PATH)
+          REFERENCE=$(pair_field REFERENCE_PATH)
+          CUTOFF=$(pair_field BASELINE_CUTOFF)
+          CUTOFF=${CUTOFF:-0}
+
+          createdb wardah_fresh
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh \
+            -f scripts/ci/fresh-db/supabase_shim.sql -q
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh -f "$BASELINE" -q
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh -f "$REFERENCE" -q
+
+          python3 scripts/ci/fresh-db/build_apply_order.py \
+            sql/migrations "$CUTOFF" > /tmp/chain_order.txt
+          REPORT=/tmp/chain_report.txt PGDATABASE=wardah_fresh \
+            bash scripts/ci/fresh-db/run_chain.sh sql/migrations /tmp/chain_order.txt
+        env:
+          PGHOST: localhost
+          PGUSER: postgres
+          PGPASSWORD: postgres
+
+      - name: Run has_permission 173 acceptance
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh \
+            -f scripts/ci/fresh-db/acceptance_173_has_permission_active_role_check.sql \
+            2>&1 | tee /tmp/has-permission-173.out
+        env:
+          PGHOST: localhost
+          PGUSER: postgres
+          PGPASSWORD: postgres
+
+      - name: Re-run Migration 172 acceptance to confirm no regression
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh \
+            -f scripts/ci/fresh-db/acceptance_172_has_permission_exact_key_match.sql \
+            2>&1 | tee /tmp/has-permission-172-rerun.out
+        env:
+          PGHOST: localhost
+          PGUSER: postgres
+          PGPASSWORD: postgres
+
+      - name: Re-run Migration 170 acceptance to confirm no regression
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh \
+            -f scripts/ci/fresh-db/acceptance_170_tenant_isolation_and_permission_hardening.sql \
+            2>&1 | tee /tmp/tenant-isolation-170-rerun.out
+        env:
+          PGHOST: localhost
+          PGUSER: postgres
+          PGPASSWORD: postgres
+
+      - name: Re-run Migration 171 acceptance to confirm no regression
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh \
+            -f scripts/ci/fresh-db/acceptance_171_ai_usage_daily.sql \
+            2>&1 | tee /tmp/ai-usage-daily-171-rerun.out
+        env:
+          PGHOST: localhost
+          PGUSER: postgres
+          PGPASSWORD: postgres
+
+      - name: Upload acceptance evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: has-permission-173-${{ github.run_id }}
+          path: |
+            /tmp/has-permission-173.out
+            /tmp/has-permission-172-rerun.out
+            /tmp/tenant-isolation-170-rerun.out
+            /tmp/ai-usage-daily-171-rerun.out
+            /tmp/chain_order.txt
+            /tmp/chain_report.txt
+          if-no-files-found: warn
+          retention-days: 30

--- a/docs/db/HAS_PERMISSION_173_RUNBOOK.md
+++ b/docs/db/HAS_PERMISSION_173_RUNBOOK.md
@@ -1,0 +1,109 @@
+# Migration 173 — `has_permission` Active-Role Check Runbook
+
+**Migration:** `173_has_permission_active_role_check.sql`
+**Scope:** Close a second gap in `has_permission()`'s ordinary-role branch — disabling a role never revoked the access it granted.
+**State:** Repository implementation, not yet applied to Production. Do not apply before the paired Fresh DB acceptance gate is green and this runbook's preflight/postflight queries have been reviewed.
+
+## 1. Purpose
+
+Found during the security review that approved Migration 172 (PR #109): `has_permission()`'s ordinary-role branch joins `user_roles` → `role_permissions` → `permissions` and never joins `public.roles` at all, so a role's own `is_active` flag is never checked. Disabling a role — a real, exposed administrative operation — leaves every user still assigned to it fully authorized for everything that role grants, as long as their `user_roles` row is untouched and unexpired.
+
+This is a distinct bug from Migration 172's same-module wildcard match: 172 fixed *which* `permission_key` values a grant satisfies; this migration fixes *whether* a grant through a since-disabled role should count at all. The reviewer explicitly separated these into two independently-testable migrations rather than one combined change, to keep each change's blast radius and test surface minimal and legible.
+
+## 2. Precedent already in this codebase
+
+Migration 166 (`wardah_has_exact_permission`, introduced for the sensitive `accounting.vouchers.unpost` control) already joins `roles` with exactly this shape:
+
+```sql
+JOIN public.roles r
+  ON r.id = ur.role_id
+ AND r.org_id = p_org_id
+ AND coalesce(r.is_active, true)
+```
+
+166's own comment ("`has_permission` intentionally supports module-level fallback for ordinary screens. Unposting is an exceptional control and must bypass that fallback.") shows the broad-match gap Migration 172 closed was a known, worked-around limitation *before* it was fixed at the root — but `has_permission()` itself was never updated to match `wardah_has_exact_permission`'s stricter role-activity check either. This migration brings it into line, mirroring the identical join shape and `COALESCE(..., true)` null-safety convention 166 already established — a role row with `is_active` left `NULL` (the schema default is `true`, but the column is not `NOT NULL`) must not silently lose access, matching how this codebase already treats nullable `is_active` flags elsewhere (e.g. Migration 170's `COALESCE(user_organizations.is_active, true)`).
+
+## 3. What the migration changes
+
+| Change | Detail |
+|---|---|
+| `has_permission` | `CREATE OR REPLACE`. Ordinary-role branch gains `INNER JOIN roles r ON r.id = ur.role_id AND r.org_id = p_org_id AND COALESCE(r.is_active, true)`. Every other branch/predicate — `auth.uid()` self-check (170), super-admin override, org-admin override, exact `permission_key` equality (172), `ur.org_id = p_org_id` scoping (172), and `user_roles.expires_at` role-expiry — is byte-identical. |
+| Grants | Unchanged (`authenticated`, `service_role` retain `EXECUTE`) — this migration narrows the ordinary-role predicate only. |
+| `scripts/ci/check_definer_guards.py` | No change needed — `has_permission` was already added to `KNOWN_EXEMPT` by Migration 170. |
+| Preflight | Fails closed (`PERMISSION_173_HAS_PERMISSION_MISSING`, `PERMISSION_173_REQUIRED_TABLE_MISSING`) if the schema has drifted from what this migration assumes. |
+| Postflight | In-transaction `$verify$` block: `has_permission`'s `prosrc` now joins `roles r` and contains `COALESCE(r.is_active, true)` (`FAIL[173]`), and every Migration 170/172 predicate/behavior text is still present (six separate `FAIL[173]` checks, one per predicate) — proving the fix added only the intended join, not a regression of prior behavior. |
+| Locking | Function-only change — no `LOCK TABLE`, matching the convention already used for 121/172. `SET LOCAL lock_timeout = '30s'`, `statement_timeout = '5min'`. |
+
+## 4. Acceptance gate
+
+```text
+scripts/ci/fresh-db/acceptance_173_has_permission_active_role_check.sql
+```
+
+Seeds one org, a dedicated permission (`perm173.rolecheck.use`, independent of any specific catalog key), and five fixture users:
+
+1. **Active**: a role holding the exact permission, `roles.is_active = true` — `has_permission` returns `true`.
+2. **Disabled — the bug scenario**: the *identically wired* grant (same permission, same org, no expiry) through a role with `roles.is_active = false` — `has_permission` must return `false`. A setup assertion first proves the grant is real by running the same join **minus** the `roles` gate directly (bypassing `has_permission`), confirming the fixture is correctly wired and isolating `roles.is_active` as the only variable. Before this migration, this case returned `true`; **mutation-tested** by reverting `has_permission` to the pre-173 (172-only) text on the same fixtures and confirming the assertion failed exactly as expected (`ACCEPTANCE_FAIL[173-2]: ... still authorized the caller`), then restoring the fix and re-confirming a clean pass.
+3. **Expired**: an expired `user_roles` grant through an *active* role still returns `false` — Migration 170 behavior, proven unaffected by the new `roles` join.
+4. **Org-admin override**: returns `true` with no role or permission grant at all — the ordinary-role branch (and its new `roles` join) is never reached.
+5. **Super-admin override**: same reasoning as case 4.
+
+Final marker: `HAS_PERMISSION_173_ACCEPTANCE_PASS`.
+
+**Confirmed green locally on real PostgreSQL 17** (installed via the PGDG apt repository in this session's sandbox, Docker unavailable there): Fresh DB built from `000_schema_baseline_20260729_210941.sql` + `001_system_reference_data_20260729_210941.sql` through the full chain (`153` → `173`) via `run_chain.sh` — **12/12 PASS**. `acceptance_173` → `HAS_PERMISSION_173_ACCEPTANCE_PASS`; re-ran `acceptance_172`, `acceptance_170`, and `acceptance_171` on the same post-173 DB — all pass cleanly, confirming no regression across the full 170→173 permission-hardening chain.
+
+## 5. Production apply
+
+Target project: Supabase `uutfztmqvajmsxnrqeiv` ("Manufacturing Process") — **not** `Wardah-Prod` (`rytzljjlthouptdqeuxh`), which is `INACTIVE`.
+
+**Preflight (read-only, before applying):**
+```sql
+-- Confirm the exact current (172-only) predicate text, for the record —
+-- expect no join to roles and no is_active check on the role.
+SELECT prosrc FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname = 'public' AND p.proname = 'has_permission';
+```
+
+**Postflight (read-only, after applying):**
+```sql
+SELECT
+  prosrc ~ 'roles r' AS roles_join_present,
+  prosrc ~ 'COALESCE\(r\.is_active,\s*true\)' AS role_active_guard_present,
+  prosrc !~ 'LIKE' AS like_still_removed,
+  prosrc ~ 'p\.permission_key\s*=\s*p_permission_key' AS exact_match_still_present,
+  prosrc ~ 'ur\.org_id\s*=\s*p_org_id' AS org_scoping_still_present,
+  prosrc ~ 'p_user_id IS DISTINCT FROM auth\.uid\(\)' AS identity_guard_still_present,
+  prosrc ~ 'super_admins' AS super_admin_override_still_present,
+  prosrc ~ 'is_org_admin' AS org_admin_override_still_present,
+  prosrc ~ 'expires_at' AS role_expiry_still_present
+FROM pg_proc WHERE proname = 'has_permission';
+-- Expect every column true.
+
+SELECT has_function_privilege('authenticated', 'has_permission(uuid,uuid,varchar)', 'EXECUTE');
+-- Expect true (unchanged, still callable).
+
+-- Ledger row landed exactly once.
+SELECT version, name FROM supabase_migrations.schema_migrations
+WHERE name = '173_has_permission_active_role_check';
+```
+
+Expected: all nine boolean columns `true`; `has_function_privilege` `true`; exactly one ledger row for 173.
+
+**Optional real-data sanity check** (read-only, informational — not a gate): after applying, if any organization currently has a disabled role (`roles.is_active = false`) with active `user_roles` assignments, this migration changes those users' effective permissions immediately (correctly — this is the fix). Worth a quick look before applying, purely so the change in behavior isn't a surprise to any org admin who disabled a role expecting it to already be inert:
+```sql
+SELECT r.org_id, r.id AS role_id, r.name, count(ur.user_id) AS affected_users
+FROM public.roles r
+JOIN public.user_roles ur ON ur.role_id = r.id
+WHERE r.is_active = false
+GROUP BY r.org_id, r.id, r.name;
+```
+
+## 6. Rollback
+
+Additive apart from replacing `has_permission()`'s ordinary-role predicate — a single `CREATE OR REPLACE FUNCTION`. Before any Production traffic depends on the tightened contract, the reviewed recovery is to correct forward with a new numbered migration rather than hand-edit 173 in place, per the project's golden rule. Do not remove the `roles` join or the `is_active` gate under any circumstance — it is the exact vulnerability this migration closes, and a disabled role is meant to be inert everywhere, not just in the UI.
+
+Never edit `supabase_migrations.schema_migrations` to remove this row, and never apply SQL that is not the exact file merged to `main`.
+
+## 7. Relationship to `reports-insights`
+
+This migration hardens `has_permission()` further but is **not** a prerequisite for the already-deployed `reports-insights` Edge Function (Migration 172 was the prerequisite for that; the function has been live on Production since immediately after 172 was applied — see PR #109's follow-up discussion). This migration is scoped purely to closing the disabled-role gap and ships as its own independent PR, per the explicit decision not to mix it with any AI-reliability follow-up work.

--- a/scripts/ci/fresh-db/acceptance_173_has_permission_active_role_check.sql
+++ b/scripts/ci/fresh-db/acceptance_173_has_permission_active_role_check.sql
@@ -1,0 +1,193 @@
+-- Acceptance for Migration 173.
+-- Proves has_permission()'s ordinary-role branch now requires the granting
+-- role to be active, while every override/scoping/expiry behavior from
+-- Migrations 170 and 172 survives untouched:
+-- (1) a role holding the exact permission, active, returns true;
+-- (2) the SAME grant shape through a DISABLED role (roles.is_active =
+--     false) returns false — the regression this migration closes;
+-- (3) an expired user_roles grant through an ACTIVE role still returns
+--     false (170 behavior, unaffected by the new join);
+-- (4) org-admin and super-admin overrides still return true with no role
+--     at all — they never reach the ordinary-role branch.
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- 1. Fixtures.
+--
+-- One org. A dedicated permission (perm173.rolecheck.use) so this test
+-- doesn't depend on any specific seeded catalog key.
+-- role_active / role_disabled are wired IDENTICALLY (same permission, same
+-- org, no user_roles.expires_at) — the only difference is roles.is_active.
+-- This isolates the variable: a false result for the Disabled user can
+-- only be attributed to the is_active gate, not a miswired fixture (the
+-- setup assertion below proves the grant is otherwise real).
+-- ---------------------------------------------------------------------------
+INSERT INTO auth.users (id, email) VALUES
+  ('99173173-0001-0001-0001-000000000001', 'perm173-active@example.test'),
+  ('99173173-0002-0002-0002-000000000002', 'perm173-disabled@example.test'),
+  ('99173173-0003-0003-0003-000000000003', 'perm173-expired@example.test'),
+  ('99173173-0004-0004-0004-000000000004', 'perm173-orgadmin@example.test'),
+  ('99173173-0005-0005-0005-000000000005', 'perm173-super@example.test');
+
+INSERT INTO public.organizations (id, name, code) VALUES
+  ('99173173-a000-a000-a000-00000000000a', 'Perm173 Org A', 'P173-A');
+
+INSERT INTO public.user_organizations (user_id, org_id, is_active, is_org_admin) VALUES
+  ('99173173-0001-0001-0001-000000000001', '99173173-a000-a000-a000-00000000000a', true, false),
+  ('99173173-0002-0002-0002-000000000002', '99173173-a000-a000-a000-00000000000a', true, false),
+  ('99173173-0003-0003-0003-000000000003', '99173173-a000-a000-a000-00000000000a', true, false),
+  ('99173173-0004-0004-0004-000000000004', '99173173-a000-a000-a000-00000000000a', true, true),
+  ('99173173-0005-0005-0005-000000000005', '99173173-a000-a000-a000-00000000000a', true, false);
+
+INSERT INTO public.super_admins (user_id, email, is_active) VALUES
+  ('99173173-0005-0005-0005-000000000005', 'perm173-super@example.test', true);
+
+INSERT INTO public.permissions (id, module_id, resource, resource_ar, action, action_ar, permission_key)
+VALUES (
+  '99173173-0000-0000-0000-000000000001', (SELECT id FROM public.modules LIMIT 1),
+  'rolecheck173', 'اختبار_173', 'use', 'استخدام', 'perm173.rolecheck.use'
+);
+
+INSERT INTO public.roles (id, org_id, name, name_ar, is_active) VALUES
+  ('99173173-0000-0000-0000-000000000020', '99173173-a000-a000-a000-00000000000a', 'Perm173 Active Role', 'دور نشط', true),
+  ('99173173-0000-0000-0000-000000000021', '99173173-a000-a000-a000-00000000000a', 'Perm173 Disabled Role', 'دور معطل', false);
+
+INSERT INTO public.role_permissions (role_id, permission_id) VALUES
+  ('99173173-0000-0000-0000-000000000020',
+   (SELECT id FROM public.permissions WHERE permission_key = 'perm173.rolecheck.use')),
+  ('99173173-0000-0000-0000-000000000021',
+   (SELECT id FROM public.permissions WHERE permission_key = 'perm173.rolecheck.use'));
+
+INSERT INTO public.user_roles (user_id, role_id, org_id, expires_at) VALUES
+  ('99173173-0001-0001-0001-000000000001', '99173173-0000-0000-0000-000000000020',
+   '99173173-a000-a000-a000-00000000000a', NULL),
+  ('99173173-0002-0002-0002-000000000002', '99173173-0000-0000-0000-000000000021',
+   '99173173-a000-a000-a000-00000000000a', NULL),
+  ('99173173-0003-0003-0003-000000000003', '99173173-0000-0000-0000-000000000020',
+   '99173173-a000-a000-a000-00000000000a', '2020-01-01T00:00:00Z');
+
+-- Setup sanity: the Disabled user's grant is wired identically to the
+-- Active user's (same permission, same org, no expiry) when the is_active
+-- gate itself is excluded from the check — proving the fixture is real,
+-- not broken, before asserting has_permission denies it.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.user_roles ur
+    JOIN public.role_permissions rp ON rp.role_id = ur.role_id
+    JOIN public.permissions p ON p.id = rp.permission_id
+    WHERE ur.user_id = '99173173-0002-0002-0002-000000000002'
+    AND ur.org_id = '99173173-a000-a000-a000-00000000000a'
+    AND p.permission_key = 'perm173.rolecheck.use'
+    AND (ur.expires_at IS NULL OR ur.expires_at > NOW())
+  ) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[173-setup]: Disabled-role fixture grant is not wired at all (fixture broken — would not isolate roles.is_active as the cause)';
+  END IF;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 2. As each fixture user, call has_permission for perm173.rolecheck.use.
+-- ---------------------------------------------------------------------------
+
+-- 2a. Active role: the grant must work.
+SELECT set_config('request.jwt.claim.sub', '99173173-0001-0001-0001-000000000001', false);
+SET LOCAL ROLE authenticated;
+DO $$
+DECLARE v_result boolean;
+BEGIN
+  SELECT public.has_permission(
+    '99173173-0001-0001-0001-000000000001',
+    '99173173-a000-a000-a000-00000000000a',
+    'perm173.rolecheck.use'
+  ) INTO v_result;
+  IF v_result IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[173-1]: active-role grant did not return true: %', v_result;
+  END IF;
+END;
+$$;
+RESET ROLE;
+
+-- 2b. THE bug scenario: the identically-wired grant through a DISABLED role
+-- must NOT authorize. Before this migration, has_permission never joined
+-- roles at all, so this returned true regardless of roles.is_active.
+SELECT set_config('request.jwt.claim.sub', '99173173-0002-0002-0002-000000000002', false);
+SET LOCAL ROLE authenticated;
+DO $$
+DECLARE v_result boolean;
+BEGIN
+  SELECT public.has_permission(
+    '99173173-0002-0002-0002-000000000002',
+    '99173173-a000-a000-a000-00000000000a',
+    'perm173.rolecheck.use'
+  ) INTO v_result;
+  IF v_result IS DISTINCT FROM false THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[173-2]: a disabled role (roles.is_active=false) still authorized the caller (active-role-check regression): %', v_result;
+  END IF;
+END;
+$$;
+RESET ROLE;
+
+-- 2c. Expired grant through an ACTIVE role must still deny (Migration 170
+-- behavior — unaffected by the new roles join).
+SELECT set_config('request.jwt.claim.sub', '99173173-0003-0003-0003-000000000003', false);
+SET LOCAL ROLE authenticated;
+DO $$
+DECLARE v_result boolean;
+BEGIN
+  SELECT public.has_permission(
+    '99173173-0003-0003-0003-000000000003',
+    '99173173-a000-a000-a000-00000000000a',
+    'perm173.rolecheck.use'
+  ) INTO v_result;
+  IF v_result IS DISTINCT FROM false THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[173-3]: expired user_roles grant through an active role still evaluated true: %', v_result;
+  END IF;
+END;
+$$;
+RESET ROLE;
+
+-- 2d. Org-admin override: true with no role/permission grant at all — the
+-- ordinary-role branch (and its new roles join) is never reached.
+SELECT set_config('request.jwt.claim.sub', '99173173-0004-0004-0004-000000000004', false);
+SET LOCAL ROLE authenticated;
+DO $$
+DECLARE v_result boolean;
+BEGIN
+  SELECT public.has_permission(
+    '99173173-0004-0004-0004-000000000004',
+    '99173173-a000-a000-a000-00000000000a',
+    'perm173.rolecheck.use'
+  ) INTO v_result;
+  IF v_result IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[173-4]: org-admin override did not return true: %', v_result;
+  END IF;
+END;
+$$;
+RESET ROLE;
+
+-- 2e. Super-admin override: true with no role/permission grant and not an
+-- org admin — same reasoning as 2d.
+SELECT set_config('request.jwt.claim.sub', '99173173-0005-0005-0005-000000000005', false);
+SET LOCAL ROLE authenticated;
+DO $$
+DECLARE v_result boolean;
+BEGIN
+  SELECT public.has_permission(
+    '99173173-0005-0005-0005-000000000005',
+    '99173173-a000-a000-a000-00000000000a',
+    'perm173.rolecheck.use'
+  ) INTO v_result;
+  IF v_result IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[173-5]: super-admin override did not return true: %', v_result;
+  END IF;
+END;
+$$;
+RESET ROLE;
+
+ROLLBACK;
+
+SELECT 'HAS_PERMISSION_173_ACCEPTANCE_PASS';

--- a/sql/migrations/173_has_permission_active_role_check.sql
+++ b/sql/migrations/173_has_permission_active_role_check.sql
@@ -1,0 +1,178 @@
+-- =====================================================================
+-- 173_has_permission_active_role_check
+-- =====================================================================
+-- Closes a second gap in has_permission(p_user_id, p_org_id,
+-- p_permission_key)'s ordinary-role branch, found during the security
+-- review that approved Migration 172: the branch joins user_roles ->
+-- role_permissions -> permissions and never joins public.roles at all, so
+-- a role's own `is_active` flag is never checked. Disabling a role (a real,
+-- exposed operation — see e.g. role management UI) leaves every user still
+-- assigned to it fully authorized for everything that role grants, as long
+-- as their user_roles row is untouched and unexpired.
+--
+-- This is a distinct bug from Migration 172's same-module wildcard match:
+-- 172 fixed WHICH permission_key values a grant satisfies; this migration
+-- fixes WHETHER a grant through a since-disabled role should count at all.
+-- Reviewed together, approved as two separate, independently-testable
+-- migrations rather than one combined change (see PR review on #109).
+--
+-- Precedent already exists in this codebase: Migration 166
+-- (wardah_has_exact_permission, introduced for the sensitive
+-- accounting.vouchers.unpost control) already joins roles with
+-- `r.org_id = p_org_id AND coalesce(r.is_active, true)` for exactly this
+-- reason — its own comment there ("has_permission intentionally supports
+-- module-level fallback... unposting must bypass that fallback") shows the
+-- broad-match gap 172 closed was a known, worked-around limitation before
+-- it was fixed at the root. has_permission() itself was never updated to
+-- match that stricter helper's role-activity check. This migration brings
+-- it into line, mirroring the identical join shape and COALESCE(...,
+-- true) null-safety convention already established in 166 — a role row
+-- with is_active left NULL (schema default is `true`, but not NOT NULL)
+-- must not silently lose access, matching how this codebase already
+-- treats nullable is_active flags elsewhere (e.g. Migration 170's
+-- `COALESCE(user_organizations.is_active, true)`).
+--
+-- Unaffected: the auth.uid() self-check (170), super-admin override
+-- (super_admins has its own is_active check, untouched), org-admin
+-- override (user_organizations has its own is_active check, untouched),
+-- exact permission_key equality (172), org scoping, and role-expiry
+-- behavior are all unchanged. Only the ordinary-role branch gains one
+-- additional join condition.
+-- =====================================================================
+
+BEGIN;
+
+SET LOCAL lock_timeout = '30s';
+SET LOCAL statement_timeout = '5min';
+
+-- ---------------------------------------------------------------------------
+-- Preflight: fail closed if the schema has already drifted from what this
+-- migration assumes, before touching anything.
+-- ---------------------------------------------------------------------------
+DO $preflight$
+BEGIN
+  IF to_regprocedure('public.has_permission(uuid,uuid,character varying)') IS NULL THEN
+    RAISE EXCEPTION 'PERMISSION_173_HAS_PERMISSION_MISSING';
+  END IF;
+
+  IF to_regclass('public.roles') IS NULL
+     OR to_regclass('public.role_permissions') IS NULL
+     OR to_regclass('public.user_roles') IS NULL
+     OR to_regclass('public.permissions') IS NULL THEN
+    RAISE EXCEPTION 'PERMISSION_173_REQUIRED_TABLE_MISSING';
+  END IF;
+END
+$preflight$;
+
+-- ---------------------------------------------------------------------------
+-- has_permission — ordinary-role branch now also requires the granting
+-- role itself to be active. Every other branch and predicate is
+-- byte-identical to Migration 172.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.has_permission(p_user_id uuid, p_org_id uuid, p_permission_key character varying) RETURNS boolean
+    LANGUAGE plpgsql STABLE SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+DECLARE
+    v_has_permission BOOLEAN;
+BEGIN
+    IF p_user_id IS DISTINCT FROM auth.uid() THEN
+        RETURN false;
+    END IF;
+
+    -- Super Admin: كل الصلاحيات
+    IF EXISTS (
+        SELECT 1 FROM super_admins
+        WHERE user_id = p_user_id AND is_active = true
+    ) THEN
+        RETURN true;
+    END IF;
+
+    -- Org Admin: كل صلاحيات منظمته
+    IF EXISTS (
+        SELECT 1 FROM user_organizations
+        WHERE user_id = p_user_id
+        AND org_id = p_org_id
+        AND is_active = true
+        AND is_org_admin = true
+    ) THEN
+        RETURN true;
+    END IF;
+
+    -- التحقق من الصلاحيات العادية: مطابقة تامة لمفتاح الصلاحية (172)، عبر
+    -- دور نشط فقط (173) — تعطيل الدور يسحب صلاحياته فورًا من كل من يحمله.
+    SELECT EXISTS (
+        SELECT 1
+        FROM user_roles ur
+        INNER JOIN roles r ON r.id = ur.role_id
+            AND r.org_id = p_org_id
+            AND COALESCE(r.is_active, true)
+        INNER JOIN role_permissions rp ON ur.role_id = rp.role_id
+        INNER JOIN permissions p ON rp.permission_id = p.id
+        WHERE ur.user_id = p_user_id
+        AND ur.org_id = p_org_id
+        AND p.permission_key = p_permission_key
+        AND (ur.expires_at IS NULL OR ur.expires_at > NOW())
+    ) INTO v_has_permission;
+
+    RETURN COALESCE(v_has_permission, false);
+END;
+$$;
+
+-- Grants unchanged: authenticated and service_role retain EXECUTE (see
+-- Migration 170) — this migration narrows the ordinary-role predicate
+-- only, not the execution boundary.
+
+-- ---------------------------------------------------------------------------
+-- Postflight: fail closed before COMMIT if the fix did not take, and that
+-- every prior behavior (170, 172) survived untouched.
+-- ---------------------------------------------------------------------------
+DO $verify$
+DECLARE
+  v_src text;
+BEGIN
+  SELECT prosrc INTO v_src FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public' AND p.proname = 'has_permission';
+
+  IF v_src IS NULL THEN
+    RAISE EXCEPTION 'FAIL[173] has_permission not found after CREATE OR REPLACE';
+  END IF;
+
+  -- The new role-activity join, null-safe per the Migration 166 convention.
+  IF v_src !~ 'roles r' THEN
+    RAISE EXCEPTION 'FAIL[173] has_permission does not join public.roles';
+  END IF;
+  IF v_src !~ 'COALESCE\(r\.is_active,\s*true\)' THEN
+    RAISE EXCEPTION 'FAIL[173] has_permission is missing the COALESCE(r.is_active, true) guard';
+  END IF;
+
+  -- Migration 172 behavior must survive untouched.
+  IF v_src ~ 'LIKE' THEN
+    RAISE EXCEPTION 'FAIL[173] has_permission regained a LIKE-based same-module match';
+  END IF;
+  IF v_src !~ 'p\.permission_key\s*=\s*p_permission_key' THEN
+    RAISE EXCEPTION 'FAIL[173] has_permission lost the exact permission_key equality predicate (172)';
+  END IF;
+  IF v_src !~ 'ur\.org_id\s*=\s*p_org_id' THEN
+    RAISE EXCEPTION 'FAIL[173] has_permission lost the ur.org_id = p_org_id scoping predicate (172)';
+  END IF;
+
+  -- Migration 170 behavior must survive untouched.
+  IF v_src !~ 'p_user_id IS DISTINCT FROM auth\.uid\(\)' THEN
+    RAISE EXCEPTION 'FAIL[173] has_permission lost the caller-identity guard (170)';
+  END IF;
+  IF v_src !~ 'super_admins' THEN
+    RAISE EXCEPTION 'FAIL[173] has_permission lost the super-admin override (170)';
+  END IF;
+  IF v_src !~ 'is_org_admin' THEN
+    RAISE EXCEPTION 'FAIL[173] has_permission lost the org-admin override (170)';
+  END IF;
+  IF v_src !~ 'expires_at' THEN
+    RAISE EXCEPTION 'FAIL[173] has_permission lost role-expiry enforcement (170)';
+  END IF;
+
+  RAISE NOTICE 'PASS[173] has_permission now requires the granting role to be active; Migration 170/172 behavior preserved';
+END
+$verify$;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Found during the security review that approved Migration 172 (PR #109, see its final comment): `has_permission()`'s ordinary-role branch joins `user_roles` → `role_permissions` → `permissions` and never joins `public.roles` at all, so a role's own `is_active` flag is never checked. Disabling a role — a real, exposed administrative operation — leaves every user still assigned to it fully authorized for everything that role grants, as long as their `user_roles` row is untouched and unexpired.

Distinct from Migration 172's fix: 172 fixed *which* `permission_key` values a grant satisfies (exact match, not same-module wildcard); this fixes *whether* a grant through a since-disabled role should count at all. Kept as an independent migration/PR, per the explicit decision not to mix it with 172 or with any AI-reliability follow-up work.

## Precedent already in this codebase

Migration 166's `wardah_has_exact_permission` (introduced for the sensitive `accounting.vouchers.unpost` control) already joins `roles` with `r.org_id = p_org_id AND coalesce(r.is_active, true)` for exactly this reason — its own comment there shows this gap was a known, worked-around limitation before Migration 172 fixed the root wildcard issue, but `has_permission()` itself was never updated to match that stricter helper's role-activity check. This migration mirrors 166's identical join shape and `COALESCE(..., true)` null-safety convention.

## What changed

- `sql/migrations/173_has_permission_active_role_check.sql`: `CREATE OR REPLACE FUNCTION has_permission` — ordinary-role branch gains `INNER JOIN roles r ON r.id = ur.role_id AND r.org_id = p_org_id AND COALESCE(r.is_active, true)`. Every other predicate (170's identity guard/admin overrides, 172's exact-match/org-scoping, role-expiry) is byte-identical; postflight asserts each survives via six separate checks.
- `scripts/ci/fresh-db/acceptance_173_has_permission_active_role_check.sql`: 5 assertions — active role (true), the identically-wired grant through a **disabled** role (false — the regression this closes), expired grant through an active role (false, 170 behavior), org-admin override (true, no role needed), super-admin override (true, no role needed). A setup assertion proves the disabled-role fixture's grant is genuinely wired before asserting denial, isolating `roles.is_active` as the only variable.
- `.github/workflows/has-permission-173-acceptance.yml`: Fresh DB (PostgreSQL 17) acceptance gate, also re-runs 172/170/171 acceptance on the same DB to prove no regression across the full permission-hardening chain.
- `docs/db/HAS_PERMISSION_173_RUNBOOK.md`: root cause, the 166 precedent, Production apply/rollback procedure, and an optional informational query to check for any org currently affected by this behavior change (a disabled role with active assignments).

## Verification

All run locally on **real PostgreSQL 17** (installed via the PGDG apt repository in this session's sandbox, Docker unavailable there):

- Fresh DB built from the current baseline through the full migration chain (`153` → `173`) via `run_chain.sh` — **12/12 PASS**.
- `acceptance_173_has_permission_active_role_check.sql` → `HAS_PERMISSION_173_ACCEPTANCE_PASS`.
- **Regression-guard proof**: temporarily reverted `has_permission` to the pre-173 (172-only) text on the same fixtures — the disabled-role assertion failed exactly as expected (`ACCEPTANCE_FAIL[173-2]: ... still authorized the caller`), then restored the fix and re-confirmed a clean pass.
- `acceptance_172_has_permission_exact_key_match.sql`, `acceptance_170_tenant_isolation_and_permission_hardening.sql`, and `acceptance_171_ai_usage_daily.sql` all re-run on the same post-173 DB → all pass, no regression across the full 170→173 chain.
- `python3 scripts/ci/check_migration_syntax.py` (pglast) — clean, 201 files.
- `python3 scripts/ci/check_definer_guards.py` — clean (`has_permission` already exempt since Migration 170).
- `python3 scripts/ci/validate_migration_ledger.py` — `status: ok`, `repo_max: 173`.

## Not in scope

- `reports-insights` — already deployed and live on Production (Migration 172 was its prerequisite, applied separately in PR #109). This migration is unrelated to that deployment.
- AI-reliability follow-up work (quota-accounting decoupling, provider-error tracking) — deliberately kept in a separate future PR per explicit decision, to avoid mixing concerns.

---
_Generated by [Claude Code](https://claude.ai/code/session_018cutU8CHzP246sWciqbGNT)_