### PR TITLE
fix(db): Migration 175 — close RBAC membership and last-admin races

### DIFF
--- a/.github/workflows/rbac-consumer-175-acceptance.yml
+++ b/.github/workflows/rbac-consumer-175-acceptance.yml
@@ -1,0 +1,115 @@
+name: RBAC Consumer 175 Acceptance
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'scripts/ci/fresh-db/acceptance_175_rbac_consumer_migration_rpcs.sql'
+      - 'sql/migrations/175_rbac_consumer_migration_rpcs.sql'
+      - '.github/workflows/rbac-consumer-175-acceptance.yml'
+  workflow_dispatch:
+
+jobs:
+  acceptance:
+    name: Confirm Migration 175 adds the RPCs without disturbing 170-174
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      PGHOST: localhost
+      PGUSER: postgres
+      PGPASSWORD: postgres
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build fresh database through migration 175
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          PAIR=$(bash scripts/ci/fresh-db/resolve_baseline_pair.sh sql/baseline)
+          pair_field() { printf '%s\n' "$PAIR" | sed -n "s/^$1=//p"; }
+          BASELINE=$(pair_field BASELINE_PATH)
+          REFERENCE=$(pair_field REFERENCE_PATH)
+          CUTOFF=$(pair_field BASELINE_CUTOFF)
+          CUTOFF=${CUTOFF:-0}
+
+          createdb wardah_fresh
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh -f scripts/ci/fresh-db/supabase_shim.sql -q
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh -f "$BASELINE" -q
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh -f "$REFERENCE" -q
+
+          python3 scripts/ci/fresh-db/build_apply_order.py sql/migrations "$CUTOFF" > /tmp/chain_order.txt
+          REPORT=/tmp/chain_report.txt PGDATABASE=wardah_fresh \
+            bash scripts/ci/fresh-db/run_chain.sh sql/migrations /tmp/chain_order.txt
+
+      - name: Run Migration 175 acceptance
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh \
+            -f scripts/ci/fresh-db/acceptance_175_rbac_consumer_migration_rpcs.sql \
+            2>&1 | tee /tmp/rbac-consumer-175.out
+          grep -q 'RBAC_CONSUMER_175_ACCEPTANCE_PASS' /tmp/rbac-consumer-175.out
+
+      - name: Re-run Migration 174 acceptance to confirm no regression
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh \
+            -f scripts/ci/fresh-db/acceptance_174_sensitive_permission_class.sql \
+            2>&1 | tee /tmp/sensitive-permission-174-rerun.out
+          grep -q 'SENSITIVE_PERMISSION_174_ACCEPTANCE_PASS' /tmp/sensitive-permission-174-rerun.out
+
+      # A suite that cannot fail proves nothing. Build the same database WITHOUT
+      # migration 175 and show removeUserFromOrg's replacement did not exist
+      # before it: rpc_remove_org_member must be absent on a chain that stops
+      # at 174. The job fails if the pre-175 database can still call it.
+      - name: Red proof — rpc_remove_org_member does not exist before 175
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          PAIR=$(bash scripts/ci/fresh-db/resolve_baseline_pair.sh sql/baseline)
+          pair_field() { printf '%s\n' "$PAIR" | sed -n "s/^$1=//p"; }
+          createdb wardah_red
+          psql -v ON_ERROR_STOP=1 -d wardah_red -f scripts/ci/fresh-db/supabase_shim.sql -q
+          psql -v ON_ERROR_STOP=1 -d wardah_red -f "$(pair_field BASELINE_PATH)" -q
+          psql -v ON_ERROR_STOP=1 -d wardah_red -f "$(pair_field REFERENCE_PATH)" -q
+          grep -v '^175_' /tmp/chain_order.txt > /tmp/chain_red.txt
+          REPORT=/tmp/red_report.txt PGDATABASE=wardah_red \
+            bash scripts/ci/fresh-db/run_chain.sh sql/migrations /tmp/chain_red.txt
+
+          EXISTS=$(psql -tA -v ON_ERROR_STOP=1 -d wardah_red -c \
+            "SELECT to_regprocedure('public.rpc_remove_org_member(jsonb)') IS NOT NULL;")
+          echo "rpc_remove_org_member exists pre-175: $EXISTS"
+          if [ "$EXISTS" != "f" ]; then
+            echo "RED PROOF FAILED: rpc_remove_org_member already existed before 175."
+            exit 1
+          fi
+
+      - name: Upload acceptance evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rbac-consumer-175-acceptance-${{ github.run_id }}
+          path: |
+            /tmp/rbac-consumer-175.out
+            /tmp/sensitive-permission-174-rerun.out
+            /tmp/chain_report.txt
+            /tmp/red_report.txt
+          retention-days: 30

--- a/.github/workflows/rbac-consumer-175-acceptance.yml
+++ b/.github/workflows/rbac-consumer-175-acceptance.yml
@@ -5,13 +5,14 @@ on:
     branches: [main]
     paths:
       - 'scripts/ci/fresh-db/acceptance_175_rbac_consumer_migration_rpcs.sql'
+      - 'scripts/ci/fresh-db/acceptance_175_rbac_concurrency.sh'
       - 'sql/migrations/175_rbac_consumer_migration_rpcs.sql'
       - '.github/workflows/rbac-consumer-175-acceptance.yml'
   workflow_dispatch:
 
 jobs:
   acceptance:
-    name: Confirm Migration 175 adds the RPCs without disturbing 170-174
+    name: Confirm Migration 175 closes membership and last-admin races
     runs-on: ubuntu-latest
 
     services:
@@ -67,6 +68,16 @@ jobs:
             2>&1 | tee /tmp/rbac-consumer-175.out
           grep -q 'RBAC_CONSUMER_175_ACCEPTANCE_PASS' /tmp/rbac-consumer-175.out
 
+      - name: Run real multi-session RBAC races
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          PGDATABASE=wardah_fresh \
+            bash scripts/ci/fresh-db/acceptance_175_rbac_concurrency.sh \
+            2>&1 | tee /tmp/rbac-consumer-175-concurrency.out
+          grep -q 'RBAC_CONSUMER_175_CONCURRENCY_PASS' \
+            /tmp/rbac-consumer-175-concurrency.out
+
       - name: Re-run Migration 174 acceptance to confirm no regression
         shell: bash
         run: |
@@ -102,6 +113,48 @@ jobs:
             exit 1
           fi
 
+          # A pre-existing assignment without an active membership must stop
+          # 175 before any object change is committed. This is remediation by
+          # explicit operator choice, never silent deletion by a migration.
+          psql -v ON_ERROR_STOP=1 -d wardah_red -q <<'SQL'
+          INSERT INTO auth.users (id, email)
+          VALUES ('99175175-dead-dead-dead-000000000001', 'p175-preflight-red@example.test');
+          INSERT INTO public.organizations (id, name, code)
+          VALUES ('99175175-dead-dead-dead-000000000002', 'P175 Preflight Red', 'P175-RED');
+          INSERT INTO public.user_organizations
+            (user_id, org_id, is_active, is_org_admin)
+          VALUES (
+            '99175175-dead-dead-dead-000000000001',
+            '99175175-dead-dead-dead-000000000002',
+            false,
+            false);
+          INSERT INTO public.roles (id, org_id, name, name_ar, is_active)
+          VALUES (
+            '99175175-dead-dead-dead-000000000003',
+            '99175175-dead-dead-dead-000000000002',
+            'P175 Invalid Preflight Role',
+            'دور فحص مسبق غير صالح',
+            true);
+          INSERT INTO public.user_roles (user_id, role_id, org_id)
+          VALUES (
+            '99175175-dead-dead-dead-000000000001',
+            '99175175-dead-dead-dead-000000000003',
+            '99175175-dead-dead-dead-000000000002');
+          SQL
+
+          set +e
+          psql -v ON_ERROR_STOP=1 -d wardah_red \
+            -f sql/migrations/175_rbac_consumer_migration_rpcs.sql \
+            > /tmp/rbac-consumer-175-preflight-red.out 2>&1
+          PREFLIGHT_STATUS=$?
+          set -e
+          if [ "$PREFLIGHT_STATUS" -eq 0 ]; then
+            echo 'RED PROOF FAILED: 175 accepted an inactive-member assignment.'
+            exit 1
+          fi
+          grep -q 'RBAC_175_INVALID_USER_ROLE_MEMBERSHIP_PREFLIGHT' \
+            /tmp/rbac-consumer-175-preflight-red.out
+
       - name: Upload acceptance evidence
         if: always()
         uses: actions/upload-artifact@v4
@@ -109,7 +162,11 @@ jobs:
           name: rbac-consumer-175-acceptance-${{ github.run_id }}
           path: |
             /tmp/rbac-consumer-175.out
+            /tmp/rbac-consumer-175-concurrency.out
+            /tmp/rbac-consumer-175-preflight-red.out
             /tmp/sensitive-permission-174-rerun.out
             /tmp/chain_report.txt
             /tmp/red_report.txt
+            /tmp/rbac-175-*.out
+            /tmp/rbac-175-*.err
           retention-days: 30

--- a/.github/workflows/rbac-consumer-175-acceptance.yml
+++ b/.github/workflows/rbac-consumer-175-acceptance.yml
@@ -113,7 +113,7 @@ jobs:
             exit 1
           fi
 
-          # A pre-existing assignment without an active membership must stop
+          # A pre-existing assignment without any matching membership must stop
           # 175 before any object change is committed. This is remediation by
           # explicit operator choice, never silent deletion by a migration.
           psql -v ON_ERROR_STOP=1 -d wardah_red -q <<'SQL'
@@ -121,13 +121,6 @@ jobs:
           VALUES ('99175175-dead-dead-dead-000000000001', 'p175-preflight-red@example.test');
           INSERT INTO public.organizations (id, name, code)
           VALUES ('99175175-dead-dead-dead-000000000002', 'P175 Preflight Red', 'P175-RED');
-          INSERT INTO public.user_organizations
-            (user_id, org_id, is_active, is_org_admin)
-          VALUES (
-            '99175175-dead-dead-dead-000000000001',
-            '99175175-dead-dead-dead-000000000002',
-            false,
-            false);
           INSERT INTO public.roles (id, org_id, name, name_ar, is_active)
           VALUES (
             '99175175-dead-dead-dead-000000000003',
@@ -149,7 +142,7 @@ jobs:
           PREFLIGHT_STATUS=$?
           set -e
           if [ "$PREFLIGHT_STATUS" -eq 0 ]; then
-            echo 'RED PROOF FAILED: 175 accepted an inactive-member assignment.'
+            echo 'RED PROOF FAILED: 175 accepted an orphan assignment.'
             exit 1
           fi
           grep -q 'RBAC_175_INVALID_USER_ROLE_MEMBERSHIP_PREFLIGHT' \

--- a/.github/workflows/rbac-consumer-175-acceptance.yml
+++ b/.github/workflows/rbac-consumer-175-acceptance.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   acceptance:
-    name: Confirm Migration 175 closes membership and last-admin races
+    name: Confirm Migration 175 closes membership, admin, and UPDATE races
     runs-on: ubuntu-latest
 
     services:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,14 +75,13 @@ React 18 + TypeScript + Vite، shadcn/ui + Tailwind، Zustand + TanStack Query،
   `docs/db/HAS_PERMISSION_172_RUNBOOK.md`، `docs/db/HAS_PERMISSION_173_RUNBOOK.md`
   — تفصيل كل migration على حدة.
 - `docs/db/RBAC_CONSUMER_175_RUNBOOK.md` — **Migration 175 (في المستودع، غير
-  مطبّقة على Production بعد)**: إضافية بالكامل، بلا سحب صلاحية. تضيف
-  `rpc_remove_org_member` الذرية المدقَّقة، وتُلحق سجل تدقيق بـ
-  `create_role_from_template` القائمة أصلًا، وتضبط `search_path` الصريح لمصنّف
-  174. تسبقها PR مستهلك منفصل يعيد توجيه `users.tsx` و`roles.tsx` من الكتابة
-  المباشرة على `user_roles`/`roles`/`role_permissions` إلى هذه الـRPCs،
-  ويحذف الدوال الميتة/الخطرة المكتشفة أثناء تدقيق #93 الثاني. سحب الكتابة
-  المباشرة نفسه مؤجَّل لـMigration 176 بعد نجاح Browser Smoke الفعلي على
-  الواجهة المنشورة.
+  مطبّقة على Production بعد)**: لا تسحب منح الجداول، لكنها ترفض تعيين دور بلا
+  عضوية نشطة عند حدّ قاعدة البيانات، وتغلق سباق آخر مسؤول بقفل مشترك على صف
+  المؤسسة. تضيف `rpc_remove_org_member` الذرية المدقَّقة، وتحصّن فرعي المنح
+  الصريحة في دالتي الصلاحيات، وتُلحق سجل تدقيق بـ`create_role_from_template`.
+  **تُطبّق 175 أولًا DB-first بعد نجاح preflight**، ثم تأتي PR المستهلك التي
+  تعيد توجيه `users.tsx` و`roles.tsx` إلى الـRPCs. سحب الكتابة المباشرة نفسه
+  مؤجَّل لـMigration 176 بعد نجاح Browser Smoke الفعلي على الواجهة المنشورة.
 
 ## Baseline
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,15 @@ React 18 + TypeScript + Vite، shadcn/ui + Tailwind، Zustand + TanStack Query،
 - `docs/db/TENANT_ISOLATION_170_RUNBOOK.md`، `docs/db/AI_USAGE_DAILY_171_RUNBOOK.md`،
   `docs/db/HAS_PERMISSION_172_RUNBOOK.md`، `docs/db/HAS_PERMISSION_173_RUNBOOK.md`
   — تفصيل كل migration على حدة.
+- `docs/db/RBAC_CONSUMER_175_RUNBOOK.md` — **Migration 175 (في المستودع، غير
+  مطبّقة على Production بعد)**: إضافية بالكامل، بلا سحب صلاحية. تضيف
+  `rpc_remove_org_member` الذرية المدقَّقة، وتُلحق سجل تدقيق بـ
+  `create_role_from_template` القائمة أصلًا، وتضبط `search_path` الصريح لمصنّف
+  174. تسبقها PR مستهلك منفصل يعيد توجيه `users.tsx` و`roles.tsx` من الكتابة
+  المباشرة على `user_roles`/`roles`/`role_permissions` إلى هذه الـRPCs،
+  ويحذف الدوال الميتة/الخطرة المكتشفة أثناء تدقيق #93 الثاني. سحب الكتابة
+  المباشرة نفسه مؤجَّل لـMigration 176 بعد نجاح Browser Smoke الفعلي على
+  الواجهة المنشورة.
 
 ## Baseline
 

--- a/docs/db/RBAC_CONSUMER_175_RUNBOOK.md
+++ b/docs/db/RBAC_CONSUMER_175_RUNBOOK.md
@@ -5,11 +5,12 @@
 audited RPC surface for role and assignment management, but a follow-up audit
 of every production TS/TSX file writing to `roles`, `role_permissions` or
 `user_roles` found the client did not fully move onto it (§1). This migration
-adds exactly the RPC surface the client needs to close every remaining gap.
+adds the RPC surface the client needs and closes two database races discovered
+during review.
 **State:** Repository implementation, **not yet applied to Production**.
-Additive only — no privilege revocation, no table grant touched. Safe to
-apply DB-first, ahead of any dependent UI change, per the standard sequencing
-in `CLAUDE.md`.
+No privilege revocation and no table grant change. Invalid assignments are,
+however, deliberately narrowed at the database boundary. Apply DB-first only
+after the read-only data preflight in §4 succeeds.
 
 ## 1. The verified gap
 
@@ -38,10 +39,14 @@ all before this migration.
 
 | Change | Detail |
 |---|---|
-| `rpc_remove_org_member(jsonb)` | **New.** Atomic, audited replacement for `removeUserFromOrg()`'s two-step client sequence. `{org_id, user_id}` payload. Guarded by `wardah_assert_org_admin`. Refuses self-removal (`RBAC_175_CANNOT_REMOVE_SELF`) and removing the last active admin (`RBAC_175_LAST_ORG_ADMIN`) — mirroring the guards `rpc_set_org_admin` (migration 103) already applies to demotion; removal is more drastic and had no server-side guard at all before this. Locks the membership row `FOR UPDATE`, deletes `user_roles` then `user_organizations` inside the same transaction, and writes one `audit_logs` row with the full pre-removal membership and role-assignment snapshot in `old_data`. |
+| Active-membership boundary | A `BEFORE INSERT/UPDATE` trigger on `user_roles` locks and requires the matching active `user_organizations` row. A parent-side trigger refuses deleting, moving, or deactivating a membership while role rows remain. This covers RPCs and the still-permitted direct writes during the 175→176 deployment window. |
+| Permission defense in depth | The explicit-role branches of both `has_permission` and `wardah_has_exact_permission` now join an active membership. Even deliberately corrupted legacy data cannot authorize a user whose membership is inactive or absent. |
+| `rpc_set_org_admin(...)` | Same signature and JSON contract. It now shares an organization-row `FOR UPDATE` lock with member removal, re-authorizes the caller after the lock, and applies `LAST_ORG_ADMIN` only when the target is currently an active admin. |
+| `rpc_remove_org_member(jsonb)` | **New.** Atomic, audited replacement for `removeUserFromOrg()`'s two-step client sequence. `{org_id, user_id}` payload. Guarded by `wardah_assert_org_admin`. Refuses self-removal (`RBAC_175_CANNOT_REMOVE_SELF`) and removing the last active admin (`RBAC_175_LAST_ORG_ADMIN`). It takes the shared organization lock, re-authorizes, locks the membership row, deletes `user_roles` then `user_organizations`, and writes the full pre-removal snapshot to `audit_logs`. |
 | `create_role_from_template(...)` | `CREATE OR REPLACE`, identical signature and return type (`uuid`), every prior statement byte-for-byte unchanged. Adds one `audit_logs` INSERT recording the granted permission keys and flagging any sensitive ones. The consumer PR repoints `roles.tsx`'s import to the already-correct function in `rbac-service.ts`; this migration's only job is to make that function's audit trail complete once it is actually called. |
 | `wardah_is_sensitive_permission(text)` | `CREATE OR REPLACE`, adds `SET search_path = ''`. The body is a pure literal comparison with no table or unqualified-name reference, so this changes nothing about its output for any input (re-asserted in postflight for all four relevant cases including `NULL`). Closes the "Function Search Path Mutable" advisory. |
-| Grants | `rpc_remove_org_member`: `REVOKE ALL FROM PUBLIC, anon, service_role`; `GRANT EXECUTE TO authenticated`. No other grant is touched anywhere in this migration. |
+| Preflight | Fails closed with `RBAC_175_INVALID_USER_ROLE_MEMBERSHIP_PREFLIGHT` if any assignment lacks a matching active membership. The two RBAC tables are locked against DML between this check and trigger installation. |
+| Grants | `rpc_remove_org_member`: `REVOKE ALL FROM PUBLIC, anon, service_role`; `GRANT EXECUTE TO authenticated`. Existing `rpc_set_org_admin` grants are reasserted. No table grant changes. |
 
 ### 2.1 What this migration deliberately does not do
 
@@ -64,6 +69,8 @@ all before this migration.
   rider on this one.
 - **No table grant is revoked.** `authenticated` keeps direct
   `INSERT`/`UPDATE`/`DELETE` on `roles`, `role_permissions` and `user_roles`.
+  Direct `user_roles` writes must now satisfy active membership, and a
+  membership with assignments must clear them before deletion/deactivation.
   That closure is **Migration 176**, applied only after the consumer PR has
   moved every real caller onto the RPC surface this migration and 174
   together provide, and the real browser smoke on the deployed UI has proven
@@ -77,45 +84,60 @@ all before this migration.
 
 ```text
 scripts/ci/fresh-db/acceptance_175_rbac_consumer_migration_rpcs.sql
+scripts/ci/fresh-db/acceptance_175_rbac_concurrency.sh
 .github/workflows/rbac-consumer-175-acceptance.yml
 ```
 
-Marker: `RBAC_CONSUMER_175_ACCEPTANCE_PASS`. Coverage:
+Markers: `RBAC_CONSUMER_175_ACCEPTANCE_PASS` and
+`RBAC_CONSUMER_175_CONCURRENCY_PASS`. Coverage:
 
-1. **Cross-org rejection** (`175-1`) — an org admin of one org cannot remove a
+1. **Database invariant** (`175-I1…I7`) — inactive-member INSERT/UPDATE and
+   parent deletion/deactivation are rejected; both permission helpers deny a
+   deliberately injected inactive-member grant.
+2. **Cross-org rejection** (`175-1`) — an org admin of one org cannot remove a
    member of another.
-2. **Self-removal rejection** (`175-2`) — `RBAC_175_CANNOT_REMOVE_SELF`, own
+3. **Self-removal rejection** (`175-2`) — `RBAC_175_CANNOT_REMOVE_SELF`, own
    membership row provably untouched afterward.
-3. **Last-admin guard** (`175-3a/3c/3d`) — a legal removal down to exactly one
+4. **Last-admin guard** (`175-3a/3b/3c/3d`) — a legal removal down to exactly one
    admin succeeds; a distinct fixture (a super admin who is a *non-admin*
    member of the target org — the only way to get an admin-gated caller
    whose identity differs from the target while the guard is still
    reachable) attempting to remove the sole remaining admin is rejected with
    `RBAC_175_LAST_ORG_ADMIN`, and the membership row is proven untouched.
-4. **Real removal + full audit verification** (`175-4a…4e`) — membership and
+   A false→false request against an ordinary target proves the guard is not
+   applied merely because the organization has one admin.
+5. **Real removal + full audit verification** (`175-4a…4e`) — membership and
    `user_roles` rows actually gone, `audit_logs` row present with
    `old_data.role_assignments` matching the exact pre-removal snapshot,
    `new_data IS NULL`, `metadata.was_org_admin` and
    `metadata.removed_role_count` correct.
-5. **`create_role_from_template` unchanged behavior + new audit row**
+6. **`create_role_from_template` unchanged behavior + new audit row**
    (`175-5a…5e`) — permissions still granted correctly from the template,
    `audit_logs` row present with `source = 'template'` and sensitive keys
    correctly flagged.
-6. **Cross-org template creation rejected** (`175-6`).
-7. **Mutation proof** (`175-M1…M7`) — every 170–174 guarantee re-asserted
+7. **Cross-org template creation rejected** (`175-6`).
+8. **Mutation proof** (`175-M1…M7`) — every 170–174 guarantee re-asserted
    plus the new grants, plus an explicit check that no table grant changed.
+9. **Three real multi-session races** — direct assignment versus removal; two
+   admins removing each other; demotion versus removal. Each uses independent
+   PostgreSQL connections queued behind the exact row lock under test and
+   proves one active admin and zero orphan assignments at completion.
+10. **Preflight red proof** — a pre-175 database is deliberately seeded with
+    an inactive-member assignment; applying 175 must fail with the exact
+    preflight marker and commit none of its object changes.
 
-### 3.1 Verification actually performed
+### 3.1 Verification required before merge
 
-Executed locally on a real **PostgreSQL 17.10** cluster, rebuilt from
-scratch immediately before commit:
+Execute on a fresh **PostgreSQL 17** cluster and retain the CI artifacts:
 
 | Check | Result |
 |---|---|
 | Baseline + chain through 175 | `PASS=14 FAIL=0 NOT_RUN=0 TOTAL=14` |
 | `acceptance_175` | `RBAC_CONSUMER_175_ACCEPTANCE_PASS` |
+| Three two-connection races | `RBAC_CONSUMER_175_CONCURRENCY_PASS` |
 | `acceptance_174` re-run on the 175 database | `SENSITIVE_PERMISSION_174_ACCEPTANCE_PASS` (no regression) |
 | **Red proof** — chain built with every `175_*.sql` file excluded | `to_regprocedure('public.rpc_remove_org_member(jsonb)') IS NOT NULL` → `f` |
+| **Preflight red proof** | inactive-member assignment rejects 175 with `RBAC_175_INVALID_USER_ROLE_MEMBERSHIP_PREFLIGHT` |
 
 Every embedded shell block in `.github/workflows/rbac-consumer-175-acceptance.yml`
 was checked with `bash -n`; the YAML was parsed with `yaml.safe_load`. The
@@ -125,14 +147,25 @@ file: `check_migration_syntax.py` (pglast — 203 files, all valid),
 unguarded `SECURITY DEFINER`), and `validate_migration_ledger.py`
 (`repo_max: 175`, numbering and naming valid).
 
-The red proof is a real CI step, not a manual note: if a pre-175 database
-ever produces `rpc_remove_org_member`, the job fails.
+Both red proofs are CI steps, not manual notes.
 
 ## 4. Production order
 
