### PR TITLE
refactor(inventory): extract StockAdjustments submit orchestration

### DIFF
--- a/src/features/inventory/__tests__/stock-adjustment-org-scope.test.ts
+++ b/src/features/inventory/__tests__/stock-adjustment-org-scope.test.ts
@@ -33,7 +33,6 @@ describe('StockAdjustments organization scope regression', () => {
     expect(source).toContain(".eq('org_id', currentOrgId)")
     expect(source).toContain(".eq('organization_id', currentOrgId)")
     expect(source).toContain('orgId: currentOrgId')
-    expect(source).toContain('org_id: currentOrgId')
 
     const saveSource = readFileSync(
       resolve(process.cwd(), 'src/features/inventory/helpers/stockAdjustmentSave.ts'),
@@ -41,6 +40,14 @@ describe('StockAdjustments organization scope regression', () => {
     )
     expect(saveSource).toContain(".eq('organization_id', orgId)")
     expect(saveSource).toContain('organization_id: orgId')
+
+    const submitSource = readFileSync(
+      resolve(process.cwd(), 'src/features/inventory/helpers/stockAdjustmentSubmit.ts'),
+      'utf8',
+    )
+    expect(submitSource).toContain(".eq('organization_id', orgId)")
+    expect(submitSource).toContain(".eq('org_id', orgId)")
+    expect(submitSource).toContain('org_id: orgId')
   })
 
   it('does not retain a warehouse selected under a previously active organization', () => {

--- a/src/features/inventory/helpers/__tests__/stockAdjustmentSubmit.test.ts
+++ b/src/features/inventory/helpers/__tests__/stockAdjustmentSubmit.test.ts
@@ -1,0 +1,301 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Database } from '@/lib/supabase';
+import { submitStockAdjustmentDraft } from '../stockAdjustmentSubmit';
+
+type HarnessOptions = {
+  adjustment?: Record<string, unknown> | null;
+  adjustmentError?: Error | null;
+  items?: ReadonlyArray<Record<string, unknown>> | null;
+  itemsError?: Error | null;
+  ledgerError?: Error | null;
+  warehouseAccounts?: Array<string | null>;
+  rpcData?: { success?: boolean; error?: string } | null;
+  rpcError?: Error | null;
+  updateError?: Error | null;
+};
+
+const defaultAdjustment = {
+  status: 'DRAFT',
+  warehouse_id: 'warehouse-1',
+  posting_date: '2026-08-20',
+  adjustment_number: 'ADJ-135',
+  reference_number: 'REF-135',
+  adjustment_type: 'PHYSICAL_COUNT',
+  increase_account_id: 'increase-account',
+  decrease_account_id: 'decrease-account',
+  reason: 'Focused submit helper test',
+};
+
+const defaultItems = [
+  {
+    product_id: 'product-increase',
+    warehouse_id: null,
+    difference_qty: 3,
+    new_qty: 13,
+    current_rate: 5,
+    value_difference: 15,
+  },
+  {
+    product_id: 'product-decrease',
+    warehouse_id: 'warehouse-item',
+    difference_qty: -2,
+    new_qty: 6,
+    current_rate: 7,
+    value_difference: -14,
+  },
+];
+
+function createSubmitHarness(options: HarnessOptions = {}) {
+  const operations: string[] = [];
+  const ledgerWrites: Array<Array<Record<string, unknown>>> = [];
+  const statusWrites: Array<Record<string, unknown>> = [];
+  const rpcCalls: Array<{ name: string; args: Record<string, unknown> }> = [];
+  const warehouseAccounts = [...(options.warehouseAccounts ?? ['inventory-account', 'inventory-account'])];
+
+  const adjustmentResult = {
+    data: options.adjustment === undefined ? defaultAdjustment : options.adjustment,
+    error: options.adjustmentError ?? null,
+  };
+  const itemsResult = {
+    data: options.items === undefined ? defaultItems : options.items,
+    error: options.itemsError ?? null,
+  };
+
+  const from = vi.fn((table: string) => {
+    if (table === 'stock_adjustments') {
+      return {
+        select: vi.fn(() => {
+          operations.push('select:adjustment');
+          return {
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                single: vi.fn(async () => adjustmentResult),
+              })),
+            })),
+          };
+        }),
+        update: vi.fn((payload: Record<string, unknown>) => {
+          operations.push('update:submitted');
+          statusWrites.push(payload);
+          return {
+            eq: vi.fn(() => ({
+              eq: vi.fn(async () => ({ data: null, error: options.updateError ?? null })),
+            })),
+          };
+        }),
+      };
+    }
+
+    if (table === 'stock_adjustment_items') {
+      return {
+        select: vi.fn(() => {
+          operations.push('select:items');
+          return {
+            eq: vi.fn(() => ({
+              eq: vi.fn(async () => itemsResult),
+            })),
+          };
+        }),
+      };
+    }
+
+    if (table === 'stock_ledger_entries') {
+      return {
+        insert: vi.fn(async (payload: Array<Record<string, unknown>>) => {
+          operations.push('insert:ledger');
+          ledgerWrites.push(payload);
+          return { data: null, error: options.ledgerError ?? null };
+        }),
+      };
+    }
+
+    if (table === 'warehouses') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn(async () => {
+                operations.push('select:warehouse');
+                return {
+                  data: { inventory_account_id: warehouseAccounts.shift() ?? null },
+                  error: null,
+                };
+              }),
+            })),
+          })),
+        })),
+      };
+    }
+
+    throw new Error(`Unexpected table: ${table}`);
+  });
+
+  const rpc = vi.fn(async (name: string, args: Record<string, unknown>) => {
+    operations.push('rpc:journal');
+    rpcCalls.push({ name, args });
+    return {
+      data: options.rpcData === undefined ? { success: true } : options.rpcData,
+      error: options.rpcError ?? null,
+    };
+  });
+
+  return {
+    supabase: { from, rpc } as unknown as SupabaseClient<Database>,
+    operations,
+    ledgerWrites,
+    statusWrites,
+    rpcCalls,
+  };
+}
+
+function submit(
+  harness: ReturnType<typeof createSubmitHarness>,
+  overrides: {
+    validateUom?: () => string | null;
+    onJournalWarning?: (message: string) => void;
+  } = {},
+) {
+  return submitStockAdjustmentDraft({
+    supabase: harness.supabase,
+    adjustmentId: 'adjustment-135',
+    orgId: 'org-1',
+    userId: 'user-1',
+    validateUom: overrides.validateUom ?? (() => null),
+    onJournalWarning: overrides.onJournalWarning ?? vi.fn(),
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('submitStockAdjustmentDraft', () => {
+  it.each([
+    ['missing adjustment', { adjustment: null }, 'لم يتم العثور على التسوية'],
+    ['adjustment lookup failure', { adjustmentError: new Error('lookup failed') }, 'لم يتم العثور على التسوية'],
+    ['non-draft adjustment', { adjustment: { ...defaultAdjustment, status: 'SUBMITTED' } }, 'يمكن فقط ترحيل التسويات بحالة مسودة'],
+    ['missing items', { items: [] }, 'لم يتم العثور على بنود التسوية'],
+    ['item lookup failure', { itemsError: new Error('items failed') }, 'لم يتم العثور على بنود التسوية'],
+  ] as const)('returns before ledger writes for %s', async (_case, options, message) => {
+    const harness = createSubmitHarness(options);
+
+    await expect(submit(harness)).resolves.toEqual({ ok: false, message });
+    expect(harness.operations).not.toContain('insert:ledger');
+    expect(harness.operations).not.toContain('update:submitted');
+  });
+
+  it('fails closed on UoM validation before ledger writes', async () => {
+    const harness = createSubmitHarness();
+
+    await expect(submit(harness, {
+      validateUom: () => 'UoM is not ready',
+    })).resolves.toEqual({ ok: false, message: 'UoM is not ready' });
+
+    expect(harness.operations).toEqual(['select:adjustment', 'select:items']);
+  });
+
+  it('requires an adjustment warehouse before ledger writes', async () => {
+    const harness = createSubmitHarness({
+      adjustment: { ...defaultAdjustment, warehouse_id: null },
+    });
+
+    await expect(submit(harness)).resolves.toEqual({
+      ok: false,
+      message: 'لم يتم تحديد المخزن في التسوية',
+    });
+    expect(harness.operations).not.toContain('insert:ledger');
+  });
+
+  it('creates ledger and journal entries in the locked order before marking submitted', async () => {
+    const harness = createSubmitHarness();
+
+    await expect(submit(harness)).resolves.toEqual({ ok: true });
+
+    expect(harness.operations).toEqual([
+      'select:adjustment',
+      'select:items',
+      'insert:ledger',
+      'select:warehouse',
+      'select:warehouse',
+      'rpc:journal',
+      'update:submitted',
+    ]);
+    expect(harness.ledgerWrites[0]).toEqual([
+      expect.objectContaining({
+        org_id: 'org-1',
+        product_id: 'product-increase',
+        warehouse_id: 'warehouse-1',
+        actual_qty: 3,
+        incoming_rate: 5,
+        outgoing_rate: 0,
+      }),
+      expect.objectContaining({
+        org_id: 'org-1',
+        product_id: 'product-decrease',
+        warehouse_id: 'warehouse-item',
+        actual_qty: -2,
+        incoming_rate: 0,
+        outgoing_rate: 7,
+      }),
+    ]);
+    expect(harness.rpcCalls).toEqual([{
+      name: 'rpc_create_journal_entry',
+      args: {
+        p_payload: expect.objectContaining({
+          org_id: 'org-1',
+          idempotency_key: 'stock-adj-adjustment-135',
+          lines: [
+            expect.objectContaining({ line_number: 1, account_id: 'inventory-account', debit: 15, credit: 0 }),
+            expect.objectContaining({ line_number: 2, account_id: 'increase-account', debit: 0, credit: 15 }),
+            expect.objectContaining({ line_number: 3, account_id: 'decrease-account', debit: 14, credit: 0 }),
+            expect.objectContaining({ line_number: 4, account_id: 'inventory-account', debit: 0, credit: 14 }),
+          ],
+        }),
+      },
+    }]);
+    expect(harness.statusWrites).toEqual([
+      expect.objectContaining({ status: 'SUBMITTED', submitted_by: 'user-1' }),
+    ]);
+  });
+
+  it('surfaces a ledger failure before journal or status writes', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const harness = createSubmitHarness({ ledgerError: new Error('ledger failed') });
+
+    await expect(submit(harness)).rejects.toThrow('فشل في إنشاء قيود المخزون: ledger failed');
+    expect(harness.operations).not.toContain('rpc:journal');
+    expect(harness.operations).not.toContain('update:submitted');
+  });
+
+  it.each([
+    ['RPC transport failure', { rpcError: new Error('rpc failed') }, 'فشل في إنشاء القيد المحاسبي: rpc failed'],
+    ['RPC business failure', { rpcData: { success: false, error: 'posting refused' } }, 'posting refused'],
+  ] as const)('warns but still marks submitted after %s', async (_case, options, warning) => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const onJournalWarning = vi.fn();
+    const harness = createSubmitHarness(options);
+
+    await expect(submit(harness, { onJournalWarning })).resolves.toEqual({ ok: true });
+    expect(onJournalWarning).toHaveBeenCalledWith(warning);
+    expect(harness.operations.at(-1)).toBe('update:submitted');
+  });
+
+  it('skips the journal RPC when no journal lines can be built', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const harness = createSubmitHarness({ warehouseAccounts: [null, null] });
+
+    await expect(submit(harness)).resolves.toEqual({ ok: true });
+    expect(harness.operations).not.toContain('rpc:journal');
+    expect(harness.operations.at(-1)).toBe('update:submitted');
+  });
+
+  it('surfaces a submitted-status update failure after successful accounting writes', async () => {
+    const updateError = new Error('status update failed');
+    const harness = createSubmitHarness({ updateError });
+
+    await expect(submit(harness)).rejects.toBe(updateError);
+    expect(harness.operations).toContain('rpc:journal');
+    expect(harness.operations.at(-1)).toBe('update:submitted');
+  });
+});

