### PR TITLE
docs: correct Migration 175 Production status to applied

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,8 +74,8 @@ React 18 + TypeScript + Vite، shadcn/ui + Tailwind، Zustand + TanStack Query،
 - `docs/db/TENANT_ISOLATION_170_RUNBOOK.md`، `docs/db/AI_USAGE_DAILY_171_RUNBOOK.md`،
   `docs/db/HAS_PERMISSION_172_RUNBOOK.md`، `docs/db/HAS_PERMISSION_173_RUNBOOK.md`
   — تفصيل كل migration على حدة.
-- `docs/db/RBAC_CONSUMER_175_RUNBOOK.md` — **Migration 175 (في المستودع، غير
-  مطبّقة على Production بعد)**: لا تسحب منح الجداول، لكنها ترفض تعيين دور بلا
+- `docs/db/RBAC_CONSUMER_175_RUNBOOK.md` — **Migration 175 (مطبّقة على Production،
+  تحقق `20260811132302`)**: لا تسحب منح الجداول، لكنها ترفض تعيين دور بلا
   عضوية نشطة عند حدّ قاعدة البيانات، وتغلق سباق آخر مسؤول بقفل مشترك على صف
   المؤسسة. تضيف `rpc_remove_org_member` الذرية المدقَّقة، وتحصّن فرعي المنح
   الصريحة في دالتي الصلاحيات، وتُلحق سجل تدقيق بـ`create_role_from_template`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ React 18 + TypeScript + Vite، shadcn/ui + Tailwind، Zustand + TanStack Query،
 الحالة الحية الموثقة بعد تطبيق Migration 175 في 2026-08-11 (الـBaseline نفسه لم يتغيّر، ولا يزال عند اللقطة المولّدة في 2026-07-29):
 
 - Baseline الحالي: `000_schema_baseline_20260729_210941.sql`, cutoff 152. لم يُحدَّث بعد ظهور 153–175 في سجل Production؛ تحديثه خطوة منفصلة عبر `generate-baseline.yml` وPR مستقل، ولا تُستنتَج ضمنيًا من هذا التحديث.
-- Production: مطبقة حتى 175 (`175_rbac_consumer_migration_rpcs`, version `20260811132302`)، عبر تسلسل 153 → 163 → 164 → 165 → 166 → 167 → 168 → 169 → 170 → 171 → 172 → 173 → 174 → 175 فوق cutoff 152. سبقتها مباشرةً Migration 174 (`174_sensitive_permission_class_and_rbac_rpcs`, version `20260809112236`)، وهي المتطلب المسبق الذي تتحقق منه postflight الخاصة بـ175.
+- Production: مطبقة حتى 175 (`175_rbac_consumer_migration_rpcs`, version `20260811132302`)، عبر تسلسل 153 → 163 → 164 → 165 → 166 → 167 → 168 → 169 → 170 → 171 → 172 → 173 → 174 → 175 فوق cutoff 152. سبقتها مباشرةً Migration 174 (`174_sensitive_permission_class_and_rbac_rpcs`, version `20260809112236`)، وهي المتطلب المسبق الذي تتحقق منه preflight الخاصة بـ175.
 - Repository: أعلى migration مرقمة هي 175 (`175_rbac_consumer_migration_rpcs.sql`).
 - Fresh DB: 153–175 تُطبَّق فوق baseline cutoff 152 دون migration معلّقة؛ 154–162 محجوزة رسميًا لمحرك التقارير المالية ولا تُعامل كفجوة (`sql/migrations/skipped_migration_numbers.yml`).
 - تدقيق السجل الحي في 2026-08-14: `live_cutoff = 175`، `repo_max = 175`، `repository_ahead_by = 0`، ولا ملفات معلّقة.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Wardah Process Costing — Project Manifest
 
-**آخر تحديث موثق:** 2026-08-09  
+**آخر تحديث موثق:** 2026-08-14  
 **Repository:** `6thd/wardah-process-costing`  
 **Supabase project:** `uutfztmqvajmsxnrqeiv`
 
@@ -27,13 +27,13 @@ React 18 + TypeScript + Vite، shadcn/ui + Tailwind، Zustand + TanStack Query،
 3. **Production:** سجل `supabase_migrations.schema_migrations`.
 
 <!-- DATABASE_STATE_START -->