-Purely additive — no operational transaction is required before applying
-this migration, unlike 174. There is no lockout risk: nothing existing is
-narrowed or revoked.
+No privilege is revoked, but the active-membership invariant intentionally
+narrows invalid writes. Run this read-only query against Production first:
+
+```sql
+SELECT ur.user_id, ur.org_id, ur.role_id, uo.is_active
+FROM public.user_roles ur
+LEFT JOIN public.user_organizations uo
+  ON uo.user_id = ur.user_id
+ AND uo.org_id = ur.org_id
+WHERE uo.user_id IS NULL OR uo.is_active IS NOT TRUE;
+-- Expect zero rows. Stop and remediate explicitly if any row is returned.
+```
+
+The migration repeats this check under table locks, so a write cannot slip
+between operator preflight and trigger installation.
 
 ### Step 1 — apply 175
 
@@ -146,7 +179,8 @@ SELECT
   prosrc ~ 'wardah_assert_org_admin'              AS org_admin_guarded,
   prosrc ~ 'RBAC_175_CANNOT_REMOVE_SELF'          AS self_removal_guard,
   prosrc ~ 'RBAC_175_LAST_ORG_ADMIN'              AS last_admin_guard,
-  prosrc ~ 'FOR UPDATE'                            AS locks_membership_row,
+  prosrc ~ 'organizations o'                       AS locks_organization_row,
+  prosrc ~ 'FOR UPDATE'                            AS locks_rows,
   prosrc ~ 'audit_logs'                            AS writes_audit
 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
 WHERE n.nspname = 'public' AND p.proname = 'rpc_remove_org_member';
@@ -155,6 +189,24 @@ WHERE n.nspname = 'public' AND p.proname = 'rpc_remove_org_member';
 SELECT has_function_privilege('anon', 'public.rpc_remove_org_member(jsonb)', 'EXECUTE') AS anon_can_call,
        has_function_privilege('authenticated', 'public.rpc_remove_org_member(jsonb)', 'EXECUTE') AS authenticated_can_call;
 -- Expect anon_can_call = false, authenticated_can_call = true.
+
+SELECT c.relname, t.tgname, t.tgenabled
+FROM pg_trigger t
+JOIN pg_class c ON c.oid = t.tgrelid
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = 'public'
+  AND t.tgname IN (
+    'trg_wardah_175_require_active_role_membership',
+    'trg_wardah_175_protect_role_membership_parent');
+-- Expect two enabled rows.
+
+SELECT proname,
+       prosrc ~ 'user_organizations uo' AS joins_membership,
+       prosrc ~ 'uo\.is_active IS TRUE' AS requires_active
+FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname = 'public'
+  AND proname IN ('has_permission', 'wardah_has_exact_permission');
+-- Expect both booleans true for both rows.
 
 SELECT prosrc ~ 'audit_logs' AS template_now_audited
 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
@@ -185,12 +237,10 @@ both paths: the RPCs are sanctioned, not yet exclusive.
 
 ## 5. Rollback
 
-Additive apart from two `CREATE OR REPLACE` bodies, both no-ops for existing
-behavior except the added audit write. Per the golden rule, a forward fix
-(a new numbered migration) is preferred over any revert. There is nothing to
-revert defensively: no grant was narrowed, no existing caller's contract
-changed, and the new RPC's execute boundary is `authenticated` only, matching
-every other RBAC RPC in this repository.
+No table grant changed and all public RPC signatures remain stable, but 175
+adds two invariant triggers and replaces authorization/admin function bodies.
+Per the golden rule, use a new numbered forward-fix migration if rollback is
+required; never edit an applied 175 or remove its ledger row.
 
 Never edit `supabase_migrations.schema_migrations`, and never apply SQL that
 is not the exact file merged to `main`.

--- a/docs/db/RBAC_CONSUMER_175_RUNBOOK.md
+++ b/docs/db/RBAC_CONSUMER_175_RUNBOOK.md
@@ -42,7 +42,7 @@ all before this migration.
 | Change | Detail |
 |---|---|
 | Assignment boundary | A `BEFORE INSERT FOR EACH ROW` trigger on `user_roles` takes organization→membership locks and requires the matching active membership. A `BEFORE UPDATE FOR EACH STATEMENT` trigger rejects every UPDATE before PostgreSQL locks a child tuple, requiring `rpc_replace_user_roles`. A parent-side trigger refuses deleting, moving, or deactivating a membership while role rows remain. This prevents both orphan grants and the inverse tuple→organization lock order during the 175→176 deployment window. |
-| `rpc_replace_user_roles(jsonb)` lock wrapper | The 174 body is renamed to a non-callable internal function without changing it. The public function keeps the same signature/result, takes the organization lock first, then delegates to the 174 body, which locks membership and preserves every replace/expiry/audit rule. This gives assignments and removals the same lock order. |
+| `rpc_replace_user_roles(jsonb)` lock wrapper | The 174 body is renamed to a non-callable internal function without changing it. The public function preserves 174's pre-authorization parsing and combined org/user required-field error, takes the organization lock first, then delegates to the 174 body, which locks membership and preserves every replace/expiry/audit rule. This gives assignments and removals the same lock order without changing validation/error ordering. |
 | Permission defense in depth | The explicit-role branches of both `has_permission` and `wardah_has_exact_permission` now join an active membership. Even deliberately corrupted legacy data cannot authorize a user whose membership is inactive or absent. |
 | `rpc_set_org_admin(...)` | Same signature and JSON contract. It now shares an organization-row `FOR UPDATE` lock with member removal, re-authorizes the caller after the lock, and applies `LAST_ORG_ADMIN` only when the target is currently an active admin. |
 | `rpc_remove_org_member(jsonb)` | **New.** Atomic, audited replacement for `removeUserFromOrg()`'s two-step client sequence. `{org_id, user_id}` payload. Guarded by `wardah_assert_org_admin`. Refuses self-removal (`RBAC_175_CANNOT_REMOVE_SELF`) and removing the last active admin (`RBAC_175_LAST_ORG_ADMIN`). It takes the shared organization lock, re-authorizes, locks the membership row, deletes `user_roles` then `user_organizations`, and writes the full pre-removal snapshot to `audit_logs`. |
@@ -101,7 +101,9 @@ Markers: `RBAC_CONSUMER_175_ACCEPTANCE_PASS` and
    redirect marker; the UPDATE trigger is proven to be `BEFORE STATEMENT`;
    parent deletion/deactivation are rejected; both permission helpers deny a
    deliberately injected inactive-member grant; the wrapped 174 replace
-   contract remains live with its internal implementation inaccessible.
+   contract remains live with its internal implementation inaccessible, and
+   missing/invalid user plus invalid expiry inputs retain 174's validation
+   order before authorization.
 2. **Cross-org rejection** (`175-1`) — an org admin of one org cannot remove a
    member of another.
 3. **Self-removal rejection** (`175-2`) — `RBAC_175_CANNOT_REMOVE_SELF`, own

--- a/docs/db/RBAC_CONSUMER_175_RUNBOOK.md
+++ b/docs/db/RBAC_CONSUMER_175_RUNBOOK.md
@@ -40,6 +40,7 @@ all before this migration.
 | Change | Detail |
 |---|---|
 | Active-membership boundary | A `BEFORE INSERT/UPDATE` trigger on `user_roles` locks and requires the matching active `user_organizations` row. A parent-side trigger refuses deleting, moving, or deactivating a membership while role rows remain. This covers RPCs and the still-permitted direct writes during the 175→176 deployment window. |
+| `rpc_replace_user_roles(jsonb)` lock wrapper | The 174 body is renamed to a non-callable internal function without changing it. The public function keeps the same signature/result, takes the organization lock first, then delegates to the 174 body, which locks membership and preserves every replace/expiry/audit rule. This gives assignments and removals the same lock order. |
 | Permission defense in depth | The explicit-role branches of both `has_permission` and `wardah_has_exact_permission` now join an active membership. Even deliberately corrupted legacy data cannot authorize a user whose membership is inactive or absent. |
 | `rpc_set_org_admin(...)` | Same signature and JSON contract. It now shares an organization-row `FOR UPDATE` lock with member removal, re-authorizes the caller after the lock, and applies `LAST_ORG_ADMIN` only when the target is currently an active admin. |
 | `rpc_remove_org_member(jsonb)` | **New.** Atomic, audited replacement for `removeUserFromOrg()`'s two-step client sequence. `{org_id, user_id}` payload. Guarded by `wardah_assert_org_admin`. Refuses self-removal (`RBAC_175_CANNOT_REMOVE_SELF`) and removing the last active admin (`RBAC_175_LAST_ORG_ADMIN`). It takes the shared organization lock, re-authorizes, locks the membership row, deletes `user_roles` then `user_organizations`, and writes the full pre-removal snapshot to `audit_logs`. |
@@ -91,9 +92,10 @@ scripts/ci/fresh-db/acceptance_175_rbac_concurrency.sh
 Markers: `RBAC_CONSUMER_175_ACCEPTANCE_PASS` and
 `RBAC_CONSUMER_175_CONCURRENCY_PASS`. Coverage:
 
-1. **Database invariant** (`175-I1…I7`) — inactive-member INSERT/UPDATE and
+1. **Database invariant** (`175-I1…I8`) — inactive-member INSERT/UPDATE and
    parent deletion/deactivation are rejected; both permission helpers deny a
-   deliberately injected inactive-member grant.
+   deliberately injected inactive-member grant; the wrapped 174 replace
+   contract remains live with its internal implementation inaccessible.
 2. **Cross-org rejection** (`175-1`) — an org admin of one org cannot remove a
    member of another.
 3. **Self-removal rejection** (`175-2`) — `RBAC_175_CANNOT_REMOVE_SELF`, own

--- a/docs/db/RBAC_CONSUMER_175_RUNBOOK.md
+++ b/docs/db/RBAC_CONSUMER_175_RUNBOOK.md
@@ -41,14 +41,14 @@ all before this migration.
 
 | Change | Detail |
 |---|---|
-| Assignment boundary | A `BEFORE INSERT FOR EACH ROW` trigger on `user_roles` takes organization→membership locks and requires the matching active membership. A `BEFORE UPDATE FOR EACH STATEMENT` trigger rejects every UPDATE before PostgreSQL locks a child tuple, requiring `rpc_replace_user_roles`. A parent-side trigger refuses deleting, moving, or deactivating a membership while role rows remain. This prevents both orphan grants and the inverse tuple→organization lock order during the 175→176 deployment window. |
+| Assignment boundary | A `BEFORE INSERT FOR EACH ROW` trigger on `user_roles` takes organization→membership locks and requires the matching active membership. A `BEFORE UPDATE FOR EACH STATEMENT` trigger rejects every UPDATE before PostgreSQL locks a child tuple, requiring `rpc_replace_user_roles`. A parent-side trigger refuses deleting or moving a membership while role rows remain. Reversible deactivation is deliberately allowed: assignments stay stored, while both permission helpers suppress them until reactivation. This preserves the live `toggleUserStatus()` flow without allowing inactive access, orphan grants, or the inverse tuple→organization lock order. |
 | `rpc_replace_user_roles(jsonb)` lock wrapper | The 174 body is renamed to a non-callable internal function without changing it. The public function preserves 174's pre-authorization parsing and combined org/user required-field error, takes the organization lock first, then delegates to the 174 body, which locks membership and preserves every replace/expiry/audit rule. This gives assignments and removals the same lock order without changing validation/error ordering. |
 | Permission defense in depth | The explicit-role branches of both `has_permission` and `wardah_has_exact_permission` now join an active membership. Even deliberately corrupted legacy data cannot authorize a user whose membership is inactive or absent. |
 | `rpc_set_org_admin(...)` | Same signature and JSON contract. It now shares an organization-row `FOR UPDATE` lock with member removal, re-authorizes the caller after the lock, and applies `LAST_ORG_ADMIN` only when the target is currently an active admin. |
 | `rpc_remove_org_member(jsonb)` | **New.** Atomic, audited replacement for `removeUserFromOrg()`'s two-step client sequence. `{org_id, user_id}` payload. Guarded by `wardah_assert_org_admin`. Refuses self-removal (`RBAC_175_CANNOT_REMOVE_SELF`) and removing the last active admin (`RBAC_175_LAST_ORG_ADMIN`). It takes the shared organization lock, re-authorizes, locks the membership row, deletes `user_roles` then `user_organizations`, and writes the full pre-removal snapshot to `audit_logs`. |
 | `create_role_from_template(...)` | `CREATE OR REPLACE`, identical signature and return type (`uuid`), every prior statement byte-for-byte unchanged. Adds one `audit_logs` INSERT recording the granted permission keys and flagging any sensitive ones. The consumer PR repoints `roles.tsx`'s import to the already-correct function in `rbac-service.ts`; this migration's only job is to make that function's audit trail complete once it is actually called. |
 | `wardah_is_sensitive_permission(text)` | `CREATE OR REPLACE`, adds `SET search_path = ''`. The body is a pure literal comparison with no table or unqualified-name reference, so this changes nothing about its output for any input (re-asserted in postflight for all four relevant cases including `NULL`). Closes the "Function Search Path Mutable" advisory. |
-| Preflight | Fails closed with `RBAC_175_INVALID_USER_ROLE_MEMBERSHIP_PREFLIGHT` if any assignment lacks a matching active membership. The two RBAC tables are locked against DML between this check and trigger installation. |
+| Preflight | Fails closed with `RBAC_175_INVALID_USER_ROLE_MEMBERSHIP_PREFLIGHT` if any assignment lacks a matching membership row. Inactive memberships with retained assignments are valid and safe because authorization requires `is_active = true`. The two RBAC tables are locked against DML between this check and trigger installation. |
 | Grants | `rpc_remove_org_member`: `REVOKE ALL FROM PUBLIC, anon, service_role`; `GRANT EXECUTE TO authenticated`. Existing `rpc_set_org_admin` grants are reasserted. No table grant changes. |
 
 ### 2.1 What this migration deliberately does not do
@@ -75,7 +75,8 @@ all before this migration.
   `user_roles`. At runtime, direct `user_roles` INSERT must satisfy active
   membership and all UPDATE statements are rejected before tuple locking;
   assignment changes must use `rpc_replace_user_roles`. A membership with
-  assignments must clear them before deletion/deactivation.
+  assignments must clear them before deletion or identity/org movement;
+  status deactivation remains reversible and retains the assignments.
   That closure is **Migration 176**, applied only after the consumer PR has
   moved every real caller onto the RPC surface this migration and 174
   together provide, and the real browser smoke on the deployed UI has proven
@@ -99,8 +100,9 @@ Markers: `RBAC_CONSUMER_175_ACCEPTANCE_PASS` and
 1. **Database invariant** (`175-I1…I8`) — inactive-member INSERT is rejected;
    key, non-key, and zero-row UPDATE statements all fail with the exact RPC
    redirect marker; the UPDATE trigger is proven to be `BEFORE STATEMENT`;
-   parent deletion/deactivation are rejected; both permission helpers deny a
-   deliberately injected inactive-member grant; the wrapped 174 replace
+   parent deletion/movement are rejected; direct deactivation/reactivation
+   preserves assignments while both permission helpers deny them during the
+   inactive period; the wrapped 174 replace
    contract remains live with its internal implementation inaccessible, and
    missing/invalid user plus invalid expiry inputs retain 174's validation
    order before authorization.
@@ -136,7 +138,7 @@ Markers: `RBAC_CONSUMER_175_ACCEPTANCE_PASS` and
    PostgreSQL connections and prove one active admin and zero orphan
    assignments at completion.
 10. **Preflight red proof** — a pre-175 database is deliberately seeded with
-    an inactive-member assignment; applying 175 must fail with the exact
+    an assignment that has no matching membership row; applying 175 must fail with the exact
     preflight marker and commit none of its object changes.
 
 ### 3.1 Verification required before merge
@@ -150,7 +152,7 @@ Execute on a fresh **PostgreSQL 17** cluster and retain the CI artifacts:
 | Four multi-session races | `RBAC_CONSUMER_175_CONCURRENCY_PASS` |
 | `acceptance_174` re-run on the 175 database | `SENSITIVE_PERMISSION_174_ACCEPTANCE_PASS` (no regression) |
 | **Red proof** — chain built with every `175_*.sql` file excluded | `to_regprocedure('public.rpc_remove_org_member(jsonb)') IS NOT NULL` → `f` |
-| **Preflight red proof** | inactive-member assignment rejects 175 with `RBAC_175_INVALID_USER_ROLE_MEMBERSHIP_PREFLIGHT` |
+| **Preflight red proof** | orphan assignment rejects 175 with `RBAC_175_INVALID_USER_ROLE_MEMBERSHIP_PREFLIGHT` |
 
 Every embedded shell block in `.github/workflows/rbac-consumer-175-acceptance.yml`
 was checked with `bash -n`; the YAML was parsed with `yaml.safe_load`. The
@@ -174,7 +176,7 @@ FROM public.user_roles ur
 LEFT JOIN public.user_organizations uo
   ON uo.user_id = ur.user_id
  AND uo.org_id = ur.org_id
-WHERE uo.user_id IS NULL OR uo.is_active IS NOT TRUE;
+WHERE uo.user_id IS NULL;
 -- Expect zero rows. Stop and remediate explicitly if any row is returned.
 ```
 

--- a/docs/db/RBAC_CONSUMER_175_RUNBOOK.md
+++ b/docs/db/RBAC_CONSUMER_175_RUNBOOK.md
@@ -5,12 +5,14 @@
 audited RPC surface for role and assignment management, but a follow-up audit
 of every production TS/TSX file writing to `roles`, `role_permissions` or
 `user_roles` found the client did not fully move onto it (§1). This migration
-adds the RPC surface the client needs and closes two database races discovered
+adds the RPC surface the client needs and closes three database races discovered
 during review.
 **State:** Repository implementation, **not yet applied to Production**.
-No privilege revocation and no table grant change. Invalid assignments are,
-however, deliberately narrowed at the database boundary. Apply DB-first only
-after the read-only data preflight in §4 succeeds.
+No privilege revocation and no table grant change. Assignment behavior is,
+however, deliberately narrowed at the database boundary: INSERT requires an
+active membership and every direct UPDATE is rejected in favor of
+`rpc_replace_user_roles`. Apply DB-first only after the read-only data
+preflight in §4 succeeds.
 
 ## 1. The verified gap
 
@@ -39,7 +41,7 @@ all before this migration.
 
 | Change | Detail |
 |---|---|
-| Active-membership boundary | A `BEFORE INSERT/UPDATE` trigger on `user_roles` locks and requires the matching active `user_organizations` row. A parent-side trigger refuses deleting, moving, or deactivating a membership while role rows remain. This covers RPCs and the still-permitted direct writes during the 175→176 deployment window. |
+| Assignment boundary | A `BEFORE INSERT FOR EACH ROW` trigger on `user_roles` takes organization→membership locks and requires the matching active membership. A `BEFORE UPDATE FOR EACH STATEMENT` trigger rejects every UPDATE before PostgreSQL locks a child tuple, requiring `rpc_replace_user_roles`. A parent-side trigger refuses deleting, moving, or deactivating a membership while role rows remain. This prevents both orphan grants and the inverse tuple→organization lock order during the 175→176 deployment window. |
 | `rpc_replace_user_roles(jsonb)` lock wrapper | The 174 body is renamed to a non-callable internal function without changing it. The public function keeps the same signature/result, takes the organization lock first, then delegates to the 174 body, which locks membership and preserves every replace/expiry/audit rule. This gives assignments and removals the same lock order. |
 | Permission defense in depth | The explicit-role branches of both `has_permission` and `wardah_has_exact_permission` now join an active membership. Even deliberately corrupted legacy data cannot authorize a user whose membership is inactive or absent. |
 | `rpc_set_org_admin(...)` | Same signature and JSON contract. It now shares an organization-row `FOR UPDATE` lock with member removal, re-authorizes the caller after the lock, and applies `LAST_ORG_ADMIN` only when the target is currently an active admin. |
@@ -68,10 +70,12 @@ all before this migration.
   including the caller-must-be-a-member-first ordering. Widening either is a
   cross-cutting change that deserves its own migration and review, not a
   rider on this one.
-- **No table grant is revoked.** `authenticated` keeps direct
-  `INSERT`/`UPDATE`/`DELETE` on `roles`, `role_permissions` and `user_roles`.
-  Direct `user_roles` writes must now satisfy active membership, and a
-  membership with assignments must clear them before deletion/deactivation.
+- **No table grant is revoked.** `authenticated` keeps the table-level
+  `INSERT`/`UPDATE`/`DELETE` grants on `roles`, `role_permissions` and
+  `user_roles`. At runtime, direct `user_roles` INSERT must satisfy active
+  membership and all UPDATE statements are rejected before tuple locking;
+  assignment changes must use `rpc_replace_user_roles`. A membership with
+  assignments must clear them before deletion/deactivation.
   That closure is **Migration 176**, applied only after the consumer PR has
   moved every real caller onto the RPC surface this migration and 174
   together provide, and the real browser smoke on the deployed UI has proven
@@ -92,7 +96,9 @@ scripts/ci/fresh-db/acceptance_175_rbac_concurrency.sh
 Markers: `RBAC_CONSUMER_175_ACCEPTANCE_PASS` and
 `RBAC_CONSUMER_175_CONCURRENCY_PASS`. Coverage:
 
-1. **Database invariant** (`175-I1…I8`) — inactive-member INSERT/UPDATE and
+1. **Database invariant** (`175-I1…I8`) — inactive-member INSERT is rejected;
+   key, non-key, and zero-row UPDATE statements all fail with the exact RPC
+   redirect marker; the UPDATE trigger is proven to be `BEFORE STATEMENT`;
    parent deletion/deactivation are rejected; both permission helpers deny a
    deliberately injected inactive-member grant; the wrapped 174 replace
    contract remains live with its internal implementation inaccessible.
@@ -120,10 +126,13 @@ Markers: `RBAC_CONSUMER_175_ACCEPTANCE_PASS` and
 7. **Cross-org template creation rejected** (`175-6`).
 8. **Mutation proof** (`175-M1…M7`) — every 170–174 guarantee re-asserted
    plus the new grants, plus an explicit check that no table grant changed.
-9. **Three real multi-session races** — direct assignment versus removal; two
-   admins removing each other; demotion versus removal. Each uses independent
-   PostgreSQL connections queued behind the exact row lock under test and
-   proves one active admin and zero orphan assignments at completion.
+9. **Four real multi-session races** — direct INSERT versus removal; two admins
+   removing each other; demotion versus removal; and direct UPDATE versus
+   removal. The fourth queues removal first on the organization lock, then
+   proves UPDATE hits the statement guard instead of taking the assignment
+   tuple and recreating the inverse-lock deadlock. All use independent
+   PostgreSQL connections and prove one active admin and zero orphan
+   assignments at completion.
 10. **Preflight red proof** — a pre-175 database is deliberately seeded with
     an inactive-member assignment; applying 175 must fail with the exact
     preflight marker and commit none of its object changes.
@@ -136,7 +145,7 @@ Execute on a fresh **PostgreSQL 17** cluster and retain the CI artifacts:
 |---|---|
 | Baseline + chain through 175 | `PASS=14 FAIL=0 NOT_RUN=0 TOTAL=14` |
 | `acceptance_175` | `RBAC_CONSUMER_175_ACCEPTANCE_PASS` |
-| Three two-connection races | `RBAC_CONSUMER_175_CONCURRENCY_PASS` |
+| Four multi-session races | `RBAC_CONSUMER_175_CONCURRENCY_PASS` |
 | `acceptance_174` re-run on the 175 database | `SENSITIVE_PERMISSION_174_ACCEPTANCE_PASS` (no regression) |
 | **Red proof** — chain built with every `175_*.sql` file excluded | `to_regprocedure('public.rpc_remove_org_member(jsonb)') IS NOT NULL` → `f` |
 | **Preflight red proof** | inactive-member assignment rejects 175 with `RBAC_175_INVALID_USER_ROLE_MEMBERSHIP_PREFLIGHT` |
@@ -153,8 +162,9 @@ Both red proofs are CI steps, not manual notes.
 
 ## 4. Production order
 
-No privilege is revoked, but the active-membership invariant intentionally
-narrows invalid writes. Run this read-only query against Production first:
+No privilege is revoked, but the assignment boundary intentionally narrows
+writes and makes `rpc_replace_user_roles` the only UPDATE mechanism. Run this
+read-only query against Production first:
 
 ```sql
 SELECT ur.user_id, ur.org_id, ur.role_id, uo.is_active
@@ -199,8 +209,18 @@ JOIN pg_namespace n ON n.oid = c.relnamespace
 WHERE n.nspname = 'public'
   AND t.tgname IN (
     'trg_wardah_175_require_active_role_membership',
+    'trg_wardah_175_reject_direct_role_update',
     'trg_wardah_175_protect_role_membership_parent');
--- Expect two enabled rows.
+-- Expect three enabled rows.
+
+SELECT pg_get_triggerdef(t.oid) AS update_guard
+FROM pg_trigger t
+JOIN pg_class c ON c.oid = t.tgrelid
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = 'public'
+  AND c.relname = 'user_roles'
+  AND t.tgname = 'trg_wardah_175_reject_direct_role_update';
+-- Expect BEFORE UPDATE ... FOR EACH STATEMENT.
 
 SELECT proname,
        prosrc ~ 'user_organizations uo' AS joins_membership,
