### PR TITLE
refactor(inventory): extract StockAdjustments submit orchestration

### DIFF
--- a/.github/workflows/phase3-slice2-submit-refactor.yml
+++ b/.github/workflows/phase3-slice2-submit-refactor.yml
@@ -39,7 +39,7 @@ jobs:
         run: npm ci
 
       - name: Focused behavior lock
-        run: npx vitest run src/features/inventory/__tests__/stock-adjustments-behavior-lock.test.tsx
+        run: npx vitest run src/features/inventory/__tests__/stock-adjustments-behavior-lock.test.tsx --coverage.enabled=false
 
       - name: TypeScript
         run: npx tsc --noEmit -p tsconfig.json

--- a/.github/workflows/phase3-slice2-submit-refactor.yml
+++ b/.github/workflows/phase3-slice2-submit-refactor.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 4
+          fetch-depth: 0
 
       - name: Verify exact ancestry
         shell: bash

--- a/.github/workflows/phase3-slice2-submit-refactor.yml
+++ b/.github/workflows/phase3-slice2-submit-refactor.yml
@@ -1,0 +1,66 @@
+name: Phase 3 Slice 2 Submit Refactor
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - .github/workflows/phase3-slice2-submit-refactor.yml
+      - scripts/ci/phase3_slice2_submit_refactor.py
+
+permissions:
+  contents: write
+
+jobs:
+  guarded-refactor:
+    if: github.event.pull_request.head.ref == 'agent/stock-adjustments-submit-refactor-phase3-v2'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout exact PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 4
+
+      - name: Verify exact ancestry
+        shell: bash
+        run: |
+          set -euo pipefail
+          BASE="4e88d72df4037949ac5e0b365337ac95c03e290b"
+          git cat-file -e "$BASE^{commit}"
+          test "$(git merge-base HEAD "$BASE")" = "$BASE"
+          test "$(git diff --name-only "$BASE"...HEAD | sort)" = $'.github/workflows/phase3-slice2-submit-refactor.yml\nscripts/ci/phase3_slice2_submit_refactor.py'
+
+      - name: Apply submit extraction
+        run: |
+          python3 scripts/ci/phase3_slice2_submit_refactor.py
+          git diff --check
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Focused behavior lock
+        run: npx vitest run src/features/inventory/__tests__/stock-adjustments-behavior-lock.test.tsx
+
+      - name: TypeScript
+        run: npx tsc --noEmit -p tsconfig.json
+
+      - name: ESLint changed source
+        run: npx eslint src/features/inventory/index.tsx src/features/inventory/helpers/stockAdjustmentSubmit.ts src/features/inventory/helpers/index.ts
+
+      - name: Full Vitest
+        run: npx vitest run
+
+      - name: Production build
+        run: npm run build
+
+      - name: Commit verified refactor and remove staging files
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git rm .github/workflows/phase3-slice2-submit-refactor.yml scripts/ci/phase3_slice2_submit_refactor.py
+          git add src/features/inventory/index.tsx src/features/inventory/helpers/index.ts src/features/inventory/helpers/stockAdjustmentSubmit.ts
+          test "$(git diff --cached --name-only | sort)" = $'.github/workflows/phase3-slice2-submit-refactor.yml\nscripts/ci/phase3_slice2_submit_refactor.py\nsrc/features/inventory/helpers/index.ts\nsrc/features/inventory/helpers/stockAdjustmentSubmit.ts\nsrc/features/inventory/index.tsx'
+          git commit -m "refactor(inventory): extract stock adjustment submit orchestration"
+          git push origin HEAD:agent/stock-adjustments-submit-refactor-phase3-v2

--- a/.github/workflows/phase3-slice2-submit-refactor.yml
+++ b/.github/workflows/phase3-slice2-submit-refactor.yml
@@ -33,6 +33,16 @@ jobs:
       - name: Apply submit extraction
         run: |
           python3 scripts/ci/phase3_slice2_submit_refactor.py