-الحالة الحية الموثقة بعد تطبيق Migration 173 في 2026-08-09 (الـBaseline نفسه لم يتغيّر، ولا يزال عند اللقطة المولّدة في 2026-07-29):
+الحالة الحية الموثقة بعد تطبيق Migration 175 في 2026-08-11 (الـBaseline نفسه لم يتغيّر، ولا يزال عند اللقطة المولّدة في 2026-07-29):
 
-- Baseline الحالي: `000_schema_baseline_20260729_210941.sql`, cutoff 152. لم يُحدَّث بعد ظهور 153–173 في سجل Production؛ تحديثه خطوة منفصلة عبر `generate-baseline.yml` وPR مستقل، ولا تُستنتَج ضمنيًا من هذا التحديث.
-- Production: مطبقة حتى 173 (`173_has_permission_active_role_check`, version `20260809051430`)، عبر تسلسل 153 → 163 → 164 → 165 → 166 → 167 → 168 → 169 → 170 → 171 → 172 → 173 فوق cutoff 152.
-- Repository: أعلى migration مرقمة هي 173 (`173_has_permission_active_role_check.sql`).
-- Fresh DB: 153–173 تُطبَّق فوق baseline cutoff 152 دون migration معلّقة؛ 154–162 محجوزة رسميًا لمحرك التقارير المالية ولا تُعامل كفجوة (`sql/migrations/skipped_migration_numbers.yml`).
-- تدقيق السجل الحي في 2026-08-09: `live_cutoff = 173`، `repo_max = 173`، `repository_ahead_by = 0`، ولا ملفات معلّقة.
+- Baseline الحالي: `000_schema_baseline_20260729_210941.sql`, cutoff 152. لم يُحدَّث بعد ظهور 153–175 في سجل Production؛ تحديثه خطوة منفصلة عبر `generate-baseline.yml` وPR مستقل، ولا تُستنتَج ضمنيًا من هذا التحديث.
+- Production: مطبقة حتى 175 (`175_rbac_consumer_migration_rpcs`, version `20260811132302`)، عبر تسلسل 153 → 163 → 164 → 165 → 166 → 167 → 168 → 169 → 170 → 171 → 172 → 173 → 174 → 175 فوق cutoff 152. سبقتها مباشرةً Migration 174 (`174_sensitive_permission_class_and_rbac_rpcs`, version `20260809112236`)، وهي المتطلب المسبق الذي تتحقق منه postflight الخاصة بـ175.
+- Repository: أعلى migration مرقمة هي 175 (`175_rbac_consumer_migration_rpcs.sql`).
+- Fresh DB: 153–175 تُطبَّق فوق baseline cutoff 152 دون migration معلّقة؛ 154–162 محجوزة رسميًا لمحرك التقارير المالية ولا تُعامل كفجوة (`sql/migrations/skipped_migration_numbers.yml`).
+- تدقيق السجل الحي في 2026-08-14: `live_cutoff = 175`، `repo_max = 175`، `repository_ahead_by = 0`، ولا ملفات معلّقة.
 - لا تعدّ أي migration مطبقة حيًا لمجرد نجاح Fresh DB؛ سجل Production هو المرجع.
 <!-- DATABASE_STATE_END -->
 
@@ -171,7 +171,7 @@ PR #32 أضاف أو حسّن:
 لذلك **عدّ صفوف `role_permissions` لا يقيس الصلاحية الفعلية**؛ الفحص الصحيح هو استدعاء
 دالة الصلاحية لكل مستخدم نشط.
 
-**Migration 174 (في المستودع، غير مطبّقة على Production بعد)** تحسم Issue #93: مصنّف مركزي
+**Migration 174 (مطبّقة على Production، تحقق `20260809112236`، سبقت 175 مباشرة)** تحسم Issue #93: مصنّف مركزي
 واحد `wardah_is_sensitive_permission(text)` — `IMMUTABLE STRICT`، مفتاحان فقط
 (`accounting.vouchers.unpost` و`accounting.vouchers.cancel`) — تستدعيه الدالتان معًا فلا
 تتباعدان. Super Admin يحتفظ بالتجاوز الكامل؛ Org Admin يحتفظ به لكل المفاتيح العادية
