### PR TITLE
docs(db): reconcile main with Production at 173 and declare the 163 ledger alias

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Wardah Process Costing — Project Manifest
 
-**آخر تحديث موثق:** 2026-07-29  
+**آخر تحديث موثق:** 2026-08-09  
 **Repository:** `6thd/wardah-process-costing`  
 **Supabase project:** `uutfztmqvajmsxnrqeiv`
 
@@ -27,12 +27,13 @@ React 18 + TypeScript + Vite، shadcn/ui + Tailwind، Zustand + TanStack Query،
 3. **Production:** سجل `supabase_migrations.schema_migrations`.
 
 <!-- DATABASE_STATE_START -->
-الحالة الحية الموثقة بعد Baseline المولد في 2026-07-29:
+الحالة الحية الموثقة بعد تطبيق Migration 173 في 2026-08-09 (الـBaseline نفسه لم يتغيّر، ولا يزال عند اللقطة المولّدة في 2026-07-29):
 
-- Baseline الحالي: `000_schema_baseline_20260729_210941.sql`, cutoff 152.
-- Production: مطبقة حتى 152 (`152_ap_allow_fully_received_purchase_orders`).
-- Repository: أعلى migration مرقمة هي 152.
-- Fresh DB: لا توجد migrations معلقة بعد cutoff عند لحظة التوليد.
+- Baseline الحالي: `000_schema_baseline_20260729_210941.sql`, cutoff 152. لم يُحدَّث بعد ظهور 153–173 في سجل Production؛ تحديثه خطوة منفصلة عبر `generate-baseline.yml` وPR مستقل، ولا تُستنتَج ضمنيًا من هذا التحديث.
+- Production: مطبقة حتى 173 (`173_has_permission_active_role_check`, version `20260809051430`)، عبر تسلسل 153 → 163 → 164 → 165 → 166 → 167 → 168 → 169 → 170 → 171 → 172 → 173 فوق cutoff 152.
+- Repository: أعلى migration مرقمة هي 173 (`173_has_permission_active_role_check.sql`).
+- Fresh DB: 153–173 تُطبَّق فوق baseline cutoff 152 دون migration معلّقة؛ 154–162 محجوزة رسميًا لمحرك التقارير المالية ولا تُعامل كفجوة (`sql/migrations/skipped_migration_numbers.yml`).
+- تدقيق السجل الحي في 2026-08-09: `live_cutoff = 173`، `repo_max = 173`، `repository_ahead_by = 0`، ولا ملفات معلّقة.
 - لا تعدّ أي migration مطبقة حيًا لمجرد نجاح Fresh DB؛ سجل Production هو المرجع.
 <!-- DATABASE_STATE_END -->
 
@@ -41,6 +42,7 @@ React 18 + TypeScript + Vite، shadcn/ui + Tailwind، Zustand + TanStack Query،
 
 - 101 و102 طُبقتا مرتين بإصدارات زمنية محددة؛ أي تكرار إضافي يفشل التدقيق.
 - سجل 121 يحمل الاسم التاريخي `fail_closed_tenant_isolation` ويطابق قانونيًا الملف `121_fail_closed_tenant_isolation.sql`.
+- سجل 163 يحمل الاسم التاريخي `payment_voucher_guarded_draft_inserts` (version `20260731102524`) ويطابق قانونيًا الملف `163_payment_voucher_atomic_draft_creation.sql`. **ظل هذا الاستثناء غير معلن حتى 2026-08-09، فكان `Audit Production Migration Ledger` يفشل مغلقًا في كل تشغيل** برسالة `has no exact repository file … and no documented alias`. الصفّ الحي لم يُمسّ.
 
 المراجع:
 
@@ -54,6 +56,20 @@ React 18 + TypeScript + Vite، shadcn/ui + Tailwind، Zustand + TanStack Query،
 - `docs/db/AP_THREE_WAY_MATCH_149_152_RUNBOOK.md` — 149–152: المطابقة الثلاثية،
   idempotency، hardening أمني، وترتيب تطبيق Production الإلزامي
   `149 → 150 → 151 → 152` مع فحوص قبل/بعد التطبيق.
