### PR TITLE
fix(rbac-ui): route admin writes through audited RPCs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -59,6 +59,9 @@ jobs:
           fi
           echo "✅ src/types/database.generated.ts موجود (${LINES} سطر)"
 
+      - name: Enforce audited RBAC write boundary
+        run: node scripts/ci/check-rbac-direct-writes.mjs
+
       - name: TypeScript type check
         id: typecheck
         run: |

--- a/scripts/ci/check-rbac-direct-writes.mjs
+++ b/scripts/ci/check-rbac-direct-writes.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import ts from 'typescript';
+
+const RBAC_TABLES = new Set(['roles', 'role_permissions', 'user_roles']);
+const WRITE_METHODS = new Set(['insert', 'update', 'upsert', 'delete']);
+
+function propertyName(expression) {
+  if (ts.isPropertyAccessExpression(expression)) return expression.name.text;
+  if (
+    ts.isElementAccessExpression(expression)
+    && expression.argumentExpression
+    && ts.isStringLiteralLike(expression.argumentExpression)
+  ) {
+    return expression.argumentExpression.text;
+  }
+  return null;
+}
+
+function tableFromExpression(expression, aliases) {
+  if (!expression) return null;
+  if (ts.isIdentifier(expression)) return aliases.get(expression.text) ?? null;
+  if (
+    ts.isParenthesizedExpression(expression)
+    || ts.isAwaitExpression(expression)
+    || ts.isAsExpression(expression)
+    || ts.isTypeAssertionExpression(expression)
+    || ts.isNonNullExpression(expression)
+  ) {
+    return tableFromExpression(expression.expression, aliases);
+  }
+  if (ts.isPropertyAccessExpression(expression) || ts.isElementAccessExpression(expression)) {
+    return tableFromExpression(expression.expression, aliases);
+  }
+  if (!ts.isCallExpression(expression)) return null;
+
+  const calledName = propertyName(expression.expression);
+  if (calledName === 'from') {
+    const tableArg = expression.arguments[0];
+    if (tableArg && ts.isStringLiteralLike(tableArg) && RBAC_TABLES.has(tableArg.text)) {
+      return tableArg.text;
+    }
+  }
+  return tableFromExpression(expression.expression, aliases);
+}
+
+function scanSource(sourceText, fileName) {
+  const source = ts.createSourceFile(
+    fileName,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    fileName.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS
+  );
+  const aliases = new Map();
+  const violations = [];
+
+  function visit(node) {
+    if (
+      ts.isVariableDeclaration(node)
+      && ts.isIdentifier(node.name)
+      && node.initializer
+    ) {
+      const table = tableFromExpression(node.initializer, aliases);
+      if (table) aliases.set(node.name.text, table);
+    }
+
+    if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+      if (ts.isIdentifier(node.left)) {
+        const table = tableFromExpression(node.right, aliases);
+        if (table) aliases.set(node.left.text, table);
+      }
+    }
+
+    if (ts.isCallExpression(node)) {
+      const method = propertyName(node.expression);
+      if (method && WRITE_METHODS.has(method)) {
+        const receiver = node.expression.expression;
+        const table = tableFromExpression(receiver, aliases);
+        if (table) {
+          const location = source.getLineAndCharacterOfPosition(node.getStart(source));
+          violations.push({
+            file: fileName,
+            line: location.line + 1,
+            column: location.character + 1,
+            table,
+            method,
+          });
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(source);
+  return violations;
+}
+
+function runSelfTest() {
+  const unsafe = scanSource(`
+    client.from('roles').insert({ name: 'x' });
+    client.from("role_permissions").delete().eq('role_id', 'r1');
+    const assignments = client.from('user_roles');
+    assignments.upsert([{ user_id: 'u1' }]);
+    let roleQuery;
+    roleQuery = client.from('roles').select('*');
+    roleQuery.update({ name: 'changed' });
+  `, 'self-test-unsafe.ts');
+  if (unsafe.length !== 4) {
+    throw new Error(`RBAC write gate self-test missed an unsafe path: ${JSON.stringify(unsafe)}`);
+  }
+
+  const safe = scanSource(`
+    client.from('roles').select('*');
+    client.from('role_permissions').select('role_id');
+    client.from('user_roles').select('*');
+    client.rpc('rpc_replace_user_roles', { p_payload: {} });
+    client.rpc('rpc_remove_org_member', { p_payload: {} });
+  `, 'self-test-safe.ts');
+  if (safe.length !== 0) {
+    throw new Error(`RBAC write gate rejected a safe read/RPC path: ${JSON.stringify(safe)}`);
+  }
+}
+
+function sourceFiles(root) {
+  const files = [];
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const fullPath = path.join(root, entry.name);
+    if (entry.isDirectory()) files.push(...sourceFiles(fullPath));
+    else if (entry.isFile() && /\.tsx?$/.test(entry.name)) files.push(fullPath);
+  }
+  return files;
+}
+
+runSelfTest();
+
+const root = path.resolve(process.cwd(), 'src');
+const files = sourceFiles(root);
+const violations = files.flatMap(file =>
+  scanSource(fs.readFileSync(file, 'utf8'), path.relative(process.cwd(), file))
+);
+
+if (violations.length > 0) {
+  console.error('RBAC_DIRECT_WRITE_GATE_FAIL: use the audited RBAC RPC surface:');
+  for (const violation of violations) {
+    console.error(
+      `  ${violation.file}:${violation.line}:${violation.column}`
+      + ` direct ${violation.method.toUpperCase()} on ${violation.table}`
+    );
+  }
+  process.exit(1);
+}
+
+console.log(`RBAC_DIRECT_WRITE_GATE_PASS files=${files.length}`);

--- a/src/pages/org-admin/__tests__/roles-rpc-path.test.tsx
+++ b/src/pages/org-admin/__tests__/roles-rpc-path.test.tsx
@@ -38,7 +38,6 @@ vi.mock('@/services/org-admin-service', () => ({
     },
   ]),
   getRoleTemplates: vi.fn(async () => []),
-  createRoleFromTemplate: vi.fn(),
 }));
 
 import OrgAdminRoles from '../roles';

