### PR TITLE
refactor(manufacturing): decompose overview cards

### DIFF
--- a/src/features/manufacturing/__tests__/manufacturing-overview-permission-gating.test.tsx
+++ b/src/features/manufacturing/__tests__/manufacturing-overview-permission-gating.test.tsx
@@ -94,4 +94,31 @@ describe('ManufacturingOverview — per-section permission-aware loading', () =>
     expect(screen.queryByText('manufacturing.overviewPage.cards.bom.title')).not.toBeInTheDocument();
     expect(screen.queryByText('manufacturing.overviewPage.cards.orders.title')).not.toBeInTheDocument();
   });
+
+  it('preserves every permitted card destination after card decomposition', async () => {
+    setPermissions([
+      'manufacturing.orders.read',
+      'manufacturing.boms.read',
+      'manufacturing.work_centers.read',
+      'manufacturing.stage_costs.read',
+      'manufacturing.stages.read',
+    ]);
+    renderOverview();
+    await waitFor(() => expect(manufacturingGetAll).toHaveBeenCalled());
+
+    const destinations = [
+      ['manufacturing.overviewPage.cards.orders.title', '/manufacturing/orders'],
+      ['manufacturing.overviewPage.cards.processCosting.title', '/manufacturing/process-costing'],
+      ['manufacturing.overviewPage.cards.workCenters.title', '/manufacturing/workcenters'],
+      ['manufacturing.overviewPage.cards.bom.title', '/manufacturing/bom'],
+      ['manufacturing.overviewPage.cards.stages.title', '/manufacturing/stages'],
+      ['manufacturing.overviewPage.cards.quality.title', '/manufacturing/quality'],
+    ] as const;
+
+    for (const [name, href] of destinations) {
+      expect(screen.getByRole('link', { name: new RegExp(name.replaceAll('.', '\\.')) }))
+        .toHaveAttribute('href', href);
+    }
+    expect(screen.getByText('manufacturing.overviewPage.cards.labor.title')).toBeInTheDocument();
+  });
 });

--- a/src/features/manufacturing/__tests__/manufacturing-overview-permission-gating.test.tsx
+++ b/src/features/manufacturing/__tests__/manufacturing-overview-permission-gating.test.tsx
@@ -116,8 +116,7 @@ describe('ManufacturingOverview — per-section permission-aware loading', () =>
     ] as const;
 
     for (const [name, href] of destinations) {
-      expect(screen.getByRole('link', { name: new RegExp(name.replaceAll('.', '\\.')) }))
-        .toHaveAttribute('href', href);
+      expect(screen.getByText(name).closest('a')).toHaveAttribute('href', href);
     }
     expect(screen.getByText('manufacturing.overviewPage.cards.labor.title')).toBeInTheDocument();
   });

--- a/src/features/manufacturing/components/ManufacturingCards.tsx
+++ b/src/features/manufacturing/components/ManufacturingCards.tsx
@@ -3,7 +3,7 @@
  * مكون بطاقات التصنيع
  */
 