@@ -234,13 +254,15 @@ direct RBAC-table mutation in `src/`.
 
 Migration 176 — the direct-write revocation on `roles`, `role_permissions`,
 `user_roles` — is applied only after the consumer PR is live and the browser
-smoke against the deployed UI has passed. Until then `authenticated` keeps
-both paths: the RPCs are sanctioned, not yet exclusive.
+smoke against the deployed UI has passed. Until then the table grants remain,
+but assignment UPDATE is already RPC-exclusive at the behavioral boundary;
+176 closes the remaining direct-write privilege surface.
 
 ## 5. Rollback
 
 No table grant changed and all public RPC signatures remain stable, but 175
-adds two invariant triggers and replaces authorization/admin function bodies.
+adds three invariant/write triggers and replaces authorization/admin function
+bodies.
 Per the golden rule, use a new numbered forward-fix migration if rollback is
 required; never edit an applied 175 or remove its ledger row.
 

--- a/docs/db/RBAC_CONSUMER_175_RUNBOOK.md
+++ b/docs/db/RBAC_CONSUMER_175_RUNBOOK.md
@@ -1,0 +1,196 @@
+# Migration 175 — RBAC Consumer Migration RPCs
+
+**Migration:** `175_rbac_consumer_migration_rpcs.sql`
+**Part of:** Issue #93, second phase. Migration 174 gave the client an atomic,
+audited RPC surface for role and assignment management, but a follow-up audit
+of every production TS/TSX file writing to `roles`, `role_permissions` or
+`user_roles` found the client did not fully move onto it (§1). This migration
+adds exactly the RPC surface the client needs to close every remaining gap.
+**State:** Repository implementation, **not yet applied to Production**.
+Additive only — no privilege revocation, no table grant touched. Safe to
+apply DB-first, ahead of any dependent UI change, per the standard sequencing
+in `CLAUDE.md`.
+
+## 1. The verified gap
+
+Read of every production TS/TSX file that mutates `roles`, `role_permissions`
+or `user_roles`, done after 174 shipped:
+
+| File | Function | Covered by 174? |
+|---|---|---|
+| `src/pages/org-admin/roles.tsx` | permission editing | ✅ via `rbac-service.ts` RPCs |
+| `src/services/rbac-service.ts` | `upsertRole` / `replaceUserRoles` / `deleteRole` | ✅ RPC-based since 174 |
+| `src/services/org-admin-service.ts` | `updateUserRoles()` | ❌ direct `DELETE`+`INSERT` on `user_roles`, no audit row, no atomicity |
+| `src/services/org-admin-service.ts` | `removeUserFromOrg()` | ❌ direct `DELETE` on `user_roles` then `user_organizations`, first error unchecked, no last-admin/self-removal guard |
+| `src/services/org-admin-service.ts` | `createRoleFromTemplate()` | ❌ separate, unrelated same-named function: direct `INSERT roles` + loop of `INSERT role_permissions`, no audit |
+| `src/services/super-admin-service.ts` | `createOrgWithUser()` | direct `INSERT user_roles` — **dead code**, see §3 |
+
+`src/pages/org-admin/roles.tsx` imports `createRoleFromTemplate` from
+`org-admin-service.ts` — the direct-write version — not the already-correct,
+already-guarded RPC-based function of the same name in `rbac-service.ts`
+(added around migration 120). The real defect was the import, not a missing
+RPC; this migration only adds the audit row that RPC was missing.
+
+`updateUserRoles()` and `removeUserFromOrg()` have no RPC-based equivalent at
+all before this migration.
+
+## 2. What this migration adds
+
+| Change | Detail |
+|---|---|
+| `rpc_remove_org_member(jsonb)` | **New.** Atomic, audited replacement for `removeUserFromOrg()`'s two-step client sequence. `{org_id, user_id}` payload. Guarded by `wardah_assert_org_admin`. Refuses self-removal (`RBAC_175_CANNOT_REMOVE_SELF`) and removing the last active admin (`RBAC_175_LAST_ORG_ADMIN`) — mirroring the guards `rpc_set_org_admin` (migration 103) already applies to demotion; removal is more drastic and had no server-side guard at all before this. Locks the membership row `FOR UPDATE`, deletes `user_roles` then `user_organizations` inside the same transaction, and writes one `audit_logs` row with the full pre-removal membership and role-assignment snapshot in `old_data`. |
+| `create_role_from_template(...)` | `CREATE OR REPLACE`, identical signature and return type (`uuid`), every prior statement byte-for-byte unchanged. Adds one `audit_logs` INSERT recording the granted permission keys and flagging any sensitive ones. The consumer PR repoints `roles.tsx`'s import to the already-correct function in `rbac-service.ts`; this migration's only job is to make that function's audit trail complete once it is actually called. |
+| `wardah_is_sensitive_permission(text)` | `CREATE OR REPLACE`, adds `SET search_path = ''`. The body is a pure literal comparison with no table or unqualified-name reference, so this changes nothing about its output for any input (re-asserted in postflight for all four relevant cases including `NULL`). Closes the "Function Search Path Mutable" advisory. |
+| Grants | `rpc_remove_org_member`: `REVOKE ALL FROM PUBLIC, anon, service_role`; `GRANT EXECUTE TO authenticated`. No other grant is touched anywhere in this migration. |
+
+### 2.1 What this migration deliberately does not do
+
+- **No RPC for `super-admin-service.ts`'s `user_roles` insert.** That code
+  looks up `roles.name = 'org_admin'` and only inserts if found. A
+  repository-wide search confirms no migration or seed has ever created a
+  role literally named `org_admin` for any organization — the only
+  `'org_admin'` string in `sql/` is a **module label** from migration 53, not
+  a role name. The lookup's `.single()` never resolves and the guarded
+  insert never executes. Building an RPC for a path that has never run would
+  add a new sanctioned write surface for nothing; the consumer PR deletes
+  the dead block instead. Real admin authority for a newly bootstrapped
+  organization is `user_organizations.is_org_admin = true`, set two
+  statements earlier in the same function — untouched, unaffected, and
+  already outside RBAC-table scope.
+- **`wardah_assert_org_admin` / `wardah_assert_org_member` are not touched.**
+  Dozens of functions across the schema depend on their current behavior,
+  including the caller-must-be-a-member-first ordering. Widening either is a
+  cross-cutting change that deserves its own migration and review, not a
+  rider on this one.
+- **No table grant is revoked.** `authenticated` keeps direct
+  `INSERT`/`UPDATE`/`DELETE` on `roles`, `role_permissions` and `user_roles`.
+  That closure is **Migration 176**, applied only after the consumer PR has
+  moved every real caller onto the RPC surface this migration and 174
+  together provide, and the real browser smoke on the deployed UI has proven
+  it end to end. Revoking here, before the consumer PR ships, would break
+  the still-live direct-write paths in the window between this migration and
+  its dependent UI deploying — the same `repository-first` / `DB-first`
+  sequencing violation `CLAUDE.md` already documents for Migration 148 and
+  (inverted) for Migration 170.
+
+## 3. Acceptance gate
+
+```text
+scripts/ci/fresh-db/acceptance_175_rbac_consumer_migration_rpcs.sql
+.github/workflows/rbac-consumer-175-acceptance.yml
+```
+
+Marker: `RBAC_CONSUMER_175_ACCEPTANCE_PASS`. Coverage:
+
+1. **Cross-org rejection** (`175-1`) — an org admin of one org cannot remove a
+   member of another.
+2. **Self-removal rejection** (`175-2`) — `RBAC_175_CANNOT_REMOVE_SELF`, own
+   membership row provably untouched afterward.
+3. **Last-admin guard** (`175-3a/3c/3d`) — a legal removal down to exactly one
+   admin succeeds; a distinct fixture (a super admin who is a *non-admin*
+   member of the target org — the only way to get an admin-gated caller
+   whose identity differs from the target while the guard is still
+   reachable) attempting to remove the sole remaining admin is rejected with
+   `RBAC_175_LAST_ORG_ADMIN`, and the membership row is proven untouched.
+4. **Real removal + full audit verification** (`175-4a…4e`) — membership and
+   `user_roles` rows actually gone, `audit_logs` row present with
+   `old_data.role_assignments` matching the exact pre-removal snapshot,
+   `new_data IS NULL`, `metadata.was_org_admin` and
+   `metadata.removed_role_count` correct.
+5. **`create_role_from_template` unchanged behavior + new audit row**
+   (`175-5a…5e`) — permissions still granted correctly from the template,
+   `audit_logs` row present with `source = 'template'` and sensitive keys
+   correctly flagged.
+6. **Cross-org template creation rejected** (`175-6`).
+7. **Mutation proof** (`175-M1…M7`) — every 170–174 guarantee re-asserted
+   plus the new grants, plus an explicit check that no table grant changed.
+
+### 3.1 Verification actually performed
+
+Executed locally on a real **PostgreSQL 17.10** cluster, rebuilt from
+scratch immediately before commit:
+
+| Check | Result |
+|---|---|
+| Baseline + chain through 175 | `PASS=14 FAIL=0 NOT_RUN=0 TOTAL=14` |
+| `acceptance_175` | `RBAC_CONSUMER_175_ACCEPTANCE_PASS` |
+| `acceptance_174` re-run on the 175 database | `SENSITIVE_PERMISSION_174_ACCEPTANCE_PASS` (no regression) |
+| **Red proof** — chain built with every `175_*.sql` file excluded | `to_regprocedure('public.rpc_remove_org_member(jsonb)') IS NOT NULL` → `f` |
+
+Every embedded shell block in `.github/workflows/rbac-consumer-175-acceptance.yml`
+was checked with `bash -n`; the YAML was parsed with `yaml.safe_load`. The
+same static gates already required by CI were run against the new migration
+file: `check_migration_syntax.py` (pglast — 203 files, all valid),
+`check_definer_guards.py` (45 migrations above the guard threshold, no
+unguarded `SECURITY DEFINER`), and `validate_migration_ledger.py`
+(`repo_max: 175`, numbering and naming valid).
+
+The red proof is a real CI step, not a manual note: if a pre-175 database
+ever produces `rpc_remove_org_member`, the job fails.
+
+## 4. Production order
+
+Purely additive — no operational transaction is required before applying
+this migration, unlike 174. There is no lockout risk: nothing existing is
+narrowed or revoked.
+
+### Step 1 — apply 175
+
+Apply the exact file merged to `main`. Its own `$verify$` block runs before
+`COMMIT` and fails the transaction on any drift.
+
+### Step 2 — read-only postflight
+
+```sql
+SELECT
+  prosrc ~ 'wardah_assert_org_admin'              AS org_admin_guarded,
+  prosrc ~ 'RBAC_175_CANNOT_REMOVE_SELF'          AS self_removal_guard,
+  prosrc ~ 'RBAC_175_LAST_ORG_ADMIN'              AS last_admin_guard,
+  prosrc ~ 'FOR UPDATE'                            AS locks_membership_row,
+  prosrc ~ 'audit_logs'                            AS writes_audit
+FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname = 'public' AND p.proname = 'rpc_remove_org_member';
+-- Expect every column true.
+
+SELECT has_function_privilege('anon', 'public.rpc_remove_org_member(jsonb)', 'EXECUTE') AS anon_can_call,
+       has_function_privilege('authenticated', 'public.rpc_remove_org_member(jsonb)', 'EXECUTE') AS authenticated_can_call;
+-- Expect anon_can_call = false, authenticated_can_call = true.
+
+SELECT prosrc ~ 'audit_logs' AS template_now_audited
+FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname = 'public' AND p.proname = 'create_role_from_template';
+-- Expect true.
+
+SELECT version, name FROM supabase_migrations.schema_migrations
+WHERE name = '175_rbac_consumer_migration_rpcs';
+-- Expect exactly one row.
+```
+
+### Step 3 — merge and deploy the separate consumer PR
+
+Only after step 2 is verified. That PR (not this migration) rewires
+`users.tsx` onto `rpc_replace_user_roles` and the new `removeOrgMember()`
+wrapper, repoints `roles.tsx`'s template-creation import to `rbac-service.ts`,
+deletes the three dead/dangerous direct-write functions from
+`org-admin-service.ts`, deletes the dead role-lookup block from
+`super-admin-service.ts`, and adds the CI gate forbidding any remaining
+direct RBAC-table mutation in `src/`.
+
+### Step 4 — real browser smoke, then Migration 176
+
+Migration 176 — the direct-write revocation on `roles`, `role_permissions`,
+`user_roles` — is applied only after the consumer PR is live and the browser
+smoke against the deployed UI has passed. Until then `authenticated` keeps
+both paths: the RPCs are sanctioned, not yet exclusive.
+
+## 5. Rollback
+
+Additive apart from two `CREATE OR REPLACE` bodies, both no-ops for existing
+behavior except the added audit write. Per the golden rule, a forward fix
+(a new numbered migration) is preferred over any revert. There is nothing to
+revert defensively: no grant was narrowed, no existing caller's contract
+changed, and the new RPC's execute boundary is `authenticated` only, matching
+every other RBAC RPC in this repository.
+
+Never edit `supabase_migrations.schema_migrations`, and never apply SQL that
+is not the exact file merged to `main`.

--- a/scripts/ci/fresh-db/acceptance_175_rbac_concurrency.sh
+++ b/scripts/ci/fresh-db/acceptance_175_rbac_concurrency.sh
@@ -262,9 +262,11 @@ wait "$demote_b_pid" || demote_b_status=$?
 wait "$demote_blocker_pid"
 
 demote_result=$(tr -d '\r' <"${tmp_prefix}-demote-a.out" | sed '/^[[:space:]]*$/d' | tail -1)
-if ! { [[ "$demote_result" == 't' && $demote_b_status -ne 0 ]] \
-       || [[ "$demote_result" == 'f' && $demote_b_status -eq 0 ]]; }; then
-  echo "RBAC_175_CONCURRENCY_FAIL: demote_result=$demote_result remove_status=$demote_b_status" >&2
+if [[ $demote_a_status -ne 0 ]] || ! {
+  [[ "$demote_result" == 't' && $demote_b_status -ne 0 ]] \
+    || [[ "$demote_result" == 'f' && $demote_b_status -eq 0 ]]
+}; then
+  echo "RBAC_175_CONCURRENCY_FAIL: demote_status=$demote_a_status demote_result=$demote_result remove_status=$demote_b_status" >&2
   cat "${tmp_prefix}-demote-a.err" "${tmp_prefix}-demote-b.err" >&2
   exit 1
 fi
@@ -300,4 +302,3 @@ fi
 printf 'RBAC_CONSUMER_175_CONCURRENCY_PASS assign_insert_status=%s mutual_remove=%s,%s demote=%s remove=%s\n' \
   "$assign_insert_status" "$remove_a_status" "$remove_b_status" \
   "$demote_result" "$demote_b_status"
-

--- a/scripts/ci/fresh-db/acceptance_175_rbac_concurrency.sh
+++ b/scripts/ci/fresh-db/acceptance_175_rbac_concurrency.sh
@@ -19,17 +19,23 @@ org_demote='99175175-a333-a333-a333-000000000003'
 demote_admin_a='99175175-3333-3333-3333-000000000001'
 demote_admin_b='99175175-3333-3333-3333-000000000002'
 
+org_update='99175175-a444-a444-a444-000000000004'
+update_admin='99175175-4444-4444-4444-000000000001'
+update_target='99175175-4444-4444-4444-000000000002'
+update_role='99175175-4444-4444-4444-000000000020'
+
 rm -f "${tmp_prefix}"-*.ready "${tmp_prefix}"-*.started \
   "${tmp_prefix}"-*.out "${tmp_prefix}"-*.err
 
 "${PSQL[@]}" <<SQL
 DELETE FROM public.organizations
-WHERE id IN ('$org_assign', '$org_remove', '$org_demote');
+WHERE id IN ('$org_assign', '$org_remove', '$org_demote', '$org_update');
 DELETE FROM auth.users
 WHERE id IN (
   '$assign_admin', '$assign_target',
   '$remove_admin_a', '$remove_admin_b',
-  '$demote_admin_a', '$demote_admin_b'
+  '$demote_admin_a', '$demote_admin_b',
+  '$update_admin', '$update_target'
 );
 
 INSERT INTO auth.users (id, email) VALUES
@@ -38,12 +44,15 @@ INSERT INTO auth.users (id, email) VALUES
   ('$remove_admin_a', 'p175-race-remove-a@example.test'),
   ('$remove_admin_b', 'p175-race-remove-b@example.test'),
   ('$demote_admin_a', 'p175-race-demote-a@example.test'),
-  ('$demote_admin_b', 'p175-race-demote-b@example.test');
+  ('$demote_admin_b', 'p175-race-demote-b@example.test'),
+  ('$update_admin', 'p175-race-update-admin@example.test'),
+  ('$update_target', 'p175-race-update-target@example.test');
 
 INSERT INTO public.organizations (id, name, code) VALUES
   ('$org_assign', 'RBAC 175 assignment race', 'P175-RA'),
   ('$org_remove', 'RBAC 175 removal race', 'P175-RR'),
-  ('$org_demote', 'RBAC 175 demotion race', 'P175-RD');
+  ('$org_demote', 'RBAC 175 demotion race', 'P175-RD'),
+  ('$org_update', 'RBAC 175 update race', 'P175-RU');
 
 INSERT INTO public.user_organizations
   (user_id, org_id, is_active, is_org_admin)
@@ -53,10 +62,17 @@ VALUES
   ('$remove_admin_a', '$org_remove', true, true),
   ('$remove_admin_b', '$org_remove', true, true),
   ('$demote_admin_a', '$org_demote', true, true),
-  ('$demote_admin_b', '$org_demote', true, true);
+  ('$demote_admin_b', '$org_demote', true, true),
+  ('$update_admin', '$org_update', true, true),
+  ('$update_target', '$org_update', true, false);
 
 INSERT INTO public.roles (id, org_id, name, name_ar, is_active)