@@ -181,11 +181,15 @@ PR #32 أضاف أو حسّن:
 في المستودع، ولم يُضَف افتراضيًا. التفاصيل وترتيب النشر الإلزامي في
 `docs/db/SENSITIVE_PERMISSIONS_174_RUNBOOK.md`.
 
-**الـLockout ليس احتمالًا نظريًا هنا:** Super Admins = 0، وتعيينات الأدوار = 0، والمفتاحان
-ممنوحان لصفر دور — ودور `Full Access` لا يحتويهما (166 من 169). فإنشاء دور
+**الـLockout لم يكن احتمالًا نظريًا وقت صياغة 174:** وفق جرد 2026-08-09 (قبل كتابة أي
+كود)، كان Super Admins = 0، وتعيينات الأدوار = 0، والمفتاحان ممنوحان لصفر دور — ودور
+`Full Access` لا يحتويهما (166 من 169). لذلك يشترط الـrunbook (§6) إنشاء دور
 `Financial Controller` ومنحه المفتاحين وتعيينه للمسؤول الحالي وإثبات
-`via_explicit_grant = true` خطوات **تسبق** تطبيق 174، لا تتبعه. وهي بيانات org-scoped
-فمكانها معاملة تشغيلية موثقة، لا migration ولا Baseline.
+`via_explicit_grant = true` كخطوات تشغيلية **يجب أن تسبق** تطبيق 174، لا تتبعه؛ الـmigration
+نفسها لا تتحقق منها برمجيًا (تتحقق فقط من وجود المفتاحين في `permissions`، لا من وجود
+منح صريح). وهي بيانات org-scoped فمكانها معاملة تشغيلية موثقة، لا migration ولا Baseline.
+يبقى هذا الإجراء المرجع الموثق لأي إعادة تطبيق أو تدقيق مستقبلي — لا إثبات بحد ذاته أن
+الخطوات نُفذت بالفعل على Production.
 
 ## i18n
 

--- a/docs/db/HAS_PERMISSION_173_RUNBOOK.md
+++ b/docs/db/HAS_PERMISSION_173_RUNBOOK.md
@@ -2,7 +2,7 @@
 
 **Migration:** `173_has_permission_active_role_check.sql`
 **Scope:** Close a second gap in `has_permission()`'s ordinary-role branch — disabling a role never revoked the access it granted.
-**State:** Applied to Production (`uutfztmqvajmsxnrqeiv`) on 2026-08-09, ledger version `20260809051430`, name `173_has_permission_active_role_check`. This is the current head of the Production ledger. All nine postflight boolean columns in §5 returned `true` against the live database, and `has_function_privilege('authenticated', …)` returned `true` — full evidence in `docs/db/PERMISSION_HARDENING_170_173_CHAIN.md` §4.
+**State:** Applied to Production (`uutfztmqvajmsxnrqeiv`) on 2026-08-09, ledger version `20260809051430`, name `173_has_permission_active_role_check`. This was the head of the Production ledger at the time of its own postflight; Production has since advanced through Migration 174 (`20260809112236`) to Migration 175 (`20260811132302`) — see `CLAUDE.md`'s `DATABASE_STATE` block for the current head. All nine postflight boolean columns in §5 returned `true` against the live database, and `has_function_privilege('authenticated', …)` returned `true` — full evidence in `docs/db/PERMISSION_HARDENING_170_173_CHAIN.md` §4.
 
 ## 1. Purpose
 

--- a/docs/db/PERMISSION_HARDENING_170_173_CHAIN.md
+++ b/docs/db/PERMISSION_HARDENING_170_173_CHAIN.md
@@ -1,7 +1,7 @@
 # Migrations 170–173 — Tenant Isolation & `has_permission()` Hardening Chain
 
 **Scope:** The four migrations that took Production from cutoff 169 to 173, and the final, verified state of the authorization surface they leave behind.
