### PR TITLE
fix(sonar): repair main new-code baseline and diagnostics

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -78,6 +78,7 @@ jobs:
         shell: bash
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          BRANCH_NAME: ${{ github.ref_name }}
         run: |
           set -u
           mkdir -p sonar-diagnostics
@@ -119,11 +120,18 @@ jobs:
               --output sonar-diagnostics/quality-gate.json || true
           fi
 
-          if [ -n "$project_key" ] && [ -n "${PR_NUMBER:-}" ]; then
+          if [ -n "$project_key" ]; then
+            scope_args=()
+            if [ -n "${PR_NUMBER:-}" ]; then
+              scope_args+=(--data-urlencode "pullRequest=$PR_NUMBER")
+            else
+              scope_args+=(--data-urlencode "branch=$BRANCH_NAME")
+            fi
+
             curl --fail --silent --show-error --get \
               --user "$SONAR_TOKEN:" \
               --data-urlencode "componentKeys=$project_key" \
-              --data-urlencode "pullRequest=$PR_NUMBER" \
+              "${scope_args[@]}" \
               --data-urlencode "statuses=OPEN,CONFIRMED" \
               --data-urlencode "types=BUG" \
               --data-urlencode "ps=500" \
@@ -133,7 +141,7 @@ jobs:
             curl --fail --silent --show-error --get \
               --user "$SONAR_TOKEN:" \
               --data-urlencode "component=$project_key" \
-              --data-urlencode "pullRequest=$PR_NUMBER" \
+              "${scope_args[@]}" \
               --data-urlencode "metricKeys=new_coverage,new_duplicated_lines_density,new_reliability_rating,new_bugs,new_lines,lines_to_cover,uncovered_lines,duplicated_lines,duplicated_blocks" \
               --data-urlencode "qualifiers=FIL" \
               --data-urlencode "strategy=leaves" \

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -138,16 +138,50 @@ jobs:
               "https://sonarcloud.io/api/issues/search" \
               --output sonar-diagnostics/open-bugs.json || true
 
-            curl --fail --silent --show-error --get \
-              --user "$SONAR_TOKEN:" \
-              --data-urlencode "component=$project_key" \
-              "${scope_args[@]}" \
-              --data-urlencode "metricKeys=new_coverage,new_duplicated_lines_density,new_reliability_rating,new_bugs,new_lines,lines_to_cover,uncovered_lines,duplicated_lines,duplicated_blocks" \
-              --data-urlencode "qualifiers=FIL" \
-              --data-urlencode "strategy=leaves" \
-              --data-urlencode "ps=500" \
-              "https://sonarcloud.io/api/measures/component_tree" \
-              --output sonar-diagnostics/file-measures.json || true
+            page=1
+            while true; do
+              page_file="sonar-diagnostics/file-measures-page-$page.json"
+              if ! curl --fail --silent --show-error --get \
+                --user "$SONAR_TOKEN:" \
+                --data-urlencode "component=$project_key" \
+                "${scope_args[@]}" \
+                --data-urlencode "metricKeys=new_coverage,new_duplicated_lines_density,new_reliability_rating,new_bugs,new_lines,lines_to_cover,uncovered_lines,duplicated_lines,duplicated_blocks" \
+                --data-urlencode "qualifiers=FIL" \
+                --data-urlencode "strategy=leaves" \
+                --data-urlencode "ps=500" \
+                --data-urlencode "p=$page" \
+                "https://sonarcloud.io/api/measures/component_tree" \
+                --output "$page_file"; then
+                break
+              fi
+
+              total="$(node -e "const fs=require('fs');try{const j=JSON.parse(fs.readFileSync('$page_file','utf8'));process.stdout.write(String(j.paging?.total??''))}catch{}")"
+              page_size="$(node -e "const fs=require('fs');try{const j=JSON.parse(fs.readFileSync('$page_file','utf8'));process.stdout.write(String(j.paging?.pageSize??''))}catch{}")"
+              if ! [[ "$total" =~ ^[0-9]+$ && "$page_size" =~ ^[1-9][0-9]*$ ]]; then
+                break
+              fi
+              if (( page * page_size >= total )); then
+                break
+              fi
+              page=$((page + 1))
+            done
+
+            node <<'NODE'
+          const fs = require('fs')
+          const pageFiles = fs.readdirSync('sonar-diagnostics')
+            .filter((name) => /^file-measures-page-\d+\.json$/.test(name))
+            .sort((a, b) => Number(a.match(/\d+/)?.[0]) - Number(b.match(/\d+/)?.[0]))
+          const pages = pageFiles.flatMap((name) => {
+            try { return [JSON.parse(fs.readFileSync(`sonar-diagnostics/${name}`, 'utf8'))] } catch { return [] }
+          })
+          const components = pages.flatMap((page) => page.components ?? [])
+          const merged = {
+            ...(pages[0] ?? {}),
+            paging: { pageIndex: 1, pageSize: components.length, total: components.length },
+            components,
+          }
+          fs.writeFileSync('sonar-diagnostics/file-measures.json', JSON.stringify(merged, null, 2))
+          NODE
           fi
 
           node <<'NODE'