-VALUES ('$assign_role', '$org_assign', 'P175 Race Role', 'دور سباق 175', true);
+VALUES
+  ('$assign_role', '$org_assign', 'P175 Race Role', 'دور سباق 175', true),
+  ('$update_role', '$org_update', 'P175 Update Race Role', 'دور سباق تحديث 175', true);
+
+INSERT INTO public.user_roles (user_id, role_id, org_id)
+VALUES ('$update_target', '$update_role', '$org_update');
 SQL
 
 wait_for_file() {
@@ -67,6 +83,26 @@ wait_for_file() {
     sleep 0.05
   done
   echo "RBAC_175_CONCURRENCY_FAIL: timed out waiting for $label" >&2
+  return 1
+}
+
+wait_for_backend_lock() {
+  local application_name=$1
+  local label=$2
+  local waiting
+  for _ in $(seq 1 100); do
+    waiting=$("${PSQL[@]}" <<SQL
+SELECT count(*)
+FROM pg_stat_activity
+WHERE application_name = '$application_name'
+  AND state = 'active'
+  AND wait_event_type = 'Lock';
+SQL
+)
+    [[ "$waiting" == '1' ]] && return 0
+    sleep 0.05
+  done
+  echo "RBAC_175_CONCURRENCY_FAIL: timed out waiting for $label to block on a lock" >&2
   return 1
 }
 
@@ -109,7 +145,8 @@ run_remove() {
   local started=$4
   local output=$5
   local error=$6
-  "${PSQL[@]}" >"$output" 2>"$error" <<SQL
+  local application_name=${7:-rbac-175-remover}
+  PGAPPNAME="$application_name" "${PSQL[@]}" >"$output" 2>"$error" <<SQL
 BEGIN;
 SELECT set_config('request.jwt.claim.sub', '$caller', true);
 SET LOCAL ROLE authenticated;
@@ -282,7 +319,74 @@ if [[ "$demote_final" != '1' ]]; then
   exit 1
 fi
 
-# Global invariant proof across every fixture left by all three races.
+# ---------------------------------------------------------------------------
+# Race 4: direct UPDATE versus member removal. The UPDATE must fail at its
+# BEFORE STATEMENT guard, before locking the assignment tuple. Removal is
+# deliberately queued first behind the organization row; the old BEFORE ROW
+# design deadlocks here by holding tuple -> waiting org while removal holds
+# org -> waiting tuple.
+# ---------------------------------------------------------------------------
+update_ready="${tmp_prefix}-update.ready"
+update_writer_started="${tmp_prefix}-update-writer.started"
+update_remove_started="${tmp_prefix}-update-remove.started"
+start_org_blocker "$org_update" "$update_ready" "${tmp_prefix}-update-blocker.out"
+update_blocker_pid=$BLOCKER_PID
+wait_for_file "$update_ready" 'direct-update blocker'
+
+run_remove "$update_admin" "$update_target" "$org_update" \
+  "$update_remove_started" "${tmp_prefix}-update-remove.out" \
+  "${tmp_prefix}-update-remove.err" 'rbac-175-update-remover' &
+update_remove_pid=$!
+wait_for_file "$update_remove_started" 'member remover during direct update'
+wait_for_backend_lock 'rbac-175-update-remover' \
+  'member remover during direct update'
+
+( "${PSQL[@]}" >"${tmp_prefix}-update-writer.out" 2>"${tmp_prefix}-update-writer.err" <<SQL
+\! touch $update_writer_started
+UPDATE public.user_roles
+SET expires_at = now() + interval '1 day'
+WHERE user_id = '$update_target'
+  AND role_id = '$update_role'
+  AND org_id = '$org_update';
+SQL
+) &
+update_writer_pid=$!
+wait_for_file "$update_writer_started" 'direct user_roles updater'
+
+update_writer_status=0
+update_remove_status=0
+wait "$update_writer_pid" || update_writer_status=$?
+wait "$update_blocker_pid"
+wait "$update_remove_pid" || update_remove_status=$?
+
+if [[ $update_writer_status -eq 0 ]] \
+   || ! grep -q 'RBAC_175_DIRECT_USER_ROLES_UPDATE_FORBIDDEN_USE_RPC_REPLACE_USER_ROLES' \
+        "${tmp_prefix}-update-writer.err"; then
+  echo "RBAC_175_CONCURRENCY_FAIL: direct UPDATE status=$update_writer_status did not hit the statement guard" >&2
+  cat "${tmp_prefix}-update-writer.err" >&2
+  exit 1
+fi
+if [[ $update_remove_status -ne 0 ]]; then
+  echo "RBAC_175_CONCURRENCY_FAIL: removal lost the direct-UPDATE race status=$update_remove_status" >&2
+  cat "${tmp_prefix}-update-remove.err" >&2
+  exit 1
+fi
+
+update_final=$("${PSQL[@]}" <<SQL
+SELECT
+  (SELECT count(*) FROM public.user_organizations
+    WHERE user_id = '$update_target' AND org_id = '$org_update')::text
+  || '|' ||
+  (SELECT count(*) FROM public.user_roles
+    WHERE user_id = '$update_target' AND org_id = '$org_update')::text;
+SQL
+)
+if [[ "$update_final" != '0|0' ]]; then
+  echo "RBAC_175_CONCURRENCY_FAIL: update/removal final membership|roles=$update_final" >&2
+  exit 1
+fi
+
+# Global invariant proof across every fixture left by all four races.
 orphan_count=$("${PSQL[@]}" <<SQL
 SELECT count(*)
 FROM public.user_roles ur
@@ -290,7 +394,7 @@ LEFT JOIN public.user_organizations uo
   ON uo.user_id = ur.user_id
  AND uo.org_id = ur.org_id
  AND uo.is_active IS TRUE
-WHERE ur.org_id IN ('$org_assign', '$org_remove', '$org_demote')
+WHERE ur.org_id IN ('$org_assign', '$org_remove', '$org_demote', '$org_update')
   AND uo.user_id IS NULL;
 SQL
 )
@@ -299,6 +403,7 @@ if [[ "$orphan_count" != '0' ]]; then
   exit 1
 fi
 
-printf 'RBAC_CONSUMER_175_CONCURRENCY_PASS assign_insert_status=%s mutual_remove=%s,%s demote=%s remove=%s\n' \
+printf 'RBAC_CONSUMER_175_CONCURRENCY_PASS assign_insert_status=%s mutual_remove=%s,%s demote=%s remove=%s direct_update=%s update_remove=%s\n' \
   "$assign_insert_status" "$remove_a_status" "$remove_b_status" \
-  "$demote_result" "$demote_b_status"
+  "$demote_result" "$demote_b_status" "$update_writer_status" \
+  "$update_remove_status"

--- a/scripts/ci/fresh-db/acceptance_175_rbac_concurrency.sh
+++ b/scripts/ci/fresh-db/acceptance_175_rbac_concurrency.sh
@@ -393,13 +393,12 @@ FROM public.user_roles ur
 LEFT JOIN public.user_organizations uo
   ON uo.user_id = ur.user_id
  AND uo.org_id = ur.org_id
- AND uo.is_active IS TRUE
 WHERE ur.org_id IN ('$org_assign', '$org_remove', '$org_demote', '$org_update')
   AND uo.user_id IS NULL;
 SQL
 )
 if [[ "$orphan_count" != '0' ]]; then
-  echo "RBAC_175_CONCURRENCY_FAIL: orphan/inactive assignments=$orphan_count" >&2
+  echo "RBAC_175_CONCURRENCY_FAIL: orphan assignments=$orphan_count" >&2
   exit 1
 fi
 

--- a/scripts/ci/fresh-db/acceptance_175_rbac_concurrency.sh
+++ b/scripts/ci/fresh-db/acceptance_175_rbac_concurrency.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+: "${PGDATABASE:?PGDATABASE must be set}"
+
+PSQL=(psql -X -v ON_ERROR_STOP=1 -qAt)
+tmp_prefix=/tmp/rbac-175
+
+org_assign='99175175-a111-a111-a111-000000000001'
+assign_admin='99175175-1111-1111-1111-000000000001'
+assign_target='99175175-1111-1111-1111-000000000002'
+assign_role='99175175-1111-1111-1111-000000000020'
+
+org_remove='99175175-a222-a222-a222-000000000002'
+remove_admin_a='99175175-2222-2222-2222-000000000001'
+remove_admin_b='99175175-2222-2222-2222-000000000002'
+
+org_demote='99175175-a333-a333-a333-000000000003'
+demote_admin_a='99175175-3333-3333-3333-000000000001'
+demote_admin_b='99175175-3333-3333-3333-000000000002'
+
+rm -f "${tmp_prefix}"-*.ready "${tmp_prefix}"-*.started \
+  "${tmp_prefix}"-*.out "${tmp_prefix}"-*.err
+
+"${PSQL[@]}" <<SQL
+DELETE FROM public.organizations
+WHERE id IN ('$org_assign', '$org_remove', '$org_demote');
+DELETE FROM auth.users
+WHERE id IN (
+  '$assign_admin', '$assign_target',
+  '$remove_admin_a', '$remove_admin_b',
+  '$demote_admin_a', '$demote_admin_b'
+);
+
+INSERT INTO auth.users (id, email) VALUES
+  ('$assign_admin', 'p175-race-assign-admin@example.test'),
+  ('$assign_target', 'p175-race-assign-target@example.test'),
+  ('$remove_admin_a', 'p175-race-remove-a@example.test'),
+  ('$remove_admin_b', 'p175-race-remove-b@example.test'),
+  ('$demote_admin_a', 'p175-race-demote-a@example.test'),
+  ('$demote_admin_b', 'p175-race-demote-b@example.test');
+
+INSERT INTO public.organizations (id, name, code) VALUES
+  ('$org_assign', 'RBAC 175 assignment race', 'P175-RA'),
+  ('$org_remove', 'RBAC 175 removal race', 'P175-RR'),
+  ('$org_demote', 'RBAC 175 demotion race', 'P175-RD');
+
+INSERT INTO public.user_organizations
+  (user_id, org_id, is_active, is_org_admin)
+VALUES
+  ('$assign_admin', '$org_assign', true, true),
+  ('$assign_target', '$org_assign', true, false),
+  ('$remove_admin_a', '$org_remove', true, true),
+  ('$remove_admin_b', '$org_remove', true, true),
+  ('$demote_admin_a', '$org_demote', true, true),
+  ('$demote_admin_b', '$org_demote', true, true);
+
+INSERT INTO public.roles (id, org_id, name, name_ar, is_active)
+VALUES ('$assign_role', '$org_assign', 'P175 Race Role', 'دور سباق 175', true);
+SQL
+
+wait_for_file() {
+  local path=$1
+  local label=$2
+  for _ in $(seq 1 100); do
+    [[ -f "$path" ]] && return 0
+    sleep 0.05
+  done
+  echo "RBAC_175_CONCURRENCY_FAIL: timed out waiting for $label" >&2
+  return 1
+}
+
+start_org_blocker() {
+  local org_id=$1
+  local ready=$2
+  local output=$3
+  "${PSQL[@]}" >"$output" 2>&1 <<SQL &
+BEGIN;
+SELECT id FROM public.organizations WHERE id = '$org_id' FOR UPDATE;
+\! touch $ready
+SELECT pg_sleep(4);
+COMMIT;
+SQL
+  BLOCKER_PID=$!
+}
+
+start_membership_blocker() {
+  local user_id=$1
+  local org_id=$2
+  local ready=$3
+  local output=$4
+  "${PSQL[@]}" >"$output" 2>&1 <<SQL &
+BEGIN;
+SELECT user_id
+FROM public.user_organizations
+WHERE user_id = '$user_id' AND org_id = '$org_id'
+FOR UPDATE;
+\! touch $ready
+SELECT pg_sleep(4);
+COMMIT;
+SQL
+  BLOCKER_PID=$!
+}
+
+run_remove() {
+  local caller=$1
+  local target=$2
+  local org_id=$3
+  local started=$4
+  local output=$5
+  local error=$6
+  "${PSQL[@]}" >"$output" 2>"$error" <<SQL
+BEGIN;
+SELECT set_config('request.jwt.claim.sub', '$caller', true);
+SET LOCAL ROLE authenticated;
+\! touch $started
+SELECT public.rpc_remove_org_member(jsonb_build_object(
+  'org_id', '$org_id', 'user_id', '$target'));
+COMMIT;
+SQL
+}
+
+run_demote() {
+  local caller=$1
+  local target=$2
+  local org_id=$3
+  local started=$4
+  local output=$5
+  local error=$6
+  "${PSQL[@]}" >"$output" 2>"$error" <<SQL
+BEGIN;
+SELECT set_config('request.jwt.claim.sub', '$caller', true);
+SET LOCAL ROLE authenticated;
+\! touch $started
+SELECT COALESCE((public.rpc_set_org_admin(
+  '$target', '$org_id', false)->>'ok')::boolean, false);
+COMMIT;
+SQL
+}
+
+# ---------------------------------------------------------------------------
+# Race 1: a still-permitted direct user_roles INSERT against member removal.
+# ---------------------------------------------------------------------------
+assign_ready="${tmp_prefix}-assign.ready"
+assign_insert_started="${tmp_prefix}-assign-insert.started"
+assign_remove_started="${tmp_prefix}-assign-remove.started"
+start_membership_blocker "$assign_target" "$org_assign" "$assign_ready" \
+  "${tmp_prefix}-assign-blocker.out"
+assign_blocker_pid=$BLOCKER_PID
+wait_for_file "$assign_ready" 'assignment blocker'
+
+( "${PSQL[@]}" >"${tmp_prefix}-assign-insert.out" 2>"${tmp_prefix}-assign-insert.err" <<SQL
+\! touch $assign_insert_started
+INSERT INTO public.user_roles (user_id, role_id, org_id)
+VALUES ('$assign_target', '$assign_role', '$org_assign');
+SQL
+) &
+assign_insert_pid=$!
+run_remove "$assign_admin" "$assign_target" "$org_assign" \
+  "$assign_remove_started" "${tmp_prefix}-assign-remove.out" \
+  "${tmp_prefix}-assign-remove.err" &
+assign_remove_pid=$!
+
+wait_for_file "$assign_insert_started" 'assignment writer'
+wait_for_file "$assign_remove_started" 'member remover'
+
+assign_insert_status=0
+assign_remove_status=0
+wait "$assign_insert_pid" || assign_insert_status=$?
+wait "$assign_remove_pid" || assign_remove_status=$?
+wait "$assign_blocker_pid"
+
+if [[ $assign_remove_status -ne 0 ]]; then
+  echo 'RBAC_175_CONCURRENCY_FAIL: member removal lost the assignment race' >&2
+  cat "${tmp_prefix}-assign-remove.err" >&2
+  exit 1
+fi
+
+assign_final=$("${PSQL[@]}" <<SQL
+SELECT
+  (SELECT count(*) FROM public.user_organizations
+    WHERE user_id = '$assign_target' AND org_id = '$org_assign')::text
+  || '|' ||
+  (SELECT count(*) FROM public.user_roles
+    WHERE user_id = '$assign_target' AND org_id = '$org_assign')::text;
+SQL
+)
+if [[ "$assign_final" != '0|0' ]]; then
+  echo "RBAC_175_CONCURRENCY_FAIL: assignment/removal final membership|roles=$assign_final" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Race 2: two admins remove each other. Exactly one call may commit.
+# ---------------------------------------------------------------------------
+remove_ready="${tmp_prefix}-remove.ready"
+remove_a_started="${tmp_prefix}-remove-a.started"
+remove_b_started="${tmp_prefix}-remove-b.started"
+start_org_blocker "$org_remove" "$remove_ready" "${tmp_prefix}-remove-blocker.out"
+remove_blocker_pid=$BLOCKER_PID
+wait_for_file "$remove_ready" 'mutual-removal blocker'
+
+run_remove "$remove_admin_a" "$remove_admin_b" "$org_remove" \
+  "$remove_a_started" "${tmp_prefix}-remove-a.out" "${tmp_prefix}-remove-a.err" &
+remove_a_pid=$!
+run_remove "$remove_admin_b" "$remove_admin_a" "$org_remove" \
+  "$remove_b_started" "${tmp_prefix}-remove-b.out" "${tmp_prefix}-remove-b.err" &
+remove_b_pid=$!
+wait_for_file "$remove_a_started" 'admin A removal'
+wait_for_file "$remove_b_started" 'admin B removal'
+
+remove_a_status=0
+remove_b_status=0
+wait "$remove_a_pid" || remove_a_status=$?
+wait "$remove_b_pid" || remove_b_status=$?
+wait "$remove_blocker_pid"
+
+remove_successes=0
+[[ $remove_a_status -eq 0 ]] && remove_successes=$((remove_successes + 1))
+[[ $remove_b_status -eq 0 ]] && remove_successes=$((remove_successes + 1))
+if [[ $remove_successes -ne 1 ]]; then
+  echo "RBAC_175_CONCURRENCY_FAIL: mutual removal successes=$remove_successes" >&2
+  cat "${tmp_prefix}-remove-a.err" "${tmp_prefix}-remove-b.err" >&2
+  exit 1
+fi
+
+remove_final=$("${PSQL[@]}" <<SQL
+SELECT count(*)::text || '|' || count(*) FILTER (WHERE is_org_admin AND is_active)::text
+FROM public.user_organizations
+WHERE org_id = '$org_remove';
+SQL
+)
+if [[ "$remove_final" != '1|1' ]]; then
+  echo "RBAC_175_CONCURRENCY_FAIL: mutual removal final members|admins=$remove_final" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Race 3: A demotes B while B removes A. The post-lock authorization check
+# rejects the second action regardless of which waiter acquires the lock first.
+# ---------------------------------------------------------------------------
+demote_ready="${tmp_prefix}-demote.ready"
+demote_a_started="${tmp_prefix}-demote-a.started"
+demote_b_started="${tmp_prefix}-demote-b.started"
+start_org_blocker "$org_demote" "$demote_ready" "${tmp_prefix}-demote-blocker.out"
+demote_blocker_pid=$BLOCKER_PID
+wait_for_file "$demote_ready" 'demotion/removal blocker'
+
+run_demote "$demote_admin_a" "$demote_admin_b" "$org_demote" \
+  "$demote_a_started" "${tmp_prefix}-demote-a.out" "${tmp_prefix}-demote-a.err" &
+demote_a_pid=$!
+run_remove "$demote_admin_b" "$demote_admin_a" "$org_demote" \
+  "$demote_b_started" "${tmp_prefix}-demote-b.out" "${tmp_prefix}-demote-b.err" &
+demote_b_pid=$!
+wait_for_file "$demote_a_started" 'admin demotion'
+wait_for_file "$demote_b_started" 'admin removal during demotion'
+
+demote_a_status=0
+demote_b_status=0
+wait "$demote_a_pid" || demote_a_status=$?
+wait "$demote_b_pid" || demote_b_status=$?
+wait "$demote_blocker_pid"
+
+demote_result=$(tr -d '\r' <"${tmp_prefix}-demote-a.out" | sed '/^[[:space:]]*$/d' | tail -1)
+if ! { [[ "$demote_result" == 't' && $demote_b_status -ne 0 ]] \
+       || [[ "$demote_result" == 'f' && $demote_b_status -eq 0 ]]; }; then
+  echo "RBAC_175_CONCURRENCY_FAIL: demote_result=$demote_result remove_status=$demote_b_status" >&2
+  cat "${tmp_prefix}-demote-a.err" "${tmp_prefix}-demote-b.err" >&2
+  exit 1
+fi
+
+demote_final=$("${PSQL[@]}" <<SQL
+SELECT count(*) FILTER (WHERE is_org_admin AND is_active)::text
+FROM public.user_organizations
+WHERE org_id = '$org_demote';
+SQL
+)
+if [[ "$demote_final" != '1' ]]; then
+  echo "RBAC_175_CONCURRENCY_FAIL: demotion/removal left $demote_final active admins" >&2
+  exit 1
+fi
+
+# Global invariant proof across every fixture left by all three races.
+orphan_count=$("${PSQL[@]}" <<SQL
+SELECT count(*)
+FROM public.user_roles ur
+LEFT JOIN public.user_organizations uo
+  ON uo.user_id = ur.user_id
+ AND uo.org_id = ur.org_id
+ AND uo.is_active IS TRUE
+WHERE ur.org_id IN ('$org_assign', '$org_remove', '$org_demote')
+  AND uo.user_id IS NULL;
+SQL
+)
+if [[ "$orphan_count" != '0' ]]; then
+  echo "RBAC_175_CONCURRENCY_FAIL: orphan/inactive assignments=$orphan_count" >&2
+  exit 1
+fi
+
+printf 'RBAC_CONSUMER_175_CONCURRENCY_PASS assign_insert_status=%s mutual_remove=%s,%s demote=%s remove=%s\n' \
+  "$assign_insert_status" "$remove_a_status" "$remove_b_status" \
+  "$demote_result" "$demote_b_status"
+

--- a/scripts/ci/fresh-db/acceptance_175_rbac_consumer_migration_rpcs.sql
+++ b/scripts/ci/fresh-db/acceptance_175_rbac_consumer_migration_rpcs.sql
@@ -3,7 +3,8 @@
 -- Proves, behaviourally:
 --   (1) user_roles INSERT can only point at active memberships; every UPDATE
 --       is rejected at statement level in favor of rpc_replace_user_roles;
---       membership deletion/deactivation cannot strand assignments.
+--       membership deletion/movement cannot strand assignments, while
+--       reversible deactivation preserves but suppresses assignments.
 --   (2) explicit-role authorization requires active membership.
 --   (3) rpc_remove_org_member: org-admin guard, self-removal guard, last-admin
 --       guard, atomic removal of roles + membership, audit row with a full
@@ -117,16 +118,22 @@ BEGIN
     RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-I2c]: UPDATE guard is not an enabled BEFORE STATEMENT trigger';
   END IF;
 
-  BEGIN
-    UPDATE public.user_organizations
-    SET is_active = false
+  UPDATE public.user_organizations
+  SET is_active = false
+  WHERE user_id = '99175175-0003-0003-0003-000000000003'
+    AND org_id = '99175175-a000-a000-a000-00000000000a';
+  IF NOT EXISTS (
+    SELECT 1 FROM public.user_organizations
     WHERE user_id = '99175175-0003-0003-0003-000000000003'
-      AND org_id = '99175175-a000-a000-a000-00000000000a';
-    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-I3]: membership deactivated while roles remained';
-  EXCEPTION WHEN OTHERS THEN
-    IF SQLERRM LIKE 'ACCEPTANCE_FAIL%' THEN RAISE; END IF;
-    IF SQLERRM NOT LIKE '%RBAC_175_MEMBERSHIP_HAS_ROLE_ASSIGNMENTS%' THEN RAISE; END IF;
-  END;
+      AND org_id = '99175175-a000-a000-a000-00000000000a'
+      AND is_active IS FALSE
+  ) OR NOT EXISTS (
+    SELECT 1 FROM public.user_roles
+    WHERE user_id = '99175175-0003-0003-0003-000000000003'
+      AND org_id = '99175175-a000-a000-a000-00000000000a'
+  ) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-I3]: deactivation did not preserve membership and assignments';
+  END IF;
 
   BEGIN
     DELETE FROM public.user_organizations
@@ -137,19 +144,22 @@ BEGIN
     IF SQLERRM LIKE 'ACCEPTANCE_FAIL%' THEN RAISE; END IF;
     IF SQLERRM NOT LIKE '%RBAC_175_MEMBERSHIP_HAS_ROLE_ASSIGNMENTS%' THEN RAISE; END IF;
   END;
+
+  BEGIN
+    UPDATE public.user_organizations
+    SET org_id = '99175175-b000-b000-b000-00000000000b'
+    WHERE user_id = '99175175-0003-0003-0003-000000000003'
+      AND org_id = '99175175-a000-a000-a000-00000000000a';
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-I4b]: membership moved while roles remained';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE 'ACCEPTANCE_FAIL%' THEN RAISE; END IF;
+    IF SQLERRM NOT LIKE '%RBAC_175_MEMBERSHIP_HAS_ROLE_ASSIGNMENTS%' THEN RAISE; END IF;
+  END;
 END;
 $$;
 
--- Defense-in-depth proof: emulate legacy invalid data by temporarily disabling
--- only the new parent guard. Both authorization helpers must still deny the
--- explicit role while the membership is inactive.
-ALTER TABLE public.user_organizations
-  DISABLE TRIGGER trg_wardah_175_protect_role_membership_parent;
-UPDATE public.user_organizations
-SET is_active = false
-WHERE user_id = '99175175-0003-0003-0003-000000000003'
-  AND org_id = '99175175-a000-a000-a000-00000000000a';
-
+-- Defense-in-depth proof: the role remains stored after the supported direct
+-- status toggle, but both authorization helpers must deny it while inactive.
 DO $$
 BEGIN
   BEGIN
@@ -194,8 +204,30 @@ UPDATE public.user_organizations
 SET is_active = true
 WHERE user_id = '99175175-0003-0003-0003-000000000003'
   AND org_id = '99175175-a000-a000-a000-00000000000a';
-ALTER TABLE public.user_organizations
-  ENABLE TRIGGER trg_wardah_175_protect_role_membership_parent;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM public.user_organizations
+    WHERE user_id = '99175175-0003-0003-0003-000000000003'
+      AND org_id = '99175175-a000-a000-a000-00000000000a'
+      AND is_active IS TRUE
+  ) OR NOT EXISTS (
+    SELECT 1 FROM public.user_roles
+    WHERE user_id = '99175175-0003-0003-0003-000000000003'
+      AND org_id = '99175175-a000-a000-a000-00000000000a'
+  ) OR NOT public.has_permission(
+    '99175175-0003-0003-0003-000000000003',
+    '99175175-a000-a000-a000-00000000000a',
+    'accounting.entries.approve'
+  ) OR NOT public.wardah_has_exact_permission(
+    '99175175-0003-0003-0003-000000000003',
+    '99175175-a000-a000-a000-00000000000a',
+    'accounting.entries.approve'
+  ) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-I7b]: reactivation did not restore the preserved assignment';
+  END IF;
+END;
+$$;
 
 -- The public 174 contract remains callable through the new organization-first
 -- wrapper, while its renamed implementation is no longer an API surface.

--- a/scripts/ci/fresh-db/acceptance_175_rbac_consumer_migration_rpcs.sql
+++ b/scripts/ci/fresh-db/acceptance_175_rbac_consumer_migration_rpcs.sql
@@ -1,8 +1,9 @@
 -- Acceptance for Migration 175.
 --
 -- Proves, behaviourally:
---   (1) user_roles can only point at active memberships and membership
---       deletion/deactivation cannot strand assignments.
+--   (1) user_roles INSERT can only point at active memberships; every UPDATE
+--       is rejected at statement level in favor of rpc_replace_user_roles;
+--       membership deletion/deactivation cannot strand assignments.
 --   (2) explicit-role authorization requires active membership.
 --   (3) rpc_remove_org_member: org-admin guard, self-removal guard, last-admin
 --       guard, atomic removal of roles + membership, audit row with a full
@@ -81,11 +82,40 @@ BEGIN
     SET user_id = '99175175-0006-0006-0006-000000000006'
     WHERE user_id = '99175175-0003-0003-0003-000000000003'
       AND org_id = '99175175-a000-a000-a000-00000000000a';
-    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-I2]: assignment moved to an inactive member';
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-I2]: direct key UPDATE was accepted';
   EXCEPTION WHEN OTHERS THEN
     IF SQLERRM LIKE 'ACCEPTANCE_FAIL%' THEN RAISE; END IF;
-    IF SQLERRM NOT LIKE '%RBAC_175_ACTIVE_MEMBERSHIP_REQUIRED%' THEN RAISE; END IF;
+    IF SQLERRM NOT LIKE '%RBAC_175_DIRECT_USER_ROLES_UPDATE_FORBIDDEN_USE_RPC_REPLACE_USER_ROLES%' THEN RAISE; END IF;
   END;
+
+  -- A statement trigger must reject even an UPDATE that matches no rows. This
+  -- proves the guard runs before PostgreSQL can lock a user_roles tuple.
+  BEGIN
+    UPDATE public.user_roles
+    SET expires_at = expires_at
+    WHERE false;
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-I2b]: zero-row direct UPDATE bypassed the statement guard';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE 'ACCEPTANCE_FAIL%' THEN RAISE; END IF;
+    IF SQLERRM NOT LIKE '%RBAC_175_DIRECT_USER_ROLES_UPDATE_FORBIDDEN_USE_RPC_REPLACE_USER_ROLES%' THEN RAISE; END IF;
+  END;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_trigger t
+    JOIN pg_class c ON c.oid = t.tgrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relname = 'user_roles'
+      AND t.tgname = 'trg_wardah_175_reject_direct_role_update'
+      AND t.tgenabled <> 'D'
+      AND NOT t.tgisinternal
+      AND (t.tgtype & 1) = 0
+      AND (t.tgtype & 2) = 2
+      AND (t.tgtype & 16) = 16
+  ) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-I2c]: UPDATE guard is not an enabled BEFORE STATEMENT trigger';
+  END IF;
 
   BEGIN
     UPDATE public.user_organizations
@@ -127,10 +157,10 @@ BEGIN
     SET expires_at = now() + interval '1 day'
     WHERE user_id = '99175175-0003-0003-0003-000000000003'
       AND org_id = '99175175-a000-a000-a000-00000000000a';
-    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-I5]: non-key UPDATE bypassed active-membership validation';
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-I5]: non-key direct UPDATE was accepted';
   EXCEPTION WHEN OTHERS THEN
     IF SQLERRM LIKE 'ACCEPTANCE_FAIL%' THEN RAISE; END IF;
-    IF SQLERRM NOT LIKE '%RBAC_175_ACTIVE_MEMBERSHIP_REQUIRED%' THEN RAISE; END IF;
+    IF SQLERRM NOT LIKE '%RBAC_175_DIRECT_USER_ROLES_UPDATE_FORBIDDEN_USE_RPC_REPLACE_USER_ROLES%' THEN RAISE; END IF;
   END;
 END;
 $$;
@@ -466,10 +496,11 @@ BEGIN
     RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-M6b]: internal replace implementation is externally callable';
   END IF;
 
-  -- No table grant has been touched: authenticated still has direct write
-  -- access. Invalid writes are now narrowed by triggers; grant revocation is
-  -- still Migration 176.
+  -- No table grant has been touched: authenticated still has table-level
+  -- write grants. user_roles UPDATE is behaviorally blocked by a statement
+  -- trigger; grant revocation remains Migration 176.
   IF NOT has_table_privilege('authenticated', 'public.user_roles', 'INSERT')
+     OR NOT has_table_privilege('authenticated', 'public.user_roles', 'UPDATE')
      OR NOT has_table_privilege('authenticated', 'public.roles', 'INSERT') THEN
     RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-M7]: 175 revoked a table grant it must not touch';
   END IF;

--- a/scripts/ci/fresh-db/acceptance_175_rbac_consumer_migration_rpcs.sql
+++ b/scripts/ci/fresh-db/acceptance_175_rbac_consumer_migration_rpcs.sql
@@ -1,15 +1,20 @@
 -- Acceptance for Migration 175.
 --
 -- Proves, behaviourally:
---   (1) rpc_remove_org_member: org-admin guard, self-removal guard, last-admin
+--   (1) user_roles can only point at active memberships and membership
+--       deletion/deactivation cannot strand assignments.
+--   (2) explicit-role authorization requires active membership.
+--   (3) rpc_remove_org_member: org-admin guard, self-removal guard, last-admin
 --       guard, atomic removal of roles + membership, audit row with a full
 --       before snapshot.
