### PR TITLE
test(quality): remove six custom thenables

### DIFF
--- a/src/features/accounting/journal-entries/__tests__/journal-entries-permission-gating.test.tsx
+++ b/src/features/accounting/journal-entries/__tests__/journal-entries-permission-gating.test.tsx
@@ -68,14 +68,12 @@ const TABLE_RESULTS: Record<string, { data: unknown; error: unknown }> = {
 
 const fromSpy = vi.fn((table: string) => {
   const result = TABLE_RESULTS[table] ?? { data: [], error: null };
-  const builder: Record<string, unknown> = {};
+  const builder = Promise.resolve(result) as Promise<typeof result> & Record<string, unknown>;
   const chain = ['select', 'insert', 'update', 'delete', 'eq', 'order', 'gte', 'in', 'limit'];
   for (const method of chain) {
     builder[method] = vi.fn(() => builder);
   }
   builder.single = vi.fn(() => Promise.resolve(result));
-  builder.then = (resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) =>
-    Promise.resolve(result).then(resolve, reject);
   return builder;
 });
 

--- a/src/features/inventory/__tests__/stock-adjustments-permission-gating.test.tsx
+++ b/src/features/inventory/__tests__/stock-adjustments-permission-gating.test.tsx
@@ -87,14 +87,12 @@ const TABLE_RESULTS: Record<string, { data: unknown; error: unknown }> = {
 
 const fromSpy = vi.fn((table: string) => {
   const result = TABLE_RESULTS[table] ?? { data: [], error: null };
-  const builder: Record<string, unknown> = {};
+  const builder = Promise.resolve(result) as Promise<typeof result> & Record<string, unknown>;
   const chain = ['select', 'insert', 'update', 'delete', 'eq', 'order', 'in', 'limit'];
   for (const method of chain) {
     builder[method] = vi.fn(() => builder);
   }
   builder.single = vi.fn(() => Promise.resolve(result.data && Array.isArray(result.data) ? { data: result.data[0], error: result.error } : result));
-  builder.then = (resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) =>
-    Promise.resolve(result).then(resolve, reject);
   return builder;
 });
 

--- a/src/features/inventory/components/__tests__/stock-transfer-permission-gating.test.tsx
+++ b/src/features/inventory/components/__tests__/stock-transfer-permission-gating.test.tsx
@@ -44,14 +44,12 @@ const TABLE_RESULTS: Record<string, { data: unknown; error: unknown }> = {
 
 const fromSpy = vi.fn((table: string) => {
   const result = TABLE_RESULTS[table] ?? { data: [], error: null };
-  const builder: Record<string, unknown> = {};
+  const builder = Promise.resolve(result) as Promise<typeof result> & Record<string, unknown>;
   const chain = ['select', 'insert', 'update', 'delete', 'eq', 'order'];
   for (const method of chain) {
     builder[method] = vi.fn(() => builder);
   }
   builder.single = vi.fn(() => Promise.resolve(result));
-  builder.then = (resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) =>
-    Promise.resolve(result).then(resolve, reject);
   return builder;
 });
 

--- a/src/features/manufacturing/__tests__/manufacturing-orders-products-gating.test.tsx
+++ b/src/features/manufacturing/__tests__/manufacturing-orders-products-gating.test.tsx
@@ -50,17 +50,14 @@ vi.mock('../services/manufacturingOrderService', () => ({
 const PRODUCTS = [{ id: 'prod-1', name: 'Widget', code: 'W-1', org_id: 'org-1' }];
 
 function makeBuilder(table: string) {
-  const builder: Record<string, unknown> = {};
+  const result = table === 'products'
+    ? { data: PRODUCTS, error: null }
+    : { data: [], error: null };
+  const builder = Promise.resolve(result) as Promise<typeof result> & Record<string, unknown>;
   builder.select = vi.fn(() => builder);
   builder.order = vi.fn(() => builder);
   builder.limit = vi.fn(() => builder);
   builder.eq = vi.fn(() => builder);
-  builder.then = (resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) => {
-    const result = table === 'products'
-      ? { data: PRODUCTS, error: null }
-      : { data: [], error: null };
-    return Promise.resolve(result).then(resolve, reject);
-  };
   return builder;
 }
 

--- a/src/features/manufacturing/__tests__/stage-costing-panel-rbac.test.tsx
+++ b/src/features/manufacturing/__tests__/stage-costing-panel-rbac.test.tsx
@@ -87,12 +87,11 @@ vi.mock('@/services/supabase-service', () => ({
 }))
 
 function chainable(result: { data: unknown[]; error: null }) {
-  const builder: Record<string, unknown> = {}
+  const builder = Promise.resolve(result) as Promise<typeof result> & Record<string, unknown>
   const methods = ['select', 'order', 'eq', 'limit', 'in']
   for (const m of methods) {
     builder[m] = vi.fn(() => builder)
   }
-  builder.then = (resolve: (v: unknown) => unknown) => Promise.resolve(result).then(resolve)
   return builder
 }
 

--- a/src/features/manufacturing/__tests__/standard-costs-list-permission-gating.test.tsx
+++ b/src/features/manufacturing/__tests__/standard-costs-list-permission-gating.test.tsx
@@ -43,16 +43,13 @@ vi.mock('@/services/supabase-service', () => ({
 }));
 
 function makeBuilder(table: string) {
-  const builder: Record<string, unknown> = {};
+  const result = table === 'products'
+    ? { data: [{ id: 'prod-1', code: 'P1', name: 'Product 1', name_ar: 'منتج 1' }], error: null }
+    : { data: [], error: null };
+  const builder = Promise.resolve(result) as Promise<typeof result> & Record<string, unknown>;
   builder.select = vi.fn(() => builder);
   builder.order = vi.fn(() => builder);
   builder.limit = vi.fn(() => builder);
-  builder.then = (resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) => {
-    const result = table === 'products'
-      ? { data: [{ id: 'prod-1', code: 'P1', name: 'Product 1', name_ar: 'منتج 1' }], error: null }
-      : { data: [], error: null };
-    return Promise.resolve(result).then(resolve, reject);
-  };
   return builder;
 }
 


### PR DESCRIPTION
## Summary
- replace the six CodeFactor `unicorn/no-thenable` test builders tracked in #118
- use native promises augmented only with the Supabase chain methods
- preserve microtask timing and existing query-chain behavior

## Verification
- focused suite: 6 files, 48 tests passed
- full Vitest suite: 277 files, 4,392 tests passed
- `npm run type-check`: passed
- `node scripts/ci/check-rbac-direct-writes.mjs`: passed
- production bundle generated; demo-password build gate passed
- `git diff --check`: passed

Refs #118