-import React from 'react'
+import React, { type ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import { Badge } from '@/components/ui/badge'
 import { cn } from '@/lib/utils'
@@ -31,6 +31,60 @@ interface ManufacturingCardsProps {
   canReadStages: boolean
 }
 
+interface ManufacturingLinkCardProps {
+  to: string
+  icon: React.ComponentType<{ className?: string }>
+  iconClassName: string
+  title: string
+  description: string
+  isRTL: boolean
+  children?: ReactNode
+}
+
+function ManufacturingLinkCard({
+  to,
+  icon: Icon,
+  iconClassName,
+  title,
+  description,
+  isRTL,
+  children,
+}: ManufacturingLinkCardProps) {
+  return (
+    <Link to={to} className="wardah-glass-card wardah-glass-card-hover p-6 transition-colors">
+      <div className={cn('flex items-center gap-3 mb-3', isRTL ? 'flex-row-reverse' : '')}>
+        <Icon className={cn('h-6 w-6', iconClassName)} />
+        <h3 className={cn('font-semibold wardah-text-gradient-google', isRTL ? 'text-right' : 'text-left')}>
+          {title}
+        </h3>
+      </div>
+      <p className={cn('text-muted-foreground text-sm', isRTL ? 'text-right' : 'text-left')}>
+        {description}
+      </p>
+      {children}
+    </Link>
+  )
+}
+
+function LaborCard({ isRTL, t }: Pick<ManufacturingCardsProps, 'isRTL' | 't'>) {
+  return (
+    <div className="wardah-glass-card wardah-glass-card-hover p-6">
+      <div className={cn('flex items-center gap-3 mb-3', isRTL ? 'flex-row-reverse' : '')}>
+        <Users className="h-6 w-6 text-secondary" />
+        <h3 className={cn('font-semibold wardah-text-gradient-google', isRTL ? 'text-right' : 'text-left')}>
+          {t('manufacturing.overviewPage.cards.labor.title')}
+        </h3>
+      </div>
+      <p className={cn('text-muted-foreground text-sm', isRTL ? 'text-right' : 'text-left')}>
+        {t('manufacturing.overviewPage.cards.labor.description')}
+      </p>
+      <Badge variant="outline" className="mt-3">
+        {t('manufacturing.overviewPage.cards.labor.badge')}
+      </Badge>
+    </div>
+  )
+}
+
 export const ManufacturingCards: React.FC<ManufacturingCardsProps> = ({
   orders,
   isRTL,
@@ -46,16 +100,14 @@ export const ManufacturingCards: React.FC<ManufacturingCardsProps> = ({
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
       {canReadOrders && (
-        <Link to="/manufacturing/orders" className="wardah-glass-card wardah-glass-card-hover p-6 transition-colors">
-          <div className={cn("flex items-center gap-3 mb-3", isRTL ? "flex-row-reverse" : "")}>
-            <Factory className="h-6 w-6 text-primary" />
-            <h3 className={cn("font-semibold wardah-text-gradient-google", isRTL ? "text-right" : "text-left")}>
-              {t('manufacturing.overviewPage.cards.orders.title')}
-            </h3>
-          </div>
-          <p className={cn("text-muted-foreground text-sm", isRTL ? "text-right" : "text-left")}>
-            {t('manufacturing.overviewPage.cards.orders.description')}
-          </p>
+        <ManufacturingLinkCard
+          to="/manufacturing/orders"
+          icon={Factory}
+          iconClassName="text-primary"
+          title={t('manufacturing.overviewPage.cards.orders.title')}
+          description={t('manufacturing.overviewPage.cards.orders.description')}
+          isRTL={isRTL}
+        >
           <div className="flex items-center gap-2 mt-3">
             <Badge variant="secondary">
               {t('manufacturing.overviewPage.cards.orders.activeBadge').replace('{count}', activeOrders.length.toString())}
@@ -64,99 +116,71 @@ export const ManufacturingCards: React.FC<ManufacturingCardsProps> = ({
               {t('manufacturing.overviewPage.cards.orders.totalBadge').replace('{count}', orders.length.toString())}
             </Badge>
           </div>
-        </Link>
+        </ManufacturingLinkCard>
       )}
 
       {canReadStageCosts && (
-        <Link to="/manufacturing/process-costing" className="wardah-glass-card wardah-glass-card-hover p-6 transition-colors">
-          <div className={cn("flex items-center gap-3 mb-3", isRTL ? "flex-row-reverse" : "")}>
-            <BarChart3 className="h-6 w-6 text-success" />
-            <h3 className={cn("font-semibold wardah-text-gradient-google", isRTL ? "text-right" : "text-left")}>
-              {t('manufacturing.overviewPage.cards.processCosting.title')}
-            </h3>
-          </div>
-          <p className={cn("text-muted-foreground text-sm", isRTL ? "text-right" : "text-left")}>
-            {t('manufacturing.overviewPage.cards.processCosting.description')}
-          </p>
+        <ManufacturingLinkCard
+          to="/manufacturing/process-costing"
+          icon={BarChart3}
+          iconClassName="text-success"
+          title={t('manufacturing.overviewPage.cards.processCosting.title')}
+          description={t('manufacturing.overviewPage.cards.processCosting.description')}
+          isRTL={isRTL}
+        >
           <Badge variant="default" className="mt-3">
             {t('manufacturing.overviewPage.cards.processCosting.badge')}
           </Badge>
-        </Link>
+        </ManufacturingLinkCard>
       )}
 
       {canReadWorkCenters && (
-        <Link to="/manufacturing/workcenters" className="wardah-glass-card wardah-glass-card-hover p-6 transition-colors">
-          <div className={cn("flex items-center gap-3 mb-3", isRTL ? "flex-row-reverse" : "")}>
-            <Settings className="h-6 w-6 text-info" />
-            <h3 className={cn("font-semibold wardah-text-gradient-google", isRTL ? "text-right" : "text-left")}>
-              {t('manufacturing.overviewPage.cards.workCenters.title')}
-            </h3>
-          </div>
-          <p className={cn("text-muted-foreground text-sm", isRTL ? "text-right" : "text-left")}>
-            {t('manufacturing.overviewPage.cards.workCenters.description')}
-          </p>
-        </Link>
+        <ManufacturingLinkCard
+          to="/manufacturing/workcenters"
+          icon={Settings}
+          iconClassName="text-info"
+          title={t('manufacturing.overviewPage.cards.workCenters.title')}
+          description={t('manufacturing.overviewPage.cards.workCenters.description')}
+          isRTL={isRTL}
+        />
       )}
 
       {canReadBoms && (
-        <Link to="/manufacturing/bom" className="wardah-glass-card wardah-glass-card-hover p-6 transition-colors">
-          <div className={cn("flex items-center gap-3 mb-3", isRTL ? "flex-row-reverse" : "")}>
-            <Package className="h-6 w-6 text-warning" />
-            <h3 className={cn("font-semibold wardah-text-gradient-google", isRTL ? "text-right" : "text-left")}>
-              {t('manufacturing.overviewPage.cards.bom.title')}
-            </h3>
-          </div>
-          <p className={cn("text-muted-foreground text-sm", isRTL ? "text-right" : "text-left")}>
-            {t('manufacturing.overviewPage.cards.bom.description')}
-          </p>
-        </Link>
+        <ManufacturingLinkCard
+          to="/manufacturing/bom"
+          icon={Package}
+          iconClassName="text-warning"
+          title={t('manufacturing.overviewPage.cards.bom.title')}
+          description={t('manufacturing.overviewPage.cards.bom.description')}
+          isRTL={isRTL}
+        />
       )}
 
       {canReadStages && (
-        <Link to="/manufacturing/stages" className="wardah-glass-card wardah-glass-card-hover p-6 transition-colors">
-          <div className={cn("flex items-center gap-3 mb-3", isRTL ? "flex-row-reverse" : "")}>
-            <Layers className="h-6 w-6 text-primary" />
-            <h3 className={cn("font-semibold wardah-text-gradient-google", isRTL ? "text-right" : "text-left")}>
-              {t('manufacturing.overviewPage.cards.stages.title')}
-            </h3>
-          </div>
-          <p className={cn("text-muted-foreground text-sm", isRTL ? "text-right" : "text-left")}>
-            {t('manufacturing.overviewPage.cards.stages.description')}
-          </p>
-        </Link>
+        <ManufacturingLinkCard
+          to="/manufacturing/stages"
+          icon={Layers}
+          iconClassName="text-primary"
+          title={t('manufacturing.overviewPage.cards.stages.title')}
+          description={t('manufacturing.overviewPage.cards.stages.description')}
+          isRTL={isRTL}
+        />
       )}
 
       {/* الجودة مربوطة في route-permissions.ts بـ manufacturing.orders.read
           (لا مورد "quality" مخصص بعد — صفحة قيد الإنشاء بلا بيانات). */}
       {canReadOrders && (
-        <Link to="/manufacturing/quality" className="wardah-glass-card wardah-glass-card-hover p-6 transition-colors">
-          <div className={cn("flex items-center gap-3 mb-3", isRTL ? "flex-row-reverse" : "")}>
-            <CheckCircle className="h-6 w-6 text-success" />
-            <h3 className={cn("font-semibold wardah-text-gradient-google", isRTL ? "text-right" : "text-left")}>
-              {t('manufacturing.overviewPage.cards.quality.title')}
-            </h3>
-          </div>
-          <p className={cn("text-muted-foreground text-sm", isRTL ? "text-right" : "text-left")}>
-            {t('manufacturing.overviewPage.cards.quality.description')}
-          </p>
-        </Link>
+        <ManufacturingLinkCard
+          to="/manufacturing/quality"
+          icon={CheckCircle}
+          iconClassName="text-success"
+          title={t('manufacturing.overviewPage.cards.quality.title')}
+          description={t('manufacturing.overviewPage.cards.quality.description')}
+          isRTL={isRTL}
+        />
       )}
 
-      <div className="wardah-glass-card wardah-glass-card-hover p-6">
-        <div className={cn("flex items-center gap-3 mb-3", isRTL ? "flex-row-reverse" : "")}>
-          <Users className="h-6 w-6 text-secondary" />
-          <h3 className={cn("font-semibold wardah-text-gradient-google", isRTL ? "text-right" : "text-left")}>
-            {t('manufacturing.overviewPage.cards.labor.title')}
-          </h3>
-        </div>
-        <p className={cn("text-muted-foreground text-sm", isRTL ? "text-right" : "text-left")}>
-          {t('manufacturing.overviewPage.cards.labor.description')}
-        </p>
-        <Badge variant="outline" className="mt-3">
-          {t('manufacturing.overviewPage.cards.labor.badge')}
-        </Badge>
-      </div>
+      <LaborCard isRTL={isRTL} t={t} />
     </div>
   )
 }
-

--- a/src/features/manufacturing/components/ManufacturingCards.tsx
+++ b/src/features/manufacturing/components/ManufacturingCards.tsx
@@ -32,13 +32,13 @@ interface ManufacturingCardsProps {
 }
 
 interface ManufacturingLinkCardProps {
-  to: string
-  icon: React.ComponentType<{ className?: string }>
-  iconClassName: string
-  title: string
-  description: string
-  isRTL: boolean
-  children?: ReactNode
+  readonly to: string
+  readonly icon: React.ComponentType<{ className?: string }>
+  readonly iconClassName: string
+  readonly title: string
+  readonly description: string
+  readonly isRTL: boolean
+  readonly children?: ReactNode
 }
 
 function ManufacturingLinkCard({
@@ -66,7 +66,7 @@ function ManufacturingLinkCard({
   )
 }
 
-function LaborCard({ isRTL, t }: Pick<ManufacturingCardsProps, 'isRTL' | 't'>) {
+function LaborCard({ isRTL, t }: Readonly<Pick<ManufacturingCardsProps, 'isRTL' | 't'>>) {
   return (
     <div className="wardah-glass-card wardah-glass-card-hover p-6">
       <div className={cn('flex items-center gap-3 mb-3', isRTL ? 'flex-row-reverse' : '')}>


### PR DESCRIPTION
## Summary
- decompose the annotated `ManufacturingCards` method into small presentational components
- preserve all six route destinations, per-resource visibility gates, active/total badges, and the labor placeholder
- add an explicit regression test for every permitted card destination

## Verification
- focused manufacturing overview suite: 5 tests passed
- full Vitest suite: 277 files, 4,393 tests passed
- TypeScript: passed
- touched-file ESLint: zero errors
- production bundle and demo-password gate: passed
- RBAC direct-write gate: passed
- `git diff --check`: clean

This is the first low-risk manufacturing complexity slice from #118; the remaining annotated manufacturing methods stay out of this PR.