---   (2) create_role_from_template: still creates the role and grants the
+--   (4) rpc_set_org_admin applies LAST_ORG_ADMIN only to a currently active
+--       admin target.
+--   (5) create_role_from_template: still creates the role and grants the
 --       template's permissions exactly as before, AND now writes an audit row
 --       carrying the granted permission keys and any sensitive ones among them.
---   (3) wardah_is_sensitive_permission: behavior is byte-identical to before
+--   (6) wardah_is_sensitive_permission: behavior is byte-identical to before
 --       this migration for every input that mattered in 174's acceptance.
---   (4) Mutation proof: every 170-174 guarantee this migration must not have
+--   (7) Mutation proof: every 170-174 guarantee this migration must not have
 --       disturbed, re-asserted individually.
 --
 -- Marker on success: RBAC_CONSUMER_175_ACCEPTANCE_PASS
@@ -25,7 +30,8 @@ INSERT INTO auth.users (id, email) VALUES
   ('99175175-0002-0002-0002-000000000002', 'p175-admin-b@example.test'),
   ('99175175-0003-0003-0003-000000000003', 'p175-member@example.test'),
   ('99175175-0004-0004-0004-000000000004', 'p175-sole-admin@example.test'),
-  ('99175175-0005-0005-0005-000000000005', 'p175-otherorg-admin@example.test');
+  ('99175175-0005-0005-0005-000000000005', 'p175-otherorg-admin@example.test'),
+  ('99175175-0006-0006-0006-000000000006', 'p175-inactive-member@example.test');
 
 INSERT INTO public.organizations (id, name, code) VALUES
   ('99175175-a000-a000-a000-00000000000a', 'Perm175 Org A', 'P175-A'),
@@ -36,6 +42,7 @@ INSERT INTO public.user_organizations (user_id, org_id, is_active, is_org_admin)
   ('99175175-0001-0001-0001-000000000001', '99175175-a000-a000-a000-00000000000a', true, true),
   ('99175175-0002-0002-0002-000000000002', '99175175-a000-a000-a000-00000000000a', true, true),
   ('99175175-0003-0003-0003-000000000003', '99175175-a000-a000-a000-00000000000a', true, false),
+  ('99175175-0006-0006-0006-000000000006', '99175175-a000-a000-a000-00000000000a', false, false),
   ('99175175-0005-0005-0005-000000000005', '99175175-b000-b000-b000-00000000000b', true, true);
 
 -- Org B: exactly ONE active admin, for the last-admin guard.
@@ -53,6 +60,113 @@ WHERE p.permission_key = 'accounting.entries.approve';
 INSERT INTO public.user_roles (user_id, role_id, org_id) VALUES
   ('99175175-0003-0003-0003-000000000003', '99175175-0000-0000-0000-000000000020', '99175175-a000-a000-a000-00000000000a');
 
+-- ---------------------------------------------------------------------------
+-- 2. Active-membership invariant, both child and parent sides.
+-- ---------------------------------------------------------------------------
+DO $$
+BEGIN
+  BEGIN
+    INSERT INTO public.user_roles (user_id, role_id, org_id) VALUES (
+      '99175175-0006-0006-0006-000000000006',
+      '99175175-0000-0000-0000-000000000020',
+      '99175175-a000-a000-a000-00000000000a');
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-I1]: inactive member received a role';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE 'ACCEPTANCE_FAIL%' THEN RAISE; END IF;
+    IF SQLERRM NOT LIKE '%RBAC_175_ACTIVE_MEMBERSHIP_REQUIRED%' THEN RAISE; END IF;
+  END;
+
+  BEGIN
+    UPDATE public.user_roles
+    SET user_id = '99175175-0006-0006-0006-000000000006'
+    WHERE user_id = '99175175-0003-0003-0003-000000000003'
+      AND org_id = '99175175-a000-a000-a000-00000000000a';
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-I2]: assignment moved to an inactive member';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE 'ACCEPTANCE_FAIL%' THEN RAISE; END IF;
+    IF SQLERRM NOT LIKE '%RBAC_175_ACTIVE_MEMBERSHIP_REQUIRED%' THEN RAISE; END IF;
+  END;
+
+  BEGIN
+    UPDATE public.user_organizations
+    SET is_active = false
+    WHERE user_id = '99175175-0003-0003-0003-000000000003'
+      AND org_id = '99175175-a000-a000-a000-00000000000a';
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-I3]: membership deactivated while roles remained';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE 'ACCEPTANCE_FAIL%' THEN RAISE; END IF;
+    IF SQLERRM NOT LIKE '%RBAC_175_MEMBERSHIP_HAS_ROLE_ASSIGNMENTS%' THEN RAISE; END IF;
+  END;
+
+  BEGIN
+    DELETE FROM public.user_organizations
+    WHERE user_id = '99175175-0003-0003-0003-000000000003'
+      AND org_id = '99175175-a000-a000-a000-00000000000a';
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-I4]: membership deleted while roles remained';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE 'ACCEPTANCE_FAIL%' THEN RAISE; END IF;
+    IF SQLERRM NOT LIKE '%RBAC_175_MEMBERSHIP_HAS_ROLE_ASSIGNMENTS%' THEN RAISE; END IF;
+  END;
+END;
+$$;
+
+-- Defense-in-depth proof: emulate legacy invalid data by temporarily disabling
+-- only the new parent guard. Both authorization helpers must still deny the
+-- explicit role while the membership is inactive.
+ALTER TABLE public.user_organizations
+  DISABLE TRIGGER trg_wardah_175_protect_role_membership_parent;
+UPDATE public.user_organizations
+SET is_active = false
+WHERE user_id = '99175175-0003-0003-0003-000000000003'
+  AND org_id = '99175175-a000-a000-a000-00000000000a';
+
+DO $$
+BEGIN
+  BEGIN
+    UPDATE public.user_roles
+    SET expires_at = now() + interval '1 day'
+    WHERE user_id = '99175175-0003-0003-0003-000000000003'
+      AND org_id = '99175175-a000-a000-a000-00000000000a';
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-I5]: non-key UPDATE bypassed active-membership validation';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE 'ACCEPTANCE_FAIL%' THEN RAISE; END IF;
+    IF SQLERRM NOT LIKE '%RBAC_175_ACTIVE_MEMBERSHIP_REQUIRED%' THEN RAISE; END IF;
+  END;
+END;
+$$;
+
+SELECT set_config('request.jwt.claim.sub', '99175175-0003-0003-0003-000000000003', false);
+SET LOCAL ROLE authenticated;
+DO $$
+BEGIN
+  IF public.has_permission(
+    '99175175-0003-0003-0003-000000000003',
+    '99175175-a000-a000-a000-00000000000a',
+    'accounting.entries.approve') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-I6]: has_permission accepted an inactive-member grant';
+  END IF;
+END;
+$$;
+RESET ROLE;
+
+DO $$
+BEGIN
+  IF public.wardah_has_exact_permission(
+    '99175175-0003-0003-0003-000000000003',
+    '99175175-a000-a000-a000-00000000000a',
+    'accounting.entries.approve') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-I7]: exact helper accepted an inactive-member grant';
+  END IF;
+END;
+$$;
+
+UPDATE public.user_organizations
+SET is_active = true
+WHERE user_id = '99175175-0003-0003-0003-000000000003'
+  AND org_id = '99175175-a000-a000-a000-00000000000a';
+ALTER TABLE public.user_organizations
+  ENABLE TRIGGER trg_wardah_175_protect_role_membership_parent;
+
 -- A role template for create_role_from_template, with one sensitive key.
 INSERT INTO public.role_templates (id, name, name_ar, description, description_ar, permission_keys, is_active)
 VALUES (
@@ -62,7 +176,7 @@ VALUES (
 );
 
 -- ---------------------------------------------------------------------------
--- 2. rpc_remove_org_member — cross-org rejection, self-removal, last-admin,
+-- 3. rpc_remove_org_member — cross-org rejection, self-removal, last-admin,
 --    then the real removal with audit proof.
 -- ---------------------------------------------------------------------------
 
@@ -138,6 +252,24 @@ INSERT INTO public.super_admins (user_id, email, is_active) VALUES
 INSERT INTO public.user_organizations (user_id, org_id, is_active, is_org_admin) VALUES
   ('99175175-0007-0007-0007-000000000007', '99175175-c000-c000-c000-00000000000c', true, false);
 
+-- A false -> false request against an ordinary target must not run the
+-- last-admin guard merely because the organization has only one real admin.
+SELECT set_config('request.jwt.claim.sub', '99175175-0004-0004-0004-000000000004', false);
+SET LOCAL ROLE authenticated;
+DO $$
+DECLARE v_res jsonb;
+BEGIN
+  v_res := public.rpc_set_org_admin(
+    '99175175-0007-0007-0007-000000000007',
+    '99175175-c000-c000-c000-00000000000c',
+    false);
+  IF NOT COALESCE((v_res->>'ok')::boolean, false) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-3b]: ordinary target hit last-admin guard: %', v_res;
+  END IF;
+END;
+$$;
+RESET ROLE;
+
 SELECT set_config('request.jwt.claim.sub', '99175175-0007-0007-0007-000000000007', false);
 SET LOCAL ROLE authenticated;
 DO $$
@@ -164,7 +296,7 @@ $$;
 RESET ROLE;
 
 -- ---------------------------------------------------------------------------
--- 2d. The real removal: org A's ordinary member (0003), by admin 0001.
+-- 3d. The real removal: org A's ordinary member (0003), by admin 0001.
 -- ---------------------------------------------------------------------------
 SELECT set_config('request.jwt.claim.sub', '99175175-0001-0001-0001-000000000001', false);
 SET LOCAL ROLE authenticated;
@@ -208,7 +340,7 @@ $$;
 RESET ROLE;
 
 -- ---------------------------------------------------------------------------
--- 3. create_role_from_template — still works, and now audits.
+-- 4. create_role_from_template — still works, and now audits.
 -- ---------------------------------------------------------------------------
 SELECT set_config('request.jwt.claim.sub', '99175175-0001-0001-0001-000000000001', false);
 SET LOCAL ROLE authenticated;
@@ -271,7 +403,7 @@ $$;
 RESET ROLE;
 
 -- ---------------------------------------------------------------------------
--- 4. Mutation proof — this migration must not have disturbed 170-174.
+-- 5. Mutation proof — this migration must not have disturbed 170-174.
 -- ---------------------------------------------------------------------------
 DO $$
 DECLARE v_hp text; v_ex text; v_cls text;
@@ -292,6 +424,10 @@ BEGIN
   IF v_hp !~ 'r\.is_active' OR v_ex !~ 'r\.is_active' THEN
     RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-M3]: 173 active-role join missing';
   END IF;
+  IF v_hp !~ 'user_organizations uo' OR v_hp !~ 'uo\.is_active IS TRUE'
+     OR v_ex !~ 'user_organizations uo' OR v_ex !~ 'uo\.is_active IS TRUE' THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-M3b]: active-membership defense missing';
+  END IF;
   IF v_hp !~ 'wardah_is_sensitive_permission' OR v_ex !~ 'wardah_is_sensitive_permission' THEN
     RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-M4]: 174 sensitive-permission narrowing missing';
   END IF;
@@ -308,7 +444,8 @@ BEGIN
   END IF;
 
   -- No table grant has been touched: authenticated still has direct write
-  -- access (175 is additive-only; revocation is Migration 176).
+  -- access. Invalid writes are now narrowed by triggers; grant revocation is
+  -- still Migration 176.
   IF NOT has_table_privilege('authenticated', 'public.user_roles', 'INSERT')
      OR NOT has_table_privilege('authenticated', 'public.roles', 'INSERT') THEN
     RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-M7]: 175 revoked a table grant it must not touch';

--- a/scripts/ci/fresh-db/acceptance_175_rbac_consumer_migration_rpcs.sql
+++ b/scripts/ci/fresh-db/acceptance_175_rbac_consumer_migration_rpcs.sql
@@ -1,0 +1,321 @@
+-- Acceptance for Migration 175.
+--
+-- Proves, behaviourally:
+--   (1) rpc_remove_org_member: org-admin guard, self-removal guard, last-admin
+--       guard, atomic removal of roles + membership, audit row with a full
+--       before snapshot.
+--   (2) create_role_from_template: still creates the role and grants the
+--       template's permissions exactly as before, AND now writes an audit row
+--       carrying the granted permission keys and any sensitive ones among them.
+--   (3) wardah_is_sensitive_permission: behavior is byte-identical to before
+--       this migration for every input that mattered in 174's acceptance.
+--   (4) Mutation proof: every 170-174 guarantee this migration must not have
+--       disturbed, re-asserted individually.
+--
+-- Marker on success: RBAC_CONSUMER_175_ACCEPTANCE_PASS
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- 1. Fixtures.
+-- ---------------------------------------------------------------------------
+INSERT INTO auth.users (id, email) VALUES
+  ('99175175-0001-0001-0001-000000000001', 'p175-admin-a@example.test'),
+  ('99175175-0002-0002-0002-000000000002', 'p175-admin-b@example.test'),
+  ('99175175-0003-0003-0003-000000000003', 'p175-member@example.test'),
+  ('99175175-0004-0004-0004-000000000004', 'p175-sole-admin@example.test'),
+  ('99175175-0005-0005-0005-000000000005', 'p175-otherorg-admin@example.test');
+
+INSERT INTO public.organizations (id, name, code) VALUES
+  ('99175175-a000-a000-a000-00000000000a', 'Perm175 Org A', 'P175-A'),
+  ('99175175-b000-b000-b000-00000000000b', 'Perm175 Org B', 'P175-B');
+
+-- Org A: two admins (so removal of one is legal) + one ordinary member.
+INSERT INTO public.user_organizations (user_id, org_id, is_active, is_org_admin) VALUES
+  ('99175175-0001-0001-0001-000000000001', '99175175-a000-a000-a000-00000000000a', true, true),
+  ('99175175-0002-0002-0002-000000000002', '99175175-a000-a000-a000-00000000000a', true, true),
+  ('99175175-0003-0003-0003-000000000003', '99175175-a000-a000-a000-00000000000a', true, false),
+  ('99175175-0005-0005-0005-000000000005', '99175175-b000-b000-b000-00000000000b', true, true);
+
+-- Org B: exactly ONE active admin, for the last-admin guard.
+INSERT INTO public.organizations (id, name, code) VALUES
+  ('99175175-c000-c000-c000-00000000000c', 'Perm175 Org C', 'P175-C');
+INSERT INTO public.user_organizations (user_id, org_id, is_active, is_org_admin) VALUES
+  ('99175175-0004-0004-0004-000000000004', '99175175-c000-c000-c000-00000000000c', true, true);
+
+-- A role the ordinary member holds, so removal must clear it.
+INSERT INTO public.roles (id, org_id, name, name_ar, is_active) VALUES
+  ('99175175-0000-0000-0000-000000000020', '99175175-a000-a000-a000-00000000000a', 'P175 Probe Role', 'دور فحص', true);
+INSERT INTO public.role_permissions (role_id, permission_id)
+SELECT '99175175-0000-0000-0000-000000000020', p.id FROM public.permissions p
+WHERE p.permission_key = 'accounting.entries.approve';
+INSERT INTO public.user_roles (user_id, role_id, org_id) VALUES
+  ('99175175-0003-0003-0003-000000000003', '99175175-0000-0000-0000-000000000020', '99175175-a000-a000-a000-00000000000a');
+
+-- A role template for create_role_from_template, with one sensitive key.
+INSERT INTO public.role_templates (id, name, name_ar, description, description_ar, permission_keys, is_active)
+VALUES (
+  '99175175-0000-0000-0000-000000000090', 'P175 Template', 'قالب 175',
+  'acceptance fixture', 'عنصر اختبار',
+  ARRAY['accounting.vouchers.unpost','accounting.entries.approve'], true
+);
+
+-- ---------------------------------------------------------------------------
+-- 2. rpc_remove_org_member — cross-org rejection, self-removal, last-admin,
+--    then the real removal with audit proof.
+-- ---------------------------------------------------------------------------
+
+-- 2a. Cross-org admin cannot touch org A at all (fails at the org-admin guard).
+SELECT set_config('request.jwt.claim.sub', '99175175-0005-0005-0005-000000000005', false);
+SET LOCAL ROLE authenticated;
+DO $$
+BEGIN
+  BEGIN
+    PERFORM public.rpc_remove_org_member(jsonb_build_object(
+      'org_id', '99175175-a000-a000-a000-00000000000a',
+      'user_id', '99175175-0003-0003-0003-000000000003'));
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-1]: a non-member admin removed a user from a foreign org';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE 'ACCEPTANCE_FAIL%' THEN RAISE; END IF;
+  END;
+END;
+$$;
+RESET ROLE;
+
+-- 2b. Self-removal is refused, even for a legitimate org admin.
+SELECT set_config('request.jwt.claim.sub', '99175175-0001-0001-0001-000000000001', false);
+SET LOCAL ROLE authenticated;
+DO $$
+BEGIN
+  BEGIN
+    PERFORM public.rpc_remove_org_member(jsonb_build_object(
+      'org_id', '99175175-a000-a000-a000-00000000000a',
+      'user_id', '99175175-0001-0001-0001-000000000001'));
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-2]: admin was allowed to remove themselves';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE 'ACCEPTANCE_FAIL%' THEN RAISE; END IF;
+    IF SQLERRM NOT LIKE '%RBAC_175_CANNOT_REMOVE_SELF%' THEN RAISE; END IF;
+  END;
+END;
+$$;
+RESET ROLE;
+
+-- 2c. Last-admin protection, two parts.
+--
+-- Part 1 (legal): org C temporarily gets a second admin (0003, promoted via
+-- direct fixture setup — production always goes through rpc_set_org_admin),
+-- then 0004 removes 0003. One admin (0004) remains: this must succeed.
+INSERT INTO public.user_organizations (user_id, org_id, is_active, is_org_admin) VALUES
+  ('99175175-0003-0003-0003-000000000003', '99175175-c000-c000-c000-00000000000c', true, true);
+
+SELECT set_config('request.jwt.claim.sub', '99175175-0004-0004-0004-000000000004', false);
+SET LOCAL ROLE authenticated;
+DO $$
+DECLARE v_res jsonb;
+BEGIN
+  v_res := public.rpc_remove_org_member(jsonb_build_object(
+    'org_id', '99175175-c000-c000-c000-00000000000c',
+    'user_id', '99175175-0003-0003-0003-000000000003'));
+  IF v_res IS NULL THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-3a]: legal removal of a non-last admin failed';
+  END IF;
+END;
+$$;
+RESET ROLE;
+
+-- Part 2 (rejected): org C now has exactly one active admin (0004). To reject
+-- a removal on the LAST_ORG_ADMIN branch specifically (as opposed to
+-- CANNOT_REMOVE_SELF), the
+-- caller must be admin-gated but distinct from the target — the only way that
+-- combination exists is a super admin who is also a plain (non-admin) member
+-- of the org: wardah_assert_org_admin's OR clause admits them without
+-- is_org_admin being true on their own row. Set that up and attempt exactly
+-- the rejected call, behaviourally, not just by source inspection.
+INSERT INTO auth.users (id, email) VALUES ('99175175-0007-0007-0007-000000000007', 'p175-super-member@example.test');
+INSERT INTO public.super_admins (user_id, email, is_active) VALUES
+  ('99175175-0007-0007-0007-000000000007', 'p175-super-member@example.test', true);
+INSERT INTO public.user_organizations (user_id, org_id, is_active, is_org_admin) VALUES
+  ('99175175-0007-0007-0007-000000000007', '99175175-c000-c000-c000-00000000000c', true, false);
+
+SELECT set_config('request.jwt.claim.sub', '99175175-0007-0007-0007-000000000007', false);
+SET LOCAL ROLE authenticated;
+DO $$
+BEGIN
+  BEGIN
+    PERFORM public.rpc_remove_org_member(jsonb_build_object(
+      'org_id', '99175175-c000-c000-c000-00000000000c',
+      'user_id', '99175175-0004-0004-0004-000000000004'));
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-3c]: the last active admin of an org was removed';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE 'ACCEPTANCE_FAIL%' THEN RAISE; END IF;
+    IF SQLERRM NOT LIKE '%RBAC_175_LAST_ORG_ADMIN%' THEN RAISE; END IF;
+  END;
+
+  -- And prove it was really rejected, not silently no-op'd: the row is untouched.
+  IF NOT EXISTS (SELECT 1 FROM public.user_organizations
+                  WHERE user_id = '99175175-0004-0004-0004-000000000004'
+                    AND org_id = '99175175-c000-c000-c000-00000000000c'
+                    AND is_active AND is_org_admin) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-3d]: rejected LAST_ORG_ADMIN call still mutated the membership row';
+  END IF;
+END;
+$$;
+RESET ROLE;
+
+-- ---------------------------------------------------------------------------
+-- 2d. The real removal: org A's ordinary member (0003), by admin 0001.
+-- ---------------------------------------------------------------------------
+SELECT set_config('request.jwt.claim.sub', '99175175-0001-0001-0001-000000000001', false);
+SET LOCAL ROLE authenticated;
+DO $$
+DECLARE
+  v_res jsonb;
+  v_row public.audit_logs%ROWTYPE;
+BEGIN
+  v_res := public.rpc_remove_org_member(jsonb_build_object(
+    'org_id', '99175175-a000-a000-a000-00000000000a',
+    'user_id', '99175175-0003-0003-0003-000000000003'));
+
+  IF (v_res->>'removed_role_count')::int <> 1 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-4a]: removed_role_count wrong, got %', v_res->>'removed_role_count';
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM public.user_roles
+              WHERE user_id = '99175175-0003-0003-0003-000000000003'
+                AND org_id = '99175175-a000-a000-a000-00000000000a') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-4b]: role assignment survived removal';
+  END IF;
+  IF EXISTS (SELECT 1 FROM public.user_organizations
+              WHERE user_id = '99175175-0003-0003-0003-000000000003'
+                AND org_id = '99175175-a000-a000-a000-00000000000a') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-4c]: membership row survived removal';
+  END IF;
+
+  SELECT * INTO v_row FROM public.audit_logs
+   WHERE action = 'rbac.org_member.remove'
+     AND entity_id = '99175175-0003-0003-0003-000000000003'
+   ORDER BY created_at DESC LIMIT 1;
+  IF v_row.old_data IS NULL OR NOT (v_row.old_data->'role_assignments' @> jsonb_build_array(
+       jsonb_build_object('role_id', '99175175-0000-0000-0000-000000000020', 'expires_at', NULL))) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-4d]: removal audit row missing the pre-removal role snapshot';
+  END IF;
+  IF v_row.new_data IS NOT NULL THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-4e]: removal audit row unexpectedly has new_data';
+  END IF;
+END;
+$$;
+RESET ROLE;
+
+-- ---------------------------------------------------------------------------
+-- 3. create_role_from_template — still works, and now audits.
+-- ---------------------------------------------------------------------------
+SELECT set_config('request.jwt.claim.sub', '99175175-0001-0001-0001-000000000001', false);
+SET LOCAL ROLE authenticated;
+DO $$
+DECLARE
+  v_role_id uuid;
+  v_row public.audit_logs%ROWTYPE;
+  v_granted text[];
+BEGIN
+  v_role_id := public.create_role_from_template(
+    '99175175-a000-a000-a000-00000000000a',
+    '99175175-0000-0000-0000-000000000090',
+    'P175 From Template');
+
+  IF v_role_id IS NULL THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-5a]: create_role_from_template returned no id';
+  END IF;
+
+  SELECT COALESCE(array_agg(p.permission_key ORDER BY p.permission_key), ARRAY[]::text[])
+    INTO v_granted
+  FROM public.role_permissions rp JOIN public.permissions p ON p.id = rp.permission_id
+  WHERE rp.role_id = v_role_id;
+  IF NOT ('accounting.vouchers.unpost' = ANY(v_granted))
+     OR NOT ('accounting.entries.approve' = ANY(v_granted)) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-5b]: template permissions not granted, got %', v_granted;
+  END IF;
+
+  SELECT * INTO v_row FROM public.audit_logs
+   WHERE action = 'rbac.role.create' AND entity_id = v_role_id::text
+   ORDER BY created_at DESC LIMIT 1;
+  IF v_row.entity_id IS NULL THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-5c]: create_role_from_template wrote no audit row (the gap this migration closes)';
+  END IF;
+  IF NOT (v_row.metadata->'sensitive_keys' @> '"accounting.vouchers.unpost"'::jsonb) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-5d]: audit row does not flag the sensitive key the template granted';
+  END IF;
+  IF v_row.metadata->>'source' <> 'template' THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-5e]: audit row does not record template as the source';
+  END IF;
+END;
+$$;
+RESET ROLE;
+
+-- Cross-org: a template create in a foreign org must fail on the guard.
+SELECT set_config('request.jwt.claim.sub', '99175175-0005-0005-0005-000000000005', false);
+SET LOCAL ROLE authenticated;
+DO $$
+BEGIN
+  BEGIN
+    PERFORM public.create_role_from_template(
+      '99175175-a000-a000-a000-00000000000a',
+      '99175175-0000-0000-0000-000000000090',
+      'Intruder');
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-6]: cross-org template creation succeeded';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE 'ACCEPTANCE_FAIL%' THEN RAISE; END IF;
+  END;
+END;
+$$;
+RESET ROLE;
+
+-- ---------------------------------------------------------------------------
+-- 4. Mutation proof — this migration must not have disturbed 170-174.
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE v_hp text; v_ex text; v_cls text;
+BEGIN
+  SELECT prosrc INTO v_hp FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+   WHERE n.nspname='public' AND p.proname='has_permission';
+  SELECT prosrc INTO v_ex FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+   WHERE n.nspname='public' AND p.proname='wardah_has_exact_permission';
+  SELECT prosrc INTO v_cls FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+   WHERE n.nspname='public' AND p.proname='wardah_is_sensitive_permission';
+
+  IF v_hp !~ 'p_user_id IS DISTINCT FROM auth\.uid\(\)' THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-M1]: 170 caller-identity guard missing';
+  END IF;
+  IF v_hp ~ 'LIKE' OR v_ex ~ 'LIKE' THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-M2]: 172 LIKE fallback reappeared';
+  END IF;
+  IF v_hp !~ 'r\.is_active' OR v_ex !~ 'r\.is_active' THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-M3]: 173 active-role join missing';
+  END IF;
+  IF v_hp !~ 'wardah_is_sensitive_permission' OR v_ex !~ 'wardah_is_sensitive_permission' THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-M4]: 174 sensitive-permission narrowing missing';
+  END IF;
+  IF v_cls !~ 'accounting\.vouchers\.unpost' OR v_cls !~ 'accounting\.vouchers\.cancel' THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-M5]: classifier lost a sensitive key during the search_path edit';
+  END IF;
+
+  -- The three original 174 RPCs must still exist and be authenticated-only.
+  IF NOT has_function_privilege('authenticated', 'public.rpc_upsert_org_role(jsonb)', 'EXECUTE')
+     OR NOT has_function_privilege('authenticated', 'public.rpc_replace_user_roles(jsonb)', 'EXECUTE')
+     OR NOT has_function_privilege('authenticated', 'public.rpc_delete_org_role(jsonb)', 'EXECUTE')
+     OR NOT has_function_privilege('authenticated', 'public.rpc_permission_snapshot(uuid)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-M6]: a 174 RPC lost its authenticated execute grant';
+  END IF;
+
+  -- No table grant has been touched: authenticated still has direct write
+  -- access (175 is additive-only; revocation is Migration 176).
+  IF NOT has_table_privilege('authenticated', 'public.user_roles', 'INSERT')
+     OR NOT has_table_privilege('authenticated', 'public.roles', 'INSERT') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-M7]: 175 revoked a table grant it must not touch';
+  END IF;
+END;
+$$;
+
+DO $$ BEGIN RAISE NOTICE 'RBAC_CONSUMER_175_ACCEPTANCE_PASS'; END $$;
+
+ROLLBACK;