--- a/docs/quality/SONARCLOUD_NEW_CODE_POLICY.md
+++ b/docs/quality/SONARCLOUD_NEW_CODE_POLICY.md
@@ -1,0 +1,38 @@
+# SonarCloud main-branch New Code policy
+
+State: repository-side correction proposed on 2026-08-15; the SonarCloud project setting must be changed by an authenticated project administrator before Issue #90 can be closed.
+
+## Problem confirmed
+
+The `main` analysis at commit `53de885e8d1c5ec66357ca7b37d6ef51fe3e69b8` used `previous_version` with a start date of 2025-12-06 because `sonar.projectVersion=2.0.0` had remained static. SonarCloud therefore treated approximately eight months of accumulated history as New Code. The resulting branch gate failures (`new_coverage=58.9%` and `new_duplicated_lines_density=50.4%`) were not measurements of PR #114 or PR #119 alone.
+
+The former security-rating failure was a real older finding and was fixed by PR #119. The current branch analysis reports an A security rating; this policy does not waive security findings.
+
+## Policy
+
+For this continuously deployed project, configure the SonarCloud project-level New Code Definition as:
+
+- Type: **Number of days**
+- Value: **30 days**
+
+Do not restore a static `sonar.projectVersion` unless the repository adopts and enforces an explicit release-version lifecycle.
+
+Quality Gate thresholds remain unchanged. In particular:
+
+- New-code coverage remains at least 80%.
+- New-code duplicated-line density remains at most 3%.
+- Security, reliability, and maintainability ratings are not relaxed.
+
+## Duplication scope
+
+`sql/migrations/**` and `sql/baseline/**` are immutable historical artifacts. Baseline files intentionally preserve complete schema and reference-data snapshots, so cross-snapshot repetition is expected and must not be refactored away.
+
+They remain in `sonar.sources` and continue to be analyzed for bugs, vulnerabilities, security hotspots, and maintainability. Only copy/paste detection is excluded for these paths. No production source is excluded from coverage or general analysis by this correction.
+
+## Verification after merge
+
+1. An authenticated SonarCloud project administrator sets New Code to **Number of days: 30**.
+2. Run a fresh analysis of `main`.
+3. Confirm the analysis period is a rolling 30-day window rather than `previous_version` starting 2025-12-06.
+4. Confirm the diagnostics artifact contains file-level coverage and duplication hotspots for a `push` event, not only for pull requests.
+5. Treat any remaining gate failure inside the valid 30-day window as real quality debt; do not lower thresholds or add blanket exclusions.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,7 +4,9 @@ sonar.organization=6thd
 
 # Project Information
 sonar.projectName=Wardah ERP - Process Costing
-sonar.projectVersion=2.0.0
+# New Code is governed by the SonarCloud project setting: Number of days = 30.
+# Do not pin sonar.projectVersion here; a stale previous_version anchor can silently
+# accumulate unrelated history and make the main-branch Quality Gate misleading.
 
 # Source Code
 sonar.sources=src,sql
@@ -108,10 +110,10 @@ sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.typescript.lcov.reportPaths=coverage/lcov.info
 
 # Duplication Exclusions
-# Numbered migrations are immutable deployment history and intentionally repeat complete
-# CREATE OR REPLACE definitions as the schema evolves. They remain fully analyzed for bugs,
-# security and maintainability; only CPD is excluded because refactoring across historical
-# migration boundaries would make fresh-chain replay non-deterministic.
+# Numbered migrations and baseline snapshots are immutable deployment/history artifacts.
+# They intentionally repeat complete schema and reference-data definitions as the chain evolves.
+# They remain fully analyzed for bugs, security and maintainability; only CPD is excluded because
+# refactoring across historical boundaries would break deterministic replay and auditability.
 sonar.cpd.exclusions=\
   **/*.test.ts,\
   **/*.test.tsx,\
@@ -123,6 +125,7 @@ sonar.cpd.exclusions=\
   **/src/features/hr/translations/**,\
   **/src/features/hr/i18n.ts,\
   sql/migrations/**,\
+  sql/baseline/**,\
   **/*.d.ts
 
 # Encoding


### PR DESCRIPTION
## Summary

Repairs the repository-side causes of Issue #90 without weakening the Quality Gate:

- removes the static `sonar.projectVersion=2.0.0` anchor that left `previous_version` measuring from 2025-12-06;
- adds `sql/baseline/**` to **CPD only**, matching the existing treatment of immutable migrations while keeping baseline SQL in general/security/maintainability analysis;
- makes the diagnostics workflow query `branch=$BRANCH_NAME` on push events, so a failing `main` analysis produces real file-level hotspots instead of empty arrays;
- records the intended SonarCloud project policy: **New Code Definition = Number of days, 30**.

Closes the repository-side portion of #90.

## Evidence

The latest `main` analysis on `53de885e8d1c5ec66357ca7b37d6ef51fe3e69b8` completed successfully but failed its gate only on:

- `new_coverage=58.9%` (required ≥ 80%);
- `new_duplicated_lines_density=50.4%` (required ≤ 3%).

Its period is `previous_version`, starting `2025-12-06T10:38:12Z`, and the dashboard labels roughly 197k accumulated lines as New Code. Security is now A after PR #119.

The duplicated-line distribution is dominated by intentionally retained baseline snapshots. This PR does not exclude those files from source analysis; it excludes only cross-snapshot copy/paste detection.

## Guardrails

- No Quality Gate threshold changed.
- No coverage exclusion added.
- No application, test, migration, dependency, deployment, or database code changed.
- No source path is excluded from general Sonar analysis.
- Remaining failures inside the valid 30-day window must be treated as real debt.

## Validation

- Compared against unchanged `main@53de885e8d1c5ec66357ca7b37d6ef51fe3e69b8`.
- Exactly three files changed.
- Workflow preserves PR-scoped diagnostics and adds the missing branch-scoped fallback.
- Repository policy and post-merge verification are documented in `docs/quality/SONARCLOUD_NEW_CODE_POLICY.md`.

## External setting gate

On 2026-08-16, an authenticated SonarCloud project administrator changed the project-level New Code Definition from **Previous version** to **Number of days: 30**, and the SonarCloud UI confirmed the update. Before #90 is closed, a fresh `main` analysis after merge must still verify the rolling window and Quality Gate result.