-**State:** All four applied to Production (`Manufacturing Process`, `uutfztmqvajmsxnrqeiv`) and verified. 173 is the current ledger head.
+**State:** All four applied to Production (`Manufacturing Process`, `uutfztmqvajmsxnrqeiv`) and verified. 173 was the ledger head at the time of this chain's own verification (§4); Production has since advanced through Migration 174 (`20260809112236`) to Migration 175 (`20260811132302`) — see `CLAUDE.md`'s `DATABASE_STATE` block for the current head.
 **Purpose of this document:** the four per-migration runbooks each describe one change in isolation. Three of them replace the *same function*, so the only way to read the current contract is to read them together. This document is that composite view, plus the live evidence that the composite actually holds.
 
 ## 1. The chain

--- a/docs/db/RBAC_CONSUMER_175_RUNBOOK.md
+++ b/docs/db/RBAC_CONSUMER_175_RUNBOOK.md
@@ -7,12 +7,20 @@ of every production TS/TSX file writing to `roles`, `role_permissions` or
 `user_roles` found the client did not fully move onto it (§1). This migration
 adds the RPC surface the client needs and closes three database races discovered
 during review.
-**State:** Repository implementation, **not yet applied to Production**.
+**State:** Applied to Production. Ledger version `20260811132302`, name
+`175_rbac_consumer_migration_rpcs`, confirmed by read-only postflight
+verification (§4, Step 2) against `supabase_migrations.schema_migrations`.
+The ledger timestamp is consistent with an application shortly after the
+PR #115 merge (`9c11d4dcd12212049bd31ece0074daa51992ffd5`, 2026-08-11). The
+repository source file (`sql/migrations/175_rbac_consumer_migration_rpcs.sql`,
+SHA-256 `c8a8ac82b462a894dbc2f9b4a94ba10b443d34cd803f66aa038842604a8c6cd7`) is
+byte-identical between `main` and that merge commit.
 No privilege revocation and no table grant change. Assignment behavior is,
 however, deliberately narrowed at the database boundary: INSERT requires an
 active membership and every direct UPDATE is rejected in favor of
-`rpc_replace_user_roles`. Apply DB-first only after the read-only data
-preflight in §4 succeeds.
+`rpc_replace_user_roles`. The steps below (§4) record the DB-first order that
+was followed and remain the reference procedure for any future re-application
+or audit.
 
 ## 1. The verified gap
 

--- a/docs/db/SENSITIVE_PERMISSIONS_174_RUNBOOK.md
+++ b/docs/db/SENSITIVE_PERMISSIONS_174_RUNBOOK.md
@@ -2,7 +2,16 @@
 
 **Migration:** `174_sensitive_permission_class_and_rbac_rpcs.sql`
 **Part of:** Issue #93 — the org-admin override branch never read `p_permission_key`, so every active org admin passed every key. **This migration does not close the issue on its own:** it is the database half. Closing #93 additionally requires the UI moved onto `rpc_permission_snapshot` and the atomic RBAC RPCs, and Migration 175 to close the direct-write surface (§4.1).
-**State:** Repository implementation, **not yet applied to Production**. The operational transaction in §6 must run and be verified *before* this migration is applied, or the organization is locked out of unpost/cancel entirely. Do not apply out of order.
+**State:** Applied to Production. Ledger version `20260809112236`
+(`174_sensitive_permission_class_and_rbac_rpcs`), immediately followed by
+Migration 175 (ledger version `20260811132302`) in the live sequence — no
+gap between them. This does not state who applied it or the exact
+application mechanism; the ledger is the only authority for that. The
+operational transaction in §6 was the mandatory precondition for applying
+this migration — the migration's own preflight checks only that the two
+sensitive permission keys exist, not that any explicit grant was made — and
+it remains the reference procedure for any future re-application (e.g.
+disaster recovery) or audit. Do not apply out of order.
 
 ## 1. The verified problem
 
@@ -69,7 +78,7 @@ Both permission functions call this one classifier, so the two cannot drift — 
 - **No `auth.uid()` guard added to `wardah_has_exact_permission`.** It is internal (`EXECUTE` is `postgres` only), its four callers pass an actor resolved inside the RPC, and adding the guard risks breaking them for no reachable gain. The postflight re-asserts the execute boundary instead.
 - **Direct `INSERT`/`UPDATE`/`DELETE` on `roles`, `role_permissions`, `user_roles` is not revoked from `authenticated`.** The live role-management UI still writes those tables directly; revoking here would break it in the window between applying 174 and deploying the dependent UI.
 