+          python3 - <<'PY'
+          from pathlib import Path
+          path = Path('src/features/inventory/index.tsx')
+          text = path.read_text(encoding='utf-8')
+          old = '      if (!result.ok) {'
+          new = '      if (result.ok === false) {'
+          if text.count(old) != 1:
+              raise SystemExit('Guard failed: submit result condition changed')
+          path.write_text(text.replace(old, new, 1), encoding='utf-8')
+          PY
           git diff --check
 
       - name: Install dependencies

--- a/scripts/ci/phase3_slice2_submit_refactor.py
+++ b/scripts/ci/phase3_slice2_submit_refactor.py
@@ -1,0 +1,406 @@
+from pathlib import Path
+
+HELPER = r'''import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '@/lib/supabase'
+import { findUnmappedAdjustmentProductIds } from './stockAdjustmentHelpers'
+
+type Supabase = SupabaseClient<Database>
+type SubmissionRecord = any
+type SubmissionItem = any
+
+interface SubmitStockAdjustmentParams {
+  supabase: Supabase
+  adjustmentId: string
+  orgId: string
+  userId: string
+  uomStatus: {
+    isEnabled: boolean
+    isSuccess: boolean
+    needsSetup: (productId: string) => boolean
+  }
+  onJournalWarning: (message: string) => void
+}
+
+export type SubmitStockAdjustmentResult =
+  | { ok: true }
+  | { ok: false; message: string }
+
+type JournalEntryLine = {
+  account_id: string
+  debit: number
+  credit: number
+  description: string
+}
+
+async function loadAdjustment(
+  supabase: Supabase,
+  adjustmentId: string,
+  orgId: string,
+): Promise<SubmissionRecord | null> {
+  const { data: adjustment, error } = await supabase
+    .from('stock_adjustments')
+    .select('*')
+    .eq('id', adjustmentId)
+    .eq('organization_id', orgId)
+    .single()
+
+  return error || !adjustment ? null : adjustment
+}
+
+async function loadAdjustmentItems(
+  supabase: Supabase,
+  adjustmentId: string,
+  orgId: string,
+): Promise<SubmissionItem[] | null> {
+  const { data: items, error } = await supabase
+    .from('stock_adjustment_items')
+    .select('*')
+    .eq('adjustment_id', adjustmentId)
+    .eq('organization_id', orgId)
+
+  return error || !items || items.length === 0 ? null : items
+}
+
+function getUomFailure(
+  items: SubmissionItem[],
+  uomStatus: SubmitStockAdjustmentParams['uomStatus'],
+): string | null {
+  if (uomStatus.isEnabled && !uomStatus.isSuccess) {
+    return 'جارٍ التحقق من إعداد وحدات الأصناف — أعد المحاولة بعد لحظات'
+  }
+  if (findUnmappedAdjustmentProductIds(items, uomStatus.needsSetup).length > 0) {
+    return 'لا يمكن الترحيل: توجد أصناف تحتاج إعداد وحدة في هذه التسوية'
+  }
+  return null
+}
+
+async function insertStockLedgerEntries(
+  supabase: Supabase,
+  adjustment: SubmissionRecord,
+  items: SubmissionItem[],
+  adjustmentId: string,
+  orgId: string,
+  userId: string,
+  warehouseId: string,
+): Promise<void> {
+  const stockLedgerEntries = items.map((item: any) => ({
+    org_id: orgId,
+    posting_date: adjustment.posting_date,
+    posting_time: new Date().toTimeString().split(' ')[0],
+    voucher_type: 'Stock Adjustment',
+    voucher_id: adjustmentId,
+    voucher_number: adjustment.adjustment_number || adjustment.reference_number || `ADJ-${adjustmentId.substring(0, 8)}`,
+    product_id: item.product_id,
+    warehouse_id: item.warehouse_id || warehouseId,
+    actual_qty: item.difference_qty,
+    qty_after_transaction: item.new_qty,
+    incoming_rate: item.difference_qty > 0 ? item.current_rate : 0,
+    outgoing_rate: item.difference_qty < 0 ? item.current_rate : 0,
+    valuation_rate: item.current_rate,
+    stock_value: item.new_qty * item.current_rate,
+    stock_value_difference: item.value_difference,
+    is_cancelled: false,
+    created_by: userId,
+  }))
+
+  const { error: ledgerError } = await supabase
+    .from('stock_ledger_entries')
+    .insert(stockLedgerEntries)
+
+  if (ledgerError) {
+    console.error('Error creating stock ledger entries:', ledgerError)
+    throw new Error('فشل في إنشاء قيود المخزون: ' + ledgerError.message)
+  }
+}
+
+async function appendIncreaseJournalLines(
+  supabase: Supabase,
+  adjustment: SubmissionRecord,
+  adjustmentId: string,
+  orgId: string,
+  totalIncrease: number,
+  journalEntries: JournalEntryLine[],
+): Promise<void> {
+  if (!(totalIncrease > 0 && adjustment.increase_account_id)) return
+
+  const { data: warehouseData } = await supabase
+    .from('warehouses')
+    .select('inventory_account_id')
+    .eq('id', adjustment.warehouse_id)
+    .eq('org_id', orgId)
+    .single()
+
+  if (warehouseData?.inventory_account_id) {
+    journalEntries.push({
+      account_id: warehouseData.inventory_account_id,
+      debit: totalIncrease,
+      credit: 0,
+      description: `زيادة مخزون - ${adjustment.adjustment_type} - ${adjustment.reference_number || adjustmentId}`,
+    })
+    journalEntries.push({
+      account_id: adjustment.increase_account_id,
+      debit: 0,
+      credit: totalIncrease,
+      description: `زيادة مخزون - ${adjustment.adjustment_type} - ${adjustment.reference_number || adjustmentId}`,
+    })
+  }
+}
+
+async function appendDecreaseJournalLines(
+  supabase: Supabase,
+  adjustment: SubmissionRecord,
+  adjustmentId: string,
+  orgId: string,
+  totalDecrease: number,
+  journalEntries: JournalEntryLine[],
+): Promise<void> {
+  if (!(totalDecrease > 0 && adjustment.decrease_account_id)) return
+
+  const { data: warehouseData } = await supabase
+    .from('warehouses')
+    .select('inventory_account_id')
+    .eq('id', adjustment.warehouse_id)
+    .eq('org_id', orgId)
+    .single()
+
+  if (warehouseData?.inventory_account_id) {
+    journalEntries.push({
+      account_id: adjustment.decrease_account_id,
+      debit: totalDecrease,
+      credit: 0,
+      description: `نقص مخزون - ${adjustment.adjustment_type} - ${adjustment.reference_number || adjustmentId}`,
+    })
+    journalEntries.push({
+      account_id: warehouseData.inventory_account_id,
+      debit: 0,
+      credit: totalDecrease,
+      description: `نقص مخزون - ${adjustment.adjustment_type} - ${adjustment.reference_number || adjustmentId}`,
+    })
+  }
+}
+
+async function createAccountingJournalEntry(
+  supabase: Supabase,
+  adjustment: SubmissionRecord,
+  items: SubmissionItem[],
+  adjustmentId: string,
+  orgId: string,
+): Promise<void> {
+  const totalIncrease = items
+    .filter((item: any) => item.difference_qty > 0)
+    .reduce((sum: number, item: any) => sum + item.value_difference, 0)
+
+  const totalDecrease = items
+    .filter((item: any) => item.difference_qty < 0)
+    .reduce((sum: number, item: any) => sum + Math.abs(item.value_difference), 0)
+
+  const journalEntries: JournalEntryLine[] = []
+
+  await appendIncreaseJournalLines(
+    supabase,
+    adjustment,
+    adjustmentId,
+    orgId,
+    totalIncrease,
+    journalEntries,
+  )
+  await appendDecreaseJournalLines(
+    supabase,
+    adjustment,
+    adjustmentId,
+    orgId,
+    totalDecrease,
+    journalEntries,
+  )
+
+  if (journalEntries.length > 0) {
+    const { data: rpcResult, error: rpcError } = await supabase.rpc(
+      'rpc_create_journal_entry',
+      {
+        p_payload: {
+          org_id: orgId,
+          entry_date: adjustment.posting_date,
+          entry_type: 'manual',
+          reference_type: 'stock_adjustments',
+          reference_number: adjustment.reference_number
+            || adjustment.adjustment_number
+            || `ADJ-${adjustmentId.substring(0, 8)}`,
+          description: `تسوية مخزون - ${adjustment.reason}`,
+          auto_post: true,
+          idempotency_key: `stock-adj-${adjustmentId}`,
+          lines: journalEntries.map((entry: any, idx: number) => ({
+            line_number: idx + 1,
+            account_id: entry.account_id,
+            debit: entry.debit || 0,
+            credit: entry.credit || 0,
+            description: entry.description || '',
+          })),
+        },
+      },
+    )
+
+    if (rpcError) {
+      console.error('Error creating GL entry:', rpcError)
+      throw new Error('فشل في إنشاء القيد المحاسبي: ' + rpcError.message)
+    }
+    const glResult = rpcResult as { success?: boolean; error?: string } | null
+    if (!glResult?.success) {
+      throw new Error(glResult?.error || 'فشل في إنشاء القيد المحاسبي')
+    }
+  } else {
+    console.warn('⚠️ No journal entries to create')
+  }
+}
+
+async function markAdjustmentSubmitted(
+  supabase: Supabase,
+  adjustmentId: string,
+  orgId: string,
+  userId: string,
+): Promise<void> {
+  const { error: updateError } = await supabase
+    .from('stock_adjustments')
+    .update({
+      status: 'SUBMITTED',
+      submitted_at: new Date().toISOString(),
+      submitted_by: userId,
+    })
+    .eq('id', adjustmentId)
+    .eq('organization_id', orgId)
+
+  if (updateError) throw updateError
+}
+
+export async function submitStockAdjustment({
+  supabase,
+  adjustmentId,
+  orgId,
+  userId,
+  uomStatus,
+  onJournalWarning,
+}: SubmitStockAdjustmentParams): Promise<SubmitStockAdjustmentResult> {
+  const adjustment = await loadAdjustment(supabase, adjustmentId, orgId)
+  if (!adjustment) return { ok: false, message: 'لم يتم العثور على التسوية' }
+
+  if (adjustment.status !== 'DRAFT') {
+    return { ok: false, message: 'يمكن فقط ترحيل التسويات بحالة مسودة' }
+  }
+
+  const items = await loadAdjustmentItems(supabase, adjustmentId, orgId)
+  if (!items) return { ok: false, message: 'لم يتم العثور على بنود التسوية' }
+
+  const uomFailure = getUomFailure(items, uomStatus)
+  if (uomFailure) return { ok: false, message: uomFailure }
+
+  const warehouseId = adjustment.warehouse_id
+  if (!warehouseId) return { ok: false, message: 'لم يتم تحديد المخزن في التسوية' }
+
+  await insertStockLedgerEntries(
+    supabase,
+    adjustment,
+    items,
+    adjustmentId,
+    orgId,
+    userId,
+    warehouseId,
+  )
+
+  try {
+    await createAccountingJournalEntry(supabase, adjustment, items, adjustmentId, orgId)
+  } catch (jeError: any) {
+    console.error('Error creating journal entries:', jeError)
+    onJournalWarning('تم ترحيل التسوية لكن فشل إنشاء القيود المحاسبية: ' + jeError.message)
+  }
+
+  await markAdjustmentSubmitted(supabase, adjustmentId, orgId, userId)
+  return { ok: true }
+}
+'''
+
+HANDLER = r'''  const handleSubmitAdjustment = async (adjustmentId: string) => {
+    if (!canApproveAdjustment) {
+      toast.error('لا تملك صلاحية ترحيل تسويات المخزون')
+      return
+    }
+    try {
+      const supabase = getSupabase()
+      const { data: { user } } = await supabase.auth.getUser()
+
+      if (!user) {
+        toast.error('الرجاء تسجيل الدخول')
+        return
+      }
+
+      if (!currentOrgId) {
+        toast.error('لم يتم تحديد المؤسسة النشطة')
+        return
+      }
+
+      const result = await submitStockAdjustment({
+        supabase,
+        adjustmentId,
+        orgId: currentOrgId,
+        userId: user.id,
+        uomStatus: {
+          isEnabled: productUomStatus.isEnabled,
+          isSuccess: productUomStatus.isSuccess,
+          needsSetup: productNeedsUomSetup,
+        },
+        onJournalWarning: (message) => toast.warning(message),
+      })
+      if (!result.ok) {
+        toast.error(result.message)
+        return
+      }
+
+      toast.success('✅ تم ترحيل التسوية بنجاح وتحديث قيود المخزون')
+      setViewMode(false)
+      setSelectedAdjustment(null)
+      loadAdjustments()
+    } catch (error: any) {
+      console.error('Error submitting adjustment:', error)
+      toast.error(error.message || 'خطأ في ترحيل التسوية')
+    }
+  }'''
+
+
+def strip_trailing(text: str) -> str:
+    return '\n'.join(line.rstrip() for line in text.splitlines()) + '\n'
+
+
+def main() -> None:
+    helper_path = Path('src/features/inventory/helpers/stockAdjustmentSubmit.ts')
+    if helper_path.exists():
+        raise SystemExit('Guard failed: helper already exists')
+    helper_path.write_text(strip_trailing(HELPER), encoding='utf-8')
+
+    index_path = Path('src/features/inventory/index.tsx')
+    text = index_path.read_text(encoding='utf-8')
+    old_import = "  saveStockAdjustmentDraft,\n  updateAdjustmentItemQuantity,"
+    new_import = "  saveStockAdjustmentDraft,\n  submitStockAdjustment,\n  updateAdjustmentItemQuantity,"
+    if text.count(old_import) != 1:
+        raise SystemExit('Guard failed: helper import anchor changed')
+    text = text.replace(old_import, new_import, 1)
+
+    start_marker = "  const handleSubmitAdjustment = async (adjustmentId: string) => {"
+    end_marker = "\n\n  const filteredProducts = products.filter("
+    if text.count(start_marker) != 1 or text.count(end_marker) != 1:
+        raise SystemExit('Guard failed: submit handler anchors changed')
+    start = text.index(start_marker)
+    end = text.index(end_marker, start)
+    text = text[:start] + strip_trailing(HANDLER).rstrip('\n') + text[end:]
+    index_path.write_text(text, encoding='utf-8')
+
+    helpers_index = Path('src/features/inventory/helpers/index.ts')
+    helper_index_text = helpers_index.read_text(encoding='utf-8')
+    anchor = "export * from './stockAdjustmentSave';\n"
+    if helper_index_text.count(anchor) != 1:
+        raise SystemExit('Guard failed: helpers index anchor changed')
+    helpers_index.write_text(
+        helper_index_text.replace(anchor, anchor + "export * from './stockAdjustmentSubmit';\n", 1),
+        encoding='utf-8',
+    )
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Phase 3 — Slice 2

Behavior-preserving extraction of `handleSubmitAdjustment` only, starting from `main@4e88d72df4037949ac5e0b365337ac95c03e290b`.

This draft initially contains a temporary guarded PR workflow whose only purpose is to apply the extraction on the runner, execute the focused StockAdjustments behavior-lock suite, TypeScript, ESLint, full Vitest, and production build, and push source changes only if all gates pass. The workflow removes itself before that push.

Frozen contracts to preserve: permission → independent `auth.getUser()` → org → adjustment/DRAFT → items → UoM → warehouse → SLE → nested GL attempt → warning without abort on GL failure → `SUBMITTED`; exact journal ordering and `stock-adj-${adjustmentId}` idempotency key; separate increase/decrease warehouse reads; no migrations, no Production changes, and no outer `StockAdjustments` decomposition in this slice.

Do not merge without final review and explicit authorization.