### PR TITLE
refactor(manufacturing): extract stage-costing form fields and write buttons

### DIFF
--- a/src/features/manufacturing/__tests__/stage-costing-fields-formdata.test.tsx
+++ b/src/features/manufacturing/__tests__/stage-costing-fields-formdata.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * Mandatory gate for the D+E slice of StageCostingPanel's decomposition.
+ *
+ * <form>, every input `name`, and data-action are the only contract between
+ * this component's DOM and stage-costing-actions.js — uiEvents reads them via
+ * element.closest('form') + FormData(form), not React props. Extracting the
+ * form-field sections and the write-button row into their own components
+ * (ManufacturingOrderStageWorkCenterFields, QuantitiesSection,
+ * CostComponentsSection, LaborDetailsSection, StageCostingActionButtons)
+ * cannot break that contract silently — TypeScript has no way to catch a
+ * mistyped `name` or a field left out of a FormData read.
+ *
+ * This test does NOT mock stage-costing-actions.js. It fills every field on
+ * the real, rendered form across all five extracted pieces, clicks each of
+ * the three write buttons through the real global uiEvents delegation, and
+ * asserts the exact payload each service call receives — proving every field
+ * name and value survived the extraction bit-for-bit.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../../test/test-utils';
+import StageCostingPanel from '../stage-costing-panel';
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/hooks/useManufacturingOrders', () => ({
+  useManufacturingOrders: () => ({
+    data: [{ id: 'mo-1', order_number: 'MO-001', product_id: 'p-1', status: 'in_progress' }],
+    isLoading: false,
+    isError: false,
+  }),
+}));
+vi.mock('@/hooks/useWorkCenters', () => ({
+  useWorkCenters: () => ({
+    data: [{ id: 'wc-1', code: 'WC1', name: 'Welding' }],
+    isLoading: false,
+    isError: false,
+  }),
+}));
+vi.mock('@/hooks/useManufacturingStages', () => ({
+  useManufacturingStages: () => ({
+    data: [{ id: 'stage-1', code: 'MIX', name: 'Mixing', is_active: true, order_sequence: 1 }],
+    isLoading: false,
+    isError: false,
+  }),
+}));
+vi.mock('@/hooks/useStageCosts', () => ({
+  useStageCosts: () => ({ data: [], isLoading: false, isError: false }),
+}));
+vi.mock('@/hooks/useRealtimeSubscription', () => ({
+  useRealtimeSubscription: vi.fn(),
+}));
+
+vi.mock('@/hooks/usePermissions', () => ({
+  usePermissions: () => ({
+    hasPermissionKey: (key: string) =>
+      [
+        'manufacturing.orders.read',
+        'manufacturing.stages.read',
+        'manufacturing.work_centers.read',
+        'manufacturing.stage_costs.read',
+        'manufacturing.stage_costs.create',
+        'manufacturing.stage_costs.update',
+      ].includes(key),
+  }),
+}));
+
+vi.mock('../stage-costing-permissions', async () => {
+  const actual = await vi.importActual<typeof import('../stage-costing-permissions')>('../stage-costing-permissions');
+  return {
+    ...actual,
+    hasLiveStageCostingPermission: vi.fn(async () => true),
+    hasLiveStageCostingPermissionAll: vi.fn(async () => true),
+  };
+});
+
+const applyLaborTime = vi.fn();
+const applyOverhead = vi.fn();
+const upsertStageCost = vi.fn();
+const getStageCosts = vi.fn();
+
+vi.mock('@/services/process-costing-service', () => ({
+  processCostingService: {
+    getStageCosts: (...args: unknown[]) => getStageCosts(...args),
+    applyLaborTime: (...args: unknown[]) => applyLaborTime(...args),
+    applyOverhead: (...args: unknown[]) => applyOverhead(...args),
+    upsertStageCost: (...args: unknown[]) => upsertStageCost(...args),
+  },
+}));
+
+async function fillEveryField() {
+  await userEvent.selectOptions(screen.getByLabelText('أمر التصنيع'), 'mo-1');
+  await userEvent.selectOptions(screen.getByLabelText('المرحلة'), 'stage-1');
+  await userEvent.selectOptions(screen.getByLabelText('مركز العمل'), 'wc-1');
+
+  await userEvent.clear(screen.getByLabelText('الكمية الجيدة'));
+  await userEvent.type(screen.getByLabelText('الكمية الجيدة'), '100');
+  await userEvent.clear(screen.getByLabelText('الكمية المعيبة'));
+  await userEvent.type(screen.getByLabelText('الكمية المعيبة'), '5');
+  await userEvent.clear(screen.getByLabelText('كمية إعادة التشغيل'));
+  await userEvent.type(screen.getByLabelText('كمية إعادة التشغيل'), '2');
+
+  await userEvent.clear(screen.getByLabelText('تكلفة المواد المباشرة (ريال)'));
+  await userEvent.type(screen.getByLabelText('تكلفة المواد المباشرة (ريال)'), '50');
+  await userEvent.clear(screen.getByLabelText('ساعات العمل'));
+  await userEvent.type(screen.getByLabelText('ساعات العمل'), '8');
+  await userEvent.clear(screen.getByLabelText('معدل الأجر بالساعة (ريال)'));
+  await userEvent.type(screen.getByLabelText('معدل الأجر بالساعة (ريال)'), '25');
+  await userEvent.clear(screen.getByLabelText('معدل التكاليف غير المباشرة (%)'));
+  await userEvent.type(screen.getByLabelText('معدل التكاليف غير المباشرة (%)'), '20');
+
+  await userEvent.type(screen.getByLabelText('اسم الموظف'), 'Ahmed');
+  await userEvent.type(screen.getByLabelText('كود العملية'), 'OP001');
+  await userEvent.type(screen.getByLabelText('ملاحظات'), 'test notes');
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  applyLaborTime.mockResolvedValue({ success: true, data: { totalLaborCost: 200 } });
+  applyOverhead.mockResolvedValue({ success: true, data: { overheadAmount: 40 } });
+  upsertStageCost.mockResolvedValue({
+    success: true,
+    data: { stageId: 'stage-1', totalCost: 500, unitCost: 5, transferredIn: 0, laborCost: 200, overheadCost: 40 },
+  });
+});
+
+describe('StageCostingPanel — real FormData wiring survives the D+E field/button extraction', () => {
+  it('apply-labor-time reads every field by its exact `name`', async () => {
+    render(<StageCostingPanel />);
+    await fillEveryField();
+
+    await userEvent.click(screen.getByRole('button', { name: 'تسجيل وقت العمل' }));
+
+    await waitFor(() => expect(applyLaborTime).toHaveBeenCalledTimes(1));
+    expect(applyLaborTime).toHaveBeenCalledWith({
+      moId: 'mo-1',
+      stageId: 'stage-1',
+      stageNo: null,
+      workCenterId: 'wc-1',
+      laborHours: 8,
+      hourlyRate: 25,
+      employeeName: 'Ahmed',
+      operationCode: 'OP001',
+      notes: 'test notes',
+    });
+  });
+
+  it('apply-overhead reads laborHours/laborRate/overheadRate — proving the *100/÷100 duality survived untouched', async () => {
+    render(<StageCostingPanel />);
+    await fillEveryField();
+
+    await userEvent.click(screen.getByRole('button', { name: 'تطبيق التكاليف غير المباشرة' }));
+
+    await waitFor(() => expect(applyOverhead).toHaveBeenCalledTimes(1));
+    // stage-costing-actions.js reads the DOM `name="overheadRate"` input directly via
+    // FormData — and that input's rendered *value* is the display-scaled percentage
+    // (formData.overheadRate * 100 = 20), not the fraction (0.2) held in React state.
+    // This pre-existing behavior (out of scope to "fix" here — see CostComponentsSection)
+    // is exactly why this test exists: it pins the real, current wiring, bug and all,
+    // so the extraction is proven not to have changed it either way.
+    expect(applyOverhead).toHaveBeenCalledWith({
+      moId: 'mo-1',
+      stageId: 'stage-1',
+      stageNo: null,
+      workCenterId: 'wc-1',
+      allocationBase: 'labor_cost',
+      baseQty: 200, // laborHours(8) * laborRate(25)
+      overheadRate: 20, // raw DOM value, not divided by 100
+      overheadType: 'variable',
+      notes: 'Applied at 2000% of labor cost', // 20 * 100, per the handler's own (unmodified) formula
+    });
+  });
+
+  it('calculate-stage-cost reads the full formData across every extracted section', async () => {
+    render(<StageCostingPanel />);
+    await fillEveryField();
+
+    await userEvent.click(screen.getByRole('button', { name: 'احتساب تكلفة المرحلة' }));
+
+    await waitFor(() => expect(upsertStageCost).toHaveBeenCalledTimes(1));
+    expect(upsertStageCost).toHaveBeenCalledWith({
+      moId: 'mo-1',
+      stageId: 'stage-1',
+      stageNo: null,
+      workCenterId: 'wc-1',
+      goodQty: 100,
+      directMaterialCost: 50,
+      mode: 'actual',
+      scrapQty: 5,
+      reworkQty: 2,
+      notes: 'test notes',
+    });
+  });
+
+  it('none of the three write buttons carry an onClick — data-action through uiEvents is the only trigger', () => {
+    render(<StageCostingPanel />);
+
+    const laborBtn = screen.getByRole('button', { name: 'تسجيل وقت العمل' });
+    const overheadBtn = screen.getByRole('button', { name: 'تطبيق التكاليف غير المباشرة' });
+    const calcBtn = screen.getByRole('button', { name: 'احتساب تكلفة المرحلة' });
+
+    for (const btn of [laborBtn, overheadBtn, calcBtn]) {
+      expect(btn).toHaveAttribute('data-action');
+    }
+  });
+});