--- a/scripts/ci/fresh-db/acceptance_175_rbac_consumer_migration_rpcs.sql
+++ b/scripts/ci/fresh-db/acceptance_175_rbac_consumer_migration_rpcs.sql
@@ -167,6 +167,24 @@ WHERE user_id = '99175175-0003-0003-0003-000000000003'
 ALTER TABLE public.user_organizations
   ENABLE TRIGGER trg_wardah_175_protect_role_membership_parent;
 
+-- The public 174 contract remains callable through the new organization-first
+-- wrapper, while its renamed implementation is no longer an API surface.
+SELECT set_config('request.jwt.claim.sub', '99175175-0001-0001-0001-000000000001', false);
+SET LOCAL ROLE authenticated;
+DO $$
+DECLARE v_res jsonb;
+BEGIN
+  v_res := public.rpc_replace_user_roles(jsonb_build_object(
+    'org_id', '99175175-a000-a000-a000-00000000000a',
+    'user_id', '99175175-0003-0003-0003-000000000003',
+    'role_ids', jsonb_build_array('99175175-0000-0000-0000-000000000020')));
+  IF (v_res->>'role_count')::int <> 1 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-I8]: replace wrapper changed the 174 result contract: %', v_res;
+  END IF;
+END;
+$$;
+RESET ROLE;
+
 -- A role template for create_role_from_template, with one sensitive key.
 INSERT INTO public.role_templates (id, name, name_ar, description, description_ar, permission_keys, is_active)
 VALUES (
@@ -441,6 +459,11 @@ BEGIN
      OR NOT has_function_privilege('authenticated', 'public.rpc_delete_org_role(jsonb)', 'EXECUTE')
      OR NOT has_function_privilege('authenticated', 'public.rpc_permission_snapshot(uuid)', 'EXECUTE') THEN
     RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-M6]: a 174 RPC lost its authenticated execute grant';
+  END IF;
+  IF has_function_privilege('authenticated', 'public.wardah_175_internal_replace_user_roles(jsonb)', 'EXECUTE')
+     OR has_function_privilege('anon', 'public.wardah_175_internal_replace_user_roles(jsonb)', 'EXECUTE')
+     OR has_function_privilege('service_role', 'public.wardah_175_internal_replace_user_roles(jsonb)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-M6b]: internal replace implementation is externally callable';
   END IF;
 
   -- No table grant has been touched: authenticated still has direct write

--- a/scripts/ci/fresh-db/acceptance_175_rbac_consumer_migration_rpcs.sql
+++ b/scripts/ci/fresh-db/acceptance_175_rbac_consumer_migration_rpcs.sql
@@ -215,6 +215,49 @@ END;
 $$;
 RESET ROLE;
 
+-- The organization-first wrapper must preserve 174's validation order before
+-- authorization. Use a caller with no authority in Org A so these assertions
+-- would expose any premature wardah_assert_org_admin call.
+SELECT set_config('request.jwt.claim.sub', '99175175-0005-0005-0005-000000000005', false);
+SET LOCAL ROLE authenticated;
+DO $$
+BEGIN
+  BEGIN
+    PERFORM public.rpc_replace_user_roles(jsonb_build_object(
+      'org_id', '99175175-a000-a000-a000-00000000000a',
+      'role_ids', '[]'::jsonb));
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-I8a]: missing user_id reached authorization';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE 'ACCEPTANCE_FAIL%' THEN RAISE; END IF;
+    IF SQLERRM NOT LIKE '%RBAC_174_ORG_AND_USER_REQUIRED%' THEN RAISE; END IF;
+  END;
+
+  BEGIN
+    PERFORM public.rpc_replace_user_roles(jsonb_build_object(
+      'org_id', '99175175-a000-a000-a000-00000000000a',
+      'user_id', 'not-a-uuid',
+      'role_ids', '[]'::jsonb));
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-I8b]: invalid user_id reached authorization';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE 'ACCEPTANCE_FAIL%' THEN RAISE; END IF;
+    IF SQLSTATE <> '22P02' THEN RAISE; END IF;
+  END;
+
+  BEGIN
+    PERFORM public.rpc_replace_user_roles(jsonb_build_object(
+      'org_id', '99175175-a000-a000-a000-00000000000a',
+      'user_id', '99175175-0003-0003-0003-000000000003',
+      'expires_at', 'not-a-timestamp',
+      'role_ids', '[]'::jsonb));
+    RAISE EXCEPTION 'ACCEPTANCE_FAIL[175-I8c]: invalid expires_at reached authorization';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM LIKE 'ACCEPTANCE_FAIL%' THEN RAISE; END IF;
+    IF SQLSTATE <> '22007' THEN RAISE; END IF;
+  END;
+END;
+$$;
+RESET ROLE;
+
 -- A role template for create_role_from_template, with one sensitive key.
 INSERT INTO public.role_templates (id, name, name_ar, description, description_ar, permission_keys, is_active)
 VALUES (

--- a/sql/migrations/175_rbac_consumer_migration_rpcs.sql
+++ b/sql/migrations/175_rbac_consumer_migration_rpcs.sql
@@ -1,0 +1,353 @@
+-- =====================================================================
+-- 175_rbac_consumer_migration_rpcs
+-- =====================================================================
+-- Additive-only. No privilege revocation in this migration. Part of Issue
+-- #93's second phase: an audit of every production TS/TSX file that writes
+-- to roles, role_permissions or user_roles found four surfaces, only two of
+-- which Migration 174 actually covered:
+--
+--   src/pages/org-admin/roles.tsx           -> covered by 174's RPCs
+--   src/services/rbac-service.ts            -> covered by 174's RPCs
+--   src/services/org-admin-service.ts       -> NOT covered:
+--     updateUserRoles()      direct DELETE+INSERT on user_roles, no audit
+--     removeUserFromOrg()    direct DELETE on user_roles then
+--                             user_organizations, unchecked first error
+--   src/services/super-admin-service.ts     -> NOT covered:
+--     createOrgWithUser()    direct INSERT on user_roles
+--
+-- This migration adds what the consumer PR (a separate PR, applied after
+-- this one is live and verified) needs to close all three gaps without a
+-- single direct write remaining anywhere in the client:
+--
+--   1. rpc_remove_org_member    — new. Atomic, audited replacement for
+--      removeUserFromOrg()'s two-step client sequence. Mirrors
+--      rpc_set_org_admin's established self-action and last-admin guards
+--      (migration 103) — removal is more drastic than demotion, so it
+--      earns the same protection.
+--   2. create_role_from_template — CREATE OR REPLACE, same signature and
+--      return type (uuid), unchanged for any existing caller. Adds an
+--      audit_logs row. This RPC already existed (migration ~120) and was
+--      already SECURITY DEFINER + wardah_assert_org_admin-guarded — the
+--      real bug was that roles.tsx imported a same-named, unrelated
+--      direct-write function from org-admin-service.ts instead of the one
+--      in rbac-service.ts that correctly calls this RPC. The consumer PR
+--      fixes the import; this migration only adds the missing audit trail.
+--   3. wardah_is_sensitive_permission — CREATE OR REPLACE, adds an explicit
+--      empty search_path. The function has zero table or schema references
+--      (a pure literal comparison), so this changes nothing about its
+--      behavior; it exists to close the "Function Search Path Mutable"
+--      advisory a linter raises on any function without one.
+--
+-- What this migration deliberately does NOT do:
+--   * super-admin-service.ts's createOrgWithUser() user_roles insert is not
+--     given a new RPC, because it is dead code: it looks up a role named
+--     literally 'org_admin' by name, and no migration or seed in this
+--     repository has ever created a role with that name for any
+--     organization — 'org_admin' appears only as a MODULE label
+--     (migration 53), never as a roles.name value. The lookup's .single()
+--     therefore never resolves, and the guarded insert never runs. The
+--     consumer PR removes this dead block outright rather than build an
+--     RPC for a code path that has never executed; real admin authority for
+--     a freshly bootstrapped organization comes entirely from
+--     user_organizations.is_org_admin = true, set two statements earlier in
+--     the same function, which already works correctly and is unaffected.
+--   * wardah_assert_org_admin / wardah_assert_org_member are not touched.
+--     They are used by dozens of functions across the whole schema, not
+--     only the RBAC surface; widening their behavior (e.g. letting a
+--     non-member super admin pass) is a separate, cross-cutting change that
+--     deserves its own migration and review, not a rider on this one.
+--   * No table grant is revoked here. authenticated keeps direct
+--     INSERT/UPDATE/DELETE on roles, role_permissions and user_roles.
+--     That closure is Migration 176, applied only after the consumer PR has
+--     moved every real caller onto the RPC surface this migration and 174
+--     together provide, and the browser smoke has proven it end to end.
+-- =====================================================================
+
+BEGIN;
+
+SET LOCAL lock_timeout = '30s';
+SET LOCAL statement_timeout = '5min';
+
+-- ---------------------------------------------------------------------------
+-- Preflight: fail closed if the schema has drifted from what this migration
+-- assumes, before touching anything.
+-- ---------------------------------------------------------------------------
+DO $preflight$
+BEGIN
+  IF to_regprocedure('public.wardah_assert_org_admin(uuid)') IS NULL
+     OR to_regprocedure('public.wardah_assert_org_member(uuid)') IS NULL THEN
+    RAISE EXCEPTION 'PERMISSION_175_ORG_GUARD_MISSING';
+  END IF;
+  IF to_regprocedure('public.create_role_from_template(uuid,uuid,character varying,uuid)') IS NULL THEN
+    RAISE EXCEPTION 'PERMISSION_175_CREATE_ROLE_FROM_TEMPLATE_MISSING';
+  END IF;
+  IF to_regprocedure('public.wardah_is_sensitive_permission(text)') IS NULL THEN
+    RAISE EXCEPTION 'PERMISSION_175_CLASSIFIER_MISSING';
+  END IF;
+  IF to_regclass('public.user_organizations') IS NULL
+     OR to_regclass('public.user_roles') IS NULL
+     OR to_regclass('public.roles') IS NULL
+     OR to_regclass('public.audit_logs') IS NULL THEN
+    RAISE EXCEPTION 'PERMISSION_175_REQUIRED_TABLE_MISSING';
+  END IF;
+END
+$preflight$;
+
+-- ---------------------------------------------------------------------------
+-- 1. rpc_remove_org_member — atomic, audited replacement for the client's
+--    two-step "delete user_roles, then delete user_organizations" sequence.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_remove_org_member(p_payload jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_org        uuid := NULLIF(p_payload->>'org_id','')::uuid;
+  v_target     uuid := NULLIF(p_payload->>'user_id','')::uuid;
+  v_old_member jsonb;
+  v_old_roles  jsonb;
+  v_was_admin  boolean;
+  v_other_admins int;
+BEGIN
+  IF v_org IS NULL OR v_target IS NULL THEN
+    RAISE EXCEPTION 'RBAC_175_ORG_AND_USER_REQUIRED';
+  END IF;
+  PERFORM public.wardah_assert_org_admin(v_org);
+
+  -- Removal is more drastic than demotion; rpc_set_org_admin (migration 103)
+  -- already refuses self-demotion and the last active admin. This mirrors
+  -- both guards for removal, which was previously enforced only by disabling
+  -- the button client-side — no server-side guard existed.
+  IF v_target = auth.uid() THEN
+    RAISE EXCEPTION 'RBAC_175_CANNOT_REMOVE_SELF';
+  END IF;
+
+  SELECT to_jsonb(uo) INTO v_old_member
+  FROM public.user_organizations uo
+  WHERE uo.user_id = v_target AND uo.org_id = v_org
+  FOR UPDATE;
+
+  IF v_old_member IS NULL THEN
+    RAISE EXCEPTION 'RBAC_174_TARGET_NOT_ACTIVE_ORG_MEMBER';
+  END IF;
+
+  v_was_admin := COALESCE((v_old_member->>'is_org_admin')::boolean, false);
+
+  IF v_was_admin THEN
+    SELECT count(*) INTO v_other_admins
+    FROM public.user_organizations
+    WHERE org_id = v_org AND is_org_admin = true AND is_active = true
+      AND user_id <> v_target;
+    IF v_other_admins = 0 THEN
+      RAISE EXCEPTION 'RBAC_175_LAST_ORG_ADMIN';
+    END IF;
+  END IF;
+
+  SELECT COALESCE(jsonb_agg(jsonb_build_object(
+           'role_id', ur.role_id, 'expires_at', ur.expires_at) ORDER BY ur.role_id), '[]'::jsonb)
+    INTO v_old_roles
+  FROM public.user_roles ur
+  WHERE ur.user_id = v_target AND ur.org_id = v_org;
+
+  DELETE FROM public.user_roles WHERE user_id = v_target AND org_id = v_org;
+  DELETE FROM public.user_organizations WHERE user_id = v_target AND org_id = v_org;
+
+  INSERT INTO public.audit_logs (org_id, user_id, action, entity_type, entity_id, old_data, new_data, metadata)
+  VALUES (
+    v_org, auth.uid(), 'rbac.org_member.remove', 'user', v_target::text,
+    jsonb_build_object('membership', v_old_member, 'role_assignments', v_old_roles),
+    NULL,
+    jsonb_build_object(
+      'migration', 175,
+      'was_org_admin', v_was_admin,
+      'removed_role_count', jsonb_array_length(v_old_roles))
+  );
+
+  RETURN jsonb_build_object(
+    'user_id', v_target,
+    'org_id', v_org,
+    'removed_role_count', jsonb_array_length(v_old_roles));
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.rpc_remove_org_member(jsonb) FROM PUBLIC, anon, service_role;
+GRANT EXECUTE ON FUNCTION public.rpc_remove_org_member(jsonb) TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 2. create_role_from_template — same signature, same return type. Adds the
+--    audit_logs row that was the only gap; everything else about this
+--    function (guard, template lookup, permission-pattern matching) is
+--    unchanged from its original body.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.create_role_from_template(
+  p_org_id uuid,
+  p_template_id uuid,
+  p_custom_name character varying DEFAULT NULL::character varying,
+  p_created_by uuid DEFAULT NULL::uuid
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_template role_templates%ROWTYPE;
+    v_new_role_id UUID;
+    v_perm_key TEXT;
+    v_granted_keys jsonb;
+BEGIN
+    -- [120] admin gate on the target org; p_created_by is ignored (would
+    -- otherwise allow impersonating a different creator).
+    PERFORM public.wardah_assert_org_admin(p_org_id);
+
+    SELECT * INTO v_template FROM role_templates WHERE id = p_template_id;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'Template not found';
+    END IF;
+
+    INSERT INTO roles (org_id, name, name_ar, description_ar, created_by)
+    VALUES (
+        p_org_id,
+        COALESCE(p_custom_name, v_template.name),
+        v_template.name_ar,
+        v_template.description_ar,
+        auth.uid()
+    )
+    RETURNING id INTO v_new_role_id;
+
+    FOREACH v_perm_key IN ARRAY v_template.permission_keys
+    LOOP
+        INSERT INTO role_permissions (role_id, permission_id, created_by)
+        SELECT v_new_role_id, p.id, auth.uid()
+        FROM permissions p
+        WHERE p.permission_key LIKE REPLACE(v_perm_key, '%', '%%')
+           OR p.permission_key LIKE v_perm_key
+        ON CONFLICT DO NOTHING;
+    END LOOP;
+
+    SELECT COALESCE(jsonb_agg(p.permission_key ORDER BY p.permission_key), '[]'::jsonb)
+      INTO v_granted_keys
+    FROM role_permissions rp
+    JOIN permissions p ON p.id = rp.permission_id
+    WHERE rp.role_id = v_new_role_id;
+
+    -- 175: the only change to this function. Every other write above is
+    -- byte-for-byte the body that shipped in migration ~120.
+    INSERT INTO audit_logs (org_id, user_id, action, entity_type, entity_id, old_data, new_data, metadata)
+    VALUES (
+      p_org_id, auth.uid(), 'rbac.role.create', 'role', v_new_role_id::text,
+      NULL,
+      jsonb_build_object('role_id', v_new_role_id,
+                         'name', COALESCE(p_custom_name, v_template.name),
+                         'permission_keys', v_granted_keys),
+      jsonb_build_object(
+        'migration', 175,
+        'source', 'template',
+        'template_id', p_template_id,
+        'permission_count', jsonb_array_length(v_granted_keys),
+        'sensitive_keys', (
+          SELECT COALESCE(jsonb_agg(k ORDER BY k), '[]'::jsonb)
+          FROM jsonb_array_elements_text(v_granted_keys) AS t(k)
+          WHERE wardah_is_sensitive_permission(k)
+        ))
+    );
+
+    RETURN v_new_role_id;
+END;
+$function$;
+
+-- ---------------------------------------------------------------------------
+-- 3. wardah_is_sensitive_permission — add an explicit search_path. The
+--    function body references no table, view or unqualified name (it is a
+--    pure `p_permission_key IN ('literal', 'literal')`), so this changes
+--    nothing about its result for any input; it only removes the advisory a
+--    linter raises for any SECURITY-relevant function with a mutable path.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.wardah_is_sensitive_permission(p_permission_key text)
+RETURNS boolean
+LANGUAGE sql
+IMMUTABLE
+STRICT
+SET search_path = ''
+AS $function$
+  SELECT p_permission_key IN (
+    'accounting.vouchers.unpost',
+    'accounting.vouchers.cancel'
+  );
+$function$;
+
+-- ---------------------------------------------------------------------------
+-- Postflight: prove the new/changed contracts before COMMIT.
+-- ---------------------------------------------------------------------------
+DO $verify$
+DECLARE
+  v_remove_src text;
+  v_template_src text;
+  v_classifier_config text[];
+BEGIN
+  SELECT prosrc INTO v_remove_src FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+   WHERE n.nspname = 'public' AND p.proname = 'rpc_remove_org_member';
+  IF v_remove_src IS NULL THEN
+    RAISE EXCEPTION 'FAIL[175] rpc_remove_org_member missing after CREATE';
+  END IF;
+  IF v_remove_src !~ 'wardah_assert_org_admin' THEN
+    RAISE EXCEPTION 'FAIL[175] rpc_remove_org_member is not org-admin guarded';
+  END IF;
+  IF v_remove_src !~ 'RBAC_175_CANNOT_REMOVE_SELF' THEN
+    RAISE EXCEPTION 'FAIL[175] rpc_remove_org_member lost the self-removal guard';
+  END IF;
+  IF v_remove_src !~ 'RBAC_175_LAST_ORG_ADMIN' THEN
+    RAISE EXCEPTION 'FAIL[175] rpc_remove_org_member lost the last-admin guard';
+  END IF;
+  IF v_remove_src !~ 'RBAC_174_TARGET_NOT_ACTIVE_ORG_MEMBER' THEN
+    RAISE EXCEPTION 'FAIL[175] rpc_remove_org_member lost the not-a-member guard';
+  END IF;
+  IF v_remove_src !~ 'FOR UPDATE' THEN
+    RAISE EXCEPTION 'FAIL[175] rpc_remove_org_member no longer locks the membership row';
+  END IF;
+  IF v_remove_src !~ 'audit_logs' THEN
+    RAISE EXCEPTION 'FAIL[175] rpc_remove_org_member does not write an audit row';
+  END IF;
+
+  IF has_function_privilege('anon', 'public.rpc_remove_org_member(jsonb)', 'EXECUTE')
+     OR has_function_privilege('service_role', 'public.rpc_remove_org_member(jsonb)', 'EXECUTE')
+     OR NOT has_function_privilege('authenticated', 'public.rpc_remove_org_member(jsonb)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'FAIL[175] rpc_remove_org_member execute boundary is wrong';
+  END IF;
+
+  SELECT prosrc INTO v_template_src FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+   WHERE n.nspname = 'public' AND p.proname = 'create_role_from_template';
+  IF v_template_src !~ 'audit_logs' THEN
+    RAISE EXCEPTION 'FAIL[175] create_role_from_template still has no audit trail';
+  END IF;
+  IF v_template_src !~ 'wardah_assert_org_admin' THEN
+    RAISE EXCEPTION 'FAIL[175] create_role_from_template lost its org-admin guard';
+  END IF;
+  -- Return type must still be uuid: no caller contract may change silently.
+  IF (SELECT pg_get_function_result(p.oid) FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+       WHERE n.nspname = 'public' AND p.proname = 'create_role_from_template') <> 'uuid' THEN
+    RAISE EXCEPTION 'FAIL[175] create_role_from_template return type changed';
+  END IF;
+
+  SELECT proconfig INTO v_classifier_config FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+   WHERE n.nspname = 'public' AND p.proname = 'wardah_is_sensitive_permission';
+  IF v_classifier_config IS NULL
+     OR NOT EXISTS (SELECT 1 FROM unnest(v_classifier_config) AS cfg WHERE cfg LIKE 'search_path=%') THEN
+    RAISE EXCEPTION 'FAIL[175] wardah_is_sensitive_permission still has no explicit search_path';
+  END IF;
+  -- Behavior must be byte-identical to 174's classifier for every input.
+  IF NOT public.wardah_is_sensitive_permission('accounting.vouchers.unpost')
+     OR NOT public.wardah_is_sensitive_permission('accounting.vouchers.cancel')
+     OR public.wardah_is_sensitive_permission('accounting.entries.approve')
+     OR public.wardah_is_sensitive_permission(NULL) IS NOT NULL THEN
+    RAISE EXCEPTION 'FAIL[175] wardah_is_sensitive_permission behavior changed';
+  END IF;
+
+  RAISE NOTICE 'PASS[175] rpc_remove_org_member live; create_role_from_template now audited; classifier search_path closed';
+END
+$verify$;
+
+COMMIT;

--- a/sql/migrations/175_rbac_consumer_migration_rpcs.sql
+++ b/sql/migrations/175_rbac_consumer_migration_rpcs.sql
@@ -1,7 +1,9 @@
 -- =====================================================================
 -- 175_rbac_consumer_migration_rpcs
 -- =====================================================================
--- Additive-only. No privilege revocation in this migration. Part of Issue
+-- Backward-compatible RPC expansion plus integrity hardening. No table grant
+-- is revoked in this migration, but invalid direct writes are now rejected at
+-- the database boundary. Part of Issue
 -- #93's second phase: an audit of every production TS/TSX file that writes
 -- to roles, role_permissions or user_roles found four surfaces, only two of
 -- which Migration 174 actually covered:
@@ -32,7 +34,14 @@
 --      direct-write function from org-admin-service.ts instead of the one
 --      in rbac-service.ts that correctly calls this RPC. The consumer PR
 --      fixes the import; this migration only adds the missing audit trail.
---   3. wardah_is_sensitive_permission — CREATE OR REPLACE, adds an explicit
+--   3. user_roles membership invariant — every INSERT/UPDATE must point at an
+--      active membership; membership deletion/deactivation is refused while
+--      role rows still exist. Both sides serialize on the membership row.
+--   4. rpc_set_org_admin + rpc_remove_org_member — serialize the last-admin
+--      decision on the organization row and re-authorize after taking it.
+--   5. has_permission + wardah_has_exact_permission — explicit-role grants
+--      require an active membership as defense in depth.
+--   6. wardah_is_sensitive_permission — CREATE OR REPLACE, adds an explicit
 --      empty search_path. The function has zero table or schema references
 --      (a pure literal comparison), so this changes nothing about its
 --      behavior; it exists to close the "Function Search Path Mutable"
@@ -58,6 +67,9 @@
 --     deserves its own migration and review, not a rider on this one.
 --   * No table grant is revoked here. authenticated keeps direct
 --     INSERT/UPDATE/DELETE on roles, role_permissions and user_roles.
+--     Invalid user_roles writes are nevertheless rejected by invariant
+--     triggers; this deliberate narrowing is required before the consumer
+--     migration window can be safe.
 --     That closure is Migration 176, applied only after the consumer PR has
 --     moved every real caller onto the RPC surface this migration and 174
 --     together provide, and the browser smoke has proven it end to end.
@@ -84,17 +96,340 @@ BEGIN
   IF to_regprocedure('public.wardah_is_sensitive_permission(text)') IS NULL THEN
     RAISE EXCEPTION 'PERMISSION_175_CLASSIFIER_MISSING';
   END IF;
+  IF to_regprocedure('public.rpc_set_org_admin(uuid,uuid,boolean)') IS NULL THEN
+    RAISE EXCEPTION 'PERMISSION_175_SET_ORG_ADMIN_MISSING';
+  END IF;
   IF to_regclass('public.user_organizations') IS NULL
      OR to_regclass('public.user_roles') IS NULL
      OR to_regclass('public.roles') IS NULL
+     OR to_regclass('public.organizations') IS NULL
      OR to_regclass('public.audit_logs') IS NULL THEN
     RAISE EXCEPTION 'PERMISSION_175_REQUIRED_TABLE_MISSING';
   END IF;
 END
 $preflight$;
 
+-- Prevent DML from slipping between the data preflight and trigger install.
+-- SHARE ROW EXCLUSIVE conflicts with every ordinary INSERT/UPDATE/DELETE while
+-- still allowing the read-only checks below.
+LOCK TABLE public.user_organizations, public.user_roles
+  IN SHARE ROW EXCLUSIVE MODE;
+
+DO $data_preflight$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM public.user_roles ur
+    LEFT JOIN public.user_organizations uo
+      ON uo.user_id = ur.user_id
+     AND uo.org_id = ur.org_id
+     AND uo.is_active IS TRUE
+    WHERE uo.user_id IS NULL
+  ) THEN
+    RAISE EXCEPTION 'RBAC_175_INVALID_USER_ROLE_MEMBERSHIP_PREFLIGHT';
+  END IF;
+END
+$data_preflight$;
+
 -- ---------------------------------------------------------------------------
--- 1. rpc_remove_org_member — atomic, audited replacement for the client's
+-- 1. Database-boundary invariant: a role assignment exists only while the
+--    corresponding membership is active.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.wardah_175_require_active_role_membership()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_active boolean;
+BEGIN
+  SELECT uo.is_active
+    INTO v_active
+  FROM public.user_organizations uo
+  WHERE uo.user_id = NEW.user_id
+    AND uo.org_id = NEW.org_id
+  FOR UPDATE;
+
+  IF NOT FOUND OR v_active IS NOT TRUE THEN
+    RAISE EXCEPTION 'RBAC_175_ACTIVE_MEMBERSHIP_REQUIRED';
+  END IF;
+
+  RETURN NEW;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.wardah_175_require_active_role_membership() FROM PUBLIC, anon, authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION public.wardah_175_protect_role_membership_parent()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_invalidates_membership boolean := false;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    v_invalidates_membership := true;
+  ELSE
+    v_invalidates_membership :=
+      OLD.user_id IS DISTINCT FROM NEW.user_id
+      OR OLD.org_id IS DISTINCT FROM NEW.org_id
+      OR (OLD.is_active IS TRUE AND NEW.is_active IS NOT TRUE);
+  END IF;
+
+  IF v_invalidates_membership AND EXISTS (
+    SELECT 1
+    FROM public.user_roles ur
+    WHERE ur.user_id = OLD.user_id
+      AND ur.org_id = OLD.org_id
+  ) THEN
+    RAISE EXCEPTION 'RBAC_175_MEMBERSHIP_HAS_ROLE_ASSIGNMENTS';
+  END IF;
+
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  END IF;
+  RETURN NEW;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.wardah_175_protect_role_membership_parent() FROM PUBLIC, anon, authenticated, service_role;
+
+DROP TRIGGER IF EXISTS trg_wardah_175_require_active_role_membership
+  ON public.user_roles;
+CREATE TRIGGER trg_wardah_175_require_active_role_membership
+BEFORE INSERT OR UPDATE ON public.user_roles
+FOR EACH ROW
+EXECUTE FUNCTION public.wardah_175_require_active_role_membership();
+
+DROP TRIGGER IF EXISTS trg_wardah_175_protect_role_membership_parent
+  ON public.user_organizations;
+CREATE TRIGGER trg_wardah_175_protect_role_membership_parent
+BEFORE UPDATE OR DELETE ON public.user_organizations
+FOR EACH ROW
+EXECUTE FUNCTION public.wardah_175_protect_role_membership_parent();
+
+-- ---------------------------------------------------------------------------
+-- 2. Defense in depth: an explicit role grant is effective only while the
+--    assignee remains an active member of that same organization.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.has_permission(
+  p_user_id uuid,
+  p_org_id uuid,
+  p_permission_key character varying
+)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_has_permission boolean;
+  v_sensitive boolean;
+BEGIN
+  IF p_user_id IS DISTINCT FROM auth.uid() THEN
+    RETURN false;
+  END IF;
+
+  v_sensitive := COALESCE(
+    public.wardah_is_sensitive_permission(p_permission_key::text), false);
+
+  IF EXISTS (
+    SELECT 1 FROM public.super_admins
+    WHERE user_id = p_user_id AND is_active = true
+  ) THEN
+    RETURN true;
+  END IF;
+
+  IF NOT v_sensitive AND EXISTS (
+    SELECT 1 FROM public.user_organizations
+    WHERE user_id = p_user_id
+      AND org_id = p_org_id
+      AND is_active = true
+      AND is_org_admin = true
+  ) THEN
+    RETURN true;
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.user_roles ur
+    INNER JOIN public.user_organizations uo
+      ON uo.user_id = ur.user_id
+     AND uo.org_id = ur.org_id
+     AND uo.is_active IS TRUE
+    INNER JOIN public.roles r
+      ON r.id = ur.role_id
+     AND r.org_id = p_org_id
+     AND COALESCE(r.is_active, true)
+    INNER JOIN public.role_permissions rp ON ur.role_id = rp.role_id
+    INNER JOIN public.permissions p ON rp.permission_id = p.id
+    WHERE ur.user_id = p_user_id
+      AND ur.org_id = p_org_id
+      AND p.permission_key = p_permission_key
+      AND (ur.expires_at IS NULL OR ur.expires_at > NOW())
+  ) INTO v_has_permission;
+
+  RETURN COALESCE(v_has_permission, false);
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.wardah_has_exact_permission(
+  p_user_id uuid,
+  p_org_id uuid,
+  p_permission_key text
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+  SELECT
+    EXISTS (
+      SELECT 1
+      FROM public.super_admins sa
+      WHERE sa.user_id = p_user_id
+        AND sa.is_active = true
+    )
+    OR (
+      NOT COALESCE(public.wardah_is_sensitive_permission(p_permission_key), false)
+      AND EXISTS (
+        SELECT 1
+        FROM public.user_organizations uo
+        WHERE uo.user_id = p_user_id
+          AND uo.org_id = p_org_id
+          AND uo.is_active = true
+          AND uo.is_org_admin = true
+      )
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.user_roles ur
+      JOIN public.user_organizations uo
+        ON uo.user_id = ur.user_id
+       AND uo.org_id = ur.org_id
+       AND uo.is_active IS TRUE
+      JOIN public.roles r
+        ON r.id = ur.role_id
+       AND r.org_id = p_org_id
+       AND COALESCE(r.is_active, true)
+      JOIN public.role_permissions rp ON rp.role_id = ur.role_id
+      JOIN public.permissions p ON p.id = rp.permission_id
+      WHERE ur.user_id = p_user_id
+        AND ur.org_id = p_org_id
+        AND p.permission_key = p_permission_key
+        AND (ur.expires_at IS NULL OR ur.expires_at > now())
+    );
+$function$;
+
+REVOKE ALL ON FUNCTION public.wardah_has_exact_permission(uuid,uuid,text)
+  FROM PUBLIC, anon, authenticated, service_role;
+
+-- ---------------------------------------------------------------------------
+-- 3. Replace rpc_set_org_admin with the same caller contract plus a shared
+--    organization-row lock. The authorization check is repeated after the
+--    lock, so a caller removed or demoted while waiting cannot act afterward.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_set_org_admin(
+  p_target_user_id uuid,
+  p_org_id uuid,
+  p_value boolean
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_caller_id uuid := auth.uid();
+  v_admins_count int;
+  v_target_is_active_admin boolean;
+  v_caller_member_active boolean;
+  v_caller_member_admin boolean;
+  v_caller_super_admin boolean := false;
+BEGIN
+  IF NOT (public.wardah_is_org_admin(p_org_id) OR public.is_super_admin()) THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'NOT_ORG_ADMIN');
+  END IF;
+  IF p_target_user_id = v_caller_id AND p_value = true THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'CANNOT_PROMOTE_SELF');
+  END IF;
+
+  PERFORM 1
+  FROM public.organizations o
+  WHERE o.id = p_org_id
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'ORG_NOT_FOUND');
+  END IF;
+
+  -- Re-authorize from locked rows after acquiring the shared organization
+  -- lock. A second call to a STABLE helper would not be as explicit about
+  -- observing a membership changed by the transaction that held this lock.
+  SELECT uo.is_active IS TRUE,
+         (uo.is_org_admin IS TRUE OR uo.role IN ('admin', 'owner'))
+    INTO v_caller_member_active, v_caller_member_admin
+  FROM public.user_organizations uo
+  WHERE uo.user_id = v_caller_id
+    AND uo.org_id = p_org_id
+  FOR UPDATE;
+
+  SELECT sa.is_active IS TRUE
+    INTO v_caller_super_admin
+  FROM public.super_admins sa
+  WHERE sa.user_id = v_caller_id
+  FOR UPDATE;
+
+  IF NOT COALESCE(v_caller_super_admin, false)
+     AND NOT (
+       COALESCE(v_caller_member_active, false)
+       AND COALESCE(v_caller_member_admin, false)
+     ) THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'NOT_ORG_ADMIN');
+  END IF;
+
+  SELECT (uo.is_active IS TRUE AND uo.is_org_admin IS TRUE)
+    INTO v_target_is_active_admin
+  FROM public.user_organizations uo
+  WHERE uo.user_id = p_target_user_id
+    AND uo.org_id = p_org_id
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'USER_NOT_MEMBER');
+  END IF;
+
+  IF p_value = false AND v_target_is_active_admin THEN
+    SELECT COUNT(*) INTO v_admins_count
+    FROM public.user_organizations
+    WHERE org_id = p_org_id
+      AND is_org_admin = true
+      AND is_active = true
+      AND user_id <> p_target_user_id;
+    IF v_admins_count = 0 THEN
+      RETURN jsonb_build_object('ok', false, 'error', 'LAST_ORG_ADMIN');
+    END IF;
+  END IF;
+
+  UPDATE public.user_organizations
+  SET is_org_admin = p_value
+  WHERE user_id = p_target_user_id
+    AND org_id = p_org_id;
+
+  RETURN jsonb_build_object('ok', true);
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.rpc_set_org_admin(uuid,uuid,boolean)
+  FROM PUBLIC, anon, service_role;
+GRANT EXECUTE ON FUNCTION public.rpc_set_org_admin(uuid,uuid,boolean)
+  TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 4. rpc_remove_org_member — atomic, audited replacement for the client's
 --    two-step "delete user_roles, then delete user_organizations" sequence.
 -- ---------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION public.rpc_remove_org_member(p_payload jsonb)