--- a/src/features/inventory/helpers/__tests__/stockAdjustmentSubmit.test.ts
+++ b/src/features/inventory/helpers/__tests__/stockAdjustmentSubmit.test.ts
@@ -12,6 +12,7 @@ type HarnessOptions = {
   warehouseAccounts?: Array<string | null>;
   rpcData?: { success?: boolean; error?: string } | null;
   rpcError?: Error | null;
+  rpcThrown?: unknown;
   updateError?: Error | null;
 };
 
@@ -134,6 +135,7 @@ function createSubmitHarness(options: HarnessOptions = {}) {
   const rpc = vi.fn(async (name: string, args: Record<string, unknown>) => {
     operations.push('rpc:journal');
     rpcCalls.push({ name, args });
+    if (options.rpcThrown !== undefined) throw options.rpcThrown;
     return {
       data: options.rpcData === undefined ? { success: true } : options.rpcData,
       error: options.rpcError ?? null,
@@ -271,6 +273,8 @@ describe('submitStockAdjustmentDraft', () => {
   it.each([
     ['RPC transport failure', { rpcError: new Error('rpc failed') }, 'فشل في إنشاء القيد المحاسبي: rpc failed'],
     ['RPC business failure', { rpcData: { success: false, error: 'posting refused' } }, 'posting refused'],
+    ['thrown string', { rpcThrown: 'unexpected failure' }, 'unexpected failure'],
+    ['thrown object', { rpcThrown: { code: 'unexpected' } }, 'فشل غير معروف في إنشاء القيد المحاسبي'],
   ] as const)('warns but still marks submitted after %s', async (_case, options, warning) => {
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
     const onJournalWarning = vi.fn();

--- a/src/features/inventory/helpers/index.ts
+++ b/src/features/inventory/helpers/index.ts
@@ -4,3 +4,4 @@
 
 export * from './stockAdjustmentHelpers';
 export * from './stockAdjustmentSave';
+export * from './stockAdjustmentSubmit';

--- a/src/features/inventory/helpers/stockAdjustmentSubmit.ts
+++ b/src/features/inventory/helpers/stockAdjustmentSubmit.ts
@@ -1,0 +1,195 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '@/lib/supabase'
+
+type SubmissionItem = {
+  product_id: string
+  warehouse_id: string | null
+  difference_qty: number
+  new_qty: number
+  current_rate: number
+  value_difference: number
+}
+
+type SubmissionAdjustment = {
+  status: string
+  warehouse_id: string | null
+  posting_date: string
+  adjustment_number: string | null
+  reference_number: string | null
+  adjustment_type: string
+  increase_account_id: string | null
+  decrease_account_id: string | null
+  reason: string
+}
+
+type JournalEntryLine = {
+  account_id: string
+  debit: number
+  credit: number
+  description: string
+}
+
+interface SubmitStockAdjustmentDraftParams {
+  supabase: SupabaseClient<Database>
+  adjustmentId: string
+  orgId: string
+  userId: string
+  validateUom: (items: Array<{ product_id: string }>) => string | null
+  onJournalWarning: (message: string) => void
+}
+
+type SubmitStockAdjustmentDraftResult =
+  | { ok: true }
+  | { ok: false; message: string }
+
+async function loadSubmissionContext(
+  supabase: SupabaseClient<Database>, adjustmentId: string, orgId: string,
+): Promise<{ adjustment: SubmissionAdjustment; items: SubmissionItem[] } | { message: string }> {
+  const { data: adjustment, error: adjError } = await supabase
+    .from('stock_adjustments')
+    .select('*')
+    .eq('id', adjustmentId)
+    .eq('organization_id', orgId)
+    .single()
+  if (adjError || !adjustment) return { message: 'لم يتم العثور على التسوية' }
+  if (adjustment.status !== 'DRAFT') return { message: 'يمكن فقط ترحيل التسويات بحالة مسودة' }
+
+  const { data: items, error: itemsError } = await supabase
+    .from('stock_adjustment_items')
+    .select('*')
+    .eq('adjustment_id', adjustmentId)
+    .eq('organization_id', orgId)
+  if (itemsError || !items || items.length === 0) return { message: 'لم يتم العثور على بنود التسوية' }
+  return { adjustment: adjustment as SubmissionAdjustment, items: items as SubmissionItem[] }
+}
+
+async function insertStockLedgerEntries(
+  supabase: SupabaseClient<Database>, adjustment: SubmissionAdjustment,
+  items: SubmissionItem[], adjustmentId: string, orgId: string, userId: string,
+): Promise<void> {
+  const warehouseId = adjustment.warehouse_id as string
+  const stockLedgerEntries = items.map((item) => ({
+    org_id: orgId,
+    posting_date: adjustment.posting_date,
+    posting_time: new Date().toTimeString().split(' ')[0],
+    voucher_type: 'Stock Adjustment',
+    voucher_id: adjustmentId,
+    voucher_number: adjustment.adjustment_number || adjustment.reference_number || `ADJ-${adjustmentId.substring(0, 8)}`,
+    product_id: item.product_id,
+    warehouse_id: item.warehouse_id || warehouseId,
+    actual_qty: item.difference_qty,
+    qty_after_transaction: item.new_qty,
+    incoming_rate: item.difference_qty > 0 ? item.current_rate : 0,
+    outgoing_rate: item.difference_qty < 0 ? item.current_rate : 0,
+    valuation_rate: item.current_rate,
+    stock_value: item.new_qty * item.current_rate,
+    stock_value_difference: item.value_difference,
+    is_cancelled: false,
+    created_by: userId,
+  }))
+  const { error: ledgerError } = await supabase.from('stock_ledger_entries').insert(stockLedgerEntries)
+  if (ledgerError) {
+    console.error('Error creating stock ledger entries:', ledgerError)
+    throw new Error('فشل في إنشاء قيود المخزون: ' + ledgerError.message)
+  }
+}
+
+async function appendIncreaseJournalEntries(
+  supabase: SupabaseClient<Database>, adjustment: SubmissionAdjustment,
+  adjustmentId: string, orgId: string, totalIncrease: number, journalEntries: JournalEntryLine[],
+): Promise<void> {
+  if (!(totalIncrease > 0 && adjustment.increase_account_id)) return
+  const { data: warehouseData } = await supabase
+    .from('warehouses').select('inventory_account_id')
+    .eq('id', adjustment.warehouse_id).eq('org_id', orgId).single()
+  if (warehouseData?.inventory_account_id) {
+    journalEntries.push({ account_id: warehouseData.inventory_account_id, debit: totalIncrease, credit: 0, description: `زيادة مخزون - ${adjustment.adjustment_type} - ${adjustment.reference_number || adjustmentId}` })
+    journalEntries.push({ account_id: adjustment.increase_account_id, debit: 0, credit: totalIncrease, description: `زيادة مخزون - ${adjustment.adjustment_type} - ${adjustment.reference_number || adjustmentId}` })
+  }
+}
+
+async function appendDecreaseJournalEntries(
+  supabase: SupabaseClient<Database>, adjustment: SubmissionAdjustment,
+  adjustmentId: string, orgId: string, totalDecrease: number, journalEntries: JournalEntryLine[],
+): Promise<void> {
+  if (!(totalDecrease > 0 && adjustment.decrease_account_id)) return
+  const { data: warehouseData } = await supabase
+    .from('warehouses').select('inventory_account_id')
+    .eq('id', adjustment.warehouse_id).eq('org_id', orgId).single()
+  if (warehouseData?.inventory_account_id) {
+    journalEntries.push({ account_id: adjustment.decrease_account_id, debit: totalDecrease, credit: 0, description: `نقص مخزون - ${adjustment.adjustment_type} - ${adjustment.reference_number || adjustmentId}` })
+    journalEntries.push({ account_id: warehouseData.inventory_account_id, debit: 0, credit: totalDecrease, description: `نقص مخزون - ${adjustment.adjustment_type} - ${adjustment.reference_number || adjustmentId}` })
+  }
+}
+
+async function createJournalEntry(
+  supabase: SupabaseClient<Database>, adjustment: SubmissionAdjustment,
+  items: SubmissionItem[], adjustmentId: string, orgId: string,
+): Promise<void> {
+  const totalIncrease = items.filter((item) => item.difference_qty > 0).reduce((sum, item) => sum + item.value_difference, 0)
+  const totalDecrease = items.filter((item) => item.difference_qty < 0).reduce((sum, item) => sum + Math.abs(item.value_difference), 0)
+  const journalEntries: JournalEntryLine[] = []
+  await appendIncreaseJournalEntries(supabase, adjustment, adjustmentId, orgId, totalIncrease, journalEntries)
+  await appendDecreaseJournalEntries(supabase, adjustment, adjustmentId, orgId, totalDecrease, journalEntries)
+  if (journalEntries.length === 0) {
+    console.warn('⚠️ No journal entries to create')
+    return
+  }
+  const { data: rpcResult, error: rpcError } = await supabase.rpc('rpc_create_journal_entry', {
+    p_payload: {
+      org_id: orgId,
+      entry_date: adjustment.posting_date,
+      entry_type: 'manual',
+      reference_type: 'stock_adjustments',
+      reference_number: adjustment.reference_number || adjustment.adjustment_number || `ADJ-${adjustmentId.substring(0, 8)}`,
+      description: `تسوية مخزون - ${adjustment.reason}`,
+      auto_post: true,
+      idempotency_key: `stock-adj-${adjustmentId}`,
+      lines: journalEntries.map((entry, idx) => ({
+        line_number: idx + 1,
+        account_id: entry.account_id,
+        debit: entry.debit || 0,
+        credit: entry.credit || 0,
+        description: entry.description || '',
+      })),
+    },
+  })
+  if (rpcError) {
+    console.error('Error creating GL entry:', rpcError)
+    throw new Error('فشل في إنشاء القيد المحاسبي: ' + rpcError.message)
+  }
+  const glResult = rpcResult as { success?: boolean; error?: string } | null
+  if (!glResult?.success) throw new Error(glResult?.error || 'فشل في إنشاء القيد المحاسبي')
+}
+
+async function markAdjustmentSubmitted(
+  supabase: SupabaseClient<Database>, adjustmentId: string, orgId: string, userId: string,
+): Promise<void> {
+  const { error: updateError } = await supabase
+    .from('stock_adjustments')
+    .update({ status: 'SUBMITTED', submitted_at: new Date().toISOString(), submitted_by: userId })
+    .eq('id', adjustmentId)
+    .eq('organization_id', orgId)
+  if (updateError) throw updateError
+}
+
+export async function submitStockAdjustmentDraft({
+  supabase, adjustmentId, orgId, userId, validateUom, onJournalWarning,
+}: SubmitStockAdjustmentDraftParams): Promise<SubmitStockAdjustmentDraftResult> {
+  const context = await loadSubmissionContext(supabase, adjustmentId, orgId)
+  if ('message' in context) return { ok: false, message: context.message }
+  const { adjustment, items } = context
+  const uomError = validateUom(items)
+  if (uomError) return { ok: false, message: uomError }
+  if (!adjustment.warehouse_id) return { ok: false, message: 'لم يتم تحديد المخزن في التسوية' }
+
+  await insertStockLedgerEntries(supabase, adjustment, items, adjustmentId, orgId, userId)
+  try {
+    await createJournalEntry(supabase, adjustment, items, adjustmentId, orgId)
+  } catch (jeError: any) {
+    console.error('Error creating journal entries:', jeError)
+    onJournalWarning(jeError.message)
+  }
+  await markAdjustmentSubmitted(supabase, adjustmentId, orgId, userId)
+  return { ok: true }
+}

--- a/src/features/inventory/helpers/stockAdjustmentSubmit.ts
+++ b/src/features/inventory/helpers/stockAdjustmentSubmit.ts
@@ -177,6 +177,12 @@ async function markAdjustmentSubmitted(
   if (updateError) throw updateError
 }
 
+function getJournalErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  if (typeof error === 'string') return error
+  return 'فشل غير معروف في إنشاء القيد المحاسبي'
+}
+
 export async function submitStockAdjustmentDraft({
   supabase, adjustmentId, orgId, userId, validateUom, onJournalWarning,
 }: SubmitStockAdjustmentDraftParams): Promise<SubmitStockAdjustmentDraftResult> {
@@ -192,7 +198,7 @@ export async function submitStockAdjustmentDraft({
     await createJournalEntry(supabase, adjustment, items, adjustmentId, orgId)
   } catch (jeError: unknown) {
     console.error('Error creating journal entries:', jeError)
-    onJournalWarning(jeError instanceof Error ? jeError.message : String(jeError))
+    onJournalWarning(getJournalErrorMessage(jeError))
   }
   await markAdjustmentSubmitted(supabase, adjustmentId, orgId, userId)
   return { ok: true }

--- a/src/features/inventory/helpers/stockAdjustmentSubmit.ts
+++ b/src/features/inventory/helpers/stockAdjustmentSubmit.ts
@@ -103,8 +103,10 @@ async function appendIncreaseJournalEntries(
     .from('warehouses').select('inventory_account_id')
     .eq('id', adjustment.warehouse_id).eq('org_id', orgId).single()
   if (warehouseData?.inventory_account_id) {
-    journalEntries.push({ account_id: warehouseData.inventory_account_id, debit: totalIncrease, credit: 0, description: `زيادة مخزون - ${adjustment.adjustment_type} - ${adjustment.reference_number || adjustmentId}` })
-    journalEntries.push({ account_id: adjustment.increase_account_id, debit: 0, credit: totalIncrease, description: `زيادة مخزون - ${adjustment.adjustment_type} - ${adjustment.reference_number || adjustmentId}` })
+    journalEntries.push(
+      { account_id: warehouseData.inventory_account_id, debit: totalIncrease, credit: 0, description: `زيادة مخزون - ${adjustment.adjustment_type} - ${adjustment.reference_number || adjustmentId}` },
+      { account_id: adjustment.increase_account_id, debit: 0, credit: totalIncrease, description: `زيادة مخزون - ${adjustment.adjustment_type} - ${adjustment.reference_number || adjustmentId}` },
+    )
   }
 }
 
@@ -117,8 +119,10 @@ async function appendDecreaseJournalEntries(
     .from('warehouses').select('inventory_account_id')
     .eq('id', adjustment.warehouse_id).eq('org_id', orgId).single()
   if (warehouseData?.inventory_account_id) {
-    journalEntries.push({ account_id: adjustment.decrease_account_id, debit: totalDecrease, credit: 0, description: `نقص مخزون - ${adjustment.adjustment_type} - ${adjustment.reference_number || adjustmentId}` })
-    journalEntries.push({ account_id: warehouseData.inventory_account_id, debit: 0, credit: totalDecrease, description: `نقص مخزون - ${adjustment.adjustment_type} - ${adjustment.reference_number || adjustmentId}` })
+    journalEntries.push(
+      { account_id: adjustment.decrease_account_id, debit: totalDecrease, credit: 0, description: `نقص مخزون - ${adjustment.adjustment_type} - ${adjustment.reference_number || adjustmentId}` },
+      { account_id: warehouseData.inventory_account_id, debit: 0, credit: totalDecrease, description: `نقص مخزون - ${adjustment.adjustment_type} - ${adjustment.reference_number || adjustmentId}` },
+    )
   }
 }
 
@@ -186,9 +190,9 @@ export async function submitStockAdjustmentDraft({
   await insertStockLedgerEntries(supabase, adjustment, items, adjustmentId, orgId, userId)
   try {
     await createJournalEntry(supabase, adjustment, items, adjustmentId, orgId)
-  } catch (jeError: any) {
+  } catch (jeError: unknown) {
     console.error('Error creating journal entries:', jeError)
-    onJournalWarning(jeError.message)
+    onJournalWarning(jeError instanceof Error ? jeError.message : String(jeError))
   }
   await markAdjustmentSubmitted(supabase, adjustmentId, orgId, userId)
   return { ok: true }

--- a/src/features/inventory/index.tsx
+++ b/src/features/inventory/index.tsx
@@ -27,6 +27,7 @@ import {
   createAdjustmentItem,
   findUnmappedAdjustmentProductIds,
   saveStockAdjustmentDraft,
+  submitStockAdjustmentDraft,
   updateAdjustmentItemQuantity,
   validateAdjustmentForm,
   type AdjustmentItem,
@@ -1192,216 +1193,36 @@ function StockAdjustments() {
         return
       }
 
-      // Get user's organization
       if (!currentOrgId) {
         toast.error('لم يتم تحديد المؤسسة النشطة')
         return
       }
 
-      // Get adjustment with items
-      const { data: adjustment, error: adjError } = await supabase
-        .from('stock_adjustments')
-        .select('*')
-        .eq('id', adjustmentId)
-        .eq('organization_id', currentOrgId)
-        .single()
-
-      if (adjError || !adjustment) {
-        toast.error('لم يتم العثور على التسوية')
-        return
-      }
-
-      if (adjustment.status !== 'DRAFT') {
-        toast.error('يمكن فقط ترحيل التسويات بحالة مسودة')
-        return
-      }
-
-      // Get adjustment items
-      const { data: items, error: itemsError } = await supabase
-        .from('stock_adjustment_items')
-        .select('*')
-        .eq('adjustment_id', adjustmentId)
-        .eq('organization_id', currentOrgId)
-
-      if (itemsError || !items || items.length === 0) {
-        toast.error('لم يتم العثور على بنود التسوية')
-        return
-      }
-
-      // Re-check UoM setup fail-closed before posting: an older draft may reference
-      // a product that is not (or no longer) MAPPED. Block before any SLE write.
-      if (productUomStatus.isEnabled && !productUomStatus.isSuccess) {
-        toast.error('جارٍ التحقق من إعداد وحدات الأصناف — أعد المحاولة بعد لحظات')
-        return
-      }
-      if (findUnmappedAdjustmentProductIds(items as Array<{ product_id: string }>, productNeedsUomSetup).length > 0) {
-        toast.error('لا يمكن الترحيل: توجد أصناف تحتاج إعداد وحدة في هذه التسوية')
-        return
-      }
-
-      // Use the warehouse from the adjustment
-      const warehouseId = adjustment.warehouse_id
-
-      if (!warehouseId) {
-        toast.error('لم يتم تحديد المخزن في التسوية')
-        return
-      }
-
-      // Create stock ledger entries for each item
-      const stockLedgerEntries = items.map((item: any) => ({
-        org_id: currentOrgId,
-        posting_date: adjustment.posting_date,
-        posting_time: new Date().toTimeString().split(' ')[0],
-        voucher_type: 'Stock Adjustment',
-        voucher_id: adjustmentId,
-        voucher_number: adjustment.adjustment_number || adjustment.reference_number || `ADJ-${adjustmentId.substring(0, 8)}`,
-        product_id: item.product_id,
-        warehouse_id: item.warehouse_id || warehouseId, // Use item's warehouse or adjustment's warehouse
-        actual_qty: item.difference_qty,
-        qty_after_transaction: item.new_qty,
-        incoming_rate: item.difference_qty > 0 ? item.current_rate : 0,
-        outgoing_rate: item.difference_qty < 0 ? item.current_rate : 0,
-        valuation_rate: item.current_rate,
-        stock_value: item.new_qty * item.current_rate,
-        stock_value_difference: item.value_difference,
-        is_cancelled: false,
-        created_by: user.id
-      }))
-
-      const { error: ledgerError } = await supabase
-        .from('stock_ledger_entries')
-        .insert(stockLedgerEntries)
-
-      if (ledgerError) {
-        console.error('Error creating stock ledger entries:', ledgerError)
-        throw new Error('فشل في إنشاء قيود المخزون: ' + ledgerError.message)
-      }
-
-      // Create Journal Entries for accounting integration
-      try {
-        // Calculate totals for increases and decreases
-        const totalIncrease = items
-          .filter((item: any) => item.difference_qty > 0)
-          .reduce((sum: number, item: any) => sum + item.value_difference, 0)
-        
-        const totalDecrease = items
-          .filter((item: any) => item.difference_qty < 0)
-          .reduce((sum: number, item: any) => sum + Math.abs(item.value_difference), 0)
-
-        const journalEntries = []
-
-        // Entry for increases (Dr: Inventory Asset, Cr: Adjustment Account)
-        if (totalIncrease > 0 && adjustment.increase_account_id) {
-          const { data: warehouseData } = await supabase
-            .from('warehouses')
-            .select('inventory_account_id')
-            .eq('id', adjustment.warehouse_id)
-            .eq('org_id', currentOrgId)
-            .single()
-
-          if (warehouseData?.inventory_account_id) {
-            journalEntries.push({
-              account_id: warehouseData.inventory_account_id,
-              debit: totalIncrease,
-              credit: 0,
-              description: `زيادة مخزون - ${adjustment.adjustment_type} - ${adjustment.reference_number || adjustmentId}`
-            })
-            journalEntries.push({
-              account_id: adjustment.increase_account_id,
-              debit: 0,
-              credit: totalIncrease,
-              description: `زيادة مخزون - ${adjustment.adjustment_type} - ${adjustment.reference_number || adjustmentId}`
-            })
+      const result = await submitStockAdjustmentDraft({
+        supabase,
+        adjustmentId,
+        orgId: currentOrgId,
+        userId: user.id,
+        validateUom: (items) => {
+          if (productUomStatus.isEnabled && !productUomStatus.isSuccess) {
+            return 'جارٍ التحقق من إعداد وحدات الأصناف — أعد المحاولة بعد لحظات'
           }
-        }
-
-        // Entry for decreases (Dr: Expense Account, Cr: Inventory Asset)
-        if (totalDecrease > 0 && adjustment.decrease_account_id) {
-          const { data: warehouseData } = await supabase
-            .from('warehouses')
-            .select('inventory_account_id')
-            .eq('id', adjustment.warehouse_id)
-            .eq('org_id', currentOrgId)
-            .single()
-
-          if (warehouseData?.inventory_account_id) {
-            journalEntries.push({
-              account_id: adjustment.decrease_account_id,
-              debit: totalDecrease,
-              credit: 0,
-              description: `نقص مخزون - ${adjustment.adjustment_type} - ${adjustment.reference_number || adjustmentId}`
-            })
-            journalEntries.push({
-              account_id: warehouseData.inventory_account_id,
-              debit: 0,
-              credit: totalDecrease,
-              description: `نقص مخزون - ${adjustment.adjustment_type} - ${adjustment.reference_number || adjustmentId}`
-            })
+          if (findUnmappedAdjustmentProductIds(items, productNeedsUomSetup).length > 0) {
+            return 'لا يمكن الترحيل: توجد أصناف تحتاج إعداد وحدة في هذه التسوية'
           }
-        }
+          return null
+        },
+        onJournalWarning: (message) => {
+          toast.warning('تم ترحيل التسوية لكن فشل إنشاء القيود المحاسبية: ' + message)
+        },
+      })
 
-        // Insert journal entries if any — عبر القناة القانونية الوحيدة للكتابة على GL
-        // (كان الرأس يُدرج في gl_entries والسطور في journal_lines القديم ⇒ قيود بلا سطور)
-        if (journalEntries.length > 0) {
-          const { data: rpcResult, error: rpcError } = await supabase.rpc(
-            'rpc_create_journal_entry',
-            {
-              p_payload: {
-                org_id: currentOrgId,
-                entry_date: adjustment.posting_date,
-                entry_type: 'manual',
-                reference_type: 'stock_adjustments',
-                reference_number: adjustment.reference_number
-                  || adjustment.adjustment_number
-                  || `ADJ-${adjustmentId.substring(0, 8)}`,
-                description: `تسوية مخزون - ${adjustment.reason}`,
-                auto_post: true,
-                // نفس مفتاح stock-adjustment-service — تكرار الترحيل من أي مسار = replay
-                idempotency_key: `stock-adj-${adjustmentId}`,
-                lines: journalEntries.map((entry: any, idx: number) => ({
-                  line_number: idx + 1,
-                  account_id: entry.account_id,
-                  debit: entry.debit || 0,
-                  credit: entry.credit || 0,
-                  description: entry.description || ''
-                }))
-              }
-            }
-          )
-
-          if (rpcError) {
-            console.error('Error creating GL entry:', rpcError)
-            throw new Error('فشل في إنشاء القيد المحاسبي: ' + rpcError.message)
-          }
-          const glResult = rpcResult as { success?: boolean; error?: string } | null
-          if (!glResult?.success) {
-            throw new Error(glResult?.error || 'فشل في إنشاء القيد المحاسبي')
-          }
-        } else {
-          console.warn('⚠️ No journal entries to create')
-        }
-      } catch (jeError: any) {
-        console.error('Error creating journal entries:', jeError)
-        // Don't fail the whole operation if journal entry creation fails
-        toast.warning('تم ترحيل التسوية لكن فشل إنشاء القيود المحاسبية: ' + jeError.message)
+      if ('message' in result) {
+        toast.error(result.message)
+        return
       }
-      
-      // Update adjustment status to SUBMITTED
-      const { error: updateError } = await supabase
-        .from('stock_adjustments')
-        .update({
-          status: 'SUBMITTED',
-          submitted_at: new Date().toISOString(),
-          submitted_by: user.id
-        })
-        .eq('id', adjustmentId)
-        .eq('organization_id', currentOrgId)
-
-      if (updateError) throw updateError
 
       toast.success('✅ تم ترحيل التسوية بنجاح وتحديث قيود المخزون')
-      
-      // Close view mode and reload
       setViewMode(false)
       setSelectedAdjustment(null)
       loadAdjustments()


### PR DESCRIPTION
## Phase 3 — Slice 2

Behavior-preserving extraction of the Stock Adjustments submit orchestration, rebased onto `main@8aa7d5ab5ffa579bbb0e95e52cbd98c2905b8f36`.

### Final scope
- Extract `handleSubmitAdjustment` persistence/accounting orchestration into `src/features/inventory/helpers/stockAdjustmentSubmit.ts`.
- Preserve permission → independent `auth.getUser()` → organization guard ordering.
- Preserve adjustment/items lookup → UoM guard → warehouse guard → stock-ledger write → nested GL attempt → `SUBMITTED` ordering.
- Preserve the red-line behavior: after a successful stock-ledger write, GL failure warns but does not block marking the adjustment `SUBMITTED`.
- Preserve separate increase/decrease warehouse lookups, journal directions/amounts, and `stock-adj-${adjustmentId}` idempotency.
- Keep organization scoping asserted in the extracted helper.
- Add focused helper coverage for guards, write ordering, ledger/RPC/status failures, journal warnings, and no-line behavior.

### Final diff
- `src/features/inventory/__tests__/stock-adjustment-org-scope.test.ts`
- `src/features/inventory/helpers/__tests__/stockAdjustmentSubmit.test.ts`
- `src/features/inventory/helpers/index.ts`
- `src/features/inventory/helpers/stockAdjustmentSubmit.ts`
- `src/features/inventory/index.tsx`

No `handleSaveAdjustment` changes, migrations, workflow changes, or unrelated production changes.

### Validation on head `21156c4b0b594385c0e31ca62d2362b5ab295ffc`
- CI/CD Pipeline — success
- SonarQube Analysis — success; 0 open PR issues, 95.4% new-code coverage, 0.0% new duplication
- Regenerate UoM Database Types — success
- Vercel preview — success
- Netlify preview — success
- Full Vitest — 285 files / 4461 tests passed
- Focused submit + behavior-lock tests — 32/32 passed
- TypeScript, production-helper ESLint, build, demo-password gate, and `git diff --check` — success
- Unresolved review threads — 0