### PR TITLE
feat(db): Migration 174 — sensitive permission class and atomic RBAC control plane (part of #93)

### DIFF
--- a/.github/workflows/sensitive-permission-174-acceptance.yml
+++ b/.github/workflows/sensitive-permission-174-acceptance.yml
@@ -1,0 +1,136 @@
+name: Sensitive Permission 174 Acceptance
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'scripts/ci/fresh-db/acceptance_174_sensitive_permission_class.sql'
+      - 'sql/migrations/174_sensitive_permission_class_and_rbac_rpcs.sql'
+      - '.github/workflows/sensitive-permission-174-acceptance.yml'
+  workflow_dispatch:
+
+jobs:
+  acceptance:
+    name: Confirm Migration 174 narrows the org-admin override without regressing 170-173
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      PGHOST: localhost
+      PGUSER: postgres
+      PGPASSWORD: postgres
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build fresh database through migration 174
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          PAIR=$(bash scripts/ci/fresh-db/resolve_baseline_pair.sh sql/baseline)
+          pair_field() { printf '%s\n' "$PAIR" | sed -n "s/^$1=//p"; }
+          BASELINE=$(pair_field BASELINE_PATH)
+          REFERENCE=$(pair_field REFERENCE_PATH)
+          CUTOFF=$(pair_field BASELINE_CUTOFF)
+          CUTOFF=${CUTOFF:-0}
+
+          createdb wardah_fresh
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh -f scripts/ci/fresh-db/supabase_shim.sql -q
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh -f "$BASELINE" -q
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh -f "$REFERENCE" -q
+
+          python3 scripts/ci/fresh-db/build_apply_order.py sql/migrations "$CUTOFF" > /tmp/chain_order.txt
+          REPORT=/tmp/chain_report.txt PGDATABASE=wardah_fresh \
+            bash scripts/ci/fresh-db/run_chain.sh sql/migrations /tmp/chain_order.txt
+
+      - name: Run Migration 174 acceptance
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh \
+            -f scripts/ci/fresh-db/acceptance_174_sensitive_permission_class.sql \
+            2>&1 | tee /tmp/sensitive-permission-174.out
+          grep -q 'SENSITIVE_PERMISSION_174_ACCEPTANCE_PASS' /tmp/sensitive-permission-174.out
+
+      - name: Re-run 172 and 173 acceptance to confirm no regression
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh \
+            -f scripts/ci/fresh-db/acceptance_172_has_permission_exact_key_match.sql \
+            2>&1 | tee /tmp/has-permission-172-rerun.out
+          grep -q 'HAS_PERMISSION_172_ACCEPTANCE_PASS' /tmp/has-permission-172-rerun.out
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh \
+            -f scripts/ci/fresh-db/acceptance_173_has_permission_active_role_check.sql \
+            2>&1 | tee /tmp/has-permission-173-rerun.out
+          grep -q 'HAS_PERMISSION_173_ACCEPTANCE_PASS' /tmp/has-permission-173-rerun.out
+
+      # A suite that cannot fail proves nothing. Build the same database WITHOUT
+      # migration 174 and show the vulnerability is live there: an org admin with
+      # no explicit grant passes accounting.vouchers.unpost. The job fails if that
+      # pre-174 database answers anything other than `t`.
+      - name: Red proof — the same contract fails without 174
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          PAIR=$(bash scripts/ci/fresh-db/resolve_baseline_pair.sh sql/baseline)
+          pair_field() { printf '%s\n' "$PAIR" | sed -n "s/^$1=//p"; }
+          createdb wardah_red
+          psql -v ON_ERROR_STOP=1 -d wardah_red -f scripts/ci/fresh-db/supabase_shim.sql -q
+          psql -v ON_ERROR_STOP=1 -d wardah_red -f "$(pair_field BASELINE_PATH)" -q
+          psql -v ON_ERROR_STOP=1 -d wardah_red -f "$(pair_field REFERENCE_PATH)" -q
+          grep -v '^174_' /tmp/chain_order.txt > /tmp/chain_red.txt
+          REPORT=/tmp/red_report.txt PGDATABASE=wardah_red \
+            bash scripts/ci/fresh-db/run_chain.sh sql/migrations /tmp/chain_red.txt
+
+          RESULT=$(psql -t -A -v ON_ERROR_STOP=1 -d wardah_red <<'SQL'
+          BEGIN;
+          INSERT INTO auth.users (id, email)
+            VALUES ('99175175-0001-0001-0001-000000000001','red-admin@example.test');
+          INSERT INTO public.organizations (id, name, code)
+            VALUES ('99175175-a000-a000-a000-00000000000a','Red Org','RED-A');
+          INSERT INTO public.user_organizations (user_id, org_id, is_active, is_org_admin)
+            VALUES ('99175175-0001-0001-0001-000000000001','99175175-a000-a000-a000-00000000000a',true,true);
+          SELECT set_config('request.jwt.claim.sub','99175175-0001-0001-0001-000000000001',false);
+          SET LOCAL ROLE authenticated;
+          SELECT public.has_permission('99175175-0001-0001-0001-000000000001',
+                                       '99175175-a000-a000-a000-00000000000a',
+                                       'accounting.vouchers.unpost');
+          RESET ROLE;
+          ROLLBACK;
+          SQL
+          )
+          echo "pre-174 ungranted org admin -> unpost: $RESULT"
+          if ! printf '%s' "$RESULT" | grep -qx 't'; then
+            echo "RED PROOF FAILED: the pre-174 database did not reproduce the Issue #93 bypass."
+            echo "Either the fixture is wrong or the vulnerability is not where the suite claims."
+            exit 1
+          fi
+
+      - name: Upload acceptance evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sensitive-permission-174-acceptance-${{ github.run_id }}
+          path: |
+            /tmp/sensitive-permission-174.out
+            /tmp/has-permission-172-rerun.out
+            /tmp/has-permission-173-rerun.out
+            /tmp/chain_report.txt
+            /tmp/red_report.txt
+          retention-days: 30

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,10 @@ React 18 + TypeScript + Vite، shadcn/ui + Tailwind، Zustand + TanStack Query،
   **الدالة نفسها**، فالعقد الحي هو اتحادها لا آخرها؛ اقرأ هذا الملف قبل أي تعديل
   لاحق على `has_permission`. يتضمن الحالة الحية المتحقَّقة، وما لم تغيّره السلسلة
   عمدًا (تجاوز org admin — Issue #93).
+- `docs/db/SENSITIVE_PERMISSIONS_174_RUNBOOK.md` — 174: فئة الصلاحيات الحساسة عبر
+  مصنّف مركزي، وتضييق تجاوز org admin، وRPCs ذرية لإدارة الأدوار والتعيينات مع
+  `rpc_permission_snapshot` مصدرًا وحيدًا لقرارات الواجهة. يتضمن **المعاملة التشغيلية
+  الإلزامية قبل التطبيق** وترتيب Production السباعي.
 - `docs/db/TENANT_ISOLATION_170_RUNBOOK.md`، `docs/db/AI_USAGE_DAILY_171_RUNBOOK.md`،
   `docs/db/HAS_PERMISSION_172_RUNBOOK.md`، `docs/db/HAS_PERMISSION_173_RUNBOOK.md`
   — تفصيل كل migration على حدة.
@@ -157,9 +161,23 @@ PR #32 أضاف أو حسّن:
 المحاسبية الحساسة (`unpost`/`cancel`/`reverse`). ينطبق ذلك على `has_permission`
 و`wardah_has_exact_permission` معًا — الأخيرة «تامة» في المفتاح لا في التجاوز. ونتيجةً
 لذلك **عدّ صفوف `role_permissions` لا يقيس الصلاحية الفعلية**؛ الفحص الصحيح هو استدعاء
-دالة الصلاحية لكل مستخدم نشط. القرار المعماري مفتوح في Issue #93، ولا يُغيَّر السلوك قبل
-حسمه؛ وإذا اعتُمد استثناء المفاتيح الحساسة فيجب منح المسؤول الحالي الدور الجديد **قبل**
-تضييق التجاوز تفاديًا للـLockout.
+دالة الصلاحية لكل مستخدم نشط.
+
+**Migration 174 (في المستودع، غير مطبّقة على Production بعد)** تحسم Issue #93: مصنّف مركزي
+واحد `wardah_is_sensitive_permission(text)` — `IMMUTABLE STRICT`، مفتاحان فقط
+(`accounting.vouchers.unpost` و`accounting.vouchers.cancel`) — تستدعيه الدالتان معًا فلا
+تتباعدان. Super Admin يحتفظ بالتجاوز الكامل؛ Org Admin يحتفظ به لكل المفاتيح العادية
+وإدارة المستخدمين والأدوار، ويفقده للمفاتيح الحساسة فتحتاج منحًا صريحًا عبر دور نشط
+غير منتهٍ — ويجوز لمسؤول المؤسسة إنشاء الدور ومنحه لنفسه، فتتحول السلطة من تجاوز خفي
+إلى قرار صريح مُدقَّق في `audit_logs`. `accounting.vouchers.reverse` **غير موجود** حيًا ولا
+في المستودع، ولم يُضَف افتراضيًا. التفاصيل وترتيب النشر الإلزامي في
+`docs/db/SENSITIVE_PERMISSIONS_174_RUNBOOK.md`.
+
+**الـLockout ليس احتمالًا نظريًا هنا:** Super Admins = 0، وتعيينات الأدوار = 0، والمفتاحان
+ممنوحان لصفر دور — ودور `Full Access` لا يحتويهما (166 من 169). فإنشاء دور
+`Financial Controller` ومنحه المفتاحين وتعيينه للمسؤول الحالي وإثبات
+`via_explicit_grant = true` خطوات **تسبق** تطبيق 174، لا تتبعه. وهي بيانات org-scoped
+فمكانها معاملة تشغيلية موثقة، لا migration ولا Baseline.
 
 ## i18n
 

--- a/docs/db/SENSITIVE_PERMISSIONS_174_RUNBOOK.md
+++ b/docs/db/SENSITIVE_PERMISSIONS_174_RUNBOOK.md
@@ -106,6 +106,10 @@ Executed locally on a real **PostgreSQL 17.10** cluster, building the baseline p
 
 The red proof is wired into the workflow as its own failing step, not left as a manual note: if a pre-174 database ever stops reproducing the bypass, the job fails rather than quietly reporting a green suite that proves nothing.
 
+The same gate then ran in CI on `postgres:17` and passed end to end — `Sensitive Permission 174 Acceptance`, including the red-proof step, on PR #112. Local and CI agree; neither is treated as sufficient alone.
+
+**Generated types.** `Regenerate UoM Database Types` rebuilds a Fresh DB from the repository migrations and runs `supabase gen types` against **that** database (`localhost/wardah_fresh`), never against Production. It therefore commits the four new RPCs and the classifier into `src/types/database.generated.ts` as soon as 174 is in the repository — which is expected and is **not** evidence that 174 has been applied to Production. The ledger remains the only authority for that.
+
 ## 6. Mandatory Production order
 
 **Steps 1–4 are not preparation for the fix; they are part of it.** With zero super admins, zero role assignments, and both sensitive keys granted to zero roles, applying 174 first would leave **nobody** able to unpost or cancel. Note that assigning the existing `Full Access` role does **not** help — it holds 166 of 169 keys and these two are among the three it lacks.

--- a/docs/db/SENSITIVE_PERMISSIONS_174_RUNBOOK.md
+++ b/docs/db/SENSITIVE_PERMISSIONS_174_RUNBOOK.md
@@ -1,7 +1,7 @@
 # Migration 174 — Sensitive Permission Class & Atomic RBAC Control Plane
 
 **Migration:** `174_sensitive_permission_class_and_rbac_rpcs.sql`
-**Closes:** Issue #93 — the org-admin override branch never read `p_permission_key`, so every active org admin passed every key.
+**Part of:** Issue #93 — the org-admin override branch never read `p_permission_key`, so every active org admin passed every key. **This migration does not close the issue on its own:** it is the database half. Closing #93 additionally requires the UI moved onto `rpc_permission_snapshot` and the atomic RBAC RPCs, and Migration 175 to close the direct-write surface (§4.1).
 **State:** Repository implementation, **not yet applied to Production**. The operational transaction in §6 must run and be verified *before* this migration is applied, or the organization is locked out of unpost/cancel entirely. Do not apply out of order.
 
 ## 1. The verified problem
@@ -58,10 +58,10 @@ Both permission functions call this one classifier, so the two cannot drift — 
 | `has_permission(uuid,uuid,varchar)` | Org-admin branch gains `NOT v_sensitive`. All five layers of the 170–173 chain reproduced verbatim. |
 | `wardah_has_exact_permission(uuid,uuid,text)` | Same narrowing, same classifier. Execute boundary re-asserted: `postgres` only. |
 | `rpc_upsert_org_role(jsonb)` | Creates or updates a role **and its complete permission set** in one transaction. Rejects unknown keys (`RBAC_174_UNKNOWN_PERMISSION_KEY`), duplicate names, system roles. `FOR UPDATE` on the role row. |
-| `rpc_replace_user_roles(jsonb)` | Atomic replace of a user's roles for one org. Rejects non-members (`RBAC_174_TARGET_NOT_ACTIVE_ORG_MEMBER`) and foreign roles (`RBAC_174_ROLE_NOT_IN_ORG`). |
+| `rpc_replace_user_roles(jsonb)` | Atomic replace of a user's roles for one org. Locks the membership row `FOR UPDATE` so concurrent replacements serialize. Rejects non-members (`RBAC_174_TARGET_NOT_ACTIVE_ORG_MEMBER`), foreign roles (`RBAC_174_ROLE_NOT_IN_ORG`) and repeated ids (`RBAC_174_DUPLICATE_ROLE_ID`). Accepts `["<uuid>"]` or `[{"role_id":…,"expires_at":…}]`; a retained role keeps its existing deadline unless one is given explicitly. |
 | `rpc_delete_org_role(jsonb)` | Refuses while users still hold the role (`RBAC_174_ROLE_STILL_ASSIGNED`) and refuses system roles. |
 | `rpc_permission_snapshot(uuid)` | Returns the caller's effective keys, `is_org_admin`, `is_super_admin`, and the sensitive-key set for badging. **The single source of truth for UI decisions.** |
-| Audit | Every mutation writes `audit_logs` with `sensitive_keys` / `sensitive_keys_granted` and a `self_assignment` flag. |
+| Audit | Every mutation writes a **complete before/after snapshot** to `old_data`/`new_data`, in the same shape on both sides so they can be diffed directly. Role create/update records the outgoing *and* incoming permission key sets plus `permissions_added` / `permissions_removed`; delete records the destroyed key set and `removed_sensitive`; assignment replacement records `{role_id, expires_at}` per role on both sides, with the after-side read back from the rows actually written rather than reconstructed from the payload. Plus `sensitive_keys` / `sensitive_keys_granted` and a `self_assignment` flag. |
 | Grants | Four RPCs: `REVOKE ALL FROM PUBLIC, anon, service_role`; `GRANT EXECUTE TO authenticated`. |
 
 ### 4.1 What this migration deliberately does **not** do
@@ -89,6 +89,8 @@ Marker: `SENSITIVE_PERMISSION_174_ACCEPTANCE_PASS`. Coverage, all eight scenario
 7. Caller-identity guard — denied when asking about another user, 170 preserved (`174-7`).
 8. Ordinary keys — override intact (`174-1c`, `174-15`).
 9. **Mutation proof** (`174-M1…M9`) — each 166–173 guarantee re-asserted as its own named assertion, so a regression in any single layer fails identifiably rather than being masked by a neighbouring check.
+10. **Duplicate `role_id` rejected** (`174-39/40/41`) — for both payload shapes, and `174-40` proves the rejected call left `user_roles` byte-identical, so the refusal cannot be a partial write.
+11. **Audit completeness** (`174-42…49`) — the outgoing permission set on update, the destroyed set and `removed_sensitive` on delete, and per-role `expires_at` on both sides of an assignment replacement. These exist so the audit trail cannot silently degrade in a later refactor.
 
 The whole matrix runs against **both** functions (§3 and §4 of the script), plus the RBAC control plane: atomicity of a rejected update, self-assignment, audit rows, delete refusal, cross-org write refusal, and snapshot correctness for granted and ungranted admins.
 
@@ -114,7 +116,7 @@ The same gate then ran in CI on `postgres:17` and passed end to end — `Sensiti
 
 **Steps 1–4 are not preparation for the fix; they are part of it.** With zero super admins, zero role assignments, and both sensitive keys granted to zero roles, applying 174 first would leave **nobody** able to unpost or cancel. Note that assigning the existing `Full Access` role does **not** help — it holds 166 of 169 keys and these two are among the three it lacks.
 
-### Step 1–3 — operational transaction (before the migration)
+### Steps 1–4 — operational transaction (before the migration)
 
 Org-scoped data, so it is **not** part of any migration and not part of the Baseline (`roles`/`user_roles` are excluded from the system reference snapshot by design). Run once, as a single transaction, against Production:
 
@@ -146,10 +148,50 @@ FROM public.roles r
 WHERE r.org_id = '00000000-0000-0000-0000-000000000001'
   AND r.name = 'Financial Controller';
 
+-- 4. Audit the bootstrap, in the SAME transaction.
+--
+-- This step creates the most consequential grant in the system — the two
+-- sensitive accounting keys, to the only administrator — and it runs BEFORE
+-- 174 exists, so none of the RPCs that would normally write audit_logs are
+-- involved. Without this insert the single most sensitive authority change in
+-- the whole rollout would be the one event with no audit row, and the trail
+-- would begin mid-story: every later grant recorded, the original one not.
+-- It is inside the transaction deliberately — if any step above rolls back,
+-- the claim that it happened must roll back with it.
+INSERT INTO public.audit_logs (org_id, user_id, action, entity_type, entity_id,
+                               old_data, new_data, metadata)
+SELECT '00000000-0000-0000-0000-000000000001',
+       'd572eb14-5a8a-4ec9-ad3b-6945fcc8be0e',
+       'rbac.sensitive_bootstrap',
+       'role',
+       r.id::text,
+       NULL,
+       jsonb_build_object(
+         'role', jsonb_build_object('id', r.id, 'name', r.name,
+                                    'org_id', r.org_id, 'is_active', r.is_active),
+         'permission_keys', jsonb_build_array('accounting.vouchers.unpost',
+                                              'accounting.vouchers.cancel'),
+         'assigned_to', jsonb_build_array('d572eb14-5a8a-4ec9-ad3b-6945fcc8be0e')),
+       jsonb_build_object(
+         'migration', 174,
+         'phase', 'pre-apply operational transaction',
+         'reason', 'Issue #93 lockout prevention: grant the sensitive keys explicitly '
+                   'before the org-admin override is narrowed by Migration 174',
+         'performed_by', 'operator (manual transaction, not an RPC)',
+         'grants_sensitive', true)
+FROM public.roles r
+WHERE r.org_id = '00000000-0000-0000-0000-000000000001'
+  AND r.name = 'Financial Controller';
+
 COMMIT;
 ```
 
-### Step 4 — prove the grant before applying anything
+The `user_id` recorded is the grant's subject, since a manual transaction has no
+`auth.uid()`; `metadata.performed_by` states plainly that no RPC was involved.
+Record the operator's identity out of band (change ticket / runbook sign-off) —
+do not invent a UUID for them.
+
+### Step 4b — prove the grant before applying anything
 
 ```sql
 SELECT p.permission_key,

--- a/docs/db/SENSITIVE_PERMISSIONS_174_RUNBOOK.md
+++ b/docs/db/SENSITIVE_PERMISSIONS_174_RUNBOOK.md
@@ -1,0 +1,222 @@
+# Migration 174 — Sensitive Permission Class & Atomic RBAC Control Plane
+
+**Migration:** `174_sensitive_permission_class_and_rbac_rpcs.sql`
+**Closes:** Issue #93 — the org-admin override branch never read `p_permission_key`, so every active org admin passed every key.
+**State:** Repository implementation, **not yet applied to Production**. The operational transaction in §6 must run and be verified *before* this migration is applied, or the organization is locked out of unpost/cancel entirely. Do not apply out of order.
+
+## 1. The verified problem
+
+Read-only inventory of the live database on 2026-08-09, before any code was written:
+
+| Fact | Value |
+|---|---|
+| Active super admins | **0** (table empty) |
+| Active org admins | **1** (`d572eb14…`, org `00000000-…-0001`) |
+| `user_roles` assignments | **0** |
+| Roles | `Accountant` (0 permissions), `Full Access` (166) — both active, both with 0 users |
+| Permission keys total | 169 |
+| Keys granted to no role | exactly 3: `accounting.vouchers.unpost`, `accounting.vouchers.cancel`, `reports.ai_insights.use` |
+
+Effective access of that single org admin, computed per branch:
+
+| Key | via super admin | via org-admin override | via explicit grant |
+|---|---|---|---|
+| `accounting.vouchers.unpost` | ❌ | ✅ | ❌ |
+| `accounting.vouchers.cancel` | ❌ | ✅ | ❌ |
+
+The authority existed **solely** through the override. `accounting.vouchers.reverse` does not exist — not in the live catalog, not anywhere in the repository — and was deliberately not invented.
+
+## 2. The approved contract
+
+| Principal | Ordinary keys | Sensitive keys |
+|---|---|---|
+| Platform super admin | ✅ override | ✅ override (emergency access) |
+| Org admin | ✅ override, including user and role administration | ❌ **requires an explicit grant** |
+| Any user | via active, unexpired, org-scoped role | via active, unexpired, org-scoped role |
+
+An org admin may create a sensitive role and assign it — including to themselves. Authority is not removed; it is converted from a silent override into an explicit, audited decision.
+
+## 3. The central classifier
+
+```sql
+public.wardah_is_sensitive_permission(text) RETURNS boolean  -- IMMUTABLE, STRICT
+```
+
+Exactly two keys: `accounting.vouchers.unpost`, `accounting.vouchers.cancel`.
+
+**A function, not a table, on purpose.** Widening the sensitive set must pass through a migration, code review and acceptance tests — never a silent data edit. `reports.ai_insights.use` is deliberately ordinary.
+
+It is `STRICT`, so `NULL` in yields `NULL` out. Every call site wraps it in `COALESCE(…, false)`; a null key must not be treated as sensitive. The acceptance suite asserts the STRICT behaviour directly (`174-0c`), because a future rewrite that drops `STRICT` would silently change how null keys are classified.
+
+Both permission functions call this one classifier, so the two cannot drift — which was the explicit requirement (no duplicated lists).
+
+## 4. What the migration changes
+
+| Change | Detail |
+|---|---|
+| `wardah_is_sensitive_permission(text)` | New. `IMMUTABLE STRICT`, no table access, not `SECURITY DEFINER`. `REVOKE` from `PUBLIC`/`anon`; `EXECUTE` to `authenticated` (the UI badges sensitive keys from it via the snapshot). |
+| `has_permission(uuid,uuid,varchar)` | Org-admin branch gains `NOT v_sensitive`. All five layers of the 170–173 chain reproduced verbatim. |
+| `wardah_has_exact_permission(uuid,uuid,text)` | Same narrowing, same classifier. Execute boundary re-asserted: `postgres` only. |
+| `rpc_upsert_org_role(jsonb)` | Creates or updates a role **and its complete permission set** in one transaction. Rejects unknown keys (`RBAC_174_UNKNOWN_PERMISSION_KEY`), duplicate names, system roles. `FOR UPDATE` on the role row. |
+| `rpc_replace_user_roles(jsonb)` | Atomic replace of a user's roles for one org. Rejects non-members (`RBAC_174_TARGET_NOT_ACTIVE_ORG_MEMBER`) and foreign roles (`RBAC_174_ROLE_NOT_IN_ORG`). |
+| `rpc_delete_org_role(jsonb)` | Refuses while users still hold the role (`RBAC_174_ROLE_STILL_ASSIGNED`) and refuses system roles. |
+| `rpc_permission_snapshot(uuid)` | Returns the caller's effective keys, `is_org_admin`, `is_super_admin`, and the sensitive-key set for badging. **The single source of truth for UI decisions.** |
+| Audit | Every mutation writes `audit_logs` with `sensitive_keys` / `sensitive_keys_granted` and a `self_assignment` flag. |
+| Grants | Four RPCs: `REVOKE ALL FROM PUBLIC, anon, service_role`; `GRANT EXECUTE TO authenticated`. |
+
+### 4.1 What this migration deliberately does **not** do
+
+- **No `auth.uid()` guard added to `wardah_has_exact_permission`.** It is internal (`EXECUTE` is `postgres` only), its four callers pass an actor resolved inside the RPC, and adding the guard risks breaking them for no reachable gain. The postflight re-asserts the execute boundary instead.
+- **Direct `INSERT`/`UPDATE`/`DELETE` on `roles`, `role_permissions`, `user_roles` is not revoked from `authenticated`.** The live role-management UI still writes those tables directly; revoking here would break it in the window between applying 174 and deploying the dependent UI.
+
+  This mirrors the sequence this repository already established with 163/167 → 169: ship the atomic RPCs, move the UI onto them, then close the direct-write surface in its own migration. **That closure is Migration 175 and is required to finish Issue #93** — until it lands, the RPCs are the sanctioned path but not yet the only one.
+
+## 5. Acceptance gate
+
+```text
+scripts/ci/fresh-db/acceptance_174_sensitive_permission_class.sql
+.github/workflows/sensitive-permission-174-acceptance.yml
+```
+
+Marker: `SENSITIVE_PERMISSION_174_ACCEPTANCE_PASS`. Coverage, all eight scenarios plus mutation proof:
+
+1. Org admin **without** a grant — sensitive denied, ordinary still allowed (`174-1a/1b/1c`).
+2. Org admin **with** a grant — allowed (`174-2`).
+3. Super admin — allowed with no role at all (`174-3`).
+4. Disabled role — denied, 173 preserved (`174-4`).
+5. Expired assignment — denied (`174-5`).
+6. Cross-org — denied for both key classes (`174-9a/9b`).
+7. Caller-identity guard — denied when asking about another user, 170 preserved (`174-7`).
+8. Ordinary keys — override intact (`174-1c`, `174-15`).
+9. **Mutation proof** (`174-M1…M9`) — each 166–173 guarantee re-asserted as its own named assertion, so a regression in any single layer fails identifiably rather than being masked by a neighbouring check.
+
+The whole matrix runs against **both** functions (§3 and §4 of the script), plus the RBAC control plane: atomicity of a rejected update, self-assignment, audit rows, delete refusal, cross-org write refusal, and snapshot correctness for granted and ungranted admins.
+
+### 5.1 Verification actually performed
+
+Executed locally on a real **PostgreSQL 17.10** cluster, building the baseline pair plus the full chain:
+
+| Check | Result |
+|---|---|
+| Baseline + chain through 174 | `PASS=13 FAIL=0 NOT_RUN=0 TOTAL=13` (174's own postflight ran inside it) |
+| `acceptance_174` | `SENSITIVE_PERMISSION_174_ACCEPTANCE_PASS` |
+| `acceptance_172` re-run on the 174 database | `HAS_PERMISSION_172_ACCEPTANCE_PASS` |
+| `acceptance_173` re-run on the 174 database | `HAS_PERMISSION_173_ACCEPTANCE_PASS` |
+| **Red proof** — same fixture on a database built only through 173 | ungranted org admin → `accounting.vouchers.unpost` returned **`t`** |
+
+The red proof is wired into the workflow as its own failing step, not left as a manual note: if a pre-174 database ever stops reproducing the bypass, the job fails rather than quietly reporting a green suite that proves nothing.
+
+## 6. Mandatory Production order
+
+**Steps 1–4 are not preparation for the fix; they are part of it.** With zero super admins, zero role assignments, and both sensitive keys granted to zero roles, applying 174 first would leave **nobody** able to unpost or cancel. Note that assigning the existing `Full Access` role does **not** help — it holds 166 of 169 keys and these two are among the three it lacks.
+
+### Step 1–3 — operational transaction (before the migration)
+
+Org-scoped data, so it is **not** part of any migration and not part of the Baseline (`roles`/`user_roles` are excluded from the system reference snapshot by design). Run once, as a single transaction, against Production:
+
+```sql
+BEGIN;
+
+-- 1. The role.
+INSERT INTO public.roles (org_id, name, name_ar, description, is_active, is_system_role)
+VALUES ('00000000-0000-0000-0000-000000000001',
+        'Financial Controller', 'المراقب المالي',
+        'Explicit authority for sensitive accounting controls (Issue #93 / Migration 174)',
+        true, false)
+RETURNING id;   -- keep this id for step 3
+
+-- 2. Exactly the two sensitive keys, nothing else.
+INSERT INTO public.role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM public.roles r
+CROSS JOIN public.permissions p
+WHERE r.org_id = '00000000-0000-0000-0000-000000000001'
+  AND r.name = 'Financial Controller'
+  AND p.permission_key IN ('accounting.vouchers.unpost','accounting.vouchers.cancel');
+
+-- 3. Assign it to the current org admin.
+INSERT INTO public.user_roles (user_id, role_id, org_id, expires_at)
+SELECT 'd572eb14-5a8a-4ec9-ad3b-6945fcc8be0e', r.id,
+       '00000000-0000-0000-0000-000000000001', NULL
+FROM public.roles r
+WHERE r.org_id = '00000000-0000-0000-0000-000000000001'
+  AND r.name = 'Financial Controller';
+
+COMMIT;
+```
+
+### Step 4 — prove the grant before applying anything
+
+```sql
+SELECT p.permission_key,
+       EXISTS (
+         SELECT 1 FROM public.user_roles ur
+         JOIN public.roles r ON r.id = ur.role_id
+           AND r.org_id = ur.org_id AND COALESCE(r.is_active, true)
+         JOIN public.role_permissions rp ON rp.role_id = ur.role_id
+         JOIN public.permissions pp ON pp.id = rp.permission_id
+         WHERE ur.user_id = 'd572eb14-5a8a-4ec9-ad3b-6945fcc8be0e'
+           AND ur.org_id = '00000000-0000-0000-0000-000000000001'
+           AND pp.permission_key = p.permission_key
+           AND (ur.expires_at IS NULL OR ur.expires_at > now())
+       ) AS via_explicit_grant
+FROM public.permissions p
+WHERE p.permission_key IN ('accounting.vouchers.unpost','accounting.vouchers.cancel');
+```
+
+**Both rows must read `via_explicit_grant = true`. If either is false, stop — do not apply the migration.**
+
+### Step 5 — apply 174 and run postflight
+
+Apply the exact file merged to `main`. The migration's own `$verify$` block runs before `COMMIT` and fails the transaction on any drift. Then, read-only:
+
+```sql
+SELECT
+  prosrc ~ 'wardah_is_sensitive_permission'          AS consults_classifier,
+  prosrc ~ 'p_user_id IS DISTINCT FROM auth\.uid\(\)' AS identity_guard_170,
+  prosrc !~ 'LIKE'                                    AS no_wildcard_172,
+  prosrc ~ 'p\.permission_key\s*=\s*p_permission_key' AS exact_key_172,
+  prosrc ~ 'COALESCE\(r\.is_active, true\)'           AS active_role_173,
+  prosrc ~ 'expires_at'                               AS role_expiry,
+  prosrc ~ 'super_admins'                             AS super_admin_override,
+  prosrc ~ 'is_org_admin'                             AS org_admin_override_present
+FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname = 'public' AND p.proname = 'has_permission';
+-- Expect every column true. `org_admin_override_present` must stay TRUE:
+-- the override is narrowed, not removed — ordinary keys still ride it.
+
+SELECT (SELECT count(*) FROM public.permissions
+         WHERE public.wardah_is_sensitive_permission(permission_key)) AS sensitive_rows;
+-- Expect exactly 2.
+
+SELECT version, name FROM supabase_migrations.schema_migrations
+WHERE name = '174_sensitive_permission_class_and_rbac_rpcs';
+-- Expect exactly one row.
+```
+
+### Step 6 — deploy the dependent UI
+
+Only after step 5 is verified. The UI PR removes the client-side override and moves role/user administration onto the RPCs. Merging it earlier would ship a client calling RPCs that do not exist; applying 174 without it leaves the UI showing unpost/cancel buttons that the backend now refuses — the divergence described in §7.
+
+### Step 7 — browser smoke on the deployed UI
+
+Create a role · edit its permissions · assign it · revoke it · confirm the `cancel`/`unpost` controls disappear for an ungranted admin and reappear once the sensitive role is assigned.
+
+## 7. Why the UI is part of the closure, not a follow-up
+
+`src/hooks/usePermissions.ts` re-implements the override client-side:
+
+```ts
+if (isSuperAdmin) return true;
+if (isOrgAdmin) return true;   // never consults the backend
+```
+
+and the loader short-circuits with `setPermissions([])` for admins. After 174, the client would still believe an ungranted org admin may unpost, while the RPC refuses — a button that fails on click. `rpc_permission_snapshot` exists precisely so the client stops deciding and starts asking.
+
+The same PR replaces the non-atomic delete-then-insert pairs in `src/services/rbac-service.ts` with `rpc_upsert_org_role` / `rpc_replace_user_roles` / `rpc_delete_org_role`, so a failed second call can no longer leave a role with no permissions or a user with no roles.
+
+## 8. Rollback
+
+Additive apart from replacing two function bodies. Both replacements only ever *narrow* authority for two keys, so a forward fix is preferred to any revert, per the golden rule. If the sensitive class must be lifted in an emergency, the reviewed path is a new numbered migration that changes the classifier — **not** a hand-edit of 174, and **not** re-widening the override, since a super admin already provides the emergency route by design.
+
+Never edit `supabase_migrations.schema_migrations`, and never apply SQL that is not the exact file merged to `main`.

--- a/scripts/ci/fresh-db/acceptance_174_sensitive_permission_class.sql
+++ b/scripts/ci/fresh-db/acceptance_174_sensitive_permission_class.sql
@@ -510,6 +510,136 @@ END;
 $$;
 RESET ROLE;
 
+-- 6l. A repeated role_id is rejected outright, and the rejection mutates
+--     nothing. Silently de-duplicating would pick one of two conflicting
+--     deadlines on the caller's behalf.
+SELECT set_config('request.jwt.claim.sub', '99174174-0001-0001-0001-000000000001', false);
+SET LOCAL ROLE authenticated;
+DO $$
+DECLARE
+  v_before jsonb;
+  v_after  jsonb;
+BEGIN
+  SELECT COALESCE(jsonb_agg(jsonb_build_object('r', role_id, 'e', expires_at) ORDER BY role_id), '[]'::jsonb)
+    INTO v_before
+  FROM public.user_roles
+  WHERE user_id = '99174174-0006-0006-0006-000000000006'
+    AND org_id  = '99174174-a000-a000-a000-00000000000a';
+
+  BEGIN
+    PERFORM public.rpc_replace_user_roles(jsonb_build_object(
+      'org_id', '99174174-a000-a000-a000-00000000000a',
+      'user_id', '99174174-0006-0006-0006-000000000006',
+      'role_ids', jsonb_build_array(
+        jsonb_build_object('role_id', '99174174-0000-0000-0000-000000000020',
+                           'expires_at', (now() + interval '10 days')::text),
+        jsonb_build_object('role_id', '99174174-0000-0000-0000-000000000020',
+                           'expires_at', NULL))));
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-39]: a duplicated role_id with conflicting expiry was accepted';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE 'ACCEPTANCE_FAIL%' THEN RAISE; END IF;
+    IF SQLERRM NOT LIKE '%RBAC_174_DUPLICATE_ROLE_ID%' THEN RAISE; END IF;
+  END;
+
+  SELECT COALESCE(jsonb_agg(jsonb_build_object('r', role_id, 'e', expires_at) ORDER BY role_id), '[]'::jsonb)
+    INTO v_after
+  FROM public.user_roles
+  WHERE user_id = '99174174-0006-0006-0006-000000000006'
+    AND org_id  = '99174174-a000-a000-a000-00000000000a';
+
+  IF v_before IS DISTINCT FROM v_after THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-40]: the rejected duplicate payload still mutated user_roles';
+  END IF;
+
+  -- A plain repeated string must be rejected the same way.
+  BEGIN
+    PERFORM public.rpc_replace_user_roles(jsonb_build_object(
+      'org_id', '99174174-a000-a000-a000-00000000000a',
+      'user_id', '99174174-0006-0006-0006-000000000006',
+      'role_ids', jsonb_build_array('99174174-0000-0000-0000-000000000020',
+                                    '99174174-0000-0000-0000-000000000020')));
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-41]: a duplicated plain role_id was accepted';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE 'ACCEPTANCE_FAIL%' THEN RAISE; END IF;
+    IF SQLERRM NOT LIKE '%RBAC_174_DUPLICATE_ROLE_ID%' THEN RAISE; END IF;
+  END;
+END;
+$$;
+RESET ROLE;
+
+-- 6m. Audit completeness: every RBAC mutation must record a full before/after
+--     snapshot, not just an identifier. These assertions are what stop the
+--     audit trail from silently degrading in a later refactor.
+SELECT set_config('request.jwt.claim.sub', '99174174-0001-0001-0001-000000000001', false);
+SET LOCAL ROLE authenticated;
+DO $$
+DECLARE
+  v_role  uuid;
+  v_row   public.audit_logs%ROWTYPE;
+BEGIN
+  -- Create with one key, then update to a different key: the update's audit row
+  -- must carry the OLD key set, not only the new one.
+  v_role := (public.rpc_upsert_org_role(jsonb_build_object(
+    'org_id', '99174174-a000-a000-a000-00000000000a',
+    'name', 'P174 Audit Probe',
+    'permission_keys', jsonb_build_array('accounting.vouchers.unpost')))->>'role_id')::uuid;
+
+  PERFORM public.rpc_upsert_org_role(jsonb_build_object(
+    'org_id', '99174174-a000-a000-a000-00000000000a',
+    'role_id', v_role, 'name', 'P174 Audit Probe',
+    'permission_keys', jsonb_build_array('accounting.vouchers.cancel')));
+
+  SELECT * INTO v_row FROM public.audit_logs
+   WHERE entity_id = v_role::text AND action = 'rbac.role.update'
+   ORDER BY created_at DESC LIMIT 1;
+
+  IF v_row.old_data IS NULL OR NOT (v_row.old_data->'permission_keys' @> '"accounting.vouchers.unpost"'::jsonb) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-42]: role update did not record the outgoing permission set';
+  END IF;
+  IF NOT (v_row.new_data->'permission_keys' @> '"accounting.vouchers.cancel"'::jsonb) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-43]: role update did not record the incoming permission set';
+  END IF;
+  IF NOT (v_row.metadata->'permissions_removed' @> '"accounting.vouchers.unpost"'::jsonb) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-44]: role update did not record which permissions were removed';
+  END IF;
+
+  -- Delete must record the permissions it destroyed.
+  PERFORM public.rpc_delete_org_role(jsonb_build_object(
+    'org_id', '99174174-a000-a000-a000-00000000000a', 'role_id', v_role));
+
+  SELECT * INTO v_row FROM public.audit_logs
+   WHERE entity_id = v_role::text AND action = 'rbac.role.delete'
+   ORDER BY created_at DESC LIMIT 1;
+
+  IF v_row.old_data IS NULL
+     OR NOT (v_row.old_data->'permission_keys' @> '"accounting.vouchers.cancel"'::jsonb) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-45]: role delete did not record the destroyed permission set';
+  END IF;
+  IF NOT COALESCE((v_row.metadata->>'removed_sensitive')::boolean, false) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-46]: role delete did not flag that a sensitive key was removed';
+  END IF;
+
+  -- Assignment replacement must record per-role expires_at on both sides.
+  SELECT * INTO v_row FROM public.audit_logs
+   WHERE action = 'rbac.user_roles.replace'
+     AND entity_id = '99174174-0006-0006-0006-000000000006'
+   ORDER BY created_at DESC LIMIT 1;
+
+  IF v_row.old_data IS NULL OR jsonb_typeof(v_row.old_data) <> 'array' THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-47]: user_roles replace did not record a before snapshot';
+  END IF;
+  IF jsonb_array_length(v_row.old_data) > 0
+     AND NOT (v_row.old_data->0 ? 'expires_at') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-48]: user_roles before snapshot omits expires_at';
+  END IF;
+  IF jsonb_array_length(v_row.new_data) > 0
+     AND NOT (v_row.new_data->0 ? 'expires_at') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-49]: user_roles after snapshot omits expires_at';
+  END IF;
+END;
+$$;
+RESET ROLE;
+
 -- 6k. A platform super admin who is NOT a member of the organization must
 --     still get a snapshot, because has_permission grants them the override
 --     independently of membership. The earlier fixture masked this by making

--- a/scripts/ci/fresh-db/acceptance_174_sensitive_permission_class.sql
+++ b/scripts/ci/fresh-db/acceptance_174_sensitive_permission_class.sql
@@ -450,6 +450,96 @@ END;
 $$;
 RESET ROLE;
 
+-- 6j. Per-assignment expiry survives a whole-set replacement.
+--
+-- A replace states WHICH roles are held; it must not silently extend a
+-- time-boxed sensitive grant to permanent just because the caller omitted a
+-- payload-level expires_at. Fixture: give the member two roles, one of them
+-- time-limited, then replace the set with only the time-limited one and no
+-- expires_at in the payload.
+SELECT set_config('request.jwt.claim.sub', '99174174-0001-0001-0001-000000000001', false);
+SET LOCAL ROLE authenticated;
+DO $$
+DECLARE
+  v_deadline timestamptz := now() + interval '30 days';
+  v_after    timestamptz;
+BEGIN
+  -- Seed: the member holds the controller role with an explicit deadline.
+  PERFORM public.rpc_replace_user_roles(jsonb_build_object(
+    'org_id', '99174174-a000-a000-a000-00000000000a',
+    'user_id', '99174174-0006-0006-0006-000000000006',
+    'role_ids', jsonb_build_array(
+      jsonb_build_object('role_id', '99174174-0000-0000-0000-000000000020',
+                         'expires_at', v_deadline))));
+
+  SELECT expires_at INTO v_after FROM public.user_roles
+   WHERE user_id = '99174174-0006-0006-0006-000000000006'
+     AND role_id = '99174174-0000-0000-0000-000000000020';
+  IF v_after IS NULL THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-34]: per-role expires_at was not honoured on assignment';
+  END IF;
+
+  -- Replace the set again, omitting expires_at entirely.
+  PERFORM public.rpc_replace_user_roles(jsonb_build_object(
+    'org_id', '99174174-a000-a000-a000-00000000000a',
+    'user_id', '99174174-0006-0006-0006-000000000006',
+    'role_ids', jsonb_build_array('99174174-0000-0000-0000-000000000020')));
+
+  SELECT expires_at INTO v_after FROM public.user_roles
+   WHERE user_id = '99174174-0006-0006-0006-000000000006'
+     AND role_id = '99174174-0000-0000-0000-000000000020';
+  IF v_after IS NULL THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-35]: a retained time-limited sensitive grant was silently made permanent';
+  END IF;
+
+  -- An explicit null must still be able to clear it deliberately.
+  PERFORM public.rpc_replace_user_roles(jsonb_build_object(
+    'org_id', '99174174-a000-a000-a000-00000000000a',
+    'user_id', '99174174-0006-0006-0006-000000000006',
+    'role_ids', jsonb_build_array(
+      jsonb_build_object('role_id', '99174174-0000-0000-0000-000000000020',
+                         'expires_at', NULL))));
+
+  SELECT expires_at INTO v_after FROM public.user_roles
+   WHERE user_id = '99174174-0006-0006-0006-000000000006'
+     AND role_id = '99174174-0000-0000-0000-000000000020';
+  IF v_after IS NOT NULL THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-36]: an explicit null expires_at did not clear the deadline';
+  END IF;
+END;
+$$;
+RESET ROLE;
+
+-- 6k. A platform super admin who is NOT a member of the organization must
+--     still get a snapshot, because has_permission grants them the override
+--     independently of membership. The earlier fixture masked this by making
+--     the super admin a member; this user deliberately is not.
+INSERT INTO auth.users (id, email)
+VALUES ('99174174-0008-0008-0008-000000000008', 'p174-super-nonmember@example.test');
+INSERT INTO public.super_admins (user_id, email, is_active)
+VALUES ('99174174-0008-0008-0008-000000000008', 'p174-super-nonmember@example.test', true);
+
+SELECT set_config('request.jwt.claim.sub', '99174174-0008-0008-0008-000000000008', false);
+SET LOCAL ROLE authenticated;
+DO $$
+DECLARE v_res jsonb;
+BEGIN
+  IF EXISTS (SELECT 1 FROM public.user_organizations
+              WHERE user_id = '99174174-0008-0008-0008-000000000008') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FIXTURE_MISSING[174]: the non-member super admin is a member after all';
+  END IF;
+
+  v_res := public.rpc_permission_snapshot('99174174-a000-a000-a000-00000000000a');
+  IF NOT (v_res->>'is_super_admin')::boolean THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-37]: snapshot did not report super-admin status';
+  END IF;
+  IF NOT (v_res->'permission_keys' @> '"accounting.vouchers.unpost"'::jsonb) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-38]: super-admin snapshot omits a sensitive key';
+  END IF;
+END;
+$$;
+RESET ROLE;
+
 -- ---------------------------------------------------------------------------
 -- 7. Mutation proof: each 166-173 guarantee re-asserted as its own failure.
 -- ---------------------------------------------------------------------------

--- a/scripts/ci/fresh-db/acceptance_174_sensitive_permission_class.sql
+++ b/scripts/ci/fresh-db/acceptance_174_sensitive_permission_class.sql
@@ -1,0 +1,496 @@
+-- Acceptance for Migration 174 — sensitive permission class (Issue #93).
+--
+-- Proves, behaviourally and on both permission functions:
+--   (1) org admin WITHOUT an explicit grant is denied the sensitive keys;
+--   (2) org admin WITH an explicit grant is allowed them;
+--   (3) super admin keeps the full override, sensitive keys included;
+--   (4) a DISABLED role does not carry a sensitive grant (173 preserved);
+--   (5) an EXPIRED assignment does not carry it either;
+--   (6) cross-org: an admin of another org gets nothing here;
+--   (7) the caller-identity guard still denies asking about someone else (170);
+--   (8) ORDINARY keys still ride the org-admin override untouched;
+--   (9) mutation proof: the 166-173 guarantees are re-asserted individually,
+--       each with its own failing assertion, so a regression in any single
+--       layer fails loudly and identifiably rather than being masked.
+--
+-- Marker on success: SENSITIVE_PERMISSION_174_ACCEPTANCE_PASS
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- 0. The two sensitive keys must exist before anything is asserted, so a
+--    missing catalog fails as a setup error rather than as a false "denied".
+-- ---------------------------------------------------------------------------
+DO $$
+BEGIN
+  IF (SELECT count(*) FROM public.permissions
+       WHERE permission_key IN ('accounting.vouchers.unpost','accounting.vouchers.cancel')) <> 2 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FIXTURE_MISSING[174]: sensitive permission keys absent from the catalog';
+  END IF;
+  IF (SELECT count(*) FROM public.permissions
+       WHERE permission_key = 'accounting.entries.approve') <> 1 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FIXTURE_MISSING[174]: ordinary control key accounting.entries.approve absent';
+  END IF;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 1. Fixtures: two orgs, seven users covering every branch.
+-- ---------------------------------------------------------------------------
+INSERT INTO auth.users (id, email) VALUES
+  ('99174174-0001-0001-0001-000000000001', 'p174-admin-nogrant@example.test'),
+  ('99174174-0002-0002-0002-000000000002', 'p174-admin-granted@example.test'),
+  ('99174174-0003-0003-0003-000000000003', 'p174-super@example.test'),
+  ('99174174-0004-0004-0004-000000000004', 'p174-disabled@example.test'),
+  ('99174174-0005-0005-0005-000000000005', 'p174-expired@example.test'),
+  ('99174174-0006-0006-0006-000000000006', 'p174-member-granted@example.test'),
+  ('99174174-0007-0007-0007-000000000007', 'p174-otherorg-admin@example.test');
+
+INSERT INTO public.organizations (id, name, code) VALUES
+  ('99174174-a000-a000-a000-00000000000a', 'Perm174 Org A', 'P174-A'),
+  ('99174174-b000-b000-b000-00000000000b', 'Perm174 Org B', 'P174-B');
+
+INSERT INTO public.user_organizations (user_id, org_id, is_active, is_org_admin) VALUES
+  ('99174174-0001-0001-0001-000000000001', '99174174-a000-a000-a000-00000000000a', true, true),
+  ('99174174-0002-0002-0002-000000000002', '99174174-a000-a000-a000-00000000000a', true, true),
+  ('99174174-0003-0003-0003-000000000003', '99174174-a000-a000-a000-00000000000a', true, false),
+  ('99174174-0004-0004-0004-000000000004', '99174174-a000-a000-a000-00000000000a', true, false),
+  ('99174174-0005-0005-0005-000000000005', '99174174-a000-a000-a000-00000000000a', true, false),
+  ('99174174-0006-0006-0006-000000000006', '99174174-a000-a000-a000-00000000000a', true, false),
+  ('99174174-0007-0007-0007-000000000007', '99174174-b000-b000-b000-00000000000b', true, true);
+
+INSERT INTO public.super_admins (user_id, email, is_active) VALUES
+  ('99174174-0003-0003-0003-000000000003', 'p174-super@example.test', true);
+
+-- Financial-controller-shaped roles: active / disabled, wired identically.
+INSERT INTO public.roles (id, org_id, name, name_ar, is_active) VALUES
+  ('99174174-0000-0000-0000-000000000020', '99174174-a000-a000-a000-00000000000a', 'P174 Financial Controller', 'مراقب مالي', true),
+  ('99174174-0000-0000-0000-000000000021', '99174174-a000-a000-a000-00000000000a', 'P174 Disabled Controller', 'مراقب معطل', false);
+
+INSERT INTO public.role_permissions (role_id, permission_id)
+SELECT r.rid, p.id
+FROM (VALUES ('99174174-0000-0000-0000-000000000020'::uuid),
+             ('99174174-0000-0000-0000-000000000021'::uuid)) AS r(rid)
+CROSS JOIN public.permissions p
+WHERE p.permission_key IN ('accounting.vouchers.unpost','accounting.vouchers.cancel');
+
+INSERT INTO public.user_roles (user_id, role_id, org_id, expires_at) VALUES
+  -- org admin WITH an explicit grant
+  ('99174174-0002-0002-0002-000000000002', '99174174-0000-0000-0000-000000000020',
+   '99174174-a000-a000-a000-00000000000a', NULL),
+  -- disabled role
+  ('99174174-0004-0004-0004-000000000004', '99174174-0000-0000-0000-000000000021',
+   '99174174-a000-a000-a000-00000000000a', NULL),
+  -- active role, expired assignment
+  ('99174174-0005-0005-0005-000000000005', '99174174-0000-0000-0000-000000000020',
+   '99174174-a000-a000-a000-00000000000a', '2020-01-01T00:00:00Z'),
+  -- ordinary member with a live grant
+  ('99174174-0006-0006-0006-000000000006', '99174174-0000-0000-0000-000000000020',
+   '99174174-a000-a000-a000-00000000000a', NULL);
+
+-- Fixture sanity: the disabled-role and expired users' grants are otherwise
+-- real. Without this, a false result below could come from a broken fixture
+-- rather than from the gate under test.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM public.user_roles ur
+    JOIN public.role_permissions rp ON rp.role_id = ur.role_id
+    JOIN public.permissions p ON p.id = rp.permission_id
+    WHERE ur.user_id = '99174174-0004-0004-0004-000000000004'
+      AND p.permission_key = 'accounting.vouchers.unpost'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM public.user_roles ur
+    JOIN public.role_permissions rp ON rp.role_id = ur.role_id
+    JOIN public.permissions p ON p.id = rp.permission_id
+    WHERE ur.user_id = '99174174-0005-0005-0005-000000000005'
+      AND p.permission_key = 'accounting.vouchers.unpost'
+  ) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FIXTURE_MISSING[174]: disabled/expired grants are not wired at all';
+  END IF;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 2. The classifier itself.
+-- ---------------------------------------------------------------------------
+DO $$
+BEGIN
+  IF NOT public.wardah_is_sensitive_permission('accounting.vouchers.unpost')
+     OR NOT public.wardah_is_sensitive_permission('accounting.vouchers.cancel') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-0a]: classifier misses a sensitive key';
+  END IF;
+  IF public.wardah_is_sensitive_permission('reports.ai_insights.use')
+     OR public.wardah_is_sensitive_permission('accounting.entries.approve')
+     OR public.wardah_is_sensitive_permission('accounting.vouchers.reverse') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-0b]: classifier over-classifies';
+  END IF;
+  IF public.wardah_is_sensitive_permission(NULL) IS NOT NULL THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-0c]: classifier is not STRICT (NULL must yield NULL)';
+  END IF;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 3. has_permission, per user. Each block runs as `authenticated` with that
+--    user's JWT subject, matching the function's own auth.uid() self-check.
+-- ---------------------------------------------------------------------------
+
+-- 3a. Org admin WITHOUT a grant: sensitive DENIED, ordinary ALLOWED.
+SELECT set_config('request.jwt.claim.sub', '99174174-0001-0001-0001-000000000001', false);
+SET LOCAL ROLE authenticated;
+DO $$
+BEGIN
+  IF public.has_permission('99174174-0001-0001-0001-000000000001',
+                           '99174174-a000-a000-a000-00000000000a',
+                           'accounting.vouchers.unpost') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-1a]: org admin still passes unpost with no explicit grant';
+  END IF;
+  IF public.has_permission('99174174-0001-0001-0001-000000000001',
+                           '99174174-a000-a000-a000-00000000000a',
+                           'accounting.vouchers.cancel') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-1b]: org admin still passes cancel with no explicit grant';
+  END IF;
+  -- (8) ordinary keys must be unaffected — this is the regression risk of 174.
+  IF NOT public.has_permission('99174174-0001-0001-0001-000000000001',
+                               '99174174-a000-a000-a000-00000000000a',
+                               'accounting.entries.approve') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-1c]: org-admin override broke for an ORDINARY key';
+  END IF;
+END;
+$$;
+RESET ROLE;
+
+-- 3b. Org admin WITH an explicit grant: sensitive ALLOWED.
+SELECT set_config('request.jwt.claim.sub', '99174174-0002-0002-0002-000000000002', false);
+SET LOCAL ROLE authenticated;
+DO $$
+BEGIN
+  IF NOT public.has_permission('99174174-0002-0002-0002-000000000002',
+                               '99174174-a000-a000-a000-00000000000a',
+                               'accounting.vouchers.unpost') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-2]: explicit grant does not authorize a sensitive key';
+  END IF;
+END;
+$$;
+RESET ROLE;
+
+-- 3c. Super admin: full override including sensitive keys, with no role.
+SELECT set_config('request.jwt.claim.sub', '99174174-0003-0003-0003-000000000003', false);
+SET LOCAL ROLE authenticated;
+DO $$
+BEGIN
+  IF NOT public.has_permission('99174174-0003-0003-0003-000000000003',
+                               '99174174-a000-a000-a000-00000000000a',
+                               'accounting.vouchers.unpost') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-3]: super-admin emergency override lost for a sensitive key';
+  END IF;
+END;
+$$;
+RESET ROLE;
+
+-- 3d. Disabled role (173 preserved under the new branch).
+SELECT set_config('request.jwt.claim.sub', '99174174-0004-0004-0004-000000000004', false);
+SET LOCAL ROLE authenticated;
+DO $$
+BEGIN
+  IF public.has_permission('99174174-0004-0004-0004-000000000004',
+                           '99174174-a000-a000-a000-00000000000a',
+                           'accounting.vouchers.unpost') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-4]: a DISABLED role still carries a sensitive grant (173 regression)';
+  END IF;
+END;
+$$;
+RESET ROLE;
+
+-- 3e. Expired assignment.
+SELECT set_config('request.jwt.claim.sub', '99174174-0005-0005-0005-000000000005', false);
+SET LOCAL ROLE authenticated;
+DO $$
+BEGIN
+  IF public.has_permission('99174174-0005-0005-0005-000000000005',
+                           '99174174-a000-a000-a000-00000000000a',
+                           'accounting.vouchers.unpost') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-5]: an EXPIRED assignment still carries a sensitive grant';
+  END IF;
+END;
+$$;
+RESET ROLE;
+
+-- 3f. Ordinary member with a live grant: allowed. And (7) the identity guard
+--     still refuses to answer about a different user.
+SELECT set_config('request.jwt.claim.sub', '99174174-0006-0006-0006-000000000006', false);
+SET LOCAL ROLE authenticated;
+DO $$
+BEGIN
+  IF NOT public.has_permission('99174174-0006-0006-0006-000000000006',
+                               '99174174-a000-a000-a000-00000000000a',
+                               'accounting.vouchers.cancel') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-6]: live explicit grant denied for an ordinary member';
+  END IF;
+  IF public.has_permission('99174174-0002-0002-0002-000000000002',
+                           '99174174-a000-a000-a000-00000000000a',
+                           'accounting.vouchers.cancel') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-7]: caller-identity guard lost (170) — answered about another user';
+  END IF;
+  -- (172) exact-key match: a sibling key in the same module must not ride along.
+  IF public.has_permission('99174174-0006-0006-0006-000000000006',
+                           '99174174-a000-a000-a000-00000000000a',
+                           'accounting.entries.approve') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-8]: same-module wildcard match reappeared (172 regression)';
+  END IF;
+END;
+$$;
+RESET ROLE;
+
+-- 3g. Cross-org: org B's admin gets nothing in org A, sensitive or ordinary.
+SELECT set_config('request.jwt.claim.sub', '99174174-0007-0007-0007-000000000007', false);
+SET LOCAL ROLE authenticated;
+DO $$
+BEGIN
+  IF public.has_permission('99174174-0007-0007-0007-000000000007',
+                           '99174174-a000-a000-a000-00000000000a',
+                           'accounting.vouchers.unpost') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-9a]: cross-org admin passed a sensitive key in a foreign org';
+  END IF;
+  IF public.has_permission('99174174-0007-0007-0007-000000000007',
+                           '99174174-a000-a000-a000-00000000000a',
+                           'accounting.entries.approve') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-9b]: cross-org admin passed an ordinary key in a foreign org';
+  END IF;
+END;
+$$;
+RESET ROLE;
+
+-- ---------------------------------------------------------------------------
+-- 4. wardah_has_exact_permission — the helper the voucher unpost/cancel RPCs
+--    actually call. Same matrix, so the two functions cannot drift.
+--    Executed as the migration owner: this helper is postgres-only by design.
+-- ---------------------------------------------------------------------------
+DO $$
+BEGIN
+  IF public.wardah_has_exact_permission('99174174-0001-0001-0001-000000000001',
+        '99174174-a000-a000-a000-00000000000a', 'accounting.vouchers.unpost') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-10]: exact helper still lets an ungranted org admin unpost';
+  END IF;
+  IF NOT public.wardah_has_exact_permission('99174174-0002-0002-0002-000000000002',
+        '99174174-a000-a000-a000-00000000000a', 'accounting.vouchers.unpost') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-11]: exact helper denies an explicitly granted admin';
+  END IF;
+  IF NOT public.wardah_has_exact_permission('99174174-0003-0003-0003-000000000003',
+        '99174174-a000-a000-a000-00000000000a', 'accounting.vouchers.cancel') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-12]: exact helper lost the super-admin override';
+  END IF;
+  IF public.wardah_has_exact_permission('99174174-0004-0004-0004-000000000004',
+        '99174174-a000-a000-a000-00000000000a', 'accounting.vouchers.unpost') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-13]: exact helper honours a DISABLED role (173 regression)';
+  END IF;
+  IF public.wardah_has_exact_permission('99174174-0005-0005-0005-000000000005',
+        '99174174-a000-a000-a000-00000000000a', 'accounting.vouchers.unpost') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-14]: exact helper honours an EXPIRED assignment';
+  END IF;
+  IF NOT public.wardah_has_exact_permission('99174174-0001-0001-0001-000000000001',
+        '99174174-a000-a000-a000-00000000000a', 'accounting.entries.approve') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-15]: exact helper broke the org-admin override for an ORDINARY key';
+  END IF;
+  IF public.wardah_has_exact_permission('99174174-0007-0007-0007-000000000007',
+        '99174174-a000-a000-a000-00000000000a', 'accounting.vouchers.unpost') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-16]: exact helper leaked across orgs';
+  END IF;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 5. Execute boundaries: the helper must stay unreachable from the client.
+-- ---------------------------------------------------------------------------
+DO $$
+BEGIN
+  IF has_function_privilege('authenticated', 'public.wardah_has_exact_permission(uuid,uuid,text)', 'EXECUTE')
+     OR has_function_privilege('anon', 'public.wardah_has_exact_permission(uuid,uuid,text)', 'EXECUTE')
+     OR has_function_privilege('service_role', 'public.wardah_has_exact_permission(uuid,uuid,text)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-17]: exact helper escaped its postgres-only execute boundary';
+  END IF;
+  IF NOT has_function_privilege('authenticated', 'public.has_permission(uuid,uuid,character varying)', 'EXECUTE')
+     OR has_function_privilege('anon', 'public.has_permission(uuid,uuid,character varying)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-18]: has_permission execute boundary drifted';
+  END IF;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 6. The RBAC control plane: atomic, org-scoped, audited — and usable by an
+--    org admin to grant themselves the sensitive role (the approved contract).
+-- ---------------------------------------------------------------------------
+SELECT set_config('request.jwt.claim.sub', '99174174-0001-0001-0001-000000000001', false);
+SET LOCAL ROLE authenticated;
+DO $$
+DECLARE
+  v_res      jsonb;
+  v_role     uuid;
+  v_audit    int;
+BEGIN
+  -- 6a. Create a role carrying both sensitive keys.
+  v_res := public.rpc_upsert_org_role(jsonb_build_object(
+    'org_id', '99174174-a000-a000-a000-00000000000a',
+    'name', 'P174 Self Granted Controller',
+    'permission_keys', jsonb_build_array('accounting.vouchers.unpost','accounting.vouchers.cancel')));
+  v_role := (v_res->>'role_id')::uuid;
+  IF v_role IS NULL OR NOT (v_res->>'created')::boolean THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-19]: rpc_upsert_org_role did not create the role';
+  END IF;
+  IF jsonb_array_length(v_res->'sensitive_keys') <> 2 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-20]: sensitive keys not reported back to the caller';
+  END IF;
+
+  -- 6b. An unknown key must fail closed, not be silently dropped.
+  BEGIN
+    PERFORM public.rpc_upsert_org_role(jsonb_build_object(
+      'org_id', '99174174-a000-a000-a000-00000000000a',
+      'role_id', v_role, 'name', 'P174 Self Granted Controller',
+      'permission_keys', jsonb_build_array('does.not.exist')));
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-21]: unknown permission key was accepted';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM NOT LIKE '%RBAC_174_UNKNOWN_PERMISSION_KEY%' THEN RAISE; END IF;
+  END;
+
+  -- The failed call must not have emptied the permission set.
+  IF (SELECT count(*) FROM public.role_permissions WHERE role_id = v_role) <> 2 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-22]: a rejected update still mutated role_permissions (not atomic)';
+  END IF;
+
+  -- 6c. Self-assignment is allowed and audited.
+  v_res := public.rpc_replace_user_roles(jsonb_build_object(
+    'org_id', '99174174-a000-a000-a000-00000000000a',
+    'user_id', '99174174-0001-0001-0001-000000000001',
+    'role_ids', jsonb_build_array(v_role)));
+  IF jsonb_array_length(v_res->'sensitive_keys_granted') <> 2 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-23]: sensitive grant not surfaced on assignment';
+  END IF;
+
+  SELECT count(*) INTO v_audit FROM public.audit_logs
+   WHERE org_id = '99174174-a000-a000-a000-00000000000a'
+     AND action IN ('rbac.role.create','rbac.user_roles.replace');
+  IF v_audit < 2 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-24]: RBAC changes were not written to audit_logs';
+  END IF;
+
+  -- 6d. Now the same admin passes the sensitive key — through the grant.
+  IF NOT public.has_permission('99174174-0001-0001-0001-000000000001',
+                               '99174174-a000-a000-a000-00000000000a',
+                               'accounting.vouchers.unpost') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-25]: self-granted sensitive role does not authorize';
+  END IF;
+
+  -- 6e. A role that is still assigned cannot be deleted out from under users.
+  BEGIN
+    PERFORM public.rpc_delete_org_role(jsonb_build_object(
+      'org_id', '99174174-a000-a000-a000-00000000000a', 'role_id', v_role));
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-26]: an assigned role was deleted';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM NOT LIKE '%RBAC_174_ROLE_STILL_ASSIGNED%' THEN RAISE; END IF;
+  END;
+
+  -- 6f. Cross-org write must fail on the guard, not on a row filter.
+  BEGIN
+    PERFORM public.rpc_upsert_org_role(jsonb_build_object(
+      'org_id', '99174174-b000-b000-b000-00000000000b', 'name', 'P174 Intruder',
+      'permission_keys', jsonb_build_array()));
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-27]: org A admin created a role in org B';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE 'ACCEPTANCE_FAIL%' THEN RAISE; END IF;
+  END;
+
+  -- 6g. Snapshot: the single source of truth the UI must consume.
+  v_res := public.rpc_permission_snapshot('99174174-a000-a000-a000-00000000000a');
+  IF NOT (v_res->>'is_org_admin')::boolean THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-28]: snapshot lost is_org_admin';
+  END IF;
+  IF NOT (v_res->'permission_keys' @> '"accounting.vouchers.unpost"'::jsonb) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-29]: snapshot omits an explicitly granted sensitive key';
+  END IF;
+  IF NOT (v_res->'sensitive_permission_keys' @> '"accounting.vouchers.cancel"'::jsonb) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-30]: snapshot does not advertise the sensitive set for badging';
+  END IF;
+END;
+$$;
+RESET ROLE;
+
+-- 6h. The ungranted admin's snapshot must NOT contain the sensitive keys,
+--     while still containing ordinary ones. This is the exact divergence the
+--     UI used to invent locally.
+SELECT set_config('request.jwt.claim.sub', '99174174-0007-0007-0007-000000000007', false);
+SET LOCAL ROLE authenticated;
+DO $$
+DECLARE v_res jsonb;
+BEGIN
+  v_res := public.rpc_permission_snapshot('99174174-b000-b000-b000-00000000000b');
+  IF v_res->'permission_keys' @> '"accounting.vouchers.unpost"'::jsonb THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-31]: snapshot grants a sensitive key to an ungranted org admin';
+  END IF;
+  IF NOT (v_res->'permission_keys' @> '"accounting.entries.approve"'::jsonb) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-32]: snapshot dropped ordinary org-admin permissions';
+  END IF;
+END;
+$$;
+RESET ROLE;
+
+-- 6i. A snapshot may only ever be about an org the caller belongs to.
+SELECT set_config('request.jwt.claim.sub', '99174174-0007-0007-0007-000000000007', false);
+SET LOCAL ROLE authenticated;
+DO $$
+BEGIN
+  BEGIN
+    PERFORM public.rpc_permission_snapshot('99174174-a000-a000-a000-00000000000a');
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-33]: snapshot returned for a foreign organization';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE 'ACCEPTANCE_FAIL%' THEN RAISE; END IF;
+  END;
+END;
+$$;
+RESET ROLE;
+
+-- ---------------------------------------------------------------------------
+-- 7. Mutation proof: each 166-173 guarantee re-asserted as its own failure.
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE v_hp text; v_ex text;
+BEGIN
+  SELECT prosrc INTO v_hp FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+   WHERE n.nspname='public' AND p.proname='has_permission';
+  SELECT prosrc INTO v_ex FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+   WHERE n.nspname='public' AND p.proname='wardah_has_exact_permission';
+
+  IF v_hp !~ 'p_user_id IS DISTINCT FROM auth\.uid\(\)' THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-M1]: 170 caller-identity guard missing';
+  END IF;
+  IF v_hp ~ 'LIKE' OR v_ex ~ 'LIKE' THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-M2]: 172 LIKE fallback reappeared';
+  END IF;
+  IF v_hp !~ 'p\.permission_key\s*=\s*p_permission_key' OR v_ex !~ 'p\.permission_key\s*=\s*p_permission_key' THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-M3]: 172 exact-key equality missing';
+  END IF;
+  IF v_hp !~ 'r\.is_active' OR v_ex !~ 'r\.is_active' THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-M4]: 173 active-role join missing';
+  END IF;
+  IF v_hp !~ 'expires_at' OR v_ex !~ 'expires_at' THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-M5]: role-expiry enforcement missing';
+  END IF;
+  IF v_hp !~ 'ur\.org_id = p_org_id' OR v_ex !~ 'ur\.org_id = p_org_id' THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-M6]: org scoping missing';
+  END IF;
+  IF v_hp !~ 'super_admins' OR v_ex !~ 'super_admins' THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-M7]: super-admin override missing';
+  END IF;
+  IF v_hp !~ 'is_org_admin' OR v_ex !~ 'is_org_admin' THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-M8]: org-admin override removed entirely';
+  END IF;
+  IF v_hp !~ 'wardah_is_sensitive_permission' OR v_ex !~ 'wardah_is_sensitive_permission' THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[174-M9]: a permission function stopped consulting the central classifier';
+  END IF;
+END;
+$$;
+
+DO $$ BEGIN RAISE NOTICE 'SENSITIVE_PERMISSION_174_ACCEPTANCE_PASS'; END $$;
+
+ROLLBACK;

--- a/sql/migrations/174_sensitive_permission_class_and_rbac_rpcs.sql
+++ b/sql/migrations/174_sensitive_permission_class_and_rbac_rpcs.sql
@@ -1,7 +1,12 @@
 -- =====================================================================
 -- 174_sensitive_permission_class_and_rbac_rpcs
 -- =====================================================================
--- Closes Issue #93: the org-admin override branch of both permission
+-- Part of Issue #93 — the database half. The issue is NOT closed by this
+-- migration: it also needs the UI moved onto rpc_permission_snapshot and the
+-- atomic RBAC RPCs, and Migration 175 to close the direct-write surface on
+-- roles/role_permissions/user_roles. See §4.1 and the runbook.
+--
+-- What this migration does fix: the org-admin override branch of both permission
 -- functions never reads p_permission_key at all, so any active org admin
 -- passes EVERY key, including the accounting controls that exist
 -- precisely to be exceptional. Verified live on 2026-08-09 before this
@@ -299,6 +304,7 @@ DECLARE
   v_old         jsonb;
   v_created     boolean := false;
   v_sensitive   text[];
+  v_old_keys    jsonb := '[]'::jsonb;
 BEGIN
   IF v_org IS NULL THEN
     RAISE EXCEPTION 'RBAC_174_ORG_REQUIRED';
@@ -369,6 +375,16 @@ BEGIN
      WHERE id = v_role_id AND org_id = v_org;
   END IF;
 
+  -- Capture the OUTGOING permission set before it is deleted. Without this the
+  -- audit row records what a role became but not what it lost, which is the
+  -- half that matters when reconstructing how someone came to hold a sensitive
+  -- key — or stopped holding it.
+  SELECT COALESCE(jsonb_agg(p.permission_key ORDER BY p.permission_key), '[]'::jsonb)
+    INTO v_old_keys
+  FROM public.role_permissions rp
+  JOIN public.permissions p ON p.id = rp.permission_id
+  WHERE rp.role_id = v_role_id;
+
   -- Replace the permission set atomically: both statements are in the same
   -- transaction as the role row itself, so a failure leaves neither applied.
   DELETE FROM public.role_permissions WHERE role_id = v_role_id;
@@ -388,11 +404,25 @@ BEGIN
   VALUES (
     v_org, auth.uid(),
     CASE WHEN v_created THEN 'rbac.role.create' ELSE 'rbac.role.update' END,
-    'role', v_role_id::text, v_old,
-    jsonb_build_object('name', v_name, 'is_active', v_is_active, 'permission_keys', to_jsonb(v_keys)),
+    'role', v_role_id::text,
+    -- Complete before/after snapshots, same shape on both sides, so a reader
+    -- can diff them without knowing which fields the RPC happened to touch.
+    jsonb_build_object('role', v_old, 'permission_keys', v_old_keys),
+    jsonb_build_object(
+      'role', jsonb_build_object(
+        'id', v_role_id, 'org_id', v_org, 'name', v_name,
+        'name_ar', COALESCE(v_name_ar, v_name), 'description', v_description,
+        'is_active', v_is_active, 'is_system_role', false),
+      'permission_keys', to_jsonb(v_keys)),
     jsonb_build_object(
       'migration', 174,
       'permission_count', COALESCE(array_length(v_keys, 1), 0),
+      'permissions_added', to_jsonb(ARRAY(
+        SELECT k FROM unnest(v_keys) AS k
+        WHERE NOT v_old_keys @> to_jsonb(k) ORDER BY k)),
+      'permissions_removed', to_jsonb(ARRAY(
+        SELECT ok FROM jsonb_array_elements_text(v_old_keys) AS o(ok)
+        WHERE NOT (ok = ANY (v_keys)) ORDER BY ok)),
       'sensitive_keys', to_jsonb(v_sensitive),
       'grants_sensitive', COALESCE(array_length(v_sensitive, 1), 0) > 0)
   );
@@ -422,6 +452,9 @@ DECLARE
   v_sensitive text[];
   v_existing_expiry jsonb;
   v_requested jsonb;
+  v_new       jsonb;
+  v_total     int;
+  v_distinct  int;
 BEGIN
   IF v_org IS NULL OR v_user IS NULL THEN
     RAISE EXCEPTION 'RBAC_174_ORG_AND_USER_REQUIRED';
@@ -454,23 +487,30 @@ BEGIN
   -- temp-table name inside a SECURITY DEFINER function whose search_path puts
   -- `public` first could be shadowed by a same-named table in public.
   SELECT COALESCE(jsonb_agg(jsonb_build_object(
-           'role_id', rid, 'has_explicit', has_exp, 'expires_at', exp)), '[]'::jsonb)
-    INTO v_requested
+           'role_id', rid, 'has_explicit', has_exp, 'expires_at', exp) ORDER BY rid), '[]'::jsonb),
+         count(*), count(DISTINCT rid)
+    INTO v_requested, v_total, v_distinct
   FROM (
-    SELECT DISTINCT ON (rid) rid, has_exp, exp
-    FROM (
-      SELECT
-        CASE WHEN jsonb_typeof(elem) = 'object'
-             THEN NULLIF(elem->>'role_id','')::uuid
-             ELSE NULLIF(elem #>> '{}','')::uuid END AS rid,
-        CASE WHEN jsonb_typeof(elem) = 'object' AND elem ? 'expires_at'
-             THEN NULLIF(elem->>'expires_at','')::timestamptz END AS exp,
-        (jsonb_typeof(elem) = 'object' AND elem ? 'expires_at') AS has_exp
-      FROM jsonb_array_elements(COALESCE(p_payload->'role_ids','[]'::jsonb)) AS t(elem)
-    ) raw
-    WHERE rid IS NOT NULL
-    ORDER BY rid
-  ) s;
+    SELECT
+      CASE WHEN jsonb_typeof(elem) = 'object'
+           THEN NULLIF(elem->>'role_id','')::uuid
+           ELSE NULLIF(elem #>> '{}','')::uuid END AS rid,
+      CASE WHEN jsonb_typeof(elem) = 'object' AND elem ? 'expires_at'
+           THEN NULLIF(elem->>'expires_at','')::timestamptz END AS exp,
+      (jsonb_typeof(elem) = 'object' AND elem ? 'expires_at') AS has_exp
+    FROM jsonb_array_elements(COALESCE(p_payload->'role_ids','[]'::jsonb)) AS t(elem)
+  ) raw
+  WHERE rid IS NOT NULL;
+
+  -- Reject a repeated role_id rather than silently keeping one of them. With
+  -- per-role expiry a duplicate can carry two conflicting deadlines, and any
+  -- de-duplication rule would be picking one on the caller's behalf without
+  -- telling them — for a sensitive grant that is the difference between a
+  -- 30-day authorization and a permanent one. This runs before any mutation,
+  -- so a rejected payload leaves the existing assignments untouched.
+  IF v_total <> v_distinct THEN
+    RAISE EXCEPTION 'RBAC_174_DUPLICATE_ROLE_ID';
+  END IF;
 
   SELECT COALESCE(array_agg((elem->>'role_id')::uuid), ARRAY[]::uuid[])
     INTO v_role_ids
@@ -486,7 +526,12 @@ BEGIN
     RAISE EXCEPTION 'RBAC_174_ROLE_NOT_IN_ORG';
   END IF;
 
-  SELECT COALESCE(jsonb_agg(ur.role_id), '[]'::jsonb) INTO v_old
+  -- Full before snapshot: role_id AND its deadline. Recording ids alone loses
+  -- the change this RPC is most likely to make invisibly — a grant's expiry
+  -- moving, or being cleared.
+  SELECT COALESCE(jsonb_agg(jsonb_build_object(
+           'role_id', ur.role_id, 'expires_at', ur.expires_at) ORDER BY ur.role_id), '[]'::jsonb)
+    INTO v_old
   FROM public.user_roles ur
   WHERE ur.user_id = v_user AND ur.org_id = v_org;
 
@@ -527,14 +572,23 @@ BEGIN
   WHERE rp.role_id = ANY (v_role_ids)
     AND public.wardah_is_sensitive_permission(p.permission_key);
 
+  -- Full after snapshot, read back from the rows actually written rather than
+  -- reconstructed from the payload, so the audit records what the database now
+  -- holds — including deadlines resolved from the retained-expiry rule above.
+  SELECT COALESCE(jsonb_agg(jsonb_build_object(
+           'role_id', ur.role_id, 'expires_at', ur.expires_at) ORDER BY ur.role_id), '[]'::jsonb)
+    INTO v_new
+  FROM public.user_roles ur
+  WHERE ur.user_id = v_user AND ur.org_id = v_org;
+
   INSERT INTO public.audit_logs (org_id, user_id, action, entity_type, entity_id, old_data, new_data, metadata)
   VALUES (
     v_org, auth.uid(), 'rbac.user_roles.replace', 'user', v_user::text,
-    v_old, to_jsonb(v_role_ids),
+    v_old, v_new,
     jsonb_build_object(
       'migration', 174,
       'role_count', COALESCE(array_length(v_role_ids, 1), 0),
-      'expires_at', v_expires,
+      'payload_default_expires_at', v_expires,
       'sensitive_keys_granted', to_jsonb(v_sensitive),
       'self_assignment', v_user = auth.uid())
   );
@@ -556,8 +610,10 @@ AS $function$
 DECLARE
   v_org     uuid := NULLIF(p_payload->>'org_id','')::uuid;
   v_role_id uuid := NULLIF(p_payload->>'role_id','')::uuid;
-  v_old     jsonb;
-  v_users   int;
+  v_old       jsonb;
+  v_users     int;
+  v_old_keys  jsonb := '[]'::jsonb;
+  v_sensitive text[];
 BEGIN
   IF v_org IS NULL OR v_role_id IS NULL THEN
     RAISE EXCEPTION 'RBAC_174_ORG_AND_ROLE_REQUIRED';
@@ -584,12 +640,32 @@ BEGIN
     RAISE EXCEPTION 'RBAC_174_ROLE_STILL_ASSIGNED: % user(s)', v_users;
   END IF;
 
+  -- Record what is being destroyed, before destroying it. A delete row that
+  -- names the role but not its permissions cannot answer "did this role carry
+  -- a sensitive key at the moment it was removed?" — which is precisely the
+  -- question an audit of sensitive access has to answer.
+  SELECT COALESCE(jsonb_agg(p.permission_key ORDER BY p.permission_key), '[]'::jsonb)
+    INTO v_old_keys
+  FROM public.role_permissions rp
+  JOIN public.permissions p ON p.id = rp.permission_id
+  WHERE rp.role_id = v_role_id;
+
+  SELECT COALESCE(array_agg(k ORDER BY k), ARRAY[]::text[]) INTO v_sensitive
+  FROM jsonb_array_elements_text(v_old_keys) AS t(k)
+  WHERE public.wardah_is_sensitive_permission(k);
+
   DELETE FROM public.role_permissions WHERE role_id = v_role_id;
   DELETE FROM public.roles WHERE id = v_role_id AND org_id = v_org;
 
   INSERT INTO public.audit_logs (org_id, user_id, action, entity_type, entity_id, old_data, new_data, metadata)
   VALUES (v_org, auth.uid(), 'rbac.role.delete', 'role', v_role_id::text,
-          v_old, NULL, jsonb_build_object('migration', 174));
+          jsonb_build_object('role', v_old, 'permission_keys', v_old_keys),
+          NULL,
+          jsonb_build_object(
+            'migration', 174,
+            'permission_count', jsonb_array_length(v_old_keys),
+            'sensitive_keys_removed', to_jsonb(v_sensitive),
+            'removed_sensitive', COALESCE(array_length(v_sensitive, 1), 0) > 0));
 
   RETURN jsonb_build_object('role_id', v_role_id, 'deleted', true);
 END;

--- a/sql/migrations/174_sensitive_permission_class_and_rbac_rpcs.sql
+++ b/sql/migrations/174_sensitive_permission_class_and_rbac_rpcs.sql
@@ -1,0 +1,741 @@
+-- =====================================================================
+-- 174_sensitive_permission_class_and_rbac_rpcs
+-- =====================================================================
+-- Closes Issue #93: the org-admin override branch of both permission
+-- functions never reads p_permission_key at all, so any active org admin
+-- passes EVERY key, including the accounting controls that exist
+-- precisely to be exceptional. Verified live on 2026-08-09 before this
+-- migration was written: the single active org admin held
+-- accounting.vouchers.unpost and accounting.vouchers.cancel purely
+-- through that override — via_super_admin = false, via_explicit_grant =
+-- false, and both keys granted to zero roles.
+--
+-- The approved contract (see docs/db/SENSITIVE_PERMISSIONS_174_RUNBOOK.md):
+--
+--   * Platform super admin  -> keeps the full override, including
+--                              sensitive keys (emergency access).
+--   * Org admin             -> keeps the override for every ordinary key,
+--                              including user and role administration,
+--                              but NOT for sensitive keys.
+--   * Sensitive key         -> requires an explicit grant through an
+--                              active, unexpired role in that org. An org
+--                              admin may create such a role and assign it,
+--                              including to themselves — authority becomes
+--                              an explicit, audited decision instead of a
+--                              silent override.
+--
+-- The sensitive set is defined by ONE central classifier,
+-- wardah_is_sensitive_permission(text), called by both permission
+-- functions. Deliberately a function and not a table: widening the
+-- sensitive set must go through a migration, code review and tests, never
+-- a silent data edit. It is IMMUTABLE and STRICT, so every caller wraps it
+-- in COALESCE(..., false) — a NULL key must not be treated as sensitive
+-- (it is simply not a real permission, and the ordinary-role branch will
+-- fail to match it anyway).
+--
+-- Sensitive keys in this migration, exactly two:
+--   accounting.vouchers.unpost
+--   accounting.vouchers.cancel
+--
+-- accounting.vouchers.reverse is NOT included: it does not exist in the
+-- live permissions table and has no reference anywhere in the repository.
+-- It is not added speculatively. reports.ai_insights.use is deliberately
+-- ordinary, not sensitive.
+--
+-- Preserved unchanged from the 170-173 chain (all five layers, in both
+-- functions, re-asserted by the postflight block at the end):
+--   170  caller-identity guard on has_permission
+--   172  exact permission_key equality, no LIKE fallback
+--   173  granting role must be active
+--   pre  role expiry (expires_at) and org scoping
+--
+-- NOT changed here, deliberately:
+--   * No auth.uid() identity guard is added to
+--     wardah_has_exact_permission. It is internal (EXECUTE is postgres
+--     only — not authenticated, not anon, not service_role), its four
+--     callers pass an actor resolved inside the RPC, and adding the guard
+--     now risks breaking them for no reachable gain. Its execute boundary
+--     is re-asserted in the postflight instead.
+--   * Direct INSERT/UPDATE/DELETE on roles, role_permissions and
+--     user_roles is NOT revoked from `authenticated` in this migration.
+--     The live role-management UI still writes those tables directly;
+--     revoking here would break it in the window between applying this
+--     migration and deploying the dependent UI. This mirrors the
+--     163/167 -> 169 sequence already established in this repository:
+--     ship the atomic RPCs first, move the UI onto them, then close the
+--     direct-write surface in its own follow-up migration (175).
+-- =====================================================================
+
+BEGIN;
+
+SET LOCAL lock_timeout = '30s';
+SET LOCAL statement_timeout = '5min';
+
+-- ---------------------------------------------------------------------------
+-- Preflight: fail closed if the schema has drifted from what this migration
+-- assumes, before touching anything.
+-- ---------------------------------------------------------------------------
+DO $preflight$
+BEGIN
+  IF to_regprocedure('public.has_permission(uuid,uuid,character varying)') IS NULL THEN
+    RAISE EXCEPTION 'PERMISSION_174_HAS_PERMISSION_MISSING';
+  END IF;
+  IF to_regprocedure('public.wardah_has_exact_permission(uuid,uuid,text)') IS NULL THEN
+    RAISE EXCEPTION 'PERMISSION_174_EXACT_HELPER_MISSING';
+  END IF;
+  IF to_regprocedure('public.wardah_assert_org_admin(uuid)') IS NULL
+     OR to_regprocedure('public.wardah_assert_org_member(uuid)') IS NULL THEN
+    RAISE EXCEPTION 'PERMISSION_174_ORG_GUARD_MISSING';
+  END IF;
+
+  IF to_regclass('public.roles') IS NULL
+     OR to_regclass('public.role_permissions') IS NULL
+     OR to_regclass('public.user_roles') IS NULL
+     OR to_regclass('public.permissions') IS NULL
+     OR to_regclass('public.user_organizations') IS NULL
+     OR to_regclass('public.super_admins') IS NULL
+     OR to_regclass('public.audit_logs') IS NULL THEN
+    RAISE EXCEPTION 'PERMISSION_174_REQUIRED_TABLE_MISSING';
+  END IF;
+
+  -- The two sensitive keys must already exist. If a future environment
+  -- renames them, this migration must be revisited rather than silently
+  -- classifying nothing.
+  IF (SELECT count(*) FROM public.permissions
+       WHERE permission_key IN ('accounting.vouchers.unpost',
+                                'accounting.vouchers.cancel')) <> 2 THEN
+    RAISE EXCEPTION 'PERMISSION_174_SENSITIVE_KEYS_NOT_FOUND';
+  END IF;
+END
+$preflight$;
+
+-- ---------------------------------------------------------------------------
+-- 1. The central classifier.
+--
+-- IMMUTABLE + STRICT: a pure function of its argument, with no table access,
+-- so it can be inlined and is safe to call inside other STABLE functions.
+-- STRICT means NULL in -> NULL out; every call site wraps it in COALESCE.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.wardah_is_sensitive_permission(p_permission_key text)
+RETURNS boolean
+LANGUAGE sql
+IMMUTABLE
+STRICT
+AS $function$
+  SELECT p_permission_key IN (
+    'accounting.vouchers.unpost',
+    'accounting.vouchers.cancel'
+  );
+$function$;
+
+COMMENT ON FUNCTION public.wardah_is_sensitive_permission(text) IS
+  'Issue #93 / Migration 174. Single source of truth for which permission keys '
+  'the org-admin override must NOT satisfy. Widening this set requires a new '
+  'migration, code review and acceptance tests — never a data edit. '
+  'STRICT: NULL in, NULL out; callers must COALESCE(..., false).';
+
+REVOKE ALL ON FUNCTION public.wardah_is_sensitive_permission(text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.wardah_is_sensitive_permission(text) TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 2. has_permission: org-admin override no longer covers sensitive keys.
+--
+-- Every other layer is reproduced verbatim from the 170/172/173 chain. This
+-- function is the union of four migrations now, not the last one — see
+-- docs/db/PERMISSION_HARDENING_170_173_CHAIN.md.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.has_permission(
+  p_user_id uuid,
+  p_org_id uuid,
+  p_permission_key character varying
+)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_has_permission BOOLEAN;
+    v_sensitive      BOOLEAN;
+BEGIN
+    -- (170) A caller may only ask about themselves.
+    IF p_user_id IS DISTINCT FROM auth.uid() THEN
+        RETURN false;
+    END IF;
+
+    -- (174) Central classification. STRICT function: COALESCE is required.
+    v_sensitive := COALESCE(
+        public.wardah_is_sensitive_permission(p_permission_key::text), false);
+
+    -- Super Admin: كل الصلاحيات، بما فيها الحساسة (تجاوز الطوارئ).
+    IF EXISTS (
+        SELECT 1 FROM super_admins
+        WHERE user_id = p_user_id AND is_active = true
+    ) THEN
+        RETURN true;
+    END IF;
+
+    -- Org Admin: كل الصلاحيات العادية في منظمته — ولا يشمل التجاوز
+    -- الصلاحيات الحساسة (174)، فهذه تحتاج منحًا صريحًا عبر دور نشط.
+    IF NOT v_sensitive AND EXISTS (
+        SELECT 1 FROM user_organizations
+        WHERE user_id = p_user_id
+        AND org_id = p_org_id
+        AND is_active = true
+        AND is_org_admin = true
+    ) THEN
+        RETURN true;
+    END IF;
+
+    -- التحقق من الصلاحيات العادية: مطابقة تامة لمفتاح الصلاحية (172)، عبر
+    -- دور نشط فقط (173) — تعطيل الدور يسحب صلاحياته فورًا من كل من يحمله.
+    -- هذا هو المسار الوحيد المتبقي للصلاحيات الحساسة لغير المسؤول المنصّي.
+    SELECT EXISTS (
+        SELECT 1
+        FROM user_roles ur
+        INNER JOIN roles r ON r.id = ur.role_id
+            AND r.org_id = p_org_id
+            AND COALESCE(r.is_active, true)
+        INNER JOIN role_permissions rp ON ur.role_id = rp.role_id
+        INNER JOIN permissions p ON rp.permission_id = p.id
+        WHERE ur.user_id = p_user_id
+        AND ur.org_id = p_org_id
+        AND p.permission_key = p_permission_key
+        AND (ur.expires_at IS NULL OR ur.expires_at > NOW())
+    ) INTO v_has_permission;
+
+    RETURN COALESCE(v_has_permission, false);
+END;
+$function$;
+
+-- ---------------------------------------------------------------------------
+-- 3. wardah_has_exact_permission: the same narrowing, so the two functions
+--    cannot drift. This is the helper the voucher unpost/cancel RPCs call.
+--
+--    Execute boundary unchanged (postgres only) and no identity guard added
+--    — see the header note.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.wardah_has_exact_permission(
+  p_user_id uuid,
+  p_org_id uuid,
+  p_permission_key text
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+  SELECT
+    -- Platform super admin keeps the full override.
+    EXISTS (
+      SELECT 1
+      FROM public.super_admins sa
+      WHERE sa.user_id = p_user_id
+        AND sa.is_active = true
+    )
+    -- Org admin override, ordinary keys only (174).
+    OR (
+      NOT COALESCE(public.wardah_is_sensitive_permission(p_permission_key), false)
+      AND EXISTS (
+        SELECT 1
+        FROM public.user_organizations uo
+        WHERE uo.user_id = p_user_id
+          AND uo.org_id = p_org_id
+          AND uo.is_active = true
+          AND uo.is_org_admin = true
+      )
+    )
+    -- Explicit grant through an active, unexpired, org-scoped role.
+    OR EXISTS (
+      SELECT 1
+      FROM public.user_roles ur
+      JOIN public.roles r
+        ON r.id = ur.role_id
+       AND r.org_id = p_org_id
+       AND coalesce(r.is_active, true)
+      JOIN public.role_permissions rp ON rp.role_id = ur.role_id
+      JOIN public.permissions p ON p.id = rp.permission_id
+      WHERE ur.user_id = p_user_id
+        AND ur.org_id = p_org_id
+        AND p.permission_key = p_permission_key
+        AND (ur.expires_at IS NULL OR ur.expires_at > now())
+    );
+$function$;
+
+-- Re-assert the postgres-only execute boundary immediately after the
+-- definition. Replacing a function in place preserves its existing grants, so
+-- this is belt-and-braces — and it keeps the boundary visible next to the
+-- function it protects rather than only in the grants section below.
+REVOKE ALL ON FUNCTION public.wardah_has_exact_permission(uuid,uuid,text) FROM PUBLIC, anon, authenticated, service_role;
+
+-- ---------------------------------------------------------------------------
+-- 4. Atomic RBAC control plane.
+--
+-- The existing UI performs role and assignment edits as separate DELETE and
+-- INSERT round-trips with unchecked errors, which can leave a role with no
+-- permissions or a user with no roles when the second call fails. These RPCs
+-- replace that with one transactional statement each, org-scoped, guarded by
+-- wardah_assert_org_admin, and written to audit_logs.
+-- ---------------------------------------------------------------------------
+
+-- 4.1 Create or update a role together with its complete permission set.
+CREATE OR REPLACE FUNCTION public.rpc_upsert_org_role(p_payload jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_org         uuid := NULLIF(p_payload->>'org_id','')::uuid;
+  v_role_id     uuid := NULLIF(p_payload->>'role_id','')::uuid;
+  v_name        text := btrim(COALESCE(p_payload->>'name',''));
+  v_name_ar     text := NULLIF(btrim(COALESCE(p_payload->>'name_ar','')),'');
+  v_description text := NULLIF(btrim(COALESCE(p_payload->>'description','')),'');
+  v_is_active   boolean := COALESCE((p_payload->>'is_active')::boolean, true);
+  v_keys        text[];
+  v_missing     text[];
+  v_old         jsonb;
+  v_created     boolean := false;
+  v_sensitive   text[];
+BEGIN
+  IF v_org IS NULL THEN
+    RAISE EXCEPTION 'RBAC_174_ORG_REQUIRED';
+  END IF;
+  PERFORM public.wardah_assert_org_admin(v_org);
+
+  IF v_name = '' THEN
+    RAISE EXCEPTION 'RBAC_174_ROLE_NAME_REQUIRED';
+  END IF;
+
+  -- Permission keys are optional (a role may legitimately have none yet) but
+  -- must all exist when supplied — an unknown key is a client bug, not a
+  -- silently-dropped grant.
+  SELECT COALESCE(array_agg(DISTINCT k), ARRAY[]::text[])
+    INTO v_keys
+  FROM jsonb_array_elements_text(COALESCE(p_payload->'permission_keys','[]'::jsonb)) AS t(k);
+
+  SELECT COALESCE(array_agg(k), ARRAY[]::text[]) INTO v_missing
+  FROM unnest(v_keys) AS k
+  WHERE NOT EXISTS (SELECT 1 FROM public.permissions p WHERE p.permission_key = k);
+
+  IF array_length(v_missing, 1) IS NOT NULL THEN
+    RAISE EXCEPTION 'RBAC_174_UNKNOWN_PERMISSION_KEY: %', array_to_string(v_missing, ', ');
+  END IF;
+
+  IF v_role_id IS NULL THEN
+    -- Create. Name must be unique within the organization.
+    IF EXISTS (
+      SELECT 1 FROM public.roles r
+      WHERE r.org_id = v_org AND lower(r.name) = lower(v_name)
+    ) THEN
+      RAISE EXCEPTION 'RBAC_174_ROLE_NAME_TAKEN';
+    END IF;
+
+    -- roles.name_ar is NOT NULL in this schema with no default; fall back to
+    -- the Latin name rather than failing on a client that omits it.
+    INSERT INTO public.roles (org_id, name, name_ar, description, is_active, is_system_role, created_by)
+    VALUES (v_org, v_name, COALESCE(v_name_ar, v_name), v_description, v_is_active, false, auth.uid())
+    RETURNING id INTO v_role_id;
+
+    v_created := true;
+  ELSE
+    -- Update. Lock the row so two concurrent editors cannot interleave.
+    SELECT to_jsonb(r) INTO v_old
+    FROM public.roles r
+    WHERE r.id = v_role_id AND r.org_id = v_org
+    FOR UPDATE;
+
+    IF v_old IS NULL THEN
+      RAISE EXCEPTION 'RBAC_174_ROLE_NOT_FOUND_IN_ORG';
+    END IF;
+    IF COALESCE((v_old->>'is_system_role')::boolean, false) THEN
+      RAISE EXCEPTION 'RBAC_174_SYSTEM_ROLE_IMMUTABLE';
+    END IF;
+    IF EXISTS (
+      SELECT 1 FROM public.roles r
+      WHERE r.org_id = v_org AND lower(r.name) = lower(v_name) AND r.id <> v_role_id
+    ) THEN
+      RAISE EXCEPTION 'RBAC_174_ROLE_NAME_TAKEN';
+    END IF;
+
+    UPDATE public.roles
+       SET name = v_name,
+           name_ar = COALESCE(v_name_ar, v_name),
+           description = v_description,
+           is_active = v_is_active,
+           updated_at = now()
+     WHERE id = v_role_id AND org_id = v_org;
+  END IF;
+
+  -- Replace the permission set atomically: both statements are in the same
+  -- transaction as the role row itself, so a failure leaves neither applied.
+  DELETE FROM public.role_permissions WHERE role_id = v_role_id;
+
+  IF array_length(v_keys, 1) IS NOT NULL THEN
+    INSERT INTO public.role_permissions (role_id, permission_id, created_by)
+    SELECT v_role_id, p.id, auth.uid()
+    FROM public.permissions p
+    WHERE p.permission_key = ANY (v_keys);
+  END IF;
+
+  SELECT COALESCE(array_agg(k), ARRAY[]::text[]) INTO v_sensitive
+  FROM unnest(v_keys) AS k
+  WHERE public.wardah_is_sensitive_permission(k);
+
+  INSERT INTO public.audit_logs (org_id, user_id, action, entity_type, entity_id, old_data, new_data, metadata)
+  VALUES (
+    v_org, auth.uid(),
+    CASE WHEN v_created THEN 'rbac.role.create' ELSE 'rbac.role.update' END,
+    'role', v_role_id::text, v_old,
+    jsonb_build_object('name', v_name, 'is_active', v_is_active, 'permission_keys', to_jsonb(v_keys)),
+    jsonb_build_object(
+      'migration', 174,
+      'permission_count', COALESCE(array_length(v_keys, 1), 0),
+      'sensitive_keys', to_jsonb(v_sensitive),
+      'grants_sensitive', COALESCE(array_length(v_sensitive, 1), 0) > 0)
+  );
+
+  RETURN jsonb_build_object(
+    'role_id', v_role_id,
+    'created', v_created,
+    'permission_count', COALESCE(array_length(v_keys, 1), 0),
+    'sensitive_keys', to_jsonb(v_sensitive));
+END;
+$function$;
+
+-- 4.2 Replace a user's complete role set for one organization.
+CREATE OR REPLACE FUNCTION public.rpc_replace_user_roles(p_payload jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_org       uuid := NULLIF(p_payload->>'org_id','')::uuid;
+  v_user      uuid := NULLIF(p_payload->>'user_id','')::uuid;
+  v_expires   timestamptz := NULLIF(p_payload->>'expires_at','')::timestamptz;
+  v_role_ids  uuid[];
+  v_bad       int;
+  v_old       jsonb;
+  v_sensitive text[];
+BEGIN
+  IF v_org IS NULL OR v_user IS NULL THEN
+    RAISE EXCEPTION 'RBAC_174_ORG_AND_USER_REQUIRED';
+  END IF;
+  PERFORM public.wardah_assert_org_admin(v_org);
+
+  -- The target must be a member of this organization; role assignment must
+  -- never be a way to reach across tenants.
+  IF NOT EXISTS (
+    SELECT 1 FROM public.user_organizations uo
+    WHERE uo.user_id = v_user AND uo.org_id = v_org AND uo.is_active IS TRUE
+  ) THEN
+    RAISE EXCEPTION 'RBAC_174_TARGET_NOT_ACTIVE_ORG_MEMBER';
+  END IF;
+
+  SELECT COALESCE(array_agg(DISTINCT rid::uuid), ARRAY[]::uuid[])
+    INTO v_role_ids
+  FROM jsonb_array_elements_text(COALESCE(p_payload->'role_ids','[]'::jsonb)) AS t(rid);
+
+  -- Every role must belong to this organization.
+  SELECT count(*) INTO v_bad
+  FROM unnest(v_role_ids) AS rid
+  WHERE NOT EXISTS (
+    SELECT 1 FROM public.roles r WHERE r.id = rid AND r.org_id = v_org
+  );
+  IF v_bad > 0 THEN
+    RAISE EXCEPTION 'RBAC_174_ROLE_NOT_IN_ORG';
+  END IF;
+
+  SELECT COALESCE(jsonb_agg(ur.role_id), '[]'::jsonb) INTO v_old
+  FROM public.user_roles ur
+  WHERE ur.user_id = v_user AND ur.org_id = v_org;
+
+  DELETE FROM public.user_roles WHERE user_id = v_user AND org_id = v_org;
+
+  IF array_length(v_role_ids, 1) IS NOT NULL THEN
+    INSERT INTO public.user_roles (user_id, role_id, org_id, assigned_by, expires_at)
+    SELECT v_user, rid, v_org, auth.uid(), v_expires
+    FROM unnest(v_role_ids) AS rid;
+  END IF;
+
+  SELECT COALESCE(array_agg(DISTINCT p.permission_key), ARRAY[]::text[])
+    INTO v_sensitive
+  FROM public.role_permissions rp
+  JOIN public.permissions p ON p.id = rp.permission_id
+  WHERE rp.role_id = ANY (v_role_ids)
+    AND public.wardah_is_sensitive_permission(p.permission_key);
+
+  INSERT INTO public.audit_logs (org_id, user_id, action, entity_type, entity_id, old_data, new_data, metadata)
+  VALUES (
+    v_org, auth.uid(), 'rbac.user_roles.replace', 'user', v_user::text,
+    v_old, to_jsonb(v_role_ids),
+    jsonb_build_object(
+      'migration', 174,
+      'role_count', COALESCE(array_length(v_role_ids, 1), 0),
+      'expires_at', v_expires,
+      'sensitive_keys_granted', to_jsonb(v_sensitive),
+      'self_assignment', v_user = auth.uid())
+  );
+
+  RETURN jsonb_build_object(
+    'user_id', v_user,
+    'role_count', COALESCE(array_length(v_role_ids, 1), 0),
+    'sensitive_keys_granted', to_jsonb(v_sensitive));
+END;
+$function$;
+
+-- 4.3 Delete a role, refusing anything that would silently strip access.
+CREATE OR REPLACE FUNCTION public.rpc_delete_org_role(p_payload jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_org     uuid := NULLIF(p_payload->>'org_id','')::uuid;
+  v_role_id uuid := NULLIF(p_payload->>'role_id','')::uuid;
+  v_old     jsonb;
+  v_users   int;
+BEGIN
+  IF v_org IS NULL OR v_role_id IS NULL THEN
+    RAISE EXCEPTION 'RBAC_174_ORG_AND_ROLE_REQUIRED';
+  END IF;
+  PERFORM public.wardah_assert_org_admin(v_org);
+
+  SELECT to_jsonb(r) INTO v_old
+  FROM public.roles r
+  WHERE r.id = v_role_id AND r.org_id = v_org
+  FOR UPDATE;
+
+  IF v_old IS NULL THEN
+    RAISE EXCEPTION 'RBAC_174_ROLE_NOT_FOUND_IN_ORG';
+  END IF;
+  IF COALESCE((v_old->>'is_system_role')::boolean, false) THEN
+    RAISE EXCEPTION 'RBAC_174_SYSTEM_ROLE_IMMUTABLE';
+  END IF;
+
+  -- Refuse while users still hold it. Revoking access is a separate,
+  -- deliberate act (rpc_replace_user_roles) and must be visible as one.
+  SELECT count(*) INTO v_users
+  FROM public.user_roles ur WHERE ur.role_id = v_role_id;
+  IF v_users > 0 THEN
+    RAISE EXCEPTION 'RBAC_174_ROLE_STILL_ASSIGNED: % user(s)', v_users;
+  END IF;
+
+  DELETE FROM public.role_permissions WHERE role_id = v_role_id;
+  DELETE FROM public.roles WHERE id = v_role_id AND org_id = v_org;
+
+  INSERT INTO public.audit_logs (org_id, user_id, action, entity_type, entity_id, old_data, new_data, metadata)
+  VALUES (v_org, auth.uid(), 'rbac.role.delete', 'role', v_role_id::text,
+          v_old, NULL, jsonb_build_object('migration', 174));
+
+  RETURN jsonb_build_object('role_id', v_role_id, 'deleted', true);
+END;
+$function$;
+
+-- 4.4 The permission snapshot: the single source of truth for the UI.
+--
+-- Returns exactly what the backend would decide, so the client can never
+-- reach a different conclusion by re-implementing the override locally.
+CREATE OR REPLACE FUNCTION public.rpc_permission_snapshot(p_org_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_uid           uuid := auth.uid();
+  v_is_super      boolean;
+  v_is_org_admin  boolean;
+  v_keys          text[];
+  v_sensitive_all text[];
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'NOT_AUTHENTICATED';
+  END IF;
+  IF p_org_id IS NULL THEN
+    RAISE EXCEPTION 'ORG_UNRESOLVED';
+  END IF;
+  -- Membership guard: a snapshot is only ever about the caller, in an org
+  -- the caller actually belongs to.
+  PERFORM public.wardah_assert_org_member(p_org_id);
+
+  SELECT EXISTS (SELECT 1 FROM public.super_admins sa
+                  WHERE sa.user_id = v_uid AND sa.is_active = true)
+    INTO v_is_super;
+
+  SELECT EXISTS (SELECT 1 FROM public.user_organizations uo
+                  WHERE uo.user_id = v_uid AND uo.org_id = p_org_id
+                    AND uo.is_active = true AND uo.is_org_admin = true)
+    INTO v_is_org_admin;
+
+  SELECT COALESCE(array_agg(p.permission_key ORDER BY p.permission_key), ARRAY[]::text[])
+    INTO v_sensitive_all
+  FROM public.permissions p
+  WHERE public.wardah_is_sensitive_permission(p.permission_key);
+
+  IF v_is_super THEN
+    -- Full override including sensitive keys.
+    SELECT COALESCE(array_agg(p.permission_key ORDER BY p.permission_key), ARRAY[]::text[])
+      INTO v_keys
+    FROM public.permissions p;
+  ELSE
+    SELECT COALESCE(array_agg(DISTINCT k ORDER BY k), ARRAY[]::text[]) INTO v_keys
+    FROM (
+      -- Ordinary keys via the org-admin override (never sensitive ones).
+      SELECT p.permission_key AS k
+      FROM public.permissions p
+      WHERE v_is_org_admin
+        AND NOT public.wardah_is_sensitive_permission(p.permission_key)
+      UNION
+      -- Explicit grants through an active, unexpired, org-scoped role.
+      SELECT p.permission_key
+      FROM public.user_roles ur
+      JOIN public.roles r ON r.id = ur.role_id
+        AND r.org_id = p_org_id AND COALESCE(r.is_active, true)
+      JOIN public.role_permissions rp ON rp.role_id = ur.role_id
+      JOIN public.permissions p ON p.id = rp.permission_id
+      WHERE ur.user_id = v_uid
+        AND ur.org_id = p_org_id
+        AND (ur.expires_at IS NULL OR ur.expires_at > now())
+    ) AS effective;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'user_id', v_uid,
+    'org_id', p_org_id,
+    'is_super_admin', v_is_super,
+    'is_org_admin', v_is_org_admin,
+    'permission_keys', to_jsonb(v_keys),
+    'sensitive_permission_keys', to_jsonb(v_sensitive_all),
+    'generated_at', now());
+END;
+$function$;
+
+-- ---------------------------------------------------------------------------
+-- 5. Grants. The RPCs are client-facing and re-check identity and membership
+--    internally; the classifier is read-only and harmless. Nothing here is
+--    reachable by anon, and service_role gets no client RPC surface.
+-- ---------------------------------------------------------------------------
+REVOKE ALL ON FUNCTION public.rpc_upsert_org_role(jsonb)      FROM PUBLIC, anon, service_role;
+REVOKE ALL ON FUNCTION public.rpc_replace_user_roles(jsonb)   FROM PUBLIC, anon, service_role;
+REVOKE ALL ON FUNCTION public.rpc_delete_org_role(jsonb)      FROM PUBLIC, anon, service_role;
+REVOKE ALL ON FUNCTION public.rpc_permission_snapshot(uuid)   FROM PUBLIC, anon, service_role;
+
+GRANT EXECUTE ON FUNCTION public.rpc_upsert_org_role(jsonb)    TO authenticated;
+GRANT EXECUTE ON FUNCTION public.rpc_replace_user_roles(jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.rpc_delete_org_role(jsonb)    TO authenticated;
+GRANT EXECUTE ON FUNCTION public.rpc_permission_snapshot(uuid) TO authenticated;
+
+-- (wardah_has_exact_permission keeps its postgres-only boundary — revoked
+--  immediately after its definition in section 3.)
+
+-- ---------------------------------------------------------------------------
+-- 6. Postflight: prove the new contract AND that nothing from 170-173 was
+--    lost, before COMMIT.
+-- ---------------------------------------------------------------------------
+DO $verify$
+DECLARE
+  v_hp  text;
+  v_ex  text;
+  v_fn  text;
+BEGIN
+  SELECT prosrc INTO v_hp FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+   WHERE n.nspname = 'public' AND p.proname = 'has_permission';
+  SELECT prosrc INTO v_ex FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+   WHERE n.nspname = 'public' AND p.proname = 'wardah_has_exact_permission';
+
+  -- The classifier exists, is IMMUTABLE and STRICT, and classifies exactly two keys.
+  IF to_regprocedure('public.wardah_is_sensitive_permission(text)') IS NULL THEN
+    RAISE EXCEPTION 'FAIL[174] classifier missing';
+  END IF;
+  SELECT CASE WHEN p.provolatile = 'i' THEN 'ok' ELSE 'not-immutable' END INTO v_fn
+    FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+   WHERE n.nspname = 'public' AND p.proname = 'wardah_is_sensitive_permission';
+  IF v_fn <> 'ok' THEN
+    RAISE EXCEPTION 'FAIL[174] classifier is not IMMUTABLE';
+  END IF;
+  IF NOT (SELECT proisstrict FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+           WHERE n.nspname = 'public' AND p.proname = 'wardah_is_sensitive_permission') THEN
+    RAISE EXCEPTION 'FAIL[174] classifier is not STRICT';
+  END IF;
+  IF NOT public.wardah_is_sensitive_permission('accounting.vouchers.unpost')
+     OR NOT public.wardah_is_sensitive_permission('accounting.vouchers.cancel') THEN
+    RAISE EXCEPTION 'FAIL[174] classifier does not cover both sensitive keys';
+  END IF;
+  IF public.wardah_is_sensitive_permission('reports.ai_insights.use')
+     OR public.wardah_is_sensitive_permission('accounting.entries.approve') THEN
+    RAISE EXCEPTION 'FAIL[174] classifier over-classifies an ordinary key';
+  END IF;
+  IF (SELECT count(*) FROM public.permissions p
+       WHERE public.wardah_is_sensitive_permission(p.permission_key)) <> 2 THEN
+    RAISE EXCEPTION 'FAIL[174] sensitive set is not exactly two live permission rows';
+  END IF;
+
+  -- Both functions consult the classifier, and both still carry every
+  -- guarantee from the 170-173 chain.
+  IF v_hp !~ 'wardah_is_sensitive_permission' THEN
+    RAISE EXCEPTION 'FAIL[174] has_permission does not consult the classifier';
+  END IF;
+  IF v_ex !~ 'wardah_is_sensitive_permission' THEN
+    RAISE EXCEPTION 'FAIL[174] wardah_has_exact_permission does not consult the classifier';
+  END IF;
+
+  IF v_hp !~ 'p_user_id IS DISTINCT FROM auth\.uid\(\)' THEN
+    RAISE EXCEPTION 'FAIL[174] has_permission lost the caller-identity guard (170)';
+  END IF;
+  IF v_hp ~ 'LIKE' OR v_ex ~ 'LIKE' THEN
+    RAISE EXCEPTION 'FAIL[174] a LIKE-based same-module match reappeared (172)';
+  END IF;
+  IF v_hp !~ 'p\.permission_key\s*=\s*p_permission_key'
+     OR v_ex !~ 'p\.permission_key\s*=\s*p_permission_key' THEN
+    RAISE EXCEPTION 'FAIL[174] exact permission_key equality lost (172)';
+  END IF;
+  IF v_hp !~ 'COALESCE\(r\.is_active, true\)' OR v_ex !~ 'coalesce\(r\.is_active, true\)' THEN
+    RAISE EXCEPTION 'FAIL[174] active-role requirement lost (173)';
+  END IF;
+  IF v_hp !~ 'expires_at' OR v_ex !~ 'expires_at' THEN
+    RAISE EXCEPTION 'FAIL[174] role-expiry enforcement lost';
+  END IF;
+  IF v_hp !~ 'ur\.org_id = p_org_id' OR v_ex !~ 'ur\.org_id = p_org_id' THEN
+    RAISE EXCEPTION 'FAIL[174] org scoping lost';
+  END IF;
+  IF v_hp !~ 'super_admins' OR v_ex !~ 'super_admins' THEN
+    RAISE EXCEPTION 'FAIL[174] super-admin override lost';
+  END IF;
+  IF v_hp !~ 'is_org_admin' OR v_ex !~ 'is_org_admin' THEN
+    RAISE EXCEPTION 'FAIL[174] org-admin override removed entirely (ordinary keys must keep it)';
+  END IF;
+
+  -- Execute boundaries.
+  IF has_function_privilege('anon', 'public.has_permission(uuid,uuid,character varying)', 'EXECUTE')
+     OR NOT has_function_privilege('authenticated', 'public.has_permission(uuid,uuid,character varying)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'FAIL[174] has_permission execute boundary drifted';
+  END IF;
+  IF has_function_privilege('authenticated', 'public.wardah_has_exact_permission(uuid,uuid,text)', 'EXECUTE')
+     OR has_function_privilege('anon', 'public.wardah_has_exact_permission(uuid,uuid,text)', 'EXECUTE')
+     OR has_function_privilege('service_role', 'public.wardah_has_exact_permission(uuid,uuid,text)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'FAIL[174] wardah_has_exact_permission escaped its postgres-only boundary';
+  END IF;
+  IF NOT has_function_privilege('authenticated', 'public.rpc_upsert_org_role(jsonb)', 'EXECUTE')
+     OR NOT has_function_privilege('authenticated', 'public.rpc_replace_user_roles(jsonb)', 'EXECUTE')
+     OR NOT has_function_privilege('authenticated', 'public.rpc_delete_org_role(jsonb)', 'EXECUTE')
+     OR NOT has_function_privilege('authenticated', 'public.rpc_permission_snapshot(uuid)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'FAIL[174] an RBAC RPC is not executable by authenticated';
+  END IF;
+  IF has_function_privilege('anon', 'public.rpc_upsert_org_role(jsonb)', 'EXECUTE')
+     OR has_function_privilege('anon', 'public.rpc_replace_user_roles(jsonb)', 'EXECUTE')
+     OR has_function_privilege('anon', 'public.rpc_delete_org_role(jsonb)', 'EXECUTE')
+     OR has_function_privilege('anon', 'public.rpc_permission_snapshot(uuid)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'FAIL[174] an RBAC RPC is reachable by anon';
+  END IF;
+
+  RAISE NOTICE 'PASS[174] sensitive-permission class active; org-admin override narrowed; 170-173 guarantees intact';
+END
+$verify$;
+
+COMMIT;

--- a/sql/migrations/174_sensitive_permission_class_and_rbac_rpcs.sql
+++ b/sql/migrations/174_sensitive_permission_class_and_rbac_rpcs.sql
@@ -420,6 +420,8 @@ DECLARE
   v_bad       int;
   v_old       jsonb;
   v_sensitive text[];
+  v_existing_expiry jsonb;
+  v_requested jsonb;
 BEGIN
   IF v_org IS NULL OR v_user IS NULL THEN
     RAISE EXCEPTION 'RBAC_174_ORG_AND_USER_REQUIRED';
@@ -431,13 +433,48 @@ BEGIN
   IF NOT EXISTS (
     SELECT 1 FROM public.user_organizations uo
     WHERE uo.user_id = v_user AND uo.org_id = v_org AND uo.is_active IS TRUE
+    FOR UPDATE
   ) THEN
     RAISE EXCEPTION 'RBAC_174_TARGET_NOT_ACTIVE_ORG_MEMBER';
   END IF;
 
-  SELECT COALESCE(array_agg(DISTINCT rid::uuid), ARRAY[]::uuid[])
+  -- The `FOR UPDATE` above is not only a membership check: it takes a
+  -- transaction-scoped lock on the membership row, which is the stable parent
+  -- of this user's assignments in this org. Without it, two administrators
+  -- replacing the same user's roles concurrently can each delete a set the
+  -- other has not yet inserted and both commit, leaving the union of the two
+  -- requests rather than either one. Serializing on the membership row makes
+  -- "replace" actually mean replace.
+
+  -- Requested roles. Two accepted shapes, so a caller can express per-role
+  -- expiry without a second round-trip:
+  --   ["<role_id>", ...]
+  --   [{"role_id": "...", "expires_at": "..."}, ...]   (expires_at may be null)
+  -- Normalized in a local jsonb value rather than a temp table: an unqualified
+  -- temp-table name inside a SECURITY DEFINER function whose search_path puts
+  -- `public` first could be shadowed by a same-named table in public.
+  SELECT COALESCE(jsonb_agg(jsonb_build_object(
+           'role_id', rid, 'has_explicit', has_exp, 'expires_at', exp)), '[]'::jsonb)
+    INTO v_requested
+  FROM (
+    SELECT DISTINCT ON (rid) rid, has_exp, exp
+    FROM (
+      SELECT
+        CASE WHEN jsonb_typeof(elem) = 'object'
+             THEN NULLIF(elem->>'role_id','')::uuid
+             ELSE NULLIF(elem #>> '{}','')::uuid END AS rid,
+        CASE WHEN jsonb_typeof(elem) = 'object' AND elem ? 'expires_at'
+             THEN NULLIF(elem->>'expires_at','')::timestamptz END AS exp,
+        (jsonb_typeof(elem) = 'object' AND elem ? 'expires_at') AS has_exp
+      FROM jsonb_array_elements(COALESCE(p_payload->'role_ids','[]'::jsonb)) AS t(elem)
+    ) raw
+    WHERE rid IS NOT NULL
+    ORDER BY rid
+  ) s;
+
+  SELECT COALESCE(array_agg((elem->>'role_id')::uuid), ARRAY[]::uuid[])
     INTO v_role_ids
-  FROM jsonb_array_elements_text(COALESCE(p_payload->'role_ids','[]'::jsonb)) AS t(rid);
+  FROM jsonb_array_elements(v_requested) AS t(elem);
 
   -- Every role must belong to this organization.
   SELECT count(*) INTO v_bad
@@ -453,13 +490,35 @@ BEGIN
   FROM public.user_roles ur
   WHERE ur.user_id = v_user AND ur.org_id = v_org;
 
+  -- Capture the expiry of each CURRENT assignment before deleting, so a
+  -- retained role keeps its own deadline. Replacing the whole set is a
+  -- statement about WHICH roles are held, not a licence to quietly extend a
+  -- time-boxed one to permanent — which is exactly what a single payload-level
+  -- expires_at applied to every row would do when the caller omits it.
+  SELECT COALESCE(jsonb_object_agg(role_id::text, to_jsonb(expires_at)), '{}'::jsonb)
+    INTO v_existing_expiry
+  FROM (
+    SELECT ur.role_id, max(ur.expires_at) AS expires_at
+    FROM public.user_roles ur
+    WHERE ur.user_id = v_user AND ur.org_id = v_org
+    GROUP BY ur.role_id
+  ) cur;
+
   DELETE FROM public.user_roles WHERE user_id = v_user AND org_id = v_org;
 
-  IF array_length(v_role_ids, 1) IS NOT NULL THEN
-    INSERT INTO public.user_roles (user_id, role_id, org_id, assigned_by, expires_at)
-    SELECT v_user, rid, v_org, auth.uid(), v_expires
-    FROM unnest(v_role_ids) AS rid;
-  END IF;
+  INSERT INTO public.user_roles (user_id, role_id, org_id, assigned_by, expires_at)
+  SELECT v_user, (elem->>'role_id')::uuid, v_org, auth.uid(),
+         CASE
+           -- 1. An explicit per-role value always wins, including explicit null.
+           WHEN (elem->>'has_explicit')::boolean
+             THEN NULLIF(elem->>'expires_at','')::timestamptz
+           -- 2. A retained role keeps the deadline it already had.
+           WHEN v_existing_expiry ? (elem->>'role_id')
+             THEN (v_existing_expiry->>(elem->>'role_id'))::timestamptz
+           -- 3. Only genuinely new assignments take the payload-level default.
+           ELSE v_expires
+         END
+  FROM jsonb_array_elements(v_requested) AS t(elem);
 
   SELECT COALESCE(array_agg(DISTINCT p.permission_key), ARRAY[]::text[])
     INTO v_sensitive
@@ -560,13 +619,21 @@ BEGIN
   IF p_org_id IS NULL THEN
     RAISE EXCEPTION 'ORG_UNRESOLVED';
   END IF;
-  -- Membership guard: a snapshot is only ever about the caller, in an org
-  -- the caller actually belongs to.
-  PERFORM public.wardah_assert_org_member(p_org_id);
-
   SELECT EXISTS (SELECT 1 FROM public.super_admins sa
                   WHERE sa.user_id = v_uid AND sa.is_active = true)
     INTO v_is_super;
+
+  -- Membership guard: a snapshot is only ever about the caller, in an org the
+  -- caller belongs to — EXCEPT for a platform super admin, whose override in
+  -- has_permission() is deliberately independent of org membership. Asserting
+  -- membership first would make the snapshot contradict the very function it
+  -- exists to mirror, and would break the emergency-access path precisely when
+  -- it is needed: an incident responder who is not a member of the affected
+  -- organization. The super-admin check therefore runs first, and the guard
+  -- applies only to everyone else.
+  IF NOT v_is_super THEN
+    PERFORM public.wardah_assert_org_member(p_org_id);
+  END IF;
 
   SELECT EXISTS (SELECT 1 FROM public.user_organizations uo
                   WHERE uo.user_id = v_uid AND uo.org_id = p_org_id

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -11040,6 +11040,7 @@ export type Database = {
         Args: { p_payload: Json }
         Returns: Json
       }
+      rpc_delete_org_role: { Args: { p_payload: Json }; Returns: Json }
       rpc_generate_fiscal_periods: {
         Args: { p_tenant?: string; p_year: number }
         Returns: Json
@@ -11114,6 +11115,7 @@ export type Database = {
         Returns: Json
       }
       rpc_manual_stock_movement_v2: { Args: { p_payload: Json }; Returns: Json }
+      rpc_permission_snapshot: { Args: { p_org_id: string }; Returns: Json }
       rpc_post_customer_receipt: {
         Args: { p_receipt_id: string }
         Returns: Json
@@ -11152,6 +11154,7 @@ export type Database = {
         }
         Returns: string
       }
+      rpc_replace_user_roles: { Args: { p_payload: Json }; Returns: Json }
       rpc_reset_customer_receipt_to_draft: {
         Args: { p_reason: string; p_receipt_id: string }
         Returns: Json
@@ -11246,6 +11249,7 @@ export type Database = {
         }
         Returns: string
       }
+      rpc_upsert_org_role: { Args: { p_payload: Json }; Returns: Json }
       schedule_work_order: {
         Args: {
           p_schedule_id?: string
@@ -11678,6 +11682,10 @@ export type Database = {
       }
       wardah_is_org_admin: { Args: { p_org: string }; Returns: boolean }
       wardah_is_org_member: { Args: { p_org: string }; Returns: boolean }
+      wardah_is_sensitive_permission: {
+        Args: { p_permission_key: string }
+        Returns: boolean
+      }
       wardah_next_voucher_number: {
         Args: { p_kind: string; p_org: string }
         Returns: string


### PR DESCRIPTION
**Part of Issue #93 — the database half. This PR does not close the issue.** Closing #93 additionally requires the UI moved onto `rpc_permission_snapshot` and the atomic RBAC RPCs, and **Migration 175** to close the direct-write surface on `roles` / `role_permissions` / `user_roles`. Database-only PR — the dependent UI ships separately, per the repository's `DB-first` rule.

> [!IMPORTANT]
> **Do not apply this migration before running the operational transaction in the runbook §6.** With 0 active super admins, 0 role assignments, and both sensitive keys granted to 0 roles, applying first locks the organization out of unpost/cancel entirely. Assigning the existing `Full Access` role does **not** help — these two keys are among the three it lacks.

## 1. The verified problem

Read-only inventory of the live database on 2026-08-09, before any code was written:

| Fact | Value |
|---|---|
| Active super admins | **0** (table empty) |
| Active org admins | **1** |
| `user_roles` assignments | **0** |
| Keys granted to no role | exactly 3: `accounting.vouchers.unpost`, `accounting.vouchers.cancel`, `reports.ai_insights.use` |

Effective access of that single admin, computed per branch: both sensitive keys `via_org_admin_override = true`, `via_super_admin = false`, `via_explicit_grant = false`. The authority existed **solely** through the override.

`accounting.vouchers.reverse` does not exist — not in the live catalog, not anywhere in the repository. It was not invented.

## 2. Contract

| Principal | Ordinary keys | Sensitive keys |
|---|---|---|
| Platform super admin | ✅ override | ✅ override (emergency access) |
| Org admin | ✅ override, incl. user + role administration | ❌ **explicit grant required** |
| Any user | active, unexpired, org-scoped role | active, unexpired, org-scoped role |

An org admin may create the sensitive role and assign it, **including to themselves**. Authority is not removed — it is converted from a silent override into an explicit, audited decision.

## 3. Central classifier

```sql
public.wardah_is_sensitive_permission(text) RETURNS boolean  -- IMMUTABLE, STRICT
```

Exactly two keys: `accounting.vouchers.unpost`, `accounting.vouchers.cancel`. `reports.ai_insights.use` stays ordinary.

**A function, not a table, on purpose** — widening the sensitive set must pass through a migration, review and tests, never a silent data edit. Both permission functions call this one classifier, so the two cannot drift into separate lists.

## 4. Atomic RBAC control plane

| RPC | Behaviour |
|---|---|
| `rpc_upsert_org_role` | role + permission set in one transaction; rejects unknown keys, duplicate names, system roles; `FOR UPDATE` on the row |
| `rpc_replace_user_roles` | atomic replacement, membership row locked `FOR UPDATE`; rejects non-members, foreign roles, and repeated ids; per-role `expires_at`, with retained roles keeping their existing deadline |
| `rpc_delete_org_role` | refuses while users still hold the role, and refuses system roles |
| `rpc_permission_snapshot` | the caller's effective decision — the single source of truth for the UI |

Every mutation writes a **complete before/after snapshot** to `old_data`/`new_data` in the same shape on both sides, so they diff directly: outgoing *and* incoming permission sets plus `permissions_added`/`permissions_removed` on update; the destroyed set and `removed_sensitive` on delete; `{role_id, expires_at}` per role on assignment replacement, with the after-side read back from the rows actually written rather than reconstructed from the payload.

## 5. Deliberately **not** done here

- **No `auth.uid()` guard on `wardah_has_exact_permission`** — internal (`EXECUTE` is `postgres` only), its four callers pass an actor resolved inside the RPC. The postflight re-asserts the execute boundary instead.
- **Direct writes on `roles`/`role_permissions`/`user_roles` are not revoked from `authenticated`.** The live UI still writes them directly; revoking here breaks it between applying 174 and deploying the UI. Mirrors the repository's own `163/167 → 169` sequence — the closure is **Migration 175**.

## 6. Verification actually performed

Run locally on a real **PostgreSQL 17.10** cluster (baseline pair + full chain), not only in CI:

| Check | Result |
|---|---|
| baseline + chain through 174 | `PASS=13 FAIL=0 NOT_RUN=0 TOTAL=13` — 174's own `$verify$` ran inside it |
| `acceptance_174` | `SENSITIVE_PERMISSION_174_ACCEPTANCE_PASS` |
| `acceptance_172` / `acceptance_173` re-run on the 174 DB | both pass — no regression |
| **red proof** — chain through 173 only | ungranted org admin → `accounting.vouchers.unpost` = **`t`** |

The red proof is wired in as its own **failing workflow step**: if a pre-174 database ever stops reproducing the bypass, the job fails rather than reporting a green suite that proves nothing.

### Acceptance coverage

Eight scenarios (org admin with/without grant · super admin · disabled role · expired assignment · cross-org · identity guard · ordinary keys unaffected) against **both** functions, plus:

- `174-M1…M9` — each 166–173 guarantee re-asserted as its own named assertion, so a single-layer regression fails identifiably.
- `174-34…38` — per-role expiry honoured, a retained deadline preserved, explicit null still clears it; a deliberately **non-member** super admin still gets a snapshot.
- `174-39…41` — duplicate `role_id` rejected for both payload shapes, with `174-40` proving the rejected call left `user_roles` byte-identical.
- `174-42…49` — audit completeness: the outgoing set on update, the destroyed set and `removed_sensitive` on delete, per-role `expires_at` on both sides of an assignment replacement.

## 7. Mandatory Production order

1–4. Operational transaction creating **`Financial Controller`**, granting exactly the two keys, assigning it to the current admin, **and writing an `rbac.sensitive_bootstrap` audit row in the same transaction** — that grant runs before 174 exists, so no RPC would otherwise record the single most consequential authority change in the rollout.
4b. Prove `via_explicit_grant = true` for both keys. **If either is false, stop.**
5. Apply 174, run postflight.
6. Deploy the dependent UI.
7. Browser smoke: create · edit · assign · revoke · confirm cancel/unpost controls appear only with the sensitive role.

Full SQL for every step in `docs/db/SENSITIVE_PERMISSIONS_174_RUNBOOK.md`.

## 8. Why the UI is part of closing #93

`src/hooks/usePermissions.ts` re-implements the override client-side (`if (isOrgAdmin) return true`) and never consults the backend. After 174 the client would still show unpost/cancel while the RPC refuses — a button that fails on click. `rpc_permission_snapshot` exists so the client stops deciding and starts asking. That work is the follow-up PR and must not merge before step 5.