### PR TITLE
fix(security): protect reports CDN assets with SRI

### DIFF
--- a/src/features/reports/__tests__/reports-cdn-integrity.test.ts
+++ b/src/features/reports/__tests__/reports-cdn-integrity.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const readRepositoryFile = (path: string) =>
+  readFileSync(resolve(process.cwd(), path), 'utf8')
+
+const publicHtml = readRepositoryFile('src/features/reports/public/index.html')
+const publicDashboardCss = readRepositoryFile(
+  'src/features/reports/public/styles/dashboard.css',
+)
+const componentDashboardCss = readRepositoryFile(
+  'src/features/reports/components/dashboard/styles.css',
+)
+const componentSource = readRepositoryFile(
+  'src/features/reports/components/dashboard/GeminiDashboard.tsx',
+)
+const fontAwesomeSri =
+  'sha384-3B6NwesSXE7YJlcLI9RpRqGf2p/EgVH8BgoKTaUrmKNDkHPStTQ3EyoYjCGXaOTS'
+
+describe('Reports dashboard CDN integrity', () => {
+  it('protects every version-pinned CDN asset in the standalone page with SRI', () => {
+    const cdnTags = publicHtml.match(
+      /<(?:link|script)\b[^>]*(?:cdn\.jsdelivr\.net|cdnjs\.cloudflare\.com)[^>]*>/gi,
+    )
+
+    expect(cdnTags).not.toBeNull()
+    expect(cdnTags).not.toHaveLength(0)
+
+    for (const tag of cdnTags ?? []) {
+      expect(tag).toMatch(/\bintegrity="sha384-[A-Za-z0-9+/=]+"/i)
+      expect(tag).toMatch(/\bcrossorigin="anonymous"/i)
+    }
+
+    const fontAwesomeTag = cdnTags?.find((tag) => tag.includes('font-awesome/6.0.0'))
+    expect(fontAwesomeTag).toContain(`integrity="${fontAwesomeSri}"`)
+  })
+
+  it('does not bypass SRI by importing Font Awesome again from CSS', () => {
+    expect(publicDashboardCss).not.toContain('cdnjs.cloudflare.com/ajax/libs/font-awesome')
+    expect(componentDashboardCss).not.toContain('cdnjs.cloudflare.com/ajax/libs/font-awesome')
+  })
+
+  it('bundles the installed Font Awesome package for the React dashboard', () => {
+    expect(componentSource).toContain(
+      "import '@fortawesome/fontawesome-free/css/all.min.css'",
+    )
+  })
+})

--- a/src/features/reports/components/dashboard/GeminiDashboard.tsx
+++ b/src/features/reports/components/dashboard/GeminiDashboard.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { loadApexCharts } from '@/lib/export-libs';
 import axios from 'axios';
+import '@fortawesome/fontawesome-free/css/all.min.css';
 import './styles.css';
 
 interface KPICardProps {

--- a/src/features/reports/components/dashboard/styles.css
+++ b/src/features/reports/components/dashboard/styles.css
@@ -1,6 +1,5 @@
 /* === استيراد الخطوط === */
 @import url('https://fonts.googleapis.com/css2?family=Cairo:wght@200;300;400;500;600;700;800;900&display=swap');
-@import url('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css');
 
 :root {
   --primary-color: #2c3e50;

--- a/src/features/reports/public/index.html
+++ b/src/features/reports/public/index.html
@@ -5,7 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>لوحة معلومات Gemini</title>
   <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@200;300;400;500;600;700;800;900&display=swap" rel="stylesheet">
-  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+  <link
+    href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
+    rel="stylesheet"
+    integrity="sha384-3B6NwesSXE7YJlcLI9RpRqGf2p/EgVH8BgoKTaUrmKNDkHPStTQ3EyoYjCGXaOTS"
+    crossorigin="anonymous"
+  >
   <!-- CDN scripts from trusted source (jsdelivr.net), version-pinned, with SRI integrity for security -->
   <script 
     src="https://cdn.jsdelivr.net/npm/particles.js@2.0.0/particles.min.js" 

--- a/src/features/reports/public/styles/dashboard.css
+++ b/src/features/reports/public/styles/dashboard.css
@@ -1,6 +1,5 @@
 /* نسخ محتوى الملف السابق styles.css */
 @import url('https://fonts.googleapis.com/css2?family=Cairo:wght@200;300;400;500;600;700;800;900&display=swap');
-@import url('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css');
 
 :root {
   --primary-color: #2c3e50;


### PR DESCRIPTION
## Summary

Fixes the Sonar vulnerability on the legacy Reports dashboard external Font Awesome stylesheet without weakening the Quality Gate.

- pins the existing Font Awesome 6.0.0 CDN stylesheet to its verified SHA-384 SRI hash
- adds `crossorigin="anonymous"`
- removes duplicate unprotected Font Awesome CSS imports
- uses the already-installed `@fortawesome/fontawesome-free` package for the React dashboard
- adds a regression contract covering all version-pinned CDN assets in the standalone page and the exact Font Awesome hash

## Verification

- Full Vitest suite: **276 files / 4,371 tests passed**
- TypeScript: **0 errors**
- Production build: **passed**
- Demo-password build gate: **passed**
- `git diff --check`: **clean**

## Review notes

The Google Fonts import is unchanged; this PR is scoped to the concrete Sonar vulnerability and the duplicate Font Awesome loading paths. No Sonar rule or Quality Gate threshold is suppressed or relaxed.