@@ -110,11 +445,47 @@ DECLARE
   v_old_roles  jsonb;
   v_was_admin  boolean;
   v_other_admins int;
+  v_caller_member_active boolean;
+  v_caller_member_admin boolean;
+  v_caller_super_admin boolean := false;
 BEGIN
   IF v_org IS NULL OR v_target IS NULL THEN
     RAISE EXCEPTION 'RBAC_175_ORG_AND_USER_REQUIRED';
   END IF;
   PERFORM public.wardah_assert_org_admin(v_org);
+
+  PERFORM 1
+  FROM public.organizations o
+  WHERE o.id = v_org
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'RBAC_175_ORG_NOT_FOUND';
+  END IF;
+
+  -- Re-authorize from locked rows. rpc_remove_org_member deliberately keeps
+  -- wardah_assert_org_admin's member-first contract even for super admins.
+  SELECT uo.is_active IS TRUE,
+         (uo.is_org_admin IS TRUE OR uo.role IN ('admin', 'owner'))
+    INTO v_caller_member_active, v_caller_member_admin
+  FROM public.user_organizations uo
+  WHERE uo.user_id = auth.uid()
+    AND uo.org_id = v_org
+  FOR UPDATE;
+
+  IF NOT FOUND OR NOT COALESCE(v_caller_member_active, false) THEN
+    RAISE EXCEPTION 'NOT_ORG_MEMBER';
+  END IF;
+
+  SELECT sa.is_active IS TRUE
+    INTO v_caller_super_admin
+  FROM public.super_admins sa
+  WHERE sa.user_id = auth.uid()
+  FOR UPDATE;
+
+  IF NOT COALESCE(v_caller_member_admin, false)
+     AND NOT COALESCE(v_caller_super_admin, false) THEN
+    RAISE EXCEPTION 'NOT_ORG_ADMIN';
+  END IF;
 
   -- Removal is more drastic than demotion; rpc_set_org_admin (migration 103)
   -- already refuses self-demotion and the last active admin. This mirrors
@@ -133,7 +504,9 @@ BEGIN
     RAISE EXCEPTION 'RBAC_174_TARGET_NOT_ACTIVE_ORG_MEMBER';
   END IF;
 
-  v_was_admin := COALESCE((v_old_member->>'is_org_admin')::boolean, false);
+  v_was_admin :=
+    COALESCE((v_old_member->>'is_active')::boolean, false)
+    AND COALESCE((v_old_member->>'is_org_admin')::boolean, false);
 
   IF v_was_admin THEN
     SELECT count(*) INTO v_other_admins
@@ -176,7 +549,7 @@ REVOKE ALL ON FUNCTION public.rpc_remove_org_member(jsonb) FROM PUBLIC, anon, se
 GRANT EXECUTE ON FUNCTION public.rpc_remove_org_member(jsonb) TO authenticated;
 
 -- ---------------------------------------------------------------------------
--- 2. create_role_from_template — same signature, same return type. Adds the
+-- 5. create_role_from_template — same signature, same return type. Adds the
 --    audit_logs row that was the only gap; everything else about this
 --    function (guard, template lookup, permission-pattern matching) is
 --    unchanged from its original body.
@@ -260,7 +633,7 @@ END;
 $function$;
 
 -- ---------------------------------------------------------------------------
--- 3. wardah_is_sensitive_permission — add an explicit search_path. The
+-- 6. wardah_is_sensitive_permission — add an explicit search_path. The
 --    function body references no table, view or unqualified name (it is a
 --    pure `p_permission_key IN ('literal', 'literal')`), so this changes
 --    nothing about its result for any input; it only removes the advisory a
@@ -285,6 +658,9 @@ $function$;
 DO $verify$
 DECLARE
   v_remove_src text;
+  v_set_admin_src text;
+  v_has_permission_src text;
+  v_exact_permission_src text;
   v_template_src text;
   v_classifier_config text[];
 BEGIN
@@ -306,7 +682,12 @@ BEGIN
     RAISE EXCEPTION 'FAIL[175] rpc_remove_org_member lost the not-a-member guard';
   END IF;
   IF v_remove_src !~ 'FOR UPDATE' THEN
-    RAISE EXCEPTION 'FAIL[175] rpc_remove_org_member no longer locks the membership row';
+    RAISE EXCEPTION 'FAIL[175] rpc_remove_org_member no longer locks rows';
+  END IF;
+  IF v_remove_src !~ 'organizations o'
+     OR v_remove_src !~ 'v_caller_member_active'
+     OR v_remove_src !~ 'v_caller_member_admin' THEN
+    RAISE EXCEPTION 'FAIL[175] rpc_remove_org_member lacks shared org lock or post-lock reauthorization';
   END IF;
   IF v_remove_src !~ 'audit_logs' THEN
     RAISE EXCEPTION 'FAIL[175] rpc_remove_org_member does not write an audit row';
@@ -316,6 +697,75 @@ BEGIN
      OR has_function_privilege('service_role', 'public.rpc_remove_org_member(jsonb)', 'EXECUTE')
      OR NOT has_function_privilege('authenticated', 'public.rpc_remove_org_member(jsonb)', 'EXECUTE') THEN
     RAISE EXCEPTION 'FAIL[175] rpc_remove_org_member execute boundary is wrong';
+  END IF;
+
+  SELECT prosrc INTO v_set_admin_src
+  FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public' AND p.proname = 'rpc_set_org_admin';
+  IF v_set_admin_src !~ 'organizations o'
+     OR v_set_admin_src !~ 'v_target_is_active_admin'
+     OR v_set_admin_src !~ 'v_caller_member_active'
+     OR v_set_admin_src !~ 'FOR UPDATE' THEN
+    RAISE EXCEPTION 'FAIL[175] rpc_set_org_admin lacks shared lock or active-target last-admin guard';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_trigger t
+    JOIN pg_class c ON c.oid = t.tgrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relname = 'user_roles'
+      AND t.tgname = 'trg_wardah_175_require_active_role_membership'
+      AND t.tgenabled <> 'D'
+      AND NOT t.tgisinternal
+      AND pg_get_triggerdef(t.oid) !~ 'UPDATE OF'
+  ) OR NOT EXISTS (
+    SELECT 1
+    FROM pg_trigger t
+    JOIN pg_class c ON c.oid = t.tgrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relname = 'user_organizations'
+      AND t.tgname = 'trg_wardah_175_protect_role_membership_parent'
+      AND t.tgenabled <> 'D'
+      AND NOT t.tgisinternal
+  ) THEN
+    RAISE EXCEPTION 'FAIL[175] active-membership invariant triggers missing or disabled';
+  END IF;
+
+  IF has_function_privilege('anon', 'public.wardah_175_require_active_role_membership()', 'EXECUTE')
+     OR has_function_privilege('authenticated', 'public.wardah_175_require_active_role_membership()', 'EXECUTE')
+     OR has_function_privilege('service_role', 'public.wardah_175_require_active_role_membership()', 'EXECUTE')
+     OR has_function_privilege('anon', 'public.wardah_175_protect_role_membership_parent()', 'EXECUTE')
+     OR has_function_privilege('authenticated', 'public.wardah_175_protect_role_membership_parent()', 'EXECUTE')
+     OR has_function_privilege('service_role', 'public.wardah_175_protect_role_membership_parent()', 'EXECUTE') THEN
+    RAISE EXCEPTION 'FAIL[175] invariant trigger function execute boundary is open';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.user_roles ur
+    LEFT JOIN public.user_organizations uo
+      ON uo.user_id = ur.user_id
+     AND uo.org_id = ur.org_id
+     AND uo.is_active IS TRUE
+    WHERE uo.user_id IS NULL
+  ) THEN
+    RAISE EXCEPTION 'FAIL[175] orphan or inactive-member assignment remains';
+  END IF;
+
+  SELECT prosrc INTO v_has_permission_src
+  FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public' AND p.proname = 'has_permission';
+  SELECT prosrc INTO v_exact_permission_src
+  FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public' AND p.proname = 'wardah_has_exact_permission';
+  IF v_has_permission_src !~ 'user_organizations uo'
+     OR v_has_permission_src !~ 'uo\.is_active IS TRUE'
+     OR v_exact_permission_src !~ 'user_organizations uo'
+     OR v_exact_permission_src !~ 'uo\.is_active IS TRUE' THEN
+    RAISE EXCEPTION 'FAIL[175] permission helpers do not require active explicit-role membership';
   END IF;
 
   SELECT prosrc INTO v_template_src FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
@@ -346,7 +796,7 @@ BEGIN
     RAISE EXCEPTION 'FAIL[175] wardah_is_sensitive_permission behavior changed';
   END IF;
 
-  RAISE NOTICE 'PASS[175] rpc_remove_org_member live; create_role_from_template now audited; classifier search_path closed';
+  RAISE NOTICE 'PASS[175] active-membership and last-admin races closed; consumer RPCs live; permission helpers hardened';
 END
 $verify$;
 

--- a/sql/migrations/175_rbac_consumer_migration_rpcs.sql
+++ b/sql/migrations/175_rbac_consumer_migration_rpcs.sql
@@ -156,9 +156,15 @@ SECURITY DEFINER
 SET search_path TO 'public', 'pg_temp'
 AS $function$
 DECLARE
-  v_org uuid := NULLIF(p_payload->>'org_id','')::uuid;
+  -- Preserve 174's pre-authorization payload-validation order. These three
+  -- casts originally ran before wardah_assert_org_admin; moving only v_org
+  -- into the wrapper would turn a missing/invalid user (or invalid expiry)
+  -- into an authorization result for callers outside the organization.
+  v_org     uuid := NULLIF(p_payload->>'org_id','')::uuid;
+  v_user    uuid := NULLIF(p_payload->>'user_id','')::uuid;
+  v_expires timestamptz := NULLIF(p_payload->>'expires_at','')::timestamptz;
 BEGIN
-  IF v_org IS NULL THEN
+  IF v_org IS NULL OR v_user IS NULL THEN
     RAISE EXCEPTION 'RBAC_174_ORG_AND_USER_REQUIRED';
   END IF;
 

--- a/sql/migrations/175_rbac_consumer_migration_rpcs.sql
+++ b/sql/migrations/175_rbac_consumer_migration_rpcs.sql
@@ -36,8 +36,10 @@
 --      fixes the import; this migration only adds the missing audit trail.
 --   3. user_roles membership/write invariant — every INSERT must point at an
 --      active membership; every UPDATE is rejected before row locking and
---      must use rpc_replace_user_roles; membership deletion/deactivation is
---      refused while role rows still exist. INSERT, replacement, and removal
+--      must use rpc_replace_user_roles; membership deletion or identity/org
+--      movement is refused while role rows still exist. Deactivation remains
+--      reversible and preserves assignments, while permission helpers make
+--      them ineffective until reactivation. INSERT, replacement, and removal
 --      take locks in the same organization-then-membership order.
 --   4. rpc_set_org_admin + rpc_remove_org_member — serialize the last-admin
 --      decision on the organization row and re-authorize after taking it.
@@ -129,7 +131,6 @@ BEGIN
     LEFT JOIN public.user_organizations uo
       ON uo.user_id = ur.user_id
      AND uo.org_id = ur.org_id
-     AND uo.is_active IS TRUE
     WHERE uo.user_id IS NULL
   ) THEN
     RAISE EXCEPTION 'RBAC_175_INVALID_USER_ROLE_MEMBERSHIP_PREFLIGHT';
@@ -190,8 +191,10 @@ REVOKE ALL ON FUNCTION public.rpc_replace_user_roles(jsonb) FROM PUBLIC, anon, s
 GRANT EXECUTE ON FUNCTION public.rpc_replace_user_roles(jsonb) TO authenticated;
 
 -- ---------------------------------------------------------------------------