--- a/src/features/manufacturing/stage-costing-panel.tsx
+++ b/src/features/manufacturing/stage-costing-panel.tsx
@@ -566,6 +566,137 @@ export function StageCostingActionButtons({
   )
 }
 
+interface StageCostingPanelHeaderProps {
+  readonly isSCLoading: boolean
+  readonly canReadStageCosts: boolean
+  readonly onRefresh: () => void
+}
+
+export function StageCostingPanelHeader({ isSCLoading, canReadStageCosts, onRefresh }: StageCostingPanelHeaderProps) {
+  return (
+    <div className="flex items-center justify-between mb-4">
+      <div className="flex items-center gap-3">
+        <Calculator className="h-6 w-6 text-primary" />
+        <h2 className="text-xl font-bold wardah-text-gradient-google">احتساب تكلفة المراحل (Process Costing)</h2>
+      </div>
+      <div className="flex gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          data-action="refresh-stage-costs"
+          onClick={onRefresh}
+          disabled={isSCLoading || !canReadStageCosts}
+        >
+          <RefreshCw className={`h-4 w-4 mr-2 ${isSCLoading ? 'animate-spin' : ''}`} />
+          تحديث
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          data-action="view-stage-report"
+          disabled={!canReadStageCosts}
+        >
+          <BarChart3 className="h-4 w-4 mr-2" />
+          تقرير المراحل
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+interface StageCostingLoadStateProps {
+  readonly isLoading: boolean
+  readonly isError: boolean
+}
+
+export function StageCostingLoadState({ isLoading, isError }: StageCostingLoadStateProps) {
+  return (
+    <>
+      {isLoading && (
+        <div className="mb-4 p-4 wardah-glass-card">
+          <p>جاري تحميل البيانات...</p>
+        </div>
+      )}
+
+      {isError && (
+        <div className="mb-4 p-4 bg-red-50 dark:bg-red-900/20 rounded-lg">
+          <p className="text-red-700 dark:text-red-300">خطأ في تحميل البيانات. يرجى التحديث.</p>
+        </div>
+      )}
+    </>
+  )
+}
+
+interface StageCostingFormSectionsProps {
+  readonly formData: StageCostingFormData
+  readonly manufacturingOrders: Array<Record<string, unknown>>
+  readonly stages: Array<Record<string, unknown>>
+  readonly workCenters: Array<Record<string, unknown>>
+  readonly selectedMO
+  readonly isMOLoading: boolean
+  readonly canReadOrders: boolean
+  readonly isStagesLoading: boolean
+  readonly canReadStages: boolean
+  readonly isWCLoading: boolean
+  readonly canReadWorkCenters: boolean
+  readonly onChange: (field: keyof StageCostingFormData, value: string | number) => void
+  readonly canApplyLaborTime: boolean
+  readonly canApplyOverhead: boolean
+  readonly canCalculateStageCost: boolean
+}
+
+export function StageCostingFormSections({
+  formData,
+  manufacturingOrders,
+  stages,
+  workCenters,
+  selectedMO,
+  isMOLoading,
+  canReadOrders,
+  isStagesLoading,
+  canReadStages,
+  isWCLoading,
+  canReadWorkCenters,
+  onChange,
+  canApplyLaborTime,
+  canApplyOverhead,
+  canCalculateStageCost,
+}: StageCostingFormSectionsProps) {
+  return (
+    <>
+      <ManufacturingOrderStageWorkCenterFields
+        formData={formData}
+        manufacturingOrders={manufacturingOrders}
+        stages={stages}
+        workCenters={workCenters}
+        selectedMO={selectedMO}
+        isMOLoading={isMOLoading}
+        canReadOrders={canReadOrders}
+        isStagesLoading={isStagesLoading}
+        canReadStages={canReadStages}
+        isWCLoading={isWCLoading}
+        canReadWorkCenters={canReadWorkCenters}
+        onChange={onChange}
+      />
+
+      <QuantitiesSection formData={formData} onChange={onChange} />
+
+      <CostComponentsSection formData={formData} onChange={onChange} />
+
+      <LaborDetailsSection formData={formData} onChange={onChange} />
+
+      <StageCostingActionButtons
+        formData={formData}
+        canApplyLaborTime={canApplyLaborTime}
+        canApplyOverhead={canApplyOverhead}
+        canCalculateStageCost={canCalculateStageCost}
+      />
+    </>
+  )
+}
+
 export default function StageCostingPanel() {
   const queryClient = useQueryClient()
   
@@ -721,51 +852,18 @@ export default function StageCostingPanel() {
       {/* Header */}
       <div className="wardah-glass-card p-6">
         <form onSubmit={(e) => e.preventDefault()}>
-          <div className="flex items-center justify-between mb-4">
-            <div className="flex items-center gap-3">
-              <Calculator className="h-6 w-6 text-primary" />
-              <h2 className="text-xl font-bold wardah-text-gradient-google">احتساب تكلفة المراحل (Process Costing)</h2>
-            </div>
-            <div className="flex gap-2">
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                data-action="refresh-stage-costs"
-                onClick={loadStageCosts}
-                disabled={isSCLoading || !canReadStageCosts}
-              >
-                <RefreshCw className={`h-4 w-4 mr-2 ${isSCLoading ? 'animate-spin' : ''}`} />
-                تحديث
-              </Button>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                data-action="view-stage-report"
-                disabled={!canReadStageCosts}
-              >
-                <BarChart3 className="h-4 w-4 mr-2" />
-                تقرير المراحل
-              </Button>
-            </div>
-          </div>
-        
-          {/* Loading and Error States */}
-          {(isMOLoading || isWCLoading || isStagesLoading || isSCLoading) && (
-            <div className="mb-4 p-4 wardah-glass-card">
-              <p>جاري تحميل البيانات...</p>
-            </div>
-          )}
-          
-          {(isMOError || isWCError || isStagesError || isSCError) && (
-            <div className="mb-4 p-4 bg-red-50 dark:bg-red-900/20 rounded-lg">
-              <p className="text-red-700 dark:text-red-300">خطأ في تحميل البيانات. يرجى التحديث.</p>
-            </div>
-          )}
-        
-          {/* Manufacturing Order Selection */}
-          <ManufacturingOrderStageWorkCenterFields
+          <StageCostingPanelHeader
+            isSCLoading={isSCLoading}
+            canReadStageCosts={canReadStageCosts}
+            onRefresh={loadStageCosts}
+          />
+
+          <StageCostingLoadState
+            isLoading={isMOLoading || isWCLoading || isStagesLoading || isSCLoading}
+            isError={isMOError || isWCError || isStagesError || isSCError}
+          />
+
+          <StageCostingFormSections
             formData={formData}
             manufacturingOrders={manufacturingOrders}
             stages={stages}
@@ -778,20 +876,6 @@ export default function StageCostingPanel() {
             isWCLoading={isWCLoading}
             canReadWorkCenters={canReadWorkCenters}
             onChange={handleInputChange}
-          />
-
-          {/* Quantities Section */}
-          <QuantitiesSection formData={formData} onChange={handleInputChange} />
-
-          {/* Cost Components */}
-          <CostComponentsSection formData={formData} onChange={handleInputChange} />
-
-          {/* Labor Details */}
-          <LaborDetailsSection formData={formData} onChange={handleInputChange} />
-
-          {/* Action Buttons */}
-          <StageCostingActionButtons
-            formData={formData}
             canApplyLaborTime={canApplyLaborTime}
             canApplyOverhead={canApplyOverhead}
             canCalculateStageCost={canCalculateStageCost}

--- a/src/features/manufacturing/stage-costing-panel.tsx
+++ b/src/features/manufacturing/stage-costing-panel.tsx
@@ -212,6 +212,360 @@ export function StageCostsHistoryTable({ stageCosts }: StageCostsHistoryTablePro
   )
 }
 
+interface ManufacturingOrderStageWorkCenterFieldsProps {
+  readonly formData: StageCostingFormData
+  readonly manufacturingOrders: Array<Record<string, unknown>>
+  readonly stages: Array<Record<string, unknown>>
+  readonly workCenters: Array<Record<string, unknown>>
+  readonly selectedMO
+  readonly isMOLoading: boolean
+  readonly canReadOrders: boolean
+  readonly isStagesLoading: boolean
+  readonly canReadStages: boolean
+  readonly isWCLoading: boolean
+  readonly canReadWorkCenters: boolean
+  readonly onChange: (field: keyof StageCostingFormData, value: string | number) => void
+}
+
+export function ManufacturingOrderStageWorkCenterFields({
+  formData,
+  manufacturingOrders,
+  stages,
+  workCenters,
+  selectedMO,
+  isMOLoading,
+  canReadOrders,
+  isStagesLoading,
+  canReadStages,
+  isWCLoading,
+  canReadWorkCenters,
+  onChange,
+}: ManufacturingOrderStageWorkCenterFieldsProps) {
+  return (
+    <div className="grid md:grid-cols-4 gap-4 mb-6">
+      <div>
+        <label htmlFor="manufacturingOrderId" className="block text-sm font-medium mb-2">أمر التصنيع</label>
+        <select
+          id="manufacturingOrderId"
+          name="manufacturingOrderId"
+          className="w-full px-3 py-2 border rounded-md wardah-glass-card"
+          value={formData.manufacturingOrderId}
+          onChange={(e) => onChange('manufacturingOrderId', e.target.value)}
+          disabled={isMOLoading || !canReadOrders}
+        >
+          <option value="">اختر أمر التصنيع</option>
+          {manufacturingOrders.map((order: any) => (
+            <option key={order.id} value={order.id}>
+              {order.order_number} - {order.product_id ? `Product ${order.product_id}` : 'N/A'}
+            </option>
+          ))}
+        </select>
+        {!canReadOrders && (
+          <p className="mt-1 flex items-center gap-1 text-xs text-muted-foreground">
+            <Lock className="h-3 w-3" /> لا تملك صلاحية عرض أوامر التصنيع
+          </p>
+        )}
+      </div>
+
+      <div>
+        <label htmlFor="stageId" className="block text-sm font-medium mb-2">المرحلة</label>
+        <select
+          id="stageId"
+          name="stageId"
+          className="w-full px-3 py-2 border rounded-md wardah-glass-card"
+          value={formData.stageId}
+          onChange={(e) => onChange('stageId', e.target.value)}
+          disabled={isStagesLoading || !canReadStages}
+        >
+          <option value="">اختر المرحلة</option>
+          {stages
+            .filter((stage: any) => stage.is_active)
+            .sort((a: any, b: any) => (a.order_sequence || 0) - (b.order_sequence || 0))
+            .map((stage: any) => (
+              <option key={stage.id} value={stage.id}>
+                {stage.code} - {stage.name_ar || stage.name} (الترتيب: {stage.order_sequence})
+              </option>
+            ))}
+        </select>
+        {!canReadStages && (
+          <p className="mt-1 flex items-center gap-1 text-xs text-muted-foreground">
+            <Lock className="h-3 w-3" /> لا تملك صلاحية عرض مراحل التصنيع
+          </p>
+        )}
+      </div>
+
+      <div>
+        <label htmlFor="workCenterId" className="block text-sm font-medium mb-2">مركز العمل</label>
+        <select
+          id="workCenterId"
+          name="workCenterId"
+          className="w-full px-3 py-2 border rounded-md wardah-glass-card"
+          value={formData.workCenterId}
+          onChange={(e) => onChange('workCenterId', e.target.value)}
+          disabled={isWCLoading || !canReadWorkCenters}
+        >
+          <option value="">اختر مركز العمل</option>
+          {workCenters.map((wc: any) => (
+            <option key={wc.id} value={wc.id}>
+              {wc.code} - {wc.name}
+            </option>
+          ))}
+        </select>
+        {!canReadWorkCenters && (
+          <p className="mt-1 flex items-center gap-1 text-xs text-muted-foreground">
+            <Lock className="h-3 w-3" /> لا تملك صلاحية عرض مراكز العمل
+          </p>
+        )}
+      </div>
+
+      <div>
+        <label htmlFor="mo-status" className="block text-sm font-medium mb-2">حالة الأمر</label>
+        <div id="mo-status" className="pt-2">
+          {selectedMO && (
+            <Badge variant={selectedMO.status === 'in_progress' ? 'default' : 'outline'}>
+              {moStatusLabel(selectedMO.status)}
+            </Badge>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface QuantitiesSectionProps {
+  readonly formData: StageCostingFormData
+  readonly onChange: (field: keyof StageCostingFormData, value: string | number) => void
+}
+
+export function QuantitiesSection({ formData, onChange }: QuantitiesSectionProps) {
+  return (
+    <div className="wardah-glass-card p-4 mb-6">
+      <h3 className="font-semibold mb-4 flex items-center gap-2 wardah-text-gradient-google">
+        <BarChart3 className="h-5 w-5" />
+        الكميات المنتجة
+      </h3>
+      <div className="grid md:grid-cols-3 gap-4">
+        <div>
+          <label htmlFor="goodQuantity" className="block text-sm font-medium mb-2">الكمية الجيدة</label>
+          <Input
+            id="goodQuantity"
+            name="goodQuantity"
+            type="number"
+            min="0"
+            value={formData.goodQuantity}
+            onChange={(e) => onChange('goodQuantity', e.target.value)}
+            className="wardah-glass-card"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="scrapQuantity" className="block text-sm font-medium mb-2">الكمية المعيبة</label>
+          <Input
+            id="scrapQuantity"
+            name="scrapQuantity"
+            type="number"
+            min="0"
+            value={formData.scrapQuantity}
+            onChange={(e) => onChange('scrapQuantity', e.target.value)}
+            className="wardah-glass-card"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="reworkQuantity" className="block text-sm font-medium mb-2">كمية إعادة التشغيل</label>
+          <Input
+            id="reworkQuantity"
+            name="reworkQuantity"
+            type="number"
+            min="0"
+            value={formData.reworkQuantity}
+            onChange={(e) => onChange('reworkQuantity', e.target.value)}
+            className="wardah-glass-card"
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface CostComponentsSectionProps {
+  readonly formData: StageCostingFormData
+  readonly onChange: (field: keyof StageCostingFormData, value: string | number) => void
+}
+
+export function CostComponentsSection({ formData, onChange }: CostComponentsSectionProps) {
+  return (
+    <div className="wardah-glass-card p-4 mb-6">
+      <h3 className="font-semibold mb-4 flex items-center gap-2 wardah-text-gradient-google">
+        <DollarSign className="h-5 w-5" />
+        مكونات التكلفة
+      </h3>
+      <div className="grid md:grid-cols-2 gap-4">
+        <div>
+          <label htmlFor="directMaterialCost" className="block text-sm font-medium mb-2">تكلفة المواد المباشرة (ريال)</label>
+          <Input
+            id="directMaterialCost"
+            name="directMaterialCost"
+            type="number"
+            min="0"
+            step="0.01"
+            value={formData.directMaterialCost}
+            onChange={(e) => onChange('directMaterialCost', e.target.value)}
+            className="wardah-glass-card"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="laborHours" className="block text-sm font-medium mb-2">ساعات العمل</label>
+          <Input
+            id="laborHours"
+            name="laborHours"
+            type="number"
+            min="0"
+            step="0.01"
+            value={formData.laborHours}
+            onChange={(e) => onChange('laborHours', e.target.value)}
+            className="wardah-glass-card"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="laborRate" className="block text-sm font-medium mb-2">معدل الأجر بالساعة (ريال)</label>
+          <Input
+            id="laborRate"
+            name="laborRate"
+            type="number"
+            min="0"
+            step="0.01"
+            value={formData.laborRate}
+            onChange={(e) => onChange('laborRate', e.target.value)}
+            className="wardah-glass-card"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="overheadRate" className="block text-sm font-medium mb-2">معدل التكاليف غير المباشرة (%)</label>
+          <Input
+            id="overheadRate"
+            name="overheadRate"
+            type="number"
+            min="0"
+            max="100"
+            step="0.01"
+            value={formData.overheadRate * 100}
+            onChange={(e) => onChange('overheadRate', Number.parseFloat(e.target.value) / 100)}
+            className="wardah-glass-card"
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface LaborDetailsSectionProps {
+  readonly formData: StageCostingFormData
+  readonly onChange: (field: keyof StageCostingFormData, value: string | number) => void
+}
+
+export function LaborDetailsSection({ formData, onChange }: LaborDetailsSectionProps) {
+  return (
+    <div className="wardah-glass-card p-4 mb-6">
+      <h3 className="font-semibold mb-4 flex items-center gap-2 wardah-text-gradient-google">
+        <Users className="h-5 w-5" />
+        تفاصيل العمالة والتشغيل
+      </h3>
+      <div className="grid md:grid-cols-3 gap-4">
+        <div>
+          <label htmlFor="employeeName" className="block text-sm font-medium mb-2">اسم الموظف</label>
+          <Input
+            id="employeeName"
+            name="employeeName"
+            value={formData.employeeName || ''}
+            onChange={(e) => onChange('employeeName', e.target.value)}
+            placeholder="اسم الموظف أو المشغل"
+            className="wardah-glass-card"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="operationCode" className="block text-sm font-medium mb-2">كود العملية</label>
+          <Input
+            id="operationCode"
+            name="operationCode"
+            value={formData.operationCode || ''}
+            onChange={(e) => onChange('operationCode', e.target.value)}
+            placeholder="OP001, WELD, CUT, etc."
+            className="wardah-glass-card"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="notes" className="block text-sm font-medium mb-2">ملاحظات</label>
+          <Input
+            id="notes"
+            name="notes"
+            value={formData.notes || ''}
+            onChange={(e) => onChange('notes', e.target.value)}
+            placeholder="أي ملاحظات إضافية"
+            className="wardah-glass-card"
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface StageCostingActionButtonsProps {
+  readonly formData: StageCostingFormData
+  readonly canApplyLaborTime: boolean
+  readonly canApplyOverhead: boolean
+  readonly canCalculateStageCost: boolean
+}
+
+export function StageCostingActionButtons({
+  formData,
+  canApplyLaborTime,
+  canApplyOverhead,
+  canCalculateStageCost,
+}: StageCostingActionButtonsProps) {
+  return (
+    <div className="flex flex-wrap gap-3 mb-6">
+      <Button
+        type="button"
+        data-action="apply-labor-time"
+        disabled={!formData.laborHours || !formData.laborRate || !canApplyLaborTime}
+        title={canApplyLaborTime ? undefined : 'لا تملك صلاحية تسجيل وقت العمل'}
+        className="bg-purple-600 hover:bg-purple-700 wardah-glass-card"
+      >
+        <Clock className="h-4 w-4 mr-2" />
+        تسجيل وقت العمل
+      </Button>
+
+      <Button
+        type="button"
+        data-action="apply-overhead"
+        disabled={!formData.overheadRate || !canApplyOverhead}
+        title={canApplyOverhead ? undefined : 'لا تملك صلاحية تطبيق التكاليف غير المباشرة'}
+        className="bg-orange-600 hover:bg-orange-700 wardah-glass-card"
+      >
+        <Settings className="h-4 w-4 mr-2" />
+        تطبيق التكاليف غير المباشرة
+      </Button>
+
+      <Button
+        type="button"
+        data-action="calculate-stage-cost"
+        disabled={!formData.manufacturingOrderId || !formData.workCenterId || !formData.goodQuantity || !canCalculateStageCost}
+        title={canCalculateStageCost ? undefined : 'لا تملك صلاحية احتساب تكلفة المرحلة'}
+        className="bg-blue-600 hover:bg-blue-700 wardah-glass-card"
+      >
+        <Calculator className="h-4 w-4 mr-2" />
+        {'احتساب تكلفة المرحلة'}
+      </Button>
+    </div>
+  )
+}
+
 export default function StageCostingPanel() {
   const queryClient = useQueryClient()
   
@@ -411,288 +765,37 @@ export default function StageCostingPanel() {
           )}
         
           {/* Manufacturing Order Selection */}
-          <div className="grid md:grid-cols-4 gap-4 mb-6">
-            <div>
-              <label htmlFor="manufacturingOrderId" className="block text-sm font-medium mb-2">أمر التصنيع</label>
-              <select
-                id="manufacturingOrderId"
-                name="manufacturingOrderId"
-                className="w-full px-3 py-2 border rounded-md wardah-glass-card"
-                value={formData.manufacturingOrderId}
-                onChange={(e) => handleInputChange('manufacturingOrderId', e.target.value)}
-                disabled={isMOLoading || !canReadOrders}
-              >
-                <option value="">اختر أمر التصنيع</option>
-                {manufacturingOrders.map((order: any) => (
-                  <option key={order.id} value={order.id}>
-                    {order.order_number} - {order.product_id ? `Product ${order.product_id}` : 'N/A'}
-                  </option>
-                ))}
-              </select>
-              {!canReadOrders && (
-                <p className="mt-1 flex items-center gap-1 text-xs text-muted-foreground">
-                  <Lock className="h-3 w-3" /> لا تملك صلاحية عرض أوامر التصنيع
-                </p>
-              )}
-            </div>
+          <ManufacturingOrderStageWorkCenterFields
+            formData={formData}
+            manufacturingOrders={manufacturingOrders}
+            stages={stages}
+            workCenters={workCenters}
+            selectedMO={selectedMO}
+            isMOLoading={isMOLoading}
+            canReadOrders={canReadOrders}
+            isStagesLoading={isStagesLoading}
+            canReadStages={canReadStages}
+            isWCLoading={isWCLoading}
+            canReadWorkCenters={canReadWorkCenters}
+            onChange={handleInputChange}
+          />
 
-            <div>
-              <label htmlFor="stageId" className="block text-sm font-medium mb-2">المرحلة</label>
-              <select
-                id="stageId"
-                name="stageId"
-                className="w-full px-3 py-2 border rounded-md wardah-glass-card"
-                value={formData.stageId}
-                onChange={(e) => handleInputChange('stageId', e.target.value)}
-                disabled={isStagesLoading || !canReadStages}
-              >
-                <option value="">اختر المرحلة</option>
-                {stages
-                  .filter((stage: any) => stage.is_active)
-                  .sort((a: any, b: any) => (a.order_sequence || 0) - (b.order_sequence || 0))
-                  .map((stage: any) => (
-                    <option key={stage.id} value={stage.id}>
-                      {stage.code} - {stage.name_ar || stage.name} (الترتيب: {stage.order_sequence})
-                    </option>
-                  ))}
-              </select>
-              {!canReadStages && (
-                <p className="mt-1 flex items-center gap-1 text-xs text-muted-foreground">
-                  <Lock className="h-3 w-3" /> لا تملك صلاحية عرض مراحل التصنيع
-                </p>
-              )}
-            </div>
-
-            <div>
-              <label htmlFor="workCenterId" className="block text-sm font-medium mb-2">مركز العمل</label>
-              <select
-                id="workCenterId"
-                name="workCenterId"
-                className="w-full px-3 py-2 border rounded-md wardah-glass-card"
-                value={formData.workCenterId}
-                onChange={(e) => handleInputChange('workCenterId', e.target.value)}
-                disabled={isWCLoading || !canReadWorkCenters}
-              >
-                <option value="">اختر مركز العمل</option>
-                {workCenters.map((wc: any) => (
-                  <option key={wc.id} value={wc.id}>
-                    {wc.code} - {wc.name}
-                  </option>
-                ))}
-              </select>
-              {!canReadWorkCenters && (
-                <p className="mt-1 flex items-center gap-1 text-xs text-muted-foreground">
-                  <Lock className="h-3 w-3" /> لا تملك صلاحية عرض مراكز العمل
-                </p>
-              )}
-            </div>
-            
-            <div>
-              <label htmlFor="mo-status" className="block text-sm font-medium mb-2">حالة الأمر</label>
-              <div id="mo-status" className="pt-2">
-                {selectedMO && (
-                  <Badge variant={selectedMO.status === 'in_progress' ? 'default' : 'outline'}>
-                    {moStatusLabel(selectedMO.status)}
-                  </Badge>
-                )}
-              </div>
-            </div>
-          </div>
-        
           {/* Quantities Section */}
-          <div className="wardah-glass-card p-4 mb-6">
-            <h3 className="font-semibold mb-4 flex items-center gap-2 wardah-text-gradient-google">
-              <BarChart3 className="h-5 w-5" />
-              الكميات المنتجة
-            </h3>
-            <div className="grid md:grid-cols-3 gap-4">
-              <div>
-                <label htmlFor="goodQuantity" className="block text-sm font-medium mb-2">الكمية الجيدة</label>
-                <Input 
-                  id="goodQuantity"
-                  name="goodQuantity"
-                  type="number"
-                  min="0"
-                  value={formData.goodQuantity}
-                  onChange={(e) => handleInputChange('goodQuantity', e.target.value)}
-                  className="wardah-glass-card"
-                />
-              </div>
-              
-              <div>
-                <label htmlFor="scrapQuantity" className="block text-sm font-medium mb-2">الكمية المعيبة</label>
-                <Input 
-                  id="scrapQuantity"
-                  name="scrapQuantity"
-                  type="number"
-                  min="0"
-                  value={formData.scrapQuantity}
-                  onChange={(e) => handleInputChange('scrapQuantity', e.target.value)}
-                  className="wardah-glass-card"
-                />
-              </div>
-              
-              <div>
-                <label htmlFor="reworkQuantity" className="block text-sm font-medium mb-2">كمية إعادة التشغيل</label>
-                <Input 
-                  id="reworkQuantity"
-                  name="reworkQuantity"
-                  type="number"
-                  min="0"
-                  value={formData.reworkQuantity}
-                  onChange={(e) => handleInputChange('reworkQuantity', e.target.value)}
-                  className="wardah-glass-card"
-                />
-              </div>
-            </div>
-          </div>
-        
+          <QuantitiesSection formData={formData} onChange={handleInputChange} />
+
           {/* Cost Components */}
-          <div className="wardah-glass-card p-4 mb-6">
-            <h3 className="font-semibold mb-4 flex items-center gap-2 wardah-text-gradient-google">
-              <DollarSign className="h-5 w-5" />
-              مكونات التكلفة
-            </h3>
-            <div className="grid md:grid-cols-2 gap-4">
-              <div>
-                <label htmlFor="directMaterialCost" className="block text-sm font-medium mb-2">تكلفة المواد المباشرة (ريال)</label>
-                <Input 
-                  id="directMaterialCost"
-                  name="directMaterialCost"
-                  type="number"
-                  min="0"
-                  step="0.01"
-                  value={formData.directMaterialCost}
-                  onChange={(e) => handleInputChange('directMaterialCost', e.target.value)}
-                  className="wardah-glass-card"
-                />
-              </div>
-              
-              <div>
-                <label htmlFor="laborHours" className="block text-sm font-medium mb-2">ساعات العمل</label>
-                <Input 
-                  id="laborHours"
-                  name="laborHours"
-                  type="number"
-                  min="0"
-                  step="0.01"
-                  value={formData.laborHours}
-                  onChange={(e) => handleInputChange('laborHours', e.target.value)}
-                  className="wardah-glass-card"
-                />
-              </div>
-              
-              <div>
-                <label htmlFor="laborRate" className="block text-sm font-medium mb-2">معدل الأجر بالساعة (ريال)</label>
-                <Input 
-                  id="laborRate"
-                  name="laborRate"
-                  type="number"
-                  min="0"
-                  step="0.01"
-                  value={formData.laborRate}
-                  onChange={(e) => handleInputChange('laborRate', e.target.value)}
-                  className="wardah-glass-card"
-                />
-              </div>
-              
-              <div>
-                <label htmlFor="overheadRate" className="block text-sm font-medium mb-2">معدل التكاليف غير المباشرة (%)</label>
-                <Input 
-                  id="overheadRate"
-                  name="overheadRate"
-                  type="number"
-                  min="0"
-                  max="100"
-                  step="0.01"
-                  value={formData.overheadRate * 100}
-                  onChange={(e) => handleInputChange('overheadRate', Number.parseFloat(e.target.value) / 100)}
-                  className="wardah-glass-card"
-                />
-              </div>
-            </div>
-          </div>
-        
+          <CostComponentsSection formData={formData} onChange={handleInputChange} />
+
           {/* Labor Details */}
-          <div className="wardah-glass-card p-4 mb-6">
-            <h3 className="font-semibold mb-4 flex items-center gap-2 wardah-text-gradient-google">
-              <Users className="h-5 w-5" />
-              تفاصيل العمالة والتشغيل
-            </h3>
-            <div className="grid md:grid-cols-3 gap-4">
-              <div>
-                <label htmlFor="employeeName" className="block text-sm font-medium mb-2">اسم الموظف</label>
-                <Input 
-                  id="employeeName"
-                  name="employeeName"
-                  value={formData.employeeName || ''}
-                  onChange={(e) => handleInputChange('employeeName', e.target.value)}
-                  placeholder="اسم الموظف أو المشغل"
-                  className="wardah-glass-card"
-                />
-              </div>
-              
-              <div>
-                <label htmlFor="operationCode" className="block text-sm font-medium mb-2">كود العملية</label>
-                <Input 
-                  id="operationCode"
-                  name="operationCode"
-                  value={formData.operationCode || ''}
-                  onChange={(e) => handleInputChange('operationCode', e.target.value)}
-                  placeholder="OP001, WELD, CUT, etc."
-                  className="wardah-glass-card"
-                />
-              </div>
-              
-              <div>
-                <label htmlFor="notes" className="block text-sm font-medium mb-2">ملاحظات</label>
-                <Input 
-                  id="notes"
-                  name="notes"
-                  value={formData.notes || ''}
-                  onChange={(e) => handleInputChange('notes', e.target.value)}
-                  placeholder="أي ملاحظات إضافية"
-                  className="wardah-glass-card"
-                />
-              </div>
-            </div>
-          </div>
-        
+          <LaborDetailsSection formData={formData} onChange={handleInputChange} />
+
           {/* Action Buttons */}
-          <div className="flex flex-wrap gap-3 mb-6">
-            <Button
-              type="button"
-              data-action="apply-labor-time"
-              disabled={!formData.laborHours || !formData.laborRate || !canApplyLaborTime}
-              title={canApplyLaborTime ? undefined : 'لا تملك صلاحية تسجيل وقت العمل'}
-              className="bg-purple-600 hover:bg-purple-700 wardah-glass-card"
-            >
-              <Clock className="h-4 w-4 mr-2" />
-              تسجيل وقت العمل
-            </Button>
-
-            <Button
-              type="button"
-              data-action="apply-overhead"
-              disabled={!formData.overheadRate || !canApplyOverhead}
-              title={canApplyOverhead ? undefined : 'لا تملك صلاحية تطبيق التكاليف غير المباشرة'}
-              className="bg-orange-600 hover:bg-orange-700 wardah-glass-card"
-            >
-              <Settings className="h-4 w-4 mr-2" />
-              تطبيق التكاليف غير المباشرة
-            </Button>
-
-            <Button
-              type="button"
-              data-action="calculate-stage-cost"
-              disabled={!formData.manufacturingOrderId || !formData.workCenterId || !formData.goodQuantity || !canCalculateStageCost}
-              title={canCalculateStageCost ? undefined : 'لا تملك صلاحية احتساب تكلفة المرحلة'}
-              className="bg-blue-600 hover:bg-blue-700 wardah-glass-card"
-            >
-              <Calculator className="h-4 w-4 mr-2" />
-              {'احتساب تكلفة المرحلة'}
-            </Button>
-          </div>
+          <StageCostingActionButtons
+            formData={formData}
+            canApplyLaborTime={canApplyLaborTime}
+            canApplyOverhead={canApplyOverhead}
+            canCalculateStageCost={canCalculateStageCost}
+          />
         </form>
 
         {/* Results Display */}


### PR DESCRIPTION
## Summary
Second (higher-risk) slice of the `StageCostingPanel` CodeFactor Complex Method, completing the decomposition started in #128 (A+B+C). Extracts the parts that live inside `<form>` and interact with the global `data-action`/`uiEvents` wiring:

- **D** — `ManufacturingOrderStageWorkCenterFields` (MO/stage/work-center selects + MO status badge), `QuantitiesSection`, `CostComponentsSection`, `LaborDetailsSection`
- **E** — `StageCostingActionButtons` (`apply-labor-time` / `apply-overhead` / `calculate-stage-cost`)

## Hard constraints honored
- no additional `<form>` introduced — every extracted piece renders directly inside the single existing `<form>`, which `stage-costing-actions.js` locates via `element.closest('form')` and reads with `FormData(form)`
- every input `name` unchanged byte-for-byte
- no `onClick` added to the three write buttons — `data-action` stays the only trigger, dispatched through the global `uiEvents` delegation
- `stage-costing-actions.js`, `uiEvents`, and the three `useEffect`s (including the `document.querySelector('form')` custom-event wiring) — untouched
- `overheadRate * 100` / `÷ 100` display/storage duality moved verbatim
- `StageCostingActionButtons` receives the full `formData` (not a `Pick`), since `calculate-stage-cost` reads three fields spanning different sections
- `selectedMO` prop stays untyped (implicit `any`, no explicit `: any`) — avoids a new `no-explicit-any` warning beyond the file's baseline (verified: 10 warnings before and after)

## Verification
- **mandatory gate**: new `stage-costing-fields-formdata.test.tsx` (4 tests) — does **not** mock `stage-costing-actions.js`; fills every field across all five extracted pieces and clicks each of the three write buttons through the real global `uiEvents` delegation, asserting the exact payload `applyLaborTime`/`applyOverhead`/`upsertStageCost` receive. Incidentally documents a pre-existing, out-of-scope quirk: the DOM-level `name="overheadRate"` input holds the display-scaled percentage (not the fraction), since `stage-costing-actions.js` reads it straight from `FormData` rather than React state — unchanged by this extraction, just pinned by the test so it isn't mistaken for a regression later.
- existing `stage-costing-panel-rbac.test.tsx` (7 tests), `stage-costing-calculate-permission.test.tsx` (4 tests), `stage-costing-panel.test.tsx` (8 tests), `stage-costing-result-display.test.tsx` (10 tests): all pass unmodified
- full Vitest suite: 280 files, 4,415 tests passed
- `tsc --noEmit -p tsconfig.json`: passed
- touched-file ESLint (`stage-costing-panel.tsx`): 0 errors, 10 warnings — identical to the pre-change baseline, no new warnings
- production build: passed; demo-password gate: `DEMO_PASSWORD_BUILD_GATE_PASS files=76`
- RBAC direct-write gate: `RBAC_DIRECT_WRITE_GATE_PASS files=752`
- `git diff --check`: clean

Fourth slice of the manufacturing complexity work tracked in #118, after #126, #127, and #128. If CodeFactor's Complex Method finding on `stage-costing-panel.tsx` clears after this, the file is done and the last #118 manufacturing item is `stage-costing-actions.js`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EPwpN85Uc9S2E22RAViECV)_