--- a/src/pages/org-admin/__tests__/roles.test.tsx
+++ b/src/pages/org-admin/__tests__/roles.test.tsx
@@ -34,8 +34,7 @@ vi.mock('@/lib/supabase', () => ({
 
 vi.mock('@/services/org-admin-service', () => ({
   getOrgRolesWithStats: vi.fn(),
-  getRoleTemplates: vi.fn(),
-  createRoleFromTemplate: vi.fn()
+  getRoleTemplates: vi.fn()
 }));
 
 // Helper Types

--- a/src/pages/org-admin/roles.tsx
+++ b/src/pages/org-admin/roles.tsx
@@ -9,9 +9,9 @@ import {
   getOrgRolesWithStats, 
   OrgRole, 
   getRoleTemplates, 
-  createRoleFromTemplate, 
   RoleTemplate 
 } from '@/services/org-admin-service';
+import { createRoleFromTemplate } from '@/services/rbac-service';
 import { getSupabase } from '@/lib/supabase';
 import {
   permissionIdsToKeys,
@@ -932,4 +932,3 @@ export default function OrgAdminRoles() {
     </div>
   );
 }
-

--- a/src/services/__tests__/org-admin-service.test.ts
+++ b/src/services/__tests__/org-admin-service.test.ts
@@ -91,6 +91,7 @@ import {
   setUserAsOrgAdmin,
   toggleUserStatus,
   removeUserFromOrg,
+  updateUserRoles,
   type OrgUser,
   type OrgRole,
   type Invitation,
@@ -256,25 +257,69 @@ describe('Org Admin Service', () => {
   });
 
   describe('removeUserFromOrg', () => {
-    it('should remove user and their roles', async () => {
-      await removeUserFromOrg('user-1', 'org-1');
+    it('removes membership and roles through the atomic Migration 175 RPC', async () => {
+      mockRpc.mockReturnValueOnce({
+        data: { user_id: 'user-1', org_id: 'org-1', removed_role_count: 2 },
+        error: null,
+      });
 
-      expect(mockFrom).toHaveBeenCalledWith('user_roles');
-      expect(mockFrom).toHaveBeenCalledWith('user_organizations');
-      expect(mockDelete).toHaveBeenCalled();
+      const result = await removeUserFromOrg('user-1', 'org-1');
+
+      expect(mockRpc).toHaveBeenCalledWith('rpc_remove_org_member', {
+        p_payload: { org_id: 'org-1', user_id: 'user-1' },
+      });
+      expect(mockFrom).not.toHaveBeenCalledWith('user_roles');
+      expect(mockFrom).not.toHaveBeenCalledWith('user_organizations');
+      expect(mockDelete).not.toHaveBeenCalled();
+      expect(result.success).toBe(true);
     });
 
-    it('should handle deletion error', async () => {
-      mockDelete.mockImplementationOnce(() => ({
-        eq: () => ({
-          eq: () => ({ error: new Error('Delete failed') }),
-        }),
-      }));
+    it('surfaces a server-side removal guard', async () => {
+      mockRpc.mockReturnValueOnce({
+        data: null,
+        error: { message: 'RBAC_175_LAST_ORG_ADMIN' },
+      });
 
-      await removeUserFromOrg('user-1', 'org-1');
+      const result = await removeUserFromOrg('user-1', 'org-1');
 
-      // Should handle error gracefully
-      expect(mockFrom).toHaveBeenCalled();
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('RBAC_175_LAST_ORG_ADMIN');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateUserRoles', () => {
+    it('replaces the complete role set through rpc_replace_user_roles', async () => {
+      mockRpc.mockReturnValueOnce({
+        data: { role_count: 2, sensitive_keys_granted: [] },
+        error: null,
+      });
+
+      const result = await updateUserRoles('user-1', 'org-1', ['role-1', 'role-2']);
+
+      expect(mockRpc).toHaveBeenCalledWith('rpc_replace_user_roles', {
+        p_payload: {
+          org_id: 'org-1',
+          user_id: 'user-1',
+          role_ids: ['role-1', 'role-2'],
+          expires_at: null,
+        },
+      });
+      expect(mockFrom).not.toHaveBeenCalledWith('user_roles');
+      expect(result.success).toBe(true);
+    });
+
+    it('does not report success when the replacement RPC rejects the request', async () => {
+      mockRpc.mockReturnValueOnce({
+        data: null,
+        error: { message: 'RBAC_174_TARGET_NOT_ACTIVE_ORG_MEMBER' },
+      });
+
+      const result = await updateUserRoles('user-1', 'org-1', ['role-1']);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('RBAC_174_TARGET_NOT_ACTIVE_ORG_MEMBER');
+      expect(mockFrom).not.toHaveBeenCalledWith('user_roles');
     });
   });
 

--- a/src/services/__tests__/rbac-service.rpc.test.ts
+++ b/src/services/__tests__/rbac-service.rpc.test.ts
@@ -19,6 +19,7 @@ import {
   createRole,
   updateRolePermissions,
   deleteRole,
+  createRoleFromTemplate,
   replaceUserRoles,
   getPermissionSnapshot,
 } from '../rbac-service';
@@ -107,6 +108,30 @@ describe('deleteRole', () => {
     const res = await deleteRole(ROLE, ORG);
     expect(res.success).toBe(false);
     expect(res.error).toContain('RBAC_174_ROLE_STILL_ASSIGNED');
+  });
+});
+
+describe('createRoleFromTemplate', () => {
+  it('uses the audited server function instead of writing roles in the client', async () => {
+    rpcMock.mockResolvedValue({ data: ROLE, error: null });
+
+    const res = await createRoleFromTemplate(ORG, 'template-1', 'Controller');
+
+    expect(rpcMock).toHaveBeenCalledWith('create_role_from_template', {
+      p_org_id: ORG,
+      p_template_id: 'template-1',
+      p_custom_name: 'Controller',
+    });
+    expect(res).toEqual({ success: true, roleId: ROLE });
+  });
+
+  it('surfaces a rejected template call', async () => {
+    rpcMock.mockResolvedValue({ data: null, error: { message: 'Template not found' } });
+
+    const res = await createRoleFromTemplate(ORG, 'missing');
+
+    expect(res.success).toBe(false);
+    expect(res.error).toContain('Template not found');
   });
 });
 

--- a/src/services/org-admin-service.ts
+++ b/src/services/org-admin-service.ts
@@ -3,6 +3,7 @@
 // خدمة Org Admin - إدارة مستخدمي وأدوار المنظمة
 
 import { getSupabase as _getSupabase } from '@/lib/supabase';
+import { replaceUserRoles } from './rbac-service';
 const getSupabase = () => _getSupabase() as import('@supabase/supabase-js').SupabaseClient
 
 // =====================================
@@ -265,19 +266,11 @@ export async function removeUserFromOrg(
   try {
     const supabase = getSupabase();
 
-    // Delete user roles first
-    await supabase
-      .from('user_roles')
-      .delete()
-      .eq('user_id', userId)
-      .eq('org_id', orgId);
-
-    // Delete user organization link
-    const { error } = await supabase
-      .from('user_organizations')
-      .delete()
-      .eq('user_id', userId)
-      .eq('org_id', orgId);
+    // Migration 175: role assignments, membership deletion, last-admin/self
+    // guards, and the audit row commit atomically on the server.
+    const { error } = await supabase.rpc('rpc_remove_org_member', {
+      p_payload: { org_id: orgId, user_id: userId },
+    });
 
     if (error) throw error;
 
@@ -296,36 +289,11 @@ export async function updateUserRoles(
   orgId: string,
   roleIds: string[]
 ): Promise<{ success: boolean; error?: string }> {
-  try {
-    const supabase = getSupabase();
-
-    // Delete existing roles
-    await supabase
-      .from('user_roles')
-      .delete()
-      .eq('user_id', userId)
-      .eq('org_id', orgId);
-
-    // Add new roles
-    if (roleIds.length > 0) {
-      const newRoles = roleIds.map(roleId => ({
-        user_id: userId,
-        role_id: roleId,
-        org_id: orgId,
-      }));
-
-      const { error } = await supabase
-        .from('user_roles')
-        .insert(newRoles);
-
-      if (error) throw error;
-    }
-
-    return { success: true };
-  } catch (error: any) {
-    console.error('Error updating user roles:', error);
-    return { success: false, error: error.message || 'فشل تحديث الأدوار' };
-  }
+  // Migration 175 rejects every direct user_roles UPDATE and 174's RPC is the
+  // atomic replacement contract. Reuse the canonical wrapper so cache clearing
+  // and payload shaping cannot drift between the Users page and RBAC service.
+  const result = await replaceUserRoles({ userId, orgId, roles: roleIds });
+  return { success: result.success, error: result.error };
 }
 
 // =====================================
@@ -579,98 +547,6 @@ export async function getRoleTemplates(): Promise<RoleTemplate[]> {
   }
 }
 
-export async function createRoleFromTemplate(
-  orgId: string,
-  templateId: string,
-  customName?: string,
-  customNameAr?: string
-): Promise<{ success: boolean; role?: OrgRole; error?: string }> {
-  try {
-    const supabase = getSupabase();
-
-    // 1. Get the template
-    const { data: template, error: templateError } = await supabase
-      .from('role_templates')
-      .select('*')
-      .eq('id', templateId)
-      .single();
-
-    if (templateError || !template) {
-      return { success: false, error: 'Template not found' };
-    }
-
-    // 2. Create the role
-    const { data: role, error: roleError } = await supabase
-      .from('roles')
-      .insert({
-        org_id: orgId,
-        name: customName || template.name,
-        name_ar: customNameAr || template.name_ar,
-        description: template.description,
-        description_ar: template.description_ar,
-        is_system_role: false,
-        is_active: true,
-      })
-      .select()
-      .single();
-
-    if (roleError || !role) {
-      console.error('Error creating role from template:', roleError);
-      return { success: false, error: roleError?.message || 'Failed to create role' };
-    }
-
-    // 3. Get permissions that match the template's permission keys
-    // Template uses patterns like 'manufacturing.%' or 'sales.customers.read'
-    const permissionKeys = template.permission_keys || [];
-    
-    if (permissionKeys.length > 0) {
-      // Build query for permissions
-      // For patterns with %, we use ilike; for exact matches, we use eq
-      const query = supabase.from('permissions').select('id, permission_key');
-      
-      // We need to handle wildcards - for now, fetch all and filter in JS
-      const { data: allPermissions } = await query;
-      
-      if (allPermissions && allPermissions.length > 0) {
-        const matchingPermissionIds: string[] = [];
-        
-        for (const perm of allPermissions) {
-          for (const pattern of permissionKeys) {
-            if (pattern.includes('%')) {
-              // Wildcard pattern - convert to regex
-              const regexPattern = pattern.replaceAll('%', '.*');
-              const regex = new RegExp(`^${regexPattern}$`);
-              if (regex.test(perm.permission_key)) {
-                matchingPermissionIds.push(perm.id);
-                break;
-              }
-            } else if (perm.permission_key === pattern) {
-              // Exact match
-              matchingPermissionIds.push(perm.id);
-              break;
-            }
-          }
-        }
-
-        // 4. Create role_permissions
-        if (matchingPermissionIds.length > 0) {
-          const rolePermissions = matchingPermissionIds.map(permId => ({
-            role_id: role.id,
-            permission_id: permId,
-          }));
-
-          await supabase.from('role_permissions').insert(rolePermissions);
-        }
-      }
-    }
-
-    return { success: true, role };
-  } catch (error: any) {
-    console.error('Error in createRoleFromTemplate:', error);
-    return { success: false, error: error.message || 'Unknown error' };
-  }
-}
-
 // =====================================
 // Helper Functions
 // =====================================
@@ -714,8 +590,6 @@ export const orgAdminService = {
   acceptInvitation,
   getOrgRolesWithStats,
   getRoleTemplates,
-  createRoleFromTemplate,
 };
 
 export default orgAdminService;
-

--- a/src/services/super-admin-service.ts
+++ b/src/services/super-admin-service.ts
@@ -374,24 +374,6 @@ async function createOrgWithUser(
 
     if (linkError) throw linkError;
 
-    // 4. Get org_admin role and assign it
-    const { data: adminRole } = await supabase
-      .from('roles')
-      .select('id')
-      .eq('org_id', org.id)
-      .eq('name', 'org_admin')
-      .single();
-
-    if (adminRole) {
-      await supabase
-        .from('user_roles')
-        .insert({
-          user_id: userId,
-          role_id: adminRole.id,
-          org_id: org.id,
-        });
-    }
-
     return { success: true, organization: org };
   } catch (error: any) {
     console.error('Error in createOrgWithUser:', error);
@@ -559,4 +541,3 @@ export const superAdminService = {
 };
 
 export default superAdminService;
-


### PR DESCRIPTION
## Summary

- route organization member removal through `rpc_remove_org_member`
- route role replacement through the canonical `rpc_replace_user_roles` wrapper
- route template role creation through `create_role_from_template`
- remove dead direct `user_roles` assignment from organization creation
- add a TypeScript-AST CI gate that rejects direct writes to `roles`, `role_permissions`, or `user_roles`

## Verification

- RBAC direct-write gate: pass (699 source files scanned)
- TypeScript: pass
- ESLint: 0 errors (existing warnings only)
- Vitest: 227 files / 3,974 tests passed
- Production build: pass

## Rollout

This is the consumer change for the audited RBAC RPC surface already present on `main`. Keep this PR separate from the later privilege-revocation migration so the hosted UI can be smoke-tested first.