--- 2. Database-boundary invariant: a role assignment exists only while the
---    corresponding membership is active.
+-- 2. Database-boundary invariant: a new role assignment requires an active
+--    membership. Existing assignments may remain while a membership is
+--    inactive so the live reversible toggle keeps working; both permission
+--    helpers below suppress those assignments until reactivation.
 -- ---------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION public.wardah_175_require_active_role_membership()
 RETURNS trigger
@@ -262,8 +265,7 @@ BEGIN
   ELSE
     v_invalidates_membership :=
       OLD.user_id IS DISTINCT FROM NEW.user_id
-      OR OLD.org_id IS DISTINCT FROM NEW.org_id
-      OR (OLD.is_active IS TRUE AND NEW.is_active IS NOT TRUE);
+      OR OLD.org_id IS DISTINCT FROM NEW.org_id;
   END IF;
 
   IF v_invalidates_membership AND EXISTS (
@@ -758,6 +760,7 @@ DECLARE
   v_exact_permission_src text;
   v_child_guard_src text;
   v_update_guard_src text;
+  v_parent_guard_src text;
   v_template_src text;
   v_classifier_config text[];
 BEGIN
@@ -894,16 +897,25 @@ BEGIN
     RAISE EXCEPTION 'FAIL[175] direct user_roles UPDATE guard marker is missing';
   END IF;
 
+  SELECT prosrc INTO v_parent_guard_src
+  FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public'
+    AND p.proname = 'wardah_175_protect_role_membership_parent';
+  IF v_parent_guard_src !~ 'OLD\.user_id'
+     OR v_parent_guard_src !~ 'OLD\.org_id'
+     OR v_parent_guard_src ~ 'OLD\.is_active' THEN
+    RAISE EXCEPTION 'FAIL[175] parent guard must block orphaning moves/deletes but allow reversible deactivation';
+  END IF;
+
   IF EXISTS (
     SELECT 1
     FROM public.user_roles ur
     LEFT JOIN public.user_organizations uo
       ON uo.user_id = ur.user_id
      AND uo.org_id = ur.org_id
-     AND uo.is_active IS TRUE
     WHERE uo.user_id IS NULL
   ) THEN
-    RAISE EXCEPTION 'FAIL[175] orphan or inactive-member assignment remains';
+    RAISE EXCEPTION 'FAIL[175] orphan assignment remains';
   END IF;
 
   SELECT prosrc INTO v_has_permission_src

--- a/sql/migrations/175_rbac_consumer_migration_rpcs.sql
+++ b/sql/migrations/175_rbac_consumer_migration_rpcs.sql
@@ -34,10 +34,11 @@
 --      direct-write function from org-admin-service.ts instead of the one
 --      in rbac-service.ts that correctly calls this RPC. The consumer PR
 --      fixes the import; this migration only adds the missing audit trail.
---   3. user_roles membership invariant — every INSERT/UPDATE must point at an
---      active membership; membership deletion/deactivation is refused while
---      role rows still exist. Direct writes and rpc_replace_user_roles take
---      locks in the same organization-then-membership order as removal.
+--   3. user_roles membership/write invariant — every INSERT must point at an
+--      active membership; every UPDATE is rejected before row locking and
+--      must use rpc_replace_user_roles; membership deletion/deactivation is
+--      refused while role rows still exist. INSERT, replacement, and removal
+--      take locks in the same organization-then-membership order.
 --   4. rpc_set_org_admin + rpc_remove_org_member — serialize the last-admin
 --      decision on the organization row and re-authorize after taking it.
 --   5. has_permission + wardah_has_exact_permission — explicit-role grants
@@ -66,11 +67,12 @@
 --     only the RBAC surface; widening their behavior (e.g. letting a
 --     non-member super admin pass) is a separate, cross-cutting change that
 --     deserves its own migration and review, not a rider on this one.
---   * No table grant is revoked here. authenticated keeps direct
---     INSERT/UPDATE/DELETE on roles, role_permissions and user_roles.
---     Invalid user_roles writes are nevertheless rejected by invariant
---     triggers; this deliberate narrowing is required before the consumer
---     migration window can be safe.
+--   * No table grant is revoked here. authenticated keeps its table-level
+--     INSERT/UPDATE/DELETE grants on roles, role_permissions and user_roles.
+--     At the user_roles database boundary, INSERT requires active membership
+--     and UPDATE is rejected entirely in favor of rpc_replace_user_roles.
+--     This deliberate behavioral narrowing is required before the consumer
+--     migration window can be safe and prevents inverse tuple/org lock order.
 --     That closure is Migration 176, applied only after the consumer PR has
 --     moved every real caller onto the RPC surface this migration and 174
 --     together provide, and the browser smoke has proven it end to end.
@@ -222,6 +224,24 @@ $function$;
 
 REVOKE ALL ON FUNCTION public.wardah_175_require_active_role_membership() FROM PUBLIC, anon, authenticated, service_role;
 
+-- PostgreSQL locks a target tuple before a BEFORE ROW UPDATE trigger runs.
+-- Taking the organization lock from that row trigger therefore inverts the
+-- organization -> assignment order used by member removal. Reject UPDATE at
+-- statement level, before tuple locking, and require the ordered replacement
+-- RPC (whose 174 body uses DELETE + INSERT) for every assignment change.
+CREATE OR REPLACE FUNCTION public.wardah_175_reject_direct_role_update()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO 'pg_catalog', 'pg_temp'
+AS $function$
+BEGIN
+  RAISE EXCEPTION
+    'RBAC_175_DIRECT_USER_ROLES_UPDATE_FORBIDDEN_USE_RPC_REPLACE_USER_ROLES';
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.wardah_175_reject_direct_role_update() FROM PUBLIC, anon, authenticated, service_role;
+
 CREATE OR REPLACE FUNCTION public.wardah_175_protect_role_membership_parent()
 RETURNS trigger
 LANGUAGE plpgsql
@@ -261,9 +281,16 @@ REVOKE ALL ON FUNCTION public.wardah_175_protect_role_membership_parent() FROM P
 DROP TRIGGER IF EXISTS trg_wardah_175_require_active_role_membership
   ON public.user_roles;
 CREATE TRIGGER trg_wardah_175_require_active_role_membership
-BEFORE INSERT OR UPDATE ON public.user_roles
+BEFORE INSERT ON public.user_roles
 FOR EACH ROW
 EXECUTE FUNCTION public.wardah_175_require_active_role_membership();
+
+DROP TRIGGER IF EXISTS trg_wardah_175_reject_direct_role_update
+  ON public.user_roles;
+CREATE TRIGGER trg_wardah_175_reject_direct_role_update
+BEFORE UPDATE ON public.user_roles
+FOR EACH STATEMENT
+EXECUTE FUNCTION public.wardah_175_reject_direct_role_update();
 
 DROP TRIGGER IF EXISTS trg_wardah_175_protect_role_membership_parent
   ON public.user_organizations;
@@ -724,6 +751,7 @@ DECLARE
   v_has_permission_src text;
   v_exact_permission_src text;
   v_child_guard_src text;
+  v_update_guard_src text;
   v_template_src text;
   v_classifier_config text[];
 BEGIN
@@ -797,7 +825,24 @@ BEGIN
       AND t.tgname = 'trg_wardah_175_require_active_role_membership'
       AND t.tgenabled <> 'D'
       AND NOT t.tgisinternal
-      AND pg_get_triggerdef(t.oid) !~ 'UPDATE OF'
+      AND (t.tgtype & 1) = 1
+      AND (t.tgtype & 2) = 2
+      AND (t.tgtype & 4) = 4
+      AND (t.tgtype & 16) = 0
+  ) OR NOT EXISTS (
+    SELECT 1
+    FROM pg_trigger t
+    JOIN pg_class c ON c.oid = t.tgrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relname = 'user_roles'
+      AND t.tgname = 'trg_wardah_175_reject_direct_role_update'
+      AND t.tgenabled <> 'D'
+      AND NOT t.tgisinternal
+      AND (t.tgtype & 1) = 0
+      AND (t.tgtype & 2) = 2
+      AND (t.tgtype & 4) = 0
+      AND (t.tgtype & 16) = 16
   ) OR NOT EXISTS (
     SELECT 1
     FROM pg_trigger t
@@ -809,12 +854,15 @@ BEGIN
       AND t.tgenabled <> 'D'
       AND NOT t.tgisinternal
   ) THEN
-    RAISE EXCEPTION 'FAIL[175] active-membership invariant triggers missing or disabled';
+    RAISE EXCEPTION 'FAIL[175] membership/update invariant triggers missing, malformed, or disabled';
   END IF;
 
   IF has_function_privilege('anon', 'public.wardah_175_require_active_role_membership()', 'EXECUTE')
      OR has_function_privilege('authenticated', 'public.wardah_175_require_active_role_membership()', 'EXECUTE')
      OR has_function_privilege('service_role', 'public.wardah_175_require_active_role_membership()', 'EXECUTE')
+     OR has_function_privilege('anon', 'public.wardah_175_reject_direct_role_update()', 'EXECUTE')
+     OR has_function_privilege('authenticated', 'public.wardah_175_reject_direct_role_update()', 'EXECUTE')
+     OR has_function_privilege('service_role', 'public.wardah_175_reject_direct_role_update()', 'EXECUTE')
      OR has_function_privilege('anon', 'public.wardah_175_protect_role_membership_parent()', 'EXECUTE')
      OR has_function_privilege('authenticated', 'public.wardah_175_protect_role_membership_parent()', 'EXECUTE')
      OR has_function_privilege('service_role', 'public.wardah_175_protect_role_membership_parent()', 'EXECUTE') THEN
@@ -830,6 +878,14 @@ BEGIN
      OR v_child_guard_src !~ 'user_organizations uo'
      OR v_child_guard_src !~ 'FOR UPDATE' THEN
     RAISE EXCEPTION 'FAIL[175] assignment trigger lock order is not org then membership';
+  END IF;
+
+  SELECT prosrc INTO v_update_guard_src
+  FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public'
+    AND p.proname = 'wardah_175_reject_direct_role_update';
+  IF v_update_guard_src !~ 'RBAC_175_DIRECT_USER_ROLES_UPDATE_FORBIDDEN_USE_RPC_REPLACE_USER_ROLES' THEN
+    RAISE EXCEPTION 'FAIL[175] direct user_roles UPDATE guard marker is missing';
   END IF;
 
   IF EXISTS (
@@ -885,7 +941,7 @@ BEGIN
     RAISE EXCEPTION 'FAIL[175] wardah_is_sensitive_permission behavior changed';
   END IF;
 
-  RAISE NOTICE 'PASS[175] active-membership and last-admin races closed; consumer RPCs live; permission helpers hardened';
+  RAISE NOTICE 'PASS[175] membership, last-admin, and direct-update races closed; consumer RPCs live; permission helpers hardened';
 END
 $verify$;
 

--- a/sql/migrations/175_rbac_consumer_migration_rpcs.sql
+++ b/sql/migrations/175_rbac_consumer_migration_rpcs.sql
@@ -36,7 +36,8 @@
 --      fixes the import; this migration only adds the missing audit trail.
 --   3. user_roles membership invariant — every INSERT/UPDATE must point at an
 --      active membership; membership deletion/deactivation is refused while
---      role rows still exist. Both sides serialize on the membership row.
+--      role rows still exist. Direct writes and rpc_replace_user_roles take
+--      locks in the same organization-then-membership order as removal.
 --   4. rpc_set_org_admin + rpc_remove_org_member — serialize the last-admin
 --      decision on the organization row and re-authorize after taking it.
 --   5. has_permission + wardah_has_exact_permission — explicit-role grants
@@ -99,6 +100,9 @@ BEGIN
   IF to_regprocedure('public.rpc_set_org_admin(uuid,uuid,boolean)') IS NULL THEN
     RAISE EXCEPTION 'PERMISSION_175_SET_ORG_ADMIN_MISSING';
   END IF;
+  IF to_regprocedure('public.rpc_replace_user_roles(jsonb)') IS NULL THEN
+    RAISE EXCEPTION 'PERMISSION_175_REPLACE_USER_ROLES_MISSING';
+  END IF;
   IF to_regclass('public.user_organizations') IS NULL
      OR to_regclass('public.user_roles') IS NULL
      OR to_regclass('public.roles') IS NULL
@@ -132,7 +136,53 @@ END
 $data_preflight$;
 
 -- ---------------------------------------------------------------------------
--- 1. Database-boundary invariant: a role assignment exists only while the
+-- 1. Preserve 174's complete replace contract behind an organization-first
+--    wrapper. The old function already locks the target membership row; taking
+--    the org row first makes its lock order consistent with member removal and
+--    with the direct-write trigger below.
+-- ---------------------------------------------------------------------------
+ALTER FUNCTION public.rpc_replace_user_roles(jsonb)
+  RENAME TO wardah_175_internal_replace_user_roles;
+
+REVOKE ALL ON FUNCTION public.wardah_175_internal_replace_user_roles(jsonb)
+  FROM PUBLIC, anon, authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION public.rpc_replace_user_roles(p_payload jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_org uuid := NULLIF(p_payload->>'org_id','')::uuid;
+BEGIN
+  IF v_org IS NULL THEN
+    RAISE EXCEPTION 'RBAC_174_ORG_AND_USER_REQUIRED';
+  END IF;
+
+  -- Reject unauthorized callers before they can hold an organization lock.
+  PERFORM public.wardah_assert_org_admin(v_org);
+
+  PERFORM 1
+  FROM public.organizations o
+  WHERE o.id = v_org
+  FOR KEY SHARE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'RBAC_175_ORG_NOT_FOUND';
+  END IF;
+
+  -- The internal 174 body re-runs the admin guard after this lock, then takes
+  -- the target membership FOR UPDATE and executes its byte-identical replace,
+  -- expiry-preservation, sensitive-key, and audit logic.
+  RETURN public.wardah_175_internal_replace_user_roles(p_payload);
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.rpc_replace_user_roles(jsonb) FROM PUBLIC, anon, service_role;
+GRANT EXECUTE ON FUNCTION public.rpc_replace_user_roles(jsonb) TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 2. Database-boundary invariant: a role assignment exists only while the
 --    corresponding membership is active.
 -- ---------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION public.wardah_175_require_active_role_membership()
@@ -144,6 +194,17 @@ AS $function$
 DECLARE
   v_active boolean;
 BEGIN
+  -- Lock order is organization -> membership everywhere. The organization
+  -- lock also prevents the audit FK from forming a member<->org deadlock with
+  -- rpc_remove_org_member, which holds the org row before deleting membership.
+  PERFORM 1
+  FROM public.organizations o
+  WHERE o.id = NEW.org_id
+  FOR KEY SHARE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'RBAC_175_ACTIVE_MEMBERSHIP_REQUIRED';
+  END IF;
+
   SELECT uo.is_active
     INTO v_active
   FROM public.user_organizations uo
@@ -212,7 +273,7 @@ FOR EACH ROW
 EXECUTE FUNCTION public.wardah_175_protect_role_membership_parent();
 
 -- ---------------------------------------------------------------------------
--- 2. Defense in depth: an explicit role grant is effective only while the
+-- 3. Defense in depth: an explicit role grant is effective only while the
 --    assignee remains an active member of that same organization.
 -- ---------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION public.has_permission(
@@ -330,7 +391,7 @@ REVOKE ALL ON FUNCTION public.wardah_has_exact_permission(uuid,uuid,text)
   FROM PUBLIC, anon, authenticated, service_role;
 
 -- ---------------------------------------------------------------------------
--- 3. Replace rpc_set_org_admin with the same caller contract plus a shared
+-- 4. Replace rpc_set_org_admin with the same caller contract plus a shared
 --    organization-row lock. The authorization check is repeated after the
 --    lock, so a caller removed or demoted while waiting cannot act afterward.
 -- ---------------------------------------------------------------------------
@@ -429,7 +490,7 @@ GRANT EXECUTE ON FUNCTION public.rpc_set_org_admin(uuid,uuid,boolean)
   TO authenticated;
 
 -- ---------------------------------------------------------------------------
--- 4. rpc_remove_org_member — atomic, audited replacement for the client's
+-- 5. rpc_remove_org_member — atomic, audited replacement for the client's
 --    two-step "delete user_roles, then delete user_organizations" sequence.
 -- ---------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION public.rpc_remove_org_member(p_payload jsonb)
@@ -549,7 +610,7 @@ REVOKE ALL ON FUNCTION public.rpc_remove_org_member(jsonb) FROM PUBLIC, anon, se
 GRANT EXECUTE ON FUNCTION public.rpc_remove_org_member(jsonb) TO authenticated;
 
 -- ---------------------------------------------------------------------------
--- 5. create_role_from_template — same signature, same return type. Adds the
+-- 6. create_role_from_template — same signature, same return type. Adds the
 --    audit_logs row that was the only gap; everything else about this
 --    function (guard, template lookup, permission-pattern matching) is
 --    unchanged from its original body.
@@ -633,7 +694,7 @@ END;
 $function$;
 
 -- ---------------------------------------------------------------------------
--- 6. wardah_is_sensitive_permission — add an explicit search_path. The
+-- 7. wardah_is_sensitive_permission — add an explicit search_path. The
 --    function body references no table, view or unqualified name (it is a
 --    pure `p_permission_key IN ('literal', 'literal')`), so this changes
 --    nothing about its result for any input; it only removes the advisory a
@@ -658,12 +719,29 @@ $function$;
 DO $verify$
 DECLARE
   v_remove_src text;
+  v_replace_src text;
   v_set_admin_src text;
   v_has_permission_src text;
   v_exact_permission_src text;
+  v_child_guard_src text;
   v_template_src text;
   v_classifier_config text[];
 BEGIN
+  SELECT prosrc INTO v_replace_src
+  FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public' AND p.proname = 'rpc_replace_user_roles';
+  IF v_replace_src !~ 'FOR KEY SHARE'
+     OR v_replace_src !~ 'wardah_175_internal_replace_user_roles'
+     OR v_replace_src !~ 'wardah_assert_org_admin' THEN
+    RAISE EXCEPTION 'FAIL[175] rpc_replace_user_roles lacks organization-first guarded wrapper';
+  END IF;
+  IF has_function_privilege('anon', 'public.wardah_175_internal_replace_user_roles(jsonb)', 'EXECUTE')
+     OR has_function_privilege('authenticated', 'public.wardah_175_internal_replace_user_roles(jsonb)', 'EXECUTE')
+     OR has_function_privilege('service_role', 'public.wardah_175_internal_replace_user_roles(jsonb)', 'EXECUTE')
+     OR NOT has_function_privilege('authenticated', 'public.rpc_replace_user_roles(jsonb)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'FAIL[175] replace-user-roles wrapper execute boundary is wrong';
+  END IF;
+
   SELECT prosrc INTO v_remove_src FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
    WHERE n.nspname = 'public' AND p.proname = 'rpc_remove_org_member';
   IF v_remove_src IS NULL THEN
@@ -741,6 +819,17 @@ BEGIN
      OR has_function_privilege('authenticated', 'public.wardah_175_protect_role_membership_parent()', 'EXECUTE')
      OR has_function_privilege('service_role', 'public.wardah_175_protect_role_membership_parent()', 'EXECUTE') THEN
     RAISE EXCEPTION 'FAIL[175] invariant trigger function execute boundary is open';
+  END IF;
+
+  SELECT prosrc INTO v_child_guard_src
+  FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public'
+    AND p.proname = 'wardah_175_require_active_role_membership';
+  IF v_child_guard_src !~ 'organizations o'
+     OR v_child_guard_src !~ 'FOR KEY SHARE'
+     OR v_child_guard_src !~ 'user_organizations uo'
+     OR v_child_guard_src !~ 'FOR UPDATE' THEN
+    RAISE EXCEPTION 'FAIL[175] assignment trigger lock order is not org then membership';
   END IF;
 
   IF EXISTS (

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -11154,6 +11154,7 @@ export type Database = {
         }
         Returns: string
       }
+      rpc_remove_org_member: { Args: { p_payload: Json }; Returns: Json }
       rpc_replace_user_roles: { Args: { p_payload: Json }; Returns: Json }
       rpc_reset_customer_receipt_to_draft: {
         Args: { p_reason: string; p_receipt_id: string }

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -11633,6 +11633,10 @@ export type Database = {
         Returns: Json
       }
       wardah_169_leave_write_context: { Args: never; Returns: undefined }
+      wardah_175_internal_replace_user_roles: {
+        Args: { p_payload: Json }
+        Returns: Json
+      }
       wardah_apply_stock_incoming: {
         Args: {
           p_org: string


### PR DESCRIPTION
## Summary

Migration 175 remains the DB-first bridge for Issue #93. Review found three real concurrency gaps plus two compatibility-contract regressions in its earlier revisions; this head closes all five before any Production application.

### What 175 now does

- Adds audited `rpc_remove_org_member(jsonb)` and completes the audit trail for `create_role_from_template`.
- Enforces the assignment boundary at the database layer:
  - every `user_roles` INSERT takes organization → membership locks and requires an active membership;
  - every direct `UPDATE user_roles` is rejected by a `BEFORE UPDATE FOR EACH STATEMENT` guard, before tuple locking, and must use `rpc_replace_user_roles`;
  - deleting or moving a membership is rejected while assignments remain;
  - reversible deactivation/reactivation retains assignments, while both permission helpers suppress inactive access and restore it on reactivation.
- Requires an active membership in the explicit-role branches of both `has_permission` and `wardah_has_exact_permission`.
- Serializes `rpc_remove_org_member` and `rpc_set_org_admin` on the same organization row.
- Preserves the full 174 `rpc_replace_user_roles` contract behind a non-callable internal body and an organization-first public wrapper, including pre-authorization parsing and validation/error ordering.
- Re-authorizes the caller from locked membership/admin rows after the organization lock, so a caller removed or demoted while waiting cannot act.
- Applies the last-admin check only when the target is currently an active org admin.
- Adds an explicit `search_path` to `wardah_is_sensitive_permission`.

No RBAC table grant is revoked in 175. Direct `user_roles` UPDATE is behaviorally blocked at the database boundary; full direct-write privilege revocation remains Migration 176.

### Fail-closed preflight

175 locks `user_organizations` and `user_roles` against DML, then aborts with `RBAC_175_INVALID_USER_ROLE_MEMBERSHIP_PREFLIGHT` if any assignment has no matching membership row. Inactive memberships with retained assignments are valid: authorization remains denied until reactivation. The migration never silently deletes or repairs live data.

## Verification

New/expanded gates on this head:

- Sequential acceptance covers active-member INSERT; key/non-key/zero-row UPDATE rejection; exact trigger shape; reversible deactivation/reactivation with assignment retention and authorization suppression/restoration; parent deletion/movement rejection; cross-org/self/last-admin guards; atomic removal + audit; template audit; and the 170–174 mutation proof.
- The wrapped 174 contract is proven for a successful replacement and for missing `user_id`, invalid UUID, and invalid `expires_at` from an unauthorized caller, preserving validation before authorization.
- A real multi-session shell suite races:
  1. direct INSERT vs member removal;
  2. two admins removing each other;
  3. demotion vs removal;
  4. direct UPDATE vs member removal, after proving the remover is blocked on the organization lock.
- Red proof 1 builds only through 174 and proves `rpc_remove_org_member` is absent.
- Red proof 2 injects a true orphan assignment pre-175 and proves the migration fails closed.
- Migration/acceptance SQL parse with the PostgreSQL parser.
- `check_definer_guards.py`, 63 local governance checks/tests, workflow YAML, Bash syntax, consumer scan, and `git diff --check` pass locally.

Verified on final head `44a53e788f00ef478c59ca46d1ff8125b33554fa`:

| Gate | Result |
|---|---|
| Fresh PostgreSQL 17.10 chain through 175 | `PASS=14 FAIL=0 NOT_RUN=0 TOTAL=14` |
| Sequential 175 acceptance | `RBAC_CONSUMER_175_ACCEPTANCE_PASS` |
| Four real multi-session races | `RBAC_CONSUMER_175_CONCURRENCY_PASS` |
| 174 regression suite | `SENSITIVE_PERMISSION_174_ACCEPTANCE_PASS` |
| Pre-175 chain | `PASS=13 FAIL=0 NOT_RUN=0 TOTAL=13`; RPC absent = `f` |
| Orphan-data red proof | exact `RBAC_175_INVALID_USER_ROLE_MEMBERSHIP_PREFLIGHT` failure |
| GitHub Actions | 8/8 successful |
| SonarQube / Vercel / Netlify | successful |
| Final Codex review | no major issues on `44a53e788f` |
| Review threads | all resolved |

## Required rollout order

1. Merge 175 only after human review.
2. Apply 175 DB-first after the runbook's read-only Production preflight returns zero orphan assignments.
3. Verify the live postflight.
4. Merge/deploy the separate production-consumer PR.
5. Rebase/fix PR #114 and run the real Browser Smoke.
6. Apply Migration 176 to revoke direct writes.

Issue #93 remains open and the Baseline remains untouched until Browser Smoke and 176 both pass.

**Not done:** no Production access/application, no consumer PR, no PR #114 changes, no Migration 176.