-  This mirrors the sequence this repository already established with 163/167 → 169: ship the atomic RPCs, move the UI onto them, then close the direct-write surface in its own migration. **That closure is Migration 175 and is required to finish Issue #93** — until it lands, the RPCs are the sanctioned path but not yet the only one.
+  This mirrors the sequence this repository already established with 163/167 → 169: ship the atomic RPCs, move the UI onto them, then close the direct-write surface in its own migration. Migration 175 is applied to Production (ledger version `20260811132302`) and is required to finish Issue #93; per `docs/db/RBAC_CONSUMER_175_RUNBOOK.md`, the direct-write revocation itself is deferred further, to Migration 176, until the dependent consumer UI is live and browser smoke has passed — until then the RPCs are the sanctioned path but not yet the only one.
 
 ## 5. Acceptance gate
 
@@ -113,6 +122,11 @@ The same gate then ran in CI on `postgres:17` and passed end to end — `Sensiti
 **Generated types.** `Regenerate UoM Database Types` rebuilds a Fresh DB from the repository migrations and runs `supabase gen types` against **that** database (`localhost/wardah_fresh`), never against Production. It therefore commits the four new RPCs and the classifier into `src/types/database.generated.ts` as soon as 174 is in the repository — which is expected and is **not** evidence that 174 has been applied to Production. The ledger remains the only authority for that.
 
 ## 6. Mandatory Production order
+
+*This migration is applied (§ State above). The steps below document the
+procedure this migration's design requires before application; they are
+preserved as the reference for any future re-application (e.g. disaster
+recovery) or audit, not as a pending to-do.*
 
 **Steps 1–4 are not preparation for the fix; they are part of it.** With zero super admins, zero role assignments, and both sensitive keys granted to zero roles, applying 174 first would leave **nobody** able to unpost or cancel. Note that assigning the existing `Full Access` role does **not** help — it holds 166 of 169 keys and these two are among the three it lacks.
 


### PR DESCRIPTION
## Summary

Documentation-only correction of stale Production-status claims in `CLAUDE.md` and related `docs/db/` runbooks. This PR has two commits:

1. **Migration 175 status** — Migration 175 (`175_rbac_consumer_migration_rpcs`) is confirmed applied to Production (ledger version `20260811132302`, verified by read-only postflight). Corrected the two docs that said it was not yet applied.
2. **Follow-up (P2 finding): full canonical-state reconciliation** — a review flagged that fixing only the 175 status line left other authoritative declarations contradicting it: the `CLAUDE.md` `DATABASE_STATE` block still said Production/repository/Fresh DB stopped at 173 (`live_cutoff = repo_max = 173`), and Migration 174 — a verified, already-applied prerequisite of 175 — was still described as "not yet applied to Production" in two files. This commit reconciles all of it against the confirmed Production ledger.

## Changes

- `CLAUDE.md`
  - `docs/db/RBAC_CONSUMER_175_RUNBOOK.md` bullet: *"Migration 175 (في المستودع، غير مطبّقة على Production بعد)"* → *"Migration 175 (مطبّقة على Production، تحقق `20260811132302`)"*.
  - `DATABASE_STATE` block: now reads through Migration 175, not 173 — `live_cutoff = 175`, `repo_max = 175`, `repository_ahead_by = 0`, Fresh DB applies 153–175, repository max is 175, and the applied sequence is spelled out as `153 → 163 → … → 173 → 174 → 175` above baseline cutoff 152. The skipped-number note for 154–162 is preserved verbatim, and the baseline-cutoff statement (`000_schema_baseline_20260729_210941.sql`, cutoff 152, not regenerated) is unchanged — no claim that the baseline itself was rebuilt.
  - Migration 174 status paragraph: *"Migration 174 (في المستودع، غير مطبّقة على Production بعد)"* → *"Migration 174 (مطبّقة على Production، تحقق `20260809112236`، سبقت 175 مباشرة)"*.
  - The "Lockout is not theoretical" paragraph reframed to anchor its zero-counts inventory to the 2026-08-09 pre-174 snapshot and to state that the migration's own preflight only checks the two permission keys exist (verified by reading `sql/migrations/174_sensitive_permission_class_and_rbac_rpcs.sql:96-113`) — not that any explicit grant was made — rather than asserting the operational transaction was actually executed on Production (unproven, not claimed).
  - `آخر تحديث موثق` bumped to 2026-08-14 to match.
- `docs/db/SENSITIVE_PERMISSIONS_174_RUNBOOK.md`
  - **State** line: *"Repository implementation, not yet applied to Production"* → **Applied to Production**, with ledger version `20260809112236` and its immediate-predecessor relationship to 175 (`20260811132302`).
  - The §4.1 sentence claiming *"That closure is Migration 175 ... until it lands"* corrected: 175 is applied, and per `docs/db/RBAC_CONSUMER_175_RUNBOOK.md` the direct-write revocation itself is actually deferred further, to Migration 176 — the original sentence conflated the two.
  - §6 given a one-line note distinguishing the historical design rationale for the operational transaction from its role as a reference procedure for any future re-application/audit.
- `docs/db/HAS_PERMISSION_173_RUNBOOK.md` and `docs/db/PERMISSION_HARDENING_170_173_CHAIN.md`: dropped the present-tense *"173 is the current ledger head"* / *"This is the current head of the Production ledger"* claims (now false), replaced with an explicit past-tense anchor to their own verification point plus a pointer to `CLAUDE.md`'s `DATABASE_STATE` block for the live head.

**Left untouched, deliberately:** point-in-time historical statements that are already correctly anchored to a specific past verification event — e.g. `docs/db/PERMISSION_HARDENING_170_173_CHAIN.md:80`'s "Ledger head confirmed as ... live_cutoff: 173" (a snapshot of that chain's own postflight run) and `docs/db/VOUCHER_WRITE_CLOSURE_169_RUNBOOK.md`'s "Production has since advanced to 173" (anchored to its 2026-08-09 re-verification). These describe what was true at a documented moment, not current state, so changing them would misrepresent history rather than correct it.

No claim is made anywhere about *who* applied either migration or the exact application mechanism — only the ledger facts.

## Facts recorded (independently verified before writing)

| Fact | Value |
|---|---|
| Production project | `uutfztmqvajmsxnrqeiv` |
| Migration 174 ledger version | `20260809112236` (`174_sensitive_permission_class_and_rbac_rpcs`) |
| Migration 175 ledger version | `20260811132302` (`175_rbac_consumer_migration_rpcs`) |
| Repository maximum on `main` | 175 |
| Repo file SHA-256 (175) | `c8a8ac82b462a894dbc2f9b4a94ba10b443d34cd803f66aa038842604a8c6cd7` (matches `sha256sum` on `main`) |
| Byte-identical `main` ↔ PR #115 merge commit | Confirmed via `git show 9c11d4dc...:sql/migrations/175_rbac_consumer_migration_rpcs.sql \| sha256sum` — same hash |
| 174 is 175's verified prerequisite | `sql/migrations/175_rbac_consumer_migration_rpcs.sql` preflight depends on objects Migration 174 introduces |

## Validation

- Exact repo-wide regex search for "174/175 ... not applied / غير مطبّقة / لم تُطبّق" (both orderings) → **no matches**.
- Exact repo-wide search for `live_cutoff = 173` / `repo_max = 173` → only the one deliberately-preserved historical snapshot line remains (see above).
- Exact repo-wide search for "current head" / "ledger head" tied to 173 → both instances corrected.
- `git diff --check` → clean except pre-existing Markdown hard-break trailing whitespace on `CLAUDE.md`'s header lines (two trailing spaces, present in the file before this PR — not introduced by these changes).
- `git diff --stat` → only `.md` files touched across both commits; no SQL, migration, application, test, workflow, or dependency changes.
- No credentials, connection strings, or secrets included.

## Out of scope (explicitly, per task instructions)

- CodeFactor cleanup and PR #114 final verification — separate later tasks.
- No changes to PR #114's branch, body, review threads, or status.
- No Production access, deploys, or merges performed.