+- `docs/db/VOUCHER_RESET_166_RUNBOOK.md`، `docs/db/VOUCHER_ALLOCATION_167_RUNBOOK.md`،
+  `docs/db/VOUCHER_ATOMIC_LIFECYCLE_168_RUNBOOK.md` — 166–168: انتقال دورة سندات
+  القبض والصرف إلى RPCs ذرية (Create/Edit/Post/Reset/Cancel).
+- `docs/db/VOUCHER_WRITE_CLOSURE_169_RUNBOOK.md` — 169: إغلاق سطح الكتابة المؤقت
+  على رؤوس السندات وأسطر التخصيص وحقول الدفع المشتقة عبر حارس مزدوج (مالك RPC
+  موثوق + GUC محلي للمعاملة معًا، لا GUC وحده).
+- `docs/db/PERMISSION_HARDENING_170_173_CHAIN.md` — **170–173 مجتمعة**: العرض
+  المركّب لسلسلة عزل المستأجرين وتشديد `has_permission()`. ثلاث migrations تستبدل
+  **الدالة نفسها**، فالعقد الحي هو اتحادها لا آخرها؛ اقرأ هذا الملف قبل أي تعديل
+  لاحق على `has_permission`. يتضمن الحالة الحية المتحقَّقة، وما لم تغيّره السلسلة
+  عمدًا (تجاوز org admin — Issue #93).
+- `docs/db/TENANT_ISOLATION_170_RUNBOOK.md`، `docs/db/AI_USAGE_DAILY_171_RUNBOOK.md`،
+  `docs/db/HAS_PERMISSION_172_RUNBOOK.md`، `docs/db/HAS_PERMISSION_173_RUNBOOK.md`
+  — تفصيل كل migration على حدة.
 
 ## Baseline
 
@@ -127,6 +143,23 @@ PR #32 أضاف أو حسّن:
 - helpers الداخلية لا تُمنح لـ`anon` أو`authenticated`.
 
 `scripts/ci/check_definer_guards.py` يفحص migrations الأحدث من cutoff بحثًا عن مرجع حارس معروف أو سحب PUBLIC. لا يثبت ترتيب أول statement أو صحة المنطق كاملة؛ المراجعة البشرية والاختبارات السلبية لازمة.
+
+### عقد `has_permission()` الحي بعد 173
+
+الدالة `public.has_permission(uuid, uuid, varchar)` هي اتحاد ثلاث migrations لا آخرها
+(170 حارس هوية المستدعي، 172 مطابقة تامة للمفتاح، 173 اشتراط دور نشط)، بالإضافة إلى
+انتهاء صلاحية الدور ونطاق المؤسسة الموروثَين. أي `CREATE OR REPLACE` لاحق يجب أن يعيد
+تثبيت الطبقات الخمس جميعًا — تفصيلها وفحص ما بعد التطبيق المركّب في
+`docs/db/PERMISSION_HARDENING_170_173_CHAIN.md`.
+
+**تجاوز org admin قائم ولم تغيّره السلسلة:** فرع `is_org_admin` لا يقرأ
+`p_permission_key` إطلاقًا، فأي مسؤول مؤسسة نشط يجتاز **كل** مفتاح بما فيه المفاتيح
+المحاسبية الحساسة (`unpost`/`cancel`/`reverse`). ينطبق ذلك على `has_permission`
+و`wardah_has_exact_permission` معًا — الأخيرة «تامة» في المفتاح لا في التجاوز. ونتيجةً
+لذلك **عدّ صفوف `role_permissions` لا يقيس الصلاحية الفعلية**؛ الفحص الصحيح هو استدعاء
+دالة الصلاحية لكل مستخدم نشط. القرار المعماري مفتوح في Issue #93، ولا يُغيَّر السلوك قبل
+حسمه؛ وإذا اعتُمد استثناء المفاتيح الحساسة فيجب منح المسؤول الحالي الدور الجديد **قبل**
+تضييق التجاوز تفاديًا للـLockout.
 
 ## i18n
 
@@ -202,6 +235,12 @@ SELECT org_id, value FROM public.org_settings WHERE key = '<flag_key>';
 ```
 
 حدثت هذه الفجوة فعلًا مع Migration 148؛ التفاصيل في `docs/db/UOM_PARTIAL_RECEIPT_148_RUNBOOK.md` §3.
+وحدثت مرة أخرى بوجه مقلوب مع Migration 170: دُمجت في `main` عبر PR #98 بينما ظل سجل
+Production عند 169، فبقيت الثغرات الثلاث **حية بالكامل** طوال تلك النافذة حتى التطبيق
+الفعلي في 2026-08-06. **الدمج يغلق الفجوة في المستودع لا في Production؛ خطوة التطبيق هي
+الإصلاح نفسه لا متابعة اختيارية.** في المقابل التُزم الترتيب مع 171 (تطبيق وتحقق في
+2026-08-06، ثم دمج واجهة `reports-insights` في 2026-08-08 عبر #106 وما بعده) — وهو
+النموذج المتَّبع. التفاصيل في `docs/db/PERMISSION_HARDENING_170_173_CHAIN.md` §6.
 
 ## Secrets
 

--- a/docs/db/AI_USAGE_DAILY_171_RUNBOOK.md
+++ b/docs/db/AI_USAGE_DAILY_171_RUNBOOK.md
@@ -2,7 +2,9 @@
 
 **Migration:** `171_ai_usage_daily_and_reports_insights_permission.sql`
 **Scope:** Add the quota-tracking table and race-safe accept/reject RPC that back the `reports-insights` Supabase Edge Function, plus seed the `reports.ai_insights.use` permission the Edge Function checks before calling any provider.
-**State:** Repository implementation, not yet applied to Production. Do not apply before the paired Fresh DB acceptance gate is green and this runbook's preflight/postflight queries have been reviewed. The Edge Function itself is deployed independently of this migration (see `docs/db/UOM_PARTIAL_RECEIPT_148_RUNBOOK.md`-style DB-first ordering in `CLAUDE.md`) — this migration must land on Production and be verified **before** any UI that depends on `reports-insights` is merged.
+**State:** Applied to Production (`uutfztmqvajmsxnrqeiv`) on 2026-08-06, ledger version `20260806061156`, name `171_ai_usage_daily_and_reports_insights_permission`. Re-verified live on 2026-08-09: `public.ai_usage_daily` exists and exactly one `permissions` row carries `permission_key = 'reports.ai_insights.use'`.
+
+**DB-first ordering was honoured here.** This migration reached Production on 2026-08-06, and the UI that depends on `reports-insights` was merged afterwards — PR #106 on 2026-08-08, then #107 and #108. That is the ordering `CLAUDE.md` §"ترتيب النشر" requires (`DB PR → apply → verify → UI PR`), and it is recorded here as the worked example to follow, in contrast to Migration 148 (`docs/db/UOM_PARTIAL_RECEIPT_148_RUNBOOK.md` §3) where the ordering was violated.
 
 ## 1. Purpose
 

--- a/docs/db/HAS_PERMISSION_172_RUNBOOK.md
+++ b/docs/db/HAS_PERMISSION_172_RUNBOOK.md
@@ -6,7 +6,7 @@
 
 ## 1. Purpose
 
-Pre-deployment verification of the (still undeployed) `reports-insights` Edge Function found that `has_permission(p_user_id, p_org_id, p_permission_key)`'s "ordinary role" branch — unchanged by Migration 170, which only added the caller-identity guard around it — matches not only an exact `permission_key`, but any `permission_key` sharing the same first dot-segment:
+Pre-deployment verification of the `reports-insights` Edge Function (undeployed *at that time* — it went live on 2026-08-08, after this migration was applied; see §7) found that `has_permission(p_user_id, p_org_id, p_permission_key)`'s "ordinary role" branch — unchanged by Migration 170, which only added the caller-identity guard around it — matches not only an exact `permission_key`, but any `permission_key` sharing the same first dot-segment:
 
 ```sql
 p.permission_key = p_permission_key
@@ -121,4 +121,16 @@ Never edit `supabase_migrations.schema_migrations` to remove this row, and never
 
 ## 7. Relationship to `reports-insights` deployment
 
-This migration is a **prerequisite** for deploying the `reports-insights` Edge Function (`verify_jwt=true`), per the repository's `repository-first` migration / `DB-first` interface ordering rule (`CLAUDE.md`). The Edge Function calls `has_permission(auth.uid(), org_id, 'reports.ai_insights.use')` to gate access before ever reaching the AI provider or the daily-quota RPC; without this fix, any role holding an unrelated `reports.*` permission would bypass that gate entirely. The function remains undeployed until: this migration is merged to `main`, applied to Production, and verified via the postflight queries in §5 above — after which the Edge Function deployment and its own agreed Production checks (401 without JWT, 403 without permission, 200 for an authorized user, immediate fallback on provider failure, 429 on quota) proceed as a separate, later step.
+This migration is a **prerequisite** for deploying the `reports-insights` Edge Function (`verify_jwt=true`), per the repository's `repository-first` migration / `DB-first` interface ordering rule (`CLAUDE.md`). The Edge Function calls `has_permission(auth.uid(), org_id, 'reports.ai_insights.use')` to gate access before ever reaching the AI provider or the daily-quota RPC; without this fix, any role holding an unrelated `reports.*` permission would bypass that gate entirely.
+
+**Prerequisite satisfied — the function is deployed.** The ordering held, verified read-only on 2026-08-09:
+
+| Step | When |
+|---|---|
+| Migration 172 merged to `main` (PR #109) | 2026-08-08 |
+| Applied to Production, ledger `20260808153737` | 2026-08-08 15:37:37 UTC |
+| `reports-insights` Edge Function deployed | 2026-08-08 15:55:45 UTC |
+
+The function is live on `uutfztmqvajmsxnrqeiv`: slug `reports-insights`, status `ACTIVE`, version 2, `verify_jwt = true` — deployed 18 minutes after the migration landed, not before it. Its own agreed Production checks (401 without JWT, 403 without permission, 200 for an authorized user, immediate fallback on provider failure, 429 on quota) belong to that deployment, not to this migration, and are not re-asserted here.
+
+Migration 173 later replaced the same function again (active-role requirement) without disturbing this gate; the exact-key predicate this migration introduced is still live — see `docs/db/PERMISSION_HARDENING_170_173_CHAIN.md` §4.

--- a/docs/db/HAS_PERMISSION_172_RUNBOOK.md
+++ b/docs/db/HAS_PERMISSION_172_RUNBOOK.md
@@ -2,7 +2,7 @@
 
 **Migration:** `172_has_permission_exact_key_match.sql`
 **Scope:** Close a same-module authorization-scope bug in `has_permission()`, inherited unchanged through Migration 170, that let any granted permission in a module implicitly satisfy every other permission key in that same module.
-**State:** Repository implementation, not yet applied to Production. Do not apply before the paired Fresh DB acceptance gate is green and this runbook's preflight/postflight queries have been reviewed.
+**State:** Applied to Production (`uutfztmqvajmsxnrqeiv`) on 2026-08-08, ledger version `20260808153737`, name `172_has_permission_exact_key_match`. Postflight verified live; the exact-match predicate was re-confirmed on 2026-08-09 after 173 replaced the same function — see `docs/db/PERMISSION_HARDENING_170_173_CHAIN.md` §4. Superseded in body but **not** in effect by Migration 173, which `CREATE OR REPLACE`s the same function and preserves this migration's exact-key predicate verbatim.
 
 ## 1. Purpose
 

--- a/docs/db/HAS_PERMISSION_173_RUNBOOK.md
+++ b/docs/db/HAS_PERMISSION_173_RUNBOOK.md
@@ -2,7 +2,7 @@
 
 **Migration:** `173_has_permission_active_role_check.sql`
 **Scope:** Close a second gap in `has_permission()`'s ordinary-role branch — disabling a role never revoked the access it granted.
-**State:** Repository implementation, not yet applied to Production. Do not apply before the paired Fresh DB acceptance gate is green and this runbook's preflight/postflight queries have been reviewed.
+**State:** Applied to Production (`uutfztmqvajmsxnrqeiv`) on 2026-08-09, ledger version `20260809051430`, name `173_has_permission_active_role_check`. This is the current head of the Production ledger. All nine postflight boolean columns in §5 returned `true` against the live database, and `has_function_privilege('authenticated', …)` returned `true` — full evidence in `docs/db/PERMISSION_HARDENING_170_173_CHAIN.md` §4.
 
 ## 1. Purpose
 

--- a/docs/db/PERMISSION_HARDENING_170_173_CHAIN.md
+++ b/docs/db/PERMISSION_HARDENING_170_173_CHAIN.md
@@ -1,0 +1,117 @@
+# Migrations 170–173 — Tenant Isolation & `has_permission()` Hardening Chain
+
+**Scope:** The four migrations that took Production from cutoff 169 to 173, and the final, verified state of the authorization surface they leave behind.
+**State:** All four applied to Production (`Manufacturing Process`, `uutfztmqvajmsxnrqeiv`) and verified. 173 is the current ledger head.
+**Purpose of this document:** the four per-migration runbooks each describe one change in isolation. Three of them replace the *same function*, so the only way to read the current contract is to read them together. This document is that composite view, plus the live evidence that the composite actually holds.
+
+## 1. The chain
+
+| # | Migration | Ledger version | Applied | PR |
+|---|---|---|---|---|
+| 170 | `170_tenant_isolation_and_permission_hardening` | `20260806043140` | 2026-08-06 | #98 |
+| 171 | `171_ai_usage_daily_and_reports_insights_permission` | `20260806061156` | 2026-08-06 | #104 |
+| 172 | `172_has_permission_exact_key_match` | `20260808153737` | 2026-08-08 | #109 |
+| 173 | `173_has_permission_active_role_check` | `20260809051430` | 2026-08-09 | #110 |
+
+Per-migration detail lives in `TENANT_ISOLATION_170_RUNBOOK.md`, `AI_USAGE_DAILY_171_RUNBOOK.md`, `HAS_PERMISSION_172_RUNBOOK.md` and `HAS_PERMISSION_173_RUNBOOK.md`. Nothing here replaces those; this is the seam between them.
+
+## 2. Three migrations, one function
+
+170, 172 and 173 each `CREATE OR REPLACE` `public.has_permission(uuid, uuid, varchar)`. Each preserves the previous one's work rather than reverting it, so the live body is the **union** of the three:
+
+| Layer | From | Contract |
+|---|---|---|
+| Caller-identity guard | 170 | `p_user_id IS DISTINCT FROM auth.uid()` → `false`. A caller can only ask about themselves; the cross-user permission-disclosure path is closed. |
+| Exact permission-key match | 172 | `p.permission_key = p_permission_key`. The `LIKE`-based same-module fallback is gone — a grant on `reports.foo` no longer satisfies `reports.bar`. |
+| Active-role requirement | 173 | `JOIN roles r … AND COALESCE(r.is_active, true)`. Disabling a role revokes what it granted, immediately, for everyone holding it. |
+| Role expiry | pre-170 | `ur.expires_at IS NULL OR ur.expires_at > NOW()` — carried through unchanged by all three. |
+| Org scoping | pre-170 | `ur.org_id = p_org_id`, and the `roles` join is org-scoped too (`r.org_id = p_org_id`). |
+
+**The layering is why a later migration must never be read as replacing an earlier one's runbook.** 173's file contains 172's predicate; if 173 were ever reverted by hand, 172's fix would go with it. Any future change to this function must re-assert all five rows of that table, and the postflight query in §4 exists precisely to catch a replacement that silently drops one.
+
+## 3. What 171 contributes
+
+171 is not part of the `has_permission()` sequence — it sits in the chain by number only. It creates `public.ai_usage_daily` (per-user and per-org daily AI quota, enforced server-side by a race-safe RPC) and seeds the `reports.ai_insights.use` permission that the `reports-insights` Edge Function checks.
+
+Its relevance to the other three is one-directional: the Edge Function's permission check *reads through* `has_permission()`, which is why the same-module wildcard 172 closed was found during 171's pre-deployment verification, and not before.
+
+## 4. Verified live state — 2026-08-09
+
+Read-only, run against Production after 173 landed. This is the composite postflight; it supersedes running the three per-migration postflights separately.
+
+```sql
+SELECT
+  prosrc ~ 'p_user_id IS DISTINCT FROM auth\.uid\(\)' AS identity_guard,      -- 170
+  prosrc !~ 'LIKE'                                    AS wildcard_removed,    -- 172
+  prosrc ~ 'p\.permission_key\s*=\s*p_permission_key' AS exact_match,         -- 172
+  prosrc ~ 'roles r'                                  AS roles_join,          -- 173
+  prosrc ~ 'COALESCE\(r\.is_active,\s*true\)'         AS role_active_guard,   -- 173
+  prosrc ~ 'ur\.org_id\s*=\s*p_org_id'                AS org_scoping,
+  prosrc ~ 'expires_at'                               AS role_expiry,
+  prosrc ~ 'super_admins'                             AS super_admin_override,
+  prosrc ~ 'is_org_admin'                             AS org_admin_override,
+  has_function_privilege('authenticated',
+    'public.has_permission(uuid,uuid,varchar)', 'EXECUTE')  AS auth_exec
+FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname = 'public' AND p.proname = 'has_permission';
+```
+
+All ten columns returned `true`.
+
+Tenant-isolation closures from 170, re-checked in the same pass:
+
+```sql
+SELECT
+  (SELECT count(*) FROM pg_policies WHERE schemaname='public'
+     AND tablename IN ('physical_count_items','physical_count_sessions')) AS physical_count_policies,
+  (SELECT count(*) FROM pg_policies WHERE schemaname='public'
+     AND tablename IN ('physical_count_items','physical_count_sessions')
+     AND (qual LIKE '%physical_count_items%' OR qual LIKE '%physical_count_sessions%')) AS self_referencing_policies,
+  (SELECT count(*) FROM information_schema.role_table_grants
+     WHERE grantee='anon' AND table_schema='public'
+       AND table_name IN ('manufacturing_stages','stage_wip_log','standard_costs')) AS anon_grants_on_mfg,
+  (SELECT to_regclass('public.ai_usage_daily') IS NOT NULL) AS ai_usage_daily_exists,
+  (SELECT count(*) FROM public.permissions
+     WHERE permission_key='reports.ai_insights.use')        AS ai_insights_permission_rows;
+```
+
+Result: `physical_count_policies = 8`, `self_referencing_policies = 0`, `anon_grants_on_mfg = 0`, `ai_usage_daily_exists = true`, `ai_insights_permission_rows = 1`.
+
+Ledger head confirmed as `20260809051430 / 173_has_permission_active_role_check`, with `scripts/ci/validate_migration_ledger.py` reporting `live_cutoff: 173`, `repo_max: 173`, `repository_ahead_by: 0`, `pending_repository_files: []`.
+
+**What this evidence is and is not.** These are catalog-level assertions about the deployed contract. The behavioural proofs — that a disabled role actually stops authorizing, that a same-module key actually stops matching — come from the paired Fresh PostgreSQL 17 acceptance workflows (`tenant-isolation-170-acceptance.yml`, `ai-usage-daily-171-acceptance.yml`, `has-permission-172-acceptance.yml`, `has-permission-173-acceptance.yml`), which run against synthetic fixtures, never Production data. Both matter; neither substitutes for the other.
+
+## 5. What this chain deliberately did **not** change
+
+Both override branches survive all four migrations, untouched and by design:
+
+```sql
+EXISTS (super_admins WHERE user_id = p_user_id AND is_active)        -- branch 1
+OR EXISTS (user_organizations WHERE user_id = p_user_id
+             AND org_id = p_org_id AND is_active AND is_org_admin)   -- branch 2
+```
+
+**Branch 2 never reads `p_permission_key`.** Any active org admin passes every key, including the sensitive accounting controls (`unpost`, `cancel`, `reverse`). Verified live on 2026-08-09: the override is present in **both** `has_permission(uuid,uuid,varchar)` and `wardah_has_exact_permission(uuid,uuid,text)`.
+
+This is open architectural question **Issue #93**, not an oversight of this chain. Two consequences follow directly, and both are live today:
+
+1. **A contract check that counts `role_permissions` rows does not measure effective authorization.** `granted_roles = 0` for a sensitive key is compatible with every org admin holding it. Checks that intend to measure real access must call the permission function per active user, not count grants.
+2. **`wardah_has_exact_permission` is "exact" only about the *key*, not about the *override*.** Migration 166 introduced it to bypass the module-level fallback for `accounting.vouchers.unpost`; it joins `roles` and checks `is_active` (173 later brought `has_permission` into line with it), but it carries the same org-admin branch. The name promises more isolation than the implementation delivers.
+
+Deciding Issue #93 — keep the override and document it, or carve out a sensitive-permission class that requires an explicit grant — is the next authorization change, and it is out of scope for 170–173. If the sensitive-class option is chosen, note the lockout risk recorded in the issue: the single active org admin must be granted the new role **before** the override is narrowed, or nobody can perform those operations afterwards.
+
+## 6. Governance record
+
+Two process facts from this window are worth keeping, because both are precedents:
+
+- **170 sat merged-but-unapplied.** It reached `main` in PR #98 while the Production ledger was still at 169, and all three vulnerabilities stayed fully live for that entire window. Merging a migration closes the gap in the repository, not in Production. See `TENANT_ISOLATION_170_RUNBOOK.md`, header note.
+- **171 honoured DB-first ordering.** The migration was applied and verified on 2026-08-06; the UI depending on `reports-insights` merged on 2026-08-08 (#106) and after (#107, #108). This is the ordering `CLAUDE.md` §"ترتيب النشر" requires, and the counter-example to Migration 148's violation.
+
+A third fact belongs to the ledger itself: the Production row for migration 163 is named `payment_voucher_guarded_draft_inserts`, not `163_payment_voucher_atomic_draft_creation`. Until that alias was declared in `sql/migrations/migration_ledger_exceptions.json`, `Audit Production Migration Ledger` failed closed on every run with:
+
+```text
+ERROR: Live migration 20260731102524/payment_voucher_guarded_draft_inserts has no
+exact repository file payment_voucher_guarded_draft_inserts.sql and no documented alias
+```
+
+The alias is now declared and the audit passes. The row itself was never touched — the historical name is preserved exactly as applied, per the golden rule.

--- a/docs/db/TENANT_ISOLATION_170_RUNBOOK.md
+++ b/docs/db/TENANT_ISOLATION_170_RUNBOOK.md
@@ -2,7 +2,9 @@
 
 **Migration:** `170_tenant_isolation_and_permission_hardening.sql`
 **Scope:** Fix a real cross-tenant RLS bypass, remove a default-organization fallback reachable by `anon`, and close a cross-user permission-disclosure path.
-**State:** Repository implementation, not yet applied to Production. Do not apply before the paired Fresh DB acceptance gate is green and this runbook's preflight/postflight queries have been reviewed.
+**State:** Applied to Production (`uutfztmqvajmsxnrqeiv`) on 2026-08-06, ledger version `20260806043140`, name `170_tenant_isolation_and_permission_hardening`. Verified via the postflight queries in §5 run directly against the live database, and re-verified on 2026-08-09 (see §5.1).
+
+**Note on the gap between merge and apply:** this migration was merged to `main` in PR #98 well before it was actually applied to Production — the ledger had stalled at 169 with 170 sitting unapplied. Independent verification against the live database on 2026-08-06 confirmed all three original vulnerabilities were still fully live in Production for that entire window (self-referencing `physical_count_*` policies, `anon` holding SELECT+INSERT on the three manufacturing tables via the default-org fallback, `has_permission` with no caller-identity guard). A migration landing on `main` closes the gap in the repository, not in Production — the apply step is not optional follow-up, it is the fix. Do not treat a merged migration as resolved until this section (or the ledger itself) says otherwise.
 
 ## 1. Purpose
 
@@ -114,6 +116,24 @@ WHERE name = '170_tenant_isolation_and_permission_hardening';
 ```
 
 Expected: all 8 policy texts reference `user_organizations.org_id` and `is_active`; both `anon` grant checks `false` for all three tables; `delegates_correctly` and `no_dead_guc` both true; `has_guard` true; `has_function_privilege` true (unchanged, still callable — just self-scoped now); exactly one ledger row for 170.
+
+### 5.1 Re-verification on 2026-08-09
+
+After Production advanced to 173, the three closures above were re-checked read-only against the live database to prove that 171–173 did not regress any of them:
+
+```sql
+SELECT
+  (SELECT count(*) FROM pg_policies WHERE schemaname='public'
+     AND tablename IN ('physical_count_items','physical_count_sessions')) AS physical_count_policies,
+  (SELECT count(*) FROM pg_policies WHERE schemaname='public'
+     AND tablename IN ('physical_count_items','physical_count_sessions')
+     AND (qual LIKE '%physical_count_items%' OR qual LIKE '%physical_count_sessions%')) AS self_referencing_policies,
+  (SELECT count(*) FROM information_schema.role_table_grants
+     WHERE grantee='anon' AND table_schema='public'
+       AND table_name IN ('manufacturing_stages','stage_wip_log','standard_costs')) AS anon_grants_on_mfg;
+```
+
+Result: `physical_count_policies = 8`, `self_referencing_policies = 0`, `anon_grants_on_mfg = 0`. The `has_permission` caller-identity guard is also still present — see `docs/db/PERMISSION_HARDENING_170_173_CHAIN.md` §4, which re-checks all three `has_permission` contracts (170 identity guard, 172 exact key, 173 active role) in one query.
 
 ## 6. Rollback
 

--- a/docs/db/VOUCHER_WRITE_CLOSURE_169_RUNBOOK.md
+++ b/docs/db/VOUCHER_WRITE_CLOSURE_169_RUNBOOK.md
@@ -1,0 +1,150 @@
+# Migration 169 — Voucher Write Closure Runbook
+
+**Migration:** `169_voucher_write_closure.sql`
+**Scope:** Withdraw the temporary direct-write surface on voucher headers and allocation lines, and close payment-derived invoice field drift in both directions.
+**State:** Applied and verified on Production (`Manufacturing Process`, `uutfztmqvajmsxnrqeiv`) on 2026-08-05, ledger version `20260805151524`. Merged to `main` via PR #96, squash commit `0bcce21a`. Production has since advanced to 173; the contract described here was re-verified live on 2026-08-09 and is unchanged (see §7).
+
+## 1. Purpose
+
+Migrations 163 and 167 left two temporary client capabilities open on purpose while the UI moved onto the atomic lifecycle RPCs (166–168):
+
+- `authenticated` `INSERT` on `customer_collections` and `supplier_payments` (163);
+- `authenticated` `INSERT` on `customer_collection_lines` and `supplier_payment_lines` (167).
+
+Migration 169 withdraws both, drops the four now-obsolete insert policies, and closes a second, independently discovered gap: nothing prevented a direct `UPDATE` from silently mutating `sales_invoices.paid_amount` / `payment_status` or `supplier_invoices.paid_amount` / payment-derived `status` outside the voucher post/reset/cancel lifecycle.
+
+## 2. Why a GUC alone is not the boundary
+
+The pre-169 allocation-line trigger (`wardah_protect_voucher_allocation_lines`, migration 167) allowed any write once the transaction-local GUC `wardah.voucher_lines_write` read `on`, with no check on who set it. Because `service_role` can call `set_config` directly, that GUC was spoofable by any RLS-bypassing session — proven by the pre-169 Acceptance run terminating on exactly this assertion (`authenticated retains direct write on customer_collections`, the catalog-level check that runs before any GUC is even touched).
+
+Migration 169's guard is a **dual-factor** condition, both required:
+
+```sql
+current_user = pg_get_userbyid(<owner of wardah_voucher_write_is_trusted>)
+AND (
+  current_setting(<capability GUC>, true) = 'on'
+  OR session_user = current_user
+)
+```
+
+The owner check makes a client-set GUC insufficient on its own; the GUC (or a genuine same-identity session, covering direct superuser/administrative access) makes the owner identity insufficient on its own, since other owner-defined routines exist. `wardah_voucher_write_is_trusted(text)` is `REVOKE`d from `PUBLIC`, `anon` and `authenticated`, and granted `EXECUTE` only to `service_role` — `authenticated` never reaches it, because its direct table grants are revoked first (see §3), so the trigger never fires for that role at all.
+
+## 3. What the migration changes
+
+| Change | Detail |
+|---|---|
+| Function rename | The ten original `rpc_*` implementations are renamed to `wardah_169_internal_*` and `REVOKE ALL ... FROM PUBLIC, anon, authenticated, service_role` — nobody may call them by name directly. |
+| New public wrappers | `CREATE OR REPLACE FUNCTION public.rpc_*` (same ten signatures, `SECURITY DEFINER`) re-checks `auth.uid()` and tenant membership, brackets the internal call with `wardah_169_enter_write_context()` / `wardah_169_leave_write_context()`, and restores the write context explicitly in an `EXCEPTION WHEN OTHERS` handler before re-raising — not only via transaction rollback. |
+| Header guard | New `BEFORE INSERT OR UPDATE OR DELETE` trigger `wardah_protect_voucher_headers()` on `customer_collections` and `supplier_payments`. Stable rejection: `VOUCHER_HEADER_WRITE_FORBIDDEN`. |
+| Allocation guard | `wardah_protect_voucher_allocation_lines()` (migration 167's function, `CREATE OR REPLACE`d in place — the existing triggers on `customer_collection_lines` / `supplier_payment_lines` keep their bindings) now requires the dual-factor check instead of the GUC alone. Stable rejection: `VOUCHER_ALLOCATION_DIRECT_MUTATION_FORBIDDEN`. |
+| Invoice payment-field guard | New `BEFORE UPDATE` trigger `wardah_protect_invoice_payment_fields()` on `sales_invoices` and `supplier_invoices`. Stable rejection: `VOUCHER_DERIVED_PAYMENT_FIELDS_WRITE_FORBIDDEN`. |
+| Table grants | `REVOKE INSERT, UPDATE, DELETE ON TABLE customer_collections, customer_collection_lines, supplier_payments, supplier_payment_lines FROM authenticated`; `SELECT` is preserved. |
+| Policies | The four temporary insert policies from 163/167 (`*_org_insert_draft`, `*_org_insert_new_draft`) are dropped. |
+| RPC grants | Ten `rpc_*` wrappers: `REVOKE ALL ... FROM PUBLIC, anon, service_role`, `GRANT EXECUTE ... TO authenticated`. |
+| Preflight | Fails closed (`VOUCHER_169_REQUIRED_RPC_MISSING`, `VOUCHER_169_ALLOCATION_GUARD_MISSING`) if any of the ten RPCs or the allocation guard function is absent before the migration touches anything. |
+| Postflight | An in-transaction `$verify$` block re-checks table grants, RPC grants and the presence of exactly six protection triggers, and raises before `COMMIT` if any check fails. |
+| Locking | `LOCK TABLE ... IN SHARE ROW EXCLUSIVE MODE` on all six affected tables for the duration of the transaction; `lock_timeout = '30s'`, `statement_timeout = '5min'`. |
+
+## 4. Invoice payment-field boundary — both directions
+
+The trigger distinguishes a payment-derived change from an ordinary business update:
+
+- **Customer invoices (`sales_invoices`):** any change to `paid_amount` or `payment_status` requires the trusted capability. This is symmetric by construction — every `payment_status` change is covered, not only specific target values.
+- **Supplier invoices (`supplier_invoices`):** any change to `paid_amount` requires the trusted capability. A `status` change requires it only when the transition is **into or out of** `partially_paid` / `paid`:
+
+  ```sql
+  NEW.status IS DISTINCT FROM OLD.status
+  AND (OLD.status IN ('partially_paid','paid') OR NEW.status IN ('partially_paid','paid'))
+  ```
+
+  The first implementation reviewed for this migration guarded only the transition *into* those two statuses. That left a live gap: an ordinary `UPDATE` (no voucher, no capability) could move an invoice **out of** `paid` or `partially_paid` — e.g. back to `approved` — without touching `paid_amount`, silently erasing the record that a payment had been posted, outside the legal reset/cancel path. The gap was found and closed before merge; the "both directions" condition above is what actually shipped.
+- **`draft → submitted → approved`, and the independent `match_status → 'matched'` transition, remain legal without any capability.** The guard does not touch `supplier_invoices.status` wholesale — only the two specific values that represent settlement.
+
+## 5. Acceptance gate
+
+```text
+scripts/ci/fresh-db/acceptance_169_voucher_write_closure.sql   (revision 1.4)
+.github/workflows/voucher-write-closure-169-red-proof.yml
+```
+
+Run on a Fresh PostgreSQL 17 database built through the paired baseline and every migration up to and including 169, seeded with the committed fixtures from `acceptance_168_voucher_atomic_lifecycle.sql`. Required markers, both must appear:
+
+```text
+VOUCHER_ATOMIC_168_ACCEPTANCE_PASS
+VOUCHER_WRITE_CLOSURE_169_ACCEPTANCE_PASS
+```
+
+What the suite proves, in order:
+
+1. `authenticated` has lost `INSERT`/`UPDATE`/`DELETE` on all four voucher tables and kept `SELECT`; the four temporary policies are gone.
+2. A direct `authenticated` header `INSERT` fails with `permission denied` (grant-level, before any trigger runs).
+3. `service_role`, having set all three capability GUCs to `'on'` itself, still cannot: create a voucher header (`VOUCHER_HEADER_WRITE_FORBIDDEN`); insert an allocation line against a real committed 168 invoice (`VOUCHER_ALLOCATION_DIRECT_MUTATION_FORBIDDEN`); or mutate `paid_amount`/payment-derived status on either invoice type (`VOUCHER_DERIVED_PAYMENT_FIELDS_WRITE_FORBIDDEN`).
+4. The `paid → approved` and `partially_paid → approved` reverse transitions are rejected the same way, and the invoice's `status` is proven unchanged afterward — not merely that the statement errored.
+5. The real forward workflow `draft → submitted → approved + matched` remains legal and untouched by the guard.
+6. A failing internal RPC call (`rpc_update_customer_receipt_draft` against a non-existent id) leaves all three capability GUCs reading `off` for the rest of the transaction — proving the explicit `EXCEPTION` handler, not only rollback, does the restoration.
+7. All ten `rpc_*` wrappers remain executable by `authenticated` and denied to `anon` and `service_role`.
+
+A fixture-existence guard (`ACCEPTANCE_FIXTURE_MISSING`) runs before the allocation-line assertions so a missing 168 fixture fails loudly as a setup error, never silently as a false "red" or false "green" on the guard itself.
+
+**This suite has run to green on Fresh PostgreSQL 17 in CI, on the exact commit merged as `0bcce21a` (PR #96). It has not been run against Production.** Production verification is catalog-level only — see §7. Do not treat a green Production catalog check as equivalent to a green Acceptance run; they check different things and both matter.
+
+## 6. Deployment record
+
+| Item | Value |
+|---|---|
+| Repository PR | #96, `fix(vouchers): close direct writes and payment-state drift` |
+| Merge | Squash, `0bcce21a`, into `main`, at the reviewed head `dccd8739` |
+| Production project | `Manufacturing Process` (`uutfztmqvajmsxnrqeiv`) — **not** `Wardah-Prod` (`rytzljjlthouptdqeuxh`), which is `INACTIVE` |
+| Applied | 2026-08-05, single transaction, no partial apply |
+| Ledger row | `supabase_migrations.schema_migrations`: version `20260805151524`, name `169_voucher_write_closure` |
+| Pre-apply state | Production ledger cutoff was 168; a verified backup was taken and confirmed logically sound before this migration was applied (free-tier project, no platform PITR/snapshot available) |
+
+The production sequence between 152 and 169 also carries a documented naming exception: the row for migration 163 is recorded as `payment_voucher_guarded_draft_inserts` rather than `163_payment_voucher_atomic_draft_creation`. This is now declared in `sql/migrations/migration_ledger_exceptions.json` (`version_name_aliases["20260731102524"]`) and confirmed against the live ledger with `scripts/ci/validate_migration_ledger.py` — same pattern as the existing 121 alias.
+
+## 7. Production verification actually performed
+
+Post-apply verification was catalog-level, run read-only against the live database (not the synthetic-fixture Acceptance script in §5):
+
+```sql
+-- Table grants: authenticated keeps SELECT only.
+SELECT has_table_privilege('authenticated','public.'||t,'INSERT') AS ins,
+       has_table_privilege('authenticated','public.'||t,'UPDATE') AS upd,
+       has_table_privilege('authenticated','public.'||t,'DELETE') AS del,
+       has_table_privilege('authenticated','public.'||t,'SELECT') AS sel
+FROM unnest(ARRAY['customer_collections','customer_collection_lines',
+                   'supplier_payments','supplier_payment_lines']) t;
+
+-- The four temporary policies are gone.
+SELECT policyname FROM pg_policies WHERE schemaname='public'
+  AND policyname IN ('customer_collections_org_insert_draft',
+                      'supplier_payments_org_insert_draft',
+                      'customer_collection_lines_org_insert_new_draft',
+                      'supplier_payment_lines_org_insert_new_draft');
+
+-- All six protection triggers exist.
+SELECT tgname FROM pg_trigger
+WHERE tgname IN ('trg_protect_customer_collections','trg_protect_supplier_payments',
+                  'trg_protect_customer_collection_lines','trg_protect_supplier_payment_lines',
+                  'trg_protect_sales_invoice_payment_fields','trg_protect_supplier_invoice_payment_fields')
+  AND NOT tgisinternal;
+
+-- RPC and internal-function grants.
+SELECT has_function_privilege('authenticated', sig, 'EXECUTE') AS auth_exec,
+       has_function_privilege('anon', sig, 'EXECUTE') AS anon_exec,
+       has_function_privilege('service_role', sig, 'EXECUTE') AS svc_exec
+FROM unnest(ARRAY['public.rpc_create_customer_receipt(jsonb)', /* … all ten … */]) sig;
+```
+
+Confirmed results: `authenticated` shows `ins=upd=del=false, sel=true` on all four tables; zero rows returned for the obsolete-policy query; all six triggers present; all ten RPCs `auth_exec=true, anon_exec=false, svc_exec=false`; the internal `wardah_169_internal_*` functions and `wardah_voucher_write_is_trusted` are unreachable by `anon`/`authenticated`, and `wardah_voucher_write_is_trusted` is reachable only by `service_role` as designed.
+
+**Re-verified on 2026-08-09**, after Production had advanced to 173, that the table-grant half of this contract still holds unchanged: `authenticated` has `ins=upd=del=false, sel=true` on all four voucher tables. Migrations 170–173 do not touch the voucher write surface, and the live catalog confirms they did not disturb it.
+
+Security/performance advisors were reviewed after the apply. The 80 `authenticated_security_definer_function_executable` warnings include the ten new `rpc_*` wrappers by design (they must be `SECURITY DEFINER` and callable by signed-in users; identity and membership are re-checked inside each wrapper) and are otherwise pre-existing, unrelated debt. Leaked-password-protection, the PostgreSQL version advisory, and the `rls_enabled_no_policy` findings on `journal_entries`/`journal_lines` all predate this migration and are independent of it.
+
+No smoke transaction was executed against Production data; the smoke path is covered by the Fresh DB Acceptance run in §5.
+
+## 8. Rollback
+
+Additive apart from replacing `wardah_protect_voucher_allocation_lines` (which only narrows an existing bypass) and renaming the ten original RPC bodies. Before any production traffic has used the new contract, the reviewed recovery is to correct forward with a new numbered migration rather than hand-edit 169 in place, per the project's golden rule. A rollback script, if ever required, must restore the exact pre-169 grants, policies, and trigger/function bodies without deleting voucher or ledger history, and is only appropriate if postflight failed before business traffic resumed on the new contract — once vouchers have been created, posted, reset or cancelled under 169, prefer a forward-fix migration instead.
+
+Never edit `supabase_migrations.schema_migrations` to remove this row, and never re-apply SQL that is not the exact file merged to `main`.

--- a/sql/migrations/migration_ledger_exceptions.json
+++ b/sql/migrations/migration_ledger_exceptions.json
@@ -14,6 +14,11 @@
       "live_name": "fail_closed_tenant_isolation",
       "canonical_file": "121_fail_closed_tenant_isolation.sql",
       "reason": "Historical apply_migration call omitted the numeric prefix; the repository filename is canonical and the production row is preserved as immutable history."
+    },
+    "20260731102524": {
+      "live_name": "payment_voucher_guarded_draft_inserts",
+      "canonical_file": "163_payment_voucher_atomic_draft_creation.sql",
+      "reason": "Historical apply_migration call used a descriptive slug instead of the numeric prefix; the repository filename is canonical and the production row is preserved as immutable history."
     }
   }
 }


### PR DESCRIPTION
Documentation and governance reconciliation only. **No migration, no runtime code, no Production change.** Built clean from the latest `main` (`25246e1`) rather than merging the stale documentation branches as-is.

## 1. The one functional fix: the 163 ledger alias

The Production row for migration 163 is named `payment_voucher_guarded_draft_inserts`, not `163_payment_voucher_atomic_draft_creation`. That alias was never declared in `migration_ledger_exceptions.json`, so **`Audit Production Migration Ledger` has been failing closed on every run**, reproduced locally against a live ledger snapshot before the fix:

```
ERROR: Live migration 20260731102524/payment_voucher_guarded_draft_inserts has no
exact repository file payment_voucher_guarded_draft_inserts.sql and no documented alias
```

Declared now, in the same shape as the existing 121 alias. **The live row is untouched** — the historical name is preserved exactly as applied, per the golden rule. After the fix:

```json
{"status": "ok", "live_cutoff": 173, "repo_max": 173, "repository_ahead_by": 0,
 "pending_repository_files": [],
 "documented_alias_versions": ["20260716201851", "20260731102524"]}
```

## 2. Documentation brought up to the live state

`main` still described Production as sitting at 152. It is at 173.

| Change | Detail |
|---|---|
| `CLAUDE.md` database-state block | 152 → 173, with the full applied sequence `153 → 163 → … → 173` and an explicit note that the **Baseline itself is unchanged** at cutoff 152 — regenerating it is a separate workflow and a separate PR, not implied by this one. |
| Missing 169 runbook | `VOUCHER_WRITE_CLOSURE_169_RUNBOOK.md` was written for PR #96 but never landed on `main`. Added, with its §7 verification re-confirmed live. |
| New chain document | `PERMISSION_HARDENING_170_173_CHAIN.md` — see §3. |
| Stale runbook headers | 170, 171, 172 and 173 all still read *"not yet applied to Production."* Corrected, each with its ledger version and apply date. |
| `CLAUDE.md` references | 166–169 runbooks, the 169 runbook, and the new chain document added to the index. |

## 3. Why the chain document exists

170, 172 and 173 each `CREATE OR REPLACE` **the same function**, `public.has_permission(uuid, uuid, varchar)`. Reading only the newest runbook gives the wrong contract — the live body is the *union* of the three:

| Layer | From | Contract |
|---|---|---|
| Caller-identity guard | 170 | `p_user_id IS DISTINCT FROM auth.uid()` → `false` |
| Exact permission-key match | 172 | `p.permission_key = p_permission_key`; the `LIKE` same-module fallback is gone |
| Active-role requirement | 173 | `JOIN roles r … AND COALESCE(r.is_active, true)` |
| Role expiry, org scoping | pre-170 | carried through unchanged by all three |

If 173 were ever reverted by hand, 172's fix would go with it. The document records that, plus a single composite postflight query that catches a future replacement silently dropping a layer.

## 4. Verified live state (read-only, 2026-08-09)

All ten columns of the composite `has_permission` postflight returned `true` — identity guard, wildcard removed, exact match, roles join, active-role guard, org scoping, role expiry, both override branches intact, `authenticated` still holds EXECUTE.

170's tenant-isolation closures re-checked in the same pass: `physical_count_policies = 8`, `self_referencing_policies = 0`, `anon_grants_on_mfg = 0`. 171's objects present: `ai_usage_daily` exists, exactly one `reports.ai_insights.use` permission row. 169's voucher grants unchanged: `authenticated` has `ins = upd = del = false, sel = true` on all four voucher tables.

These are catalog-level assertions. The behavioural proofs remain the paired Fresh PostgreSQL 17 acceptance workflows; neither substitutes for the other, and the documents say so.

## 5. Security model: recorded, not changed

The `is_org_admin` branch of `has_permission()` **never reads `p_permission_key`**. Any active org admin passes every key, including `unpost` / `cancel` / `reverse`. Verified live that this holds for `wardah_has_exact_permission()` too — that function is "exact" about the *key*, not about the *override*.

Direct consequence, now written down: **counting `role_permissions` rows does not measure effective authorization.** `granted_roles = 0` on a sensitive key is fully compatible with every org admin holding it. Contract checks that intend to measure real access must call the permission function per active user.

This is open **Issue #93** and behaviour is deliberately unchanged here. The lockout risk is recorded alongside it: if the sensitive-permission-class option is chosen, the current single active org admin must be granted the new role **before** the override is narrowed.

## 6. Governance precedents kept

- **170 sat merged-but-unapplied.** It reached `main` in PR #98 while the ledger was still at 169; all three vulnerabilities stayed fully live in Production for that window. Merging closes the gap in the repository, not in Production.
- **171 honoured DB-first ordering** — applied and verified 2026-08-06, dependent UI merged 2026-08-08 (#106, then #107/#108). Recorded as the model, against 148 as the counter-example.

## 7. Verification run for this PR

All governance gates run locally and green: ledger validator offline and against the live snapshot, its unit tests (5/5), baseline-docs updater tests, system reference data tests, baseline pair resolver, and JSON validity of the exceptions file.

## 8. Related PRs

`#103` (170 applied-state) and `#102` (reports-insights Edge Function) are superseded by this PR and by #106–#108 respectively; `#97`'s content is absorbed here. `#105` stays Draft for later review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJ3hjmWeS1fZ3GG3T7V7jY)_