### PR TITLE
refactor(inventory): decompose stock adjustment presentation

### DIFF
--- a/src/features/inventory/__tests__/stock-adjustments-behavior-lock.test.tsx
+++ b/src/features/inventory/__tests__/stock-adjustments-behavior-lock.test.tsx
@@ -345,6 +345,62 @@ beforeEach(() => {
   hasPermissionKeyMock.mockReturnValue(false);
 });
 
+describe('StockAdjustments — extracted details behavior lock', () => {
+  it('closes the details card without mutating the selected adjustment', async () => {
+    await openAdjustmentView();
+
+    await userEvent.click(screen.getByRole('button', { name: /إغلاق/ }));
+
+    expect(screen.queryByText('تفاصيل التسوية')).not.toBeInTheDocument();
+    expect(writePayloads).toHaveLength(0);
+  });
+
+  it('does not cancel when the user rejects the confirmation', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    await openAdjustmentView();
+    operationLog.length = 0;
+    writePayloads.length = 0;
+
+    await userEvent.click(screen.getByRole('button', { name: /إلغاء/ }));
+
+    expect(writePayloads).toHaveLength(0);
+    expect(screen.getByText('تفاصيل التسوية')).toBeInTheDocument();
+  });
+
+  it('preserves the CANCELLED update, success toast, close and reload sequence', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    await openAdjustmentView();
+    operationLog.length = 0;
+    writePayloads.length = 0;
+
+    await userEvent.click(screen.getByRole('button', { name: /إلغاء/ }));
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith('تم إلغاء التسوية بنجاح'));
+    expect(writePayloads).toContainEqual({
+      table: 'stock_adjustments',
+      action: 'update',
+      payload: { status: 'CANCELLED' },
+    });
+    expect(operationLog.slice(0, 3)).toEqual([
+      'update:stock_adjustments',
+      'auth:getUser',
+      'select:stock_adjustments',
+    ]);
+    expect(screen.queryByText('تفاصيل التسوية')).not.toBeInTheDocument();
+  });
+
+  it('keeps details open and reports the existing error message when cancellation fails', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    await openAdjustmentView();
+    saveHeaderResult = { data: null, error: new Error('cancel failed') };
+
+    await userEvent.click(screen.getByRole('button', { name: /إلغاء/ }));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('فشل إلغاء التسوية: cancel failed'));
+    expect(screen.getByText('تفاصيل التسوية')).toBeInTheDocument();
+  });
+});
+
 describe('StockAdjustments — handleSaveAdjustment behavior lock', () => {
   it('re-checks create permission before validation/UoM/auth and performs zero writes after revocation', async () => {
     const { rerender } = await openValidCreateForm();

--- a/src/features/inventory/components/StockAdjustmentSections.tsx
+++ b/src/features/inventory/components/StockAdjustmentSections.tsx
@@ -1,0 +1,470 @@
+import { ClipboardList, Plus } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { EmptyState } from '@/components/ui/empty-state'
+import { ADJUSTMENT_TYPES } from '../helpers'
+import { UomStatusBadge } from './UomStatusBadge'
+
+export type StockAdjustmentRecord = {
+  id: string
+  adjustment_number?: string | null
+  adjustment_date: string
+  adjustment_type: string
+  status: string
+  reason?: string | null
+  reference_number?: string | null
+  warehouse_id?: string | null
+  increase_account_id?: string | null
+  decrease_account_id?: string | null
+  total_items?: number | null
+  total_qty_difference?: number | null
+  total_value_difference?: number | null
+  requires_approval?: boolean | null
+}
+
+type StockAdjustmentCreateActionProps = {
+  canCreateAdjustment: boolean
+  canOpenAdjustmentForm: boolean
+  onCreate: () => void
+}
+
+export function StockAdjustmentCreateAction({
+  canCreateAdjustment,
+  canOpenAdjustmentForm,
+  onCreate,
+}: Readonly<StockAdjustmentCreateActionProps>) {
+  if (!canCreateAdjustment || !canOpenAdjustmentForm) return null
+
+  return (
+    <Button onClick={onCreate} className="gap-2">
+      <Plus className="w-4 h-4" />
+      تسوية جديدة
+    </Button>
+  )
+}
+
+type StockAdjustmentDetailsCardProps = {
+  adjustment: StockAdjustmentRecord
+  canUpdateAdjustment: boolean
+  canApproveAdjustment: boolean
+  canOpenAdjustmentForm: boolean
+  onClose: () => void
+  onEdit: () => void
+  onSubmit: () => void
+  onCancel: () => void
+}
+
+function adjustmentStatusVariant(status: string): 'default' | 'secondary' | 'destructive' {
+  if (status === 'SUBMITTED') return 'default'
+  if (status === 'DRAFT') return 'secondary'
+  return 'destructive'
+}
+
+function adjustmentStatusLabel(status: string): string {
+  if (status === 'SUBMITTED') return 'مرحل'
+  if (status === 'DRAFT') return 'مسودة'
+  return 'ملغي'
+}
+
+function StockAdjustmentDraftActions({
+  canUpdateAdjustment,
+  canApproveAdjustment,
+  canOpenAdjustmentForm,
+  onEdit,
+  onSubmit,
+  onCancel,
+}: Readonly<Omit<StockAdjustmentDetailsCardProps, 'adjustment' | 'onClose'>>) {
+  return (
+    <div className="flex justify-end gap-2">
+      {canUpdateAdjustment && canOpenAdjustmentForm && (
+        <Button variant="outline" onClick={onEdit}>
+          ✏️ تعديل
+        </Button>
+      )}
+      {canApproveAdjustment && (
+        <Button onClick={onSubmit}>
+          ✅ ترحيل
+        </Button>
+      )}
+      {canUpdateAdjustment && (
+        <Button variant="destructive" onClick={onCancel}>
+          🗑️ إلغاء
+        </Button>
+      )}
+    </div>
+  )
+}
+
+export function StockAdjustmentDetailsCard({
+  adjustment,
+  canUpdateAdjustment,
+  canApproveAdjustment,
+  canOpenAdjustmentForm,
+  onClose,
+  onEdit,
+  onSubmit,
+  onCancel,
+}: Readonly<StockAdjustmentDetailsCardProps>) {
+  const adjustmentType = ADJUSTMENT_TYPES[
+    adjustment.adjustment_type as keyof typeof ADJUSTMENT_TYPES
+  ]
+
+  return (
+    <Card className="p-6">
+      <div className="space-y-4">
+        <div className="flex justify-between items-center">
+          <h3 className="text-2xl font-bold flex items-center gap-2">
+            <span>{adjustmentType?.icon}</span>{' '}
+            تفاصيل التسوية
+          </h3>
+          <Button variant="outline" onClick={onClose}>
+            ✕ إغلاق
+          </Button>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4 p-4 bg-muted/50 dark:bg-gray-900 rounded-lg">
+          <div>
+            <span className="text-sm text-muted-foreground">رقم التسوية:</span>
+            <p className="font-medium">{adjustment.adjustment_number}</p>
+          </div>
+          <div>
+            <span className="text-sm text-muted-foreground">التاريخ:</span>
+            <p className="font-medium">
+              {new Date(adjustment.adjustment_date).toLocaleDateString('en-US')}
+            </p>
+          </div>
+          <div>
+            <span className="text-sm text-muted-foreground">النوع:</span>
+            <p className="font-medium">{adjustmentType?.label}</p>
+          </div>
+          <div>
+            <span className="text-sm text-muted-foreground">الحالة:</span>
+            <Badge variant={adjustmentStatusVariant(adjustment.status)}>
+              {adjustmentStatusLabel(adjustment.status)}
+            </Badge>
+          </div>
+          <div className="col-span-2">
+            <span className="text-sm text-muted-foreground">السبب:</span>
+            <p className="font-medium">{adjustment.reason}</p>
+          </div>
+          {adjustment.reference_number && (
+            <div className="col-span-2">
+              <span className="text-sm text-muted-foreground">رقم المرجع:</span>
+              <p className="font-medium">{adjustment.reference_number}</p>
+            </div>
+          )}
+        </div>
+
+        <div className="grid grid-cols-4 gap-4">
+          <div className="p-4 bg-blue-50 dark:bg-blue-950 rounded-lg">
+            <p className="text-sm text-muted-foreground">إجمالي المنتجات</p>
+            <p className="text-2xl font-bold">{adjustment.total_items || 0}</p>
+          </div>
+          <div className="p-4 bg-purple-50 dark:bg-purple-950 rounded-lg">
+            <p className="text-sm text-muted-foreground">فرق الكمية</p>
+            <p className="text-2xl font-bold">{adjustment.total_qty_difference || 0}</p>
+          </div>
+          <div className="p-4 bg-green-50 dark:bg-green-950 rounded-lg">
+            <p className="text-sm text-muted-foreground">فرق القيمة</p>
+            <p className="text-2xl font-bold">
+              {(adjustment.total_value_difference || 0).toFixed(2)} ر.س
+            </p>
+          </div>
+          <div className="p-4 bg-amber-50 dark:bg-amber-950 rounded-lg">
+            <p className="text-sm text-muted-foreground">يتطلب موافقة</p>
+            <p className="text-2xl font-bold">{adjustment.requires_approval ? 'نعم' : 'لا'}</p>
+          </div>
+        </div>
+
+        {adjustment.status === 'DRAFT' && (
+          <StockAdjustmentDraftActions
+            canUpdateAdjustment={canUpdateAdjustment}
+            canApproveAdjustment={canApproveAdjustment}
+            canOpenAdjustmentForm={canOpenAdjustmentForm}
+            onEdit={onEdit}
+            onSubmit={onSubmit}
+            onCancel={onCancel}
+          />
+        )}
+      </div>
+    </Card>
+  )
+}
+
+type StockAdjustmentFiltersProps = {
+  filterStatus: string
+  filterType: string
+  onStatusChange: (value: string) => void
+  onTypeChange: (value: string) => void
+}
+
+export function StockAdjustmentFilters({
+  filterStatus,
+  filterType,
+  onStatusChange,
+  onTypeChange,
+}: Readonly<StockAdjustmentFiltersProps>) {
+  return (
+    <Card className="p-4">
+      <div className="flex gap-4">
+        <div className="flex-1">
+          <label htmlFor="filter-status" className="block text-sm font-medium mb-1">الحالة</label>
+          <select
+            id="filter-status"
+            value={filterStatus}
+            onChange={(event) => onStatusChange(event.target.value)}
+            className="w-full px-3 py-2 border border-border dark:border-gray-700 rounded-md bg-card dark:bg-gray-800 text-foreground dark:text-gray-100 hover:bg-muted/50 dark:hover:bg-gray-700 transition-colors focus:outline-none focus:ring-2 focus:ring-primary"
+          >
+            <option value="all">الكل</option>
+            <option value="DRAFT">مسودة</option>
+            <option value="SUBMITTED">مرحل</option>
+            <option value="CANCELLED">ملغي</option>
+          </select>
+        </div>
+        <div className="flex-1">
+          <label htmlFor="filter-type" className="block text-sm font-medium mb-1">النوع</label>
+          <select
+            id="filter-type"
+            value={filterType}
+            onChange={(event) => onTypeChange(event.target.value)}
+            className="w-full px-3 py-2 border border-border dark:border-gray-700 rounded-md bg-card dark:bg-gray-800 text-foreground dark:text-gray-100 hover:bg-muted/50 dark:hover:bg-gray-700 transition-colors focus:outline-none focus:ring-2 focus:ring-primary"
+          >
+            <option value="all">الكل</option>
+            {Object.entries(ADJUSTMENT_TYPES).map(([key, value]) => (
+              <option key={key} value={key}>
+                {value.icon} {value.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+    </Card>
+  )
+}
+
+export type StockAdjustmentProduct = {
+  id: string
+  name: string
+  code?: string | null
+  stock_quantity?: number | null
+}
+
+type StockAdjustmentProductPickerProps = {
+  warehouseId: string
+  searchTerm: string
+  showProductSearch: boolean
+  filteredProducts: StockAdjustmentProduct[]
+  selectedProduct: StockAdjustmentProduct | null
+  productUomStatus: {
+    isEnabled: boolean
+    isLoading: boolean
+    isError: boolean
+  }
+  productNeedsUomSetup: (productId: string) => boolean
+  onSearchTermChange: (value: string) => void
+  onSearchFocus: () => void
+  onProductSelect: (product: StockAdjustmentProduct) => void
+  onAddItem: () => void
+}
+
+type StockAdjustmentProductSearchResultsProps = Pick<
+  StockAdjustmentProductPickerProps,
+  'filteredProducts' | 'productUomStatus' | 'productNeedsUomSetup' | 'onProductSelect'
+>
+
+function StockAdjustmentProductSearchResults({
+  filteredProducts,
+  productUomStatus,
+  productNeedsUomSetup,
+  onProductSelect,
+}: Readonly<StockAdjustmentProductSearchResultsProps>) {
+  if (productUomStatus.isEnabled && productUomStatus.isLoading) {
+    return (
+      <div className="px-4 py-4 text-center text-muted-foreground bg-card dark:bg-gray-950">
+        جارٍ التحقق من إعداد وحدات الأصناف…
+      </div>
+    )
+  }
+
+  if (productUomStatus.isEnabled && productUomStatus.isError) {
+    return (
+      <div className="px-4 py-4 text-center text-red-600 bg-card dark:bg-gray-950">
+        تعذّر التحقق من حالة وحدات الأصناف — لا يمكن اختيار صنف الآن
+      </div>
+    )
+  }
+
+  if (filteredProducts.length === 0) {
+    return (
+      <div className="px-4 py-4 text-center text-muted-foreground dark:text-muted-foreground bg-card dark:bg-gray-950">
+        لا توجد نتائج
+      </div>
+    )
+  }
+
+  return filteredProducts.map((product) => {
+    if (productNeedsUomSetup(product.id)) {
+      return (
+        <div
+          key={product.id}
+          className="w-full px-4 py-3 text-right border-b border-border dark:border-gray-700 last:border-b-0 bg-muted/40 dark:bg-gray-900 opacity-80"
+        >
+          <div className="flex items-center justify-between gap-2">
+            <div className="font-medium text-foreground dark:text-white">{product.name}</div>
+            <UomStatusBadge />
+          </div>
+          <div className="text-sm text-muted-foreground dark:text-muted-foreground">
+            {product.code} - الرصيد: {product.stock_quantity}
+          </div>
+        </div>
+      )
+    }
+
+    return (
+      <button
+        key={product.id}
+        type="button"
+        onClick={() => onProductSelect(product)}
+        className="w-full px-4 py-3 text-right hover:bg-muted dark:hover:bg-gray-800 border-b border-border dark:border-gray-700 last:border-b-0 transition-colors bg-card dark:bg-gray-950"
+      >
+        <div className="font-medium text-foreground dark:text-white">{product.name}</div>
+        <div className="text-sm text-muted-foreground dark:text-muted-foreground">
+          {product.code} - الرصيد: {product.stock_quantity}
+        </div>
+      </button>
+    )
+  })
+}
+
+export function StockAdjustmentProductPicker({
+  warehouseId,
+  searchTerm,
+  showProductSearch,
+  filteredProducts,
+  selectedProduct,
+  productUomStatus,
+  productNeedsUomSetup,
+  onSearchTermChange,
+  onSearchFocus,
+  onProductSelect,
+  onAddItem,
+}: Readonly<StockAdjustmentProductPickerProps>) {
+  return (
+    <div className="relative z-20">
+      <label htmlFor="adjustment-add-item" className="block text-sm font-medium mb-2">
+        إضافة منتج
+      </label>
+
+      {!warehouseId && (
+        <div className="mb-2 p-3 bg-amber-50 dark:bg-amber-950 border border-amber-200 dark:border-amber-800 rounded-md">
+          <p className="text-sm text-amber-800 dark:text-amber-200 flex items-center gap-2">
+            <span>⚠️</span>
+            <span>يجب اختيار المخزن أولاً قبل إضافة المنتجات</span>
+          </p>
+        </div>
+      )}
+
+      <div className="flex gap-2">
+        <div className="flex-1 relative product-search-container">
+          <input
+            id="adjustment-add-item"
+            type="text"
+            value={searchTerm}
+            onChange={(event) => onSearchTermChange(event.target.value)}
+            onFocus={onSearchFocus}
+            placeholder="ابحث عن منتج..."
+            disabled={!warehouseId}
+            className="w-full px-3 py-2 border rounded-md disabled:opacity-50 disabled:cursor-not-allowed"
+          />
+
+          {showProductSearch && searchTerm && (
+            <div
+              className="absolute z-[9999] w-full mt-1 bg-card dark:bg-gray-950 border-2 border-gray-400 dark:border-gray-400 rounded-lg shadow-2xl max-h-60 overflow-y-auto"
+              style={{
+                boxShadow: '0 25px 50px -12px rgba(0, 0, 0, 0.95), 0 0 0 1px rgba(255, 255, 255, 0.1)',
+              }}
+            >
+              <StockAdjustmentProductSearchResults
+                filteredProducts={filteredProducts}
+                productUomStatus={productUomStatus}
+                productNeedsUomSetup={productNeedsUomSetup}
+                onProductSelect={onProductSelect}
+              />
+            </div>
+          )}
+        </div>
+        <Button onClick={onAddItem} disabled={!warehouseId || !selectedProduct}>
+          إضافة
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+type StockAdjustmentsListProps = {
+  adjustments: StockAdjustmentRecord[]
+  onSelect: (adjustment: StockAdjustmentRecord) => void
+}
+
+export function StockAdjustmentsList({
+  adjustments,
+  onSelect,
+}: Readonly<StockAdjustmentsListProps>) {
+  if (adjustments.length === 0) {
+    return (
+      <div className="bg-card rounded-lg border">
+        <EmptyState
+          icon={<ClipboardList aria-hidden="true" />}
+          title="لا توجد تسويات مخزون بعد"
+          description="ابدأ بإنشاء تسوية جديدة بالزر أعلاه"
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div className="bg-card rounded-lg border">
+      <div className="divide-y">
+        {adjustments.map((adjustment) => {
+          const adjustmentType = ADJUSTMENT_TYPES[
+            adjustment.adjustment_type as keyof typeof ADJUSTMENT_TYPES
+          ]
+
+          return (
+            <button
+              key={adjustment.id}
+              type="button"
+              aria-label={`عرض تفاصيل تسوية المخزون ${adjustment.id}`}
+              className="w-full text-start p-4 hover:bg-muted/50 cursor-pointer transition-colors border-0 bg-transparent"
+              onClick={() => onSelect(adjustment)}
+            >
+              <div className="flex justify-between items-start">
+                <div>
+                  <div className="flex items-center gap-2">
+                    <span className="text-2xl">{adjustmentType?.icon}</span>
+                    <div>
+                      <h3 className="font-medium">{adjustmentType?.label}</h3>
+                      <p className="text-sm text-muted-foreground">
+                        {adjustment.reference_number || adjustment.id}
+                      </p>
+                    </div>
+                  </div>
+                  <p className="text-sm mt-2">{adjustment.reason}</p>
+                </div>
+                <div className="text-start">
+                  <Badge variant={adjustmentStatusVariant(adjustment.status)}>
+                    {adjustmentStatusLabel(adjustment.status)}
+                  </Badge>
+                  <div className="text-sm text-muted-foreground mt-2">
+                    {new Date(adjustment.adjustment_date).toLocaleDateString('en-US')}
+                  </div>
+                </div>
+              </div>
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/features/inventory/components/__tests__/stock-adjustment-sections.test.tsx
+++ b/src/features/inventory/components/__tests__/stock-adjustment-sections.test.tsx
@@ -1,0 +1,310 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  StockAdjustmentCreateAction,
+  StockAdjustmentDetailsCard,
+  StockAdjustmentFilters,
+  StockAdjustmentProductPicker,
+  StockAdjustmentsList,
+  type StockAdjustmentRecord,
+} from '../StockAdjustmentSections'
+
+const adjustment: StockAdjustmentRecord = {
+  id: 'adjustment-1',
+  adjustment_number: 'ADJ-001',
+  adjustment_date: '2026-08-20',
+  adjustment_type: 'PHYSICAL_COUNT',
+  status: 'DRAFT',
+  reason: 'Behavior-preserving extraction',
+  reference_number: 'REF-001',
+  total_items: 2,
+  total_qty_difference: 3,
+  total_value_difference: 15,
+  requires_approval: true,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('StockAdjustmentCreateAction', () => {
+  it('requires create and every reference-data read before exposing the trigger', async () => {
+    const onCreate = vi.fn()
+    const { rerender } = render(
+      <StockAdjustmentCreateAction
+        canCreateAdjustment={false}
+        canOpenAdjustmentForm
+        onCreate={onCreate}
+      />,
+    )
+
+    expect(screen.queryByRole('button', { name: /تسوية جديدة/ })).not.toBeInTheDocument()
+
+    rerender(
+      <StockAdjustmentCreateAction
+        canCreateAdjustment
+        canOpenAdjustmentForm={false}
+        onCreate={onCreate}
+      />,
+    )
+    expect(screen.queryByRole('button', { name: /تسوية جديدة/ })).not.toBeInTheDocument()
+
+    rerender(
+      <StockAdjustmentCreateAction
+        canCreateAdjustment
+        canOpenAdjustmentForm
+        onCreate={onCreate}
+      />,
+    )
+    await userEvent.click(screen.getByRole('button', { name: /تسوية جديدة/ }))
+    expect(onCreate).toHaveBeenCalledOnce()
+  })
+})
+
+describe('StockAdjustmentDetailsCard', () => {
+  it('keeps draft actions independently gated and delegates them to the parent', async () => {
+    const onEdit = vi.fn()
+    const onSubmit = vi.fn()
+    const onCancel = vi.fn()
+
+    render(
+      <StockAdjustmentDetailsCard
+        adjustment={adjustment}
+        canUpdateAdjustment
+        canApproveAdjustment
+        canOpenAdjustmentForm
+        onClose={vi.fn()}
+        onEdit={onEdit}
+        onSubmit={onSubmit}
+        onCancel={onCancel}
+      />,
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: /تعديل/ }))
+    await userEvent.click(screen.getByRole('button', { name: /ترحيل/ }))
+    await userEvent.click(screen.getByRole('button', { name: /إلغاء/ }))
+
+    expect(onEdit).toHaveBeenCalledOnce()
+    expect(onSubmit).toHaveBeenCalledOnce()
+    expect(onCancel).toHaveBeenCalledOnce()
+  })
+
+  it('does not let one draft permission expose another action', () => {
+    const { rerender } = render(
+      <StockAdjustmentDetailsCard
+        adjustment={adjustment}
+        canUpdateAdjustment={false}
+        canApproveAdjustment
+        canOpenAdjustmentForm
+        onClose={vi.fn()}
+        onEdit={vi.fn()}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    expect(screen.queryByRole('button', { name: /تعديل/ })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /ترحيل/ })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /إلغاء/ })).not.toBeInTheDocument()
+
+    rerender(
+      <StockAdjustmentDetailsCard
+        adjustment={adjustment}
+        canUpdateAdjustment
+        canApproveAdjustment={false}
+        canOpenAdjustmentForm={false}
+        onClose={vi.fn()}
+        onEdit={vi.fn()}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    expect(screen.queryByRole('button', { name: /تعديل/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /ترحيل/ })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /إلغاء/ })).toBeInTheDocument()
+  })
+
+  it('never renders write actions for a non-draft adjustment', () => {
+    render(
+      <StockAdjustmentDetailsCard
+        adjustment={{
+          ...adjustment,
+          status: 'SUBMITTED',
+          reference_number: null,
+          total_items: 0,
+          total_qty_difference: 0,
+          total_value_difference: 0,
+          requires_approval: false,
+        }}
+        canUpdateAdjustment
+        canApproveAdjustment
+        canOpenAdjustmentForm
+        onClose={vi.fn()}
+        onEdit={vi.fn()}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('مرحل')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /تعديل/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /ترحيل/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /إلغاء/ })).not.toBeInTheDocument()
+  })
+})
+
+describe('StockAdjustmentFilters', () => {
+  it('preserves the status and type filter callback values', async () => {
+    const onStatusChange = vi.fn()
+    const onTypeChange = vi.fn()
+    render(
+      <StockAdjustmentFilters
+        filterStatus="all"
+        filterType="all"
+        onStatusChange={onStatusChange}
+        onTypeChange={onTypeChange}
+      />,
+    )
+
+    await userEvent.selectOptions(screen.getByLabelText('الحالة'), 'DRAFT')
+    await userEvent.selectOptions(screen.getByLabelText('النوع'), 'PHYSICAL_COUNT')
+
+    expect(onStatusChange).toHaveBeenCalledWith('DRAFT')
+    expect(onTypeChange).toHaveBeenCalledWith('PHYSICAL_COUNT')
+  })
+})
+
+describe('StockAdjustmentProductPicker', () => {
+  const product = {
+    id: 'product-1',
+    name: 'Mapped product',
+    code: 'P-001',
+    stock_quantity: 12,
+  }
+  const baseProps = {
+    warehouseId: 'warehouse-1',
+    searchTerm: '',
+    showProductSearch: false,
+    filteredProducts: [product],
+    selectedProduct: null,
+    productUomStatus: { isEnabled: false, isLoading: false, isError: false },
+    productNeedsUomSetup: vi.fn(() => false),
+    onSearchTermChange: vi.fn(),
+    onSearchFocus: vi.fn(),
+    onProductSelect: vi.fn(),
+    onAddItem: vi.fn(),
+  }
+
+  it('keeps warehouse and selected-product gating while delegating input and add actions', async () => {
+    const { rerender } = render(
+      <StockAdjustmentProductPicker {...baseProps} warehouseId="" />,
+    )
+
+    expect(screen.getByText('يجب اختيار المخزن أولاً قبل إضافة المنتجات')).toBeInTheDocument()
+    expect(screen.getByLabelText('إضافة منتج')).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'إضافة' })).toBeDisabled()
+
+    rerender(
+      <StockAdjustmentProductPicker
+        {...baseProps}
+        selectedProduct={product}
+      />,
+    )
+    const searchInput = screen.getByLabelText('إضافة منتج')
+    await userEvent.click(searchInput)
+    await userEvent.type(searchInput, 'P')
+    await userEvent.click(screen.getByRole('button', { name: 'إضافة' }))
+
+    expect(baseProps.onSearchFocus).toHaveBeenCalledOnce()
+    expect(baseProps.onSearchTermChange).toHaveBeenCalledWith('P')
+    expect(baseProps.onAddItem).toHaveBeenCalledOnce()
+  })
+
+  it('renders the UoM loading, error and empty-result states', () => {
+    const visibleProps = {
+      ...baseProps,
+      searchTerm: 'product',
+      showProductSearch: true,
+      productUomStatus: { isEnabled: true, isLoading: true, isError: false },
+    }
+    const { rerender } = render(<StockAdjustmentProductPicker {...visibleProps} />)
+
+    expect(screen.getByText('جارٍ التحقق من إعداد وحدات الأصناف…')).toBeInTheDocument()
+
+    rerender(
+      <StockAdjustmentProductPicker
+        {...visibleProps}
+        productUomStatus={{ isEnabled: true, isLoading: false, isError: true }}
+      />,
+    )
+    expect(screen.getByText(/تعذّر التحقق من حالة وحدات الأصناف/)).toBeInTheDocument()
+
+    rerender(
+      <StockAdjustmentProductPicker
+        {...visibleProps}
+        filteredProducts={[]}
+        productUomStatus={{ isEnabled: false, isLoading: false, isError: false }}
+      />,
+    )
+    expect(screen.getByText('لا توجد نتائج')).toBeInTheDocument()
+  })
+
+  it('keeps unmapped products non-interactive and delegates mapped selection', async () => {
+    const unmappedProduct = {
+      ...product,
+      id: 'product-2',
+      name: 'Unmapped product',
+    }
+    const onProductSelect = vi.fn()
+    render(
+      <MemoryRouter>
+        <StockAdjustmentProductPicker
+          {...baseProps}
+          searchTerm="product"
+          showProductSearch
+          filteredProducts={[unmappedProduct, product]}
+          productNeedsUomSetup={(productId) => productId === unmappedProduct.id}
+          onProductSelect={onProductSelect}
+        />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByText('يحتاج إعداد وحدة')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Unmapped product/ })).not.toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: /Mapped product/ }))
+    expect(onProductSelect).toHaveBeenCalledWith(product)
+  })
+})
+
+describe('StockAdjustmentsList', () => {
+  it('preserves the row label, status and selected record', async () => {
+    const onSelect = vi.fn()
+    const cancelledAdjustment = {
+      ...adjustment,
+      id: 'adjustment-2',
+      status: 'CANCELLED',
+      reference_number: null,
+    }
+    render(
+      <StockAdjustmentsList
+        adjustments={[adjustment, cancelledAdjustment]}
+        onSelect={onSelect}
+      />,
+    )
+
+    expect(screen.getByText('مسودة')).toBeInTheDocument()
+    expect(screen.getByText('ملغي')).toBeInTheDocument()
+    await userEvent.click(
+      screen.getByRole('button', { name: 'عرض تفاصيل تسوية المخزون adjustment-2' }),
+    )
+    expect(onSelect).toHaveBeenCalledWith(cancelledAdjustment)
+  })
+
+  it('preserves the empty state when no adjustments match', () => {
+    render(<StockAdjustmentsList adjustments={[]} onSelect={vi.fn()} />)
+    expect(screen.getByText('لا توجد تسويات مخزون بعد')).toBeInTheDocument()
+  })
+})

--- a/src/features/inventory/index.tsx
+++ b/src/features/inventory/index.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Badge } from '@/components/ui/badge'
 import { Card } from '@/components/ui/card'
-import { Plus, X, Trash2, PackageOpen, ClipboardList } from 'lucide-react'
+import { X, Trash2, PackageOpen } from 'lucide-react'
 import { PageHeader } from '@/components/ui/page-header'
 import { EmptyState } from '@/components/ui/empty-state'
 import { itemsService, categoriesService, stockMovementsService } from '@/services/supabase-service'
@@ -19,8 +19,15 @@ import { useAuth } from '@/contexts/AuthContext'
 import { usePermissions } from '@/hooks/usePermissions'
 import { ProductUomSettings } from './components/ProductUomSettings'
 import { UomBackfillIssues } from './components/UomBackfillIssues'
-import { UomStatusBadge } from './components/UomStatusBadge'
 import { InventoryKeyMetrics, InventoryQuickActions, LowStockAlert } from './components/InventoryOverviewSections'
+import {
+  StockAdjustmentCreateAction,
+  StockAdjustmentDetailsCard,
+  StockAdjustmentFilters,
+  StockAdjustmentProductPicker,
+  StockAdjustmentsList,
+  type StockAdjustmentRecord,
+} from './components/StockAdjustmentSections'
 import { 
   ADJUSTMENT_TYPES,
   calculateAdjustmentTotals,
@@ -1233,6 +1240,87 @@ function StockAdjustments() {
     }
   }
 
+  const handleCloseAdjustmentDetails = () => {
+    setViewMode(false)
+    setSelectedAdjustment(null)
+  }
+
+  const handleEditSelectedAdjustment = async () => {
+    if (!canUpdateAdjustment || !selectedAdjustment) return
+
+    try {
+      const supabase = getSupabase()
+      const { data: items, error } = await supabase
+        .from('stock_adjustment_items')
+        .select('*, products(*)')
+        .eq('adjustment_id', selectedAdjustment.id)
+
+      if (error) throw error
+
+      setNewAdjustment({
+        adjustment_date: selectedAdjustment.adjustment_date,
+        adjustment_type: selectedAdjustment.adjustment_type,
+        reason: selectedAdjustment.reason || '',
+        reference_number: selectedAdjustment.reference_number,
+        warehouse_id: selectedAdjustment.warehouse_id,
+        increase_account_id: selectedAdjustment.increase_account_id || '',
+        decrease_account_id: selectedAdjustment.decrease_account_id || '',
+        items: items?.map(item => ({
+          id: item.id,
+          product_id: item.product_id,
+          product: item.products,
+          warehouse_id: item.warehouse_id,
+          current_qty: item.current_qty || 0,
+          new_qty: item.new_qty || 0,
+          difference_qty: item.difference_qty || 0,
+          current_rate: item.current_rate || 0,
+          value_difference: item.value_difference || 0,
+          reason: item.reason || ''
+        })) || []
+      })
+
+      setViewMode(false)
+      setSelectedAdjustment({ ...selectedAdjustment, isEditing: true })
+      setShowNewForm(true)
+    } catch (error: any) {
+      toast.error('فشل تحميل بيانات التسوية: ' + error.message)
+    }
+  }
+
+  const handleSubmitSelectedAdjustment = async () => {
+    if (!canApproveAdjustment || !selectedAdjustment) return
+    if (confirm('هل أنت متأكد من ترحيل هذه التسوية؟ سيتم تحديث أرصدة المخزون وإنشاء القيود المحاسبية.')) {
+      await handleSubmitAdjustment(selectedAdjustment.id)
+    }
+  }
+
+  const handleCancelSelectedAdjustment = async () => {
+    if (!canUpdateAdjustment || !selectedAdjustment) return
+    if (!confirm('هل أنت متأكد من إلغاء هذه التسوية؟')) return
+
+    try {
+      const supabase = getSupabase()
+      const { error } = await supabase
+        .from('stock_adjustments')
+        .update({ status: 'CANCELLED' })
+        .eq('id', selectedAdjustment.id)
+
+      if (error) throw error
+
+      toast.success('تم إلغاء التسوية بنجاح')
+      setViewMode(false)
+      setSelectedAdjustment(null)
+      loadAdjustments()
+    } catch (error: any) {
+      toast.error('فشل إلغاء التسوية: ' + error.message)
+    }
+  }
+
+  const handleSelectAdjustment = (adjustment: StockAdjustmentRecord) => {
+    setSelectedAdjustment(adjustment)
+    setViewMode(true)
+  }
+
   const filteredProducts = products.filter(
     (p: any) =>
       p.name?.toLowerCase().includes(searchTerm.toLowerCase()) ||
@@ -1254,12 +1342,11 @@ function StockAdjustments() {
         description="تعديل وتصحيح أرصدة المخزون حسب المعايير المحاسبية"
         hideOnPrint={false}
         actions={
-          canCreateAdjustment && canOpenAdjustmentForm && (
-            <Button onClick={() => setShowNewForm(true)} className="gap-2">
-              <Plus className="w-4 h-4" />
-              تسوية جديدة
-            </Button>
-          )
+          <StockAdjustmentCreateAction
+            canCreateAdjustment={canCreateAdjustment}
+            canOpenAdjustmentForm={canOpenAdjustmentForm}
+            onCreate={() => setShowNewForm(true)}
+          />
         }
       />
 
@@ -1492,106 +1579,26 @@ function StockAdjustments() {
               />
             </div>
 
-            {/* Product Selection */}
-            <div className="relative z-20">
-              <label htmlFor="adjustment-add-item" className="block text-sm font-medium mb-2">
-                إضافة منتج
-              </label>
-              
-              {!newAdjustment.warehouse_id && (
-                <div className="mb-2 p-3 bg-amber-50 dark:bg-amber-950 border border-amber-200 dark:border-amber-800 rounded-md">
-                  <p className="text-sm text-amber-800 dark:text-amber-200 flex items-center gap-2">
-                    <span>⚠️</span>
-                    <span>يجب اختيار المخزن أولاً قبل إضافة المنتجات</span>
-                  </p>
-                </div>
-              )}
-
-              <div className="flex gap-2">
-                <div className="flex-1 relative product-search-container">
-                  <input
-                    type="text"
-                    value={searchTerm}
-                    onChange={(e) => {
-                      setSearchTerm(e.target.value)
-                      setShowProductSearch(true)
-                    }}
-                    onFocus={() => setShowProductSearch(true)}
-                    placeholder="ابحث عن منتج..."
-                    disabled={!newAdjustment.warehouse_id}
-                    className="w-full px-3 py-2 border rounded-md disabled:opacity-50 disabled:cursor-not-allowed"
-                  />
-                  
-                  {showProductSearch && searchTerm && (
-                    <div 
-                      className="absolute z-[9999] w-full mt-1 bg-card dark:bg-gray-950 border-2 border-gray-400 dark:border-gray-400 rounded-lg shadow-2xl max-h-60 overflow-y-auto"
-                      style={{ 
-                        boxShadow: '0 25px 50px -12px rgba(0, 0, 0, 0.95), 0 0 0 1px rgba(255, 255, 255, 0.1)',
-                      }}
-                    >
-                      {productUomStatus.isEnabled && productUomStatus.isLoading ? (
-                        <div className="px-4 py-4 text-center text-muted-foreground bg-card dark:bg-gray-950">
-                          جارٍ التحقق من إعداد وحدات الأصناف…
-                        </div>
-                      ) : productUomStatus.isEnabled && productUomStatus.isError ? (
-                        <div className="px-4 py-4 text-center text-red-600 bg-card dark:bg-gray-950">
-                          تعذّر التحقق من حالة وحدات الأصناف — لا يمكن اختيار صنف الآن
-                        </div>
-                      ) : filteredProducts.length > 0 ? (
-                        filteredProducts.map((product) => {
-                          const needsUom = productNeedsUomSetup(product.id)
-                          // Unmapped product: not a selectable button — a non-interactive
-                          // row carrying a linked badge so the repair link stays reachable
-                          // and keyboard-accessible (a link inside a disabled button is not).
-                          if (needsUom) {
-                            return (
-                              <div
-                                key={product.id}
-                                className="w-full px-4 py-3 text-right border-b border-border dark:border-gray-700 last:border-b-0 bg-muted/40 dark:bg-gray-900 opacity-80"
-                              >
-                                <div className="flex items-center justify-between gap-2">
-                                  <div className="font-medium text-foreground dark:text-white">{product.name}</div>
-                                  <UomStatusBadge />
-                                </div>
-                                <div className="text-sm text-muted-foreground dark:text-muted-foreground">
-                                  {product.code} - الرصيد: {product.stock_quantity}
-                                </div>
-                              </div>
-                            )
-                          }
-                          return (
-                          <button
-                            key={product.id}
-                            onClick={() => {
-                              setSelectedProduct(product)
-                              setSearchTerm(product.name)
-                              setShowProductSearch(false)
-                            }}
-                            className="w-full px-4 py-3 text-right hover:bg-muted dark:hover:bg-gray-800 border-b border-border dark:border-gray-700 last:border-b-0 transition-colors bg-card dark:bg-gray-950"
-                          >
-                            <div className="font-medium text-foreground dark:text-white">{product.name}</div>
-                            <div className="text-sm text-muted-foreground dark:text-muted-foreground">
-                              {product.code} - الرصيد: {product.stock_quantity}
-                            </div>
-                          </button>
-                          )
-                        })
-                      ) : (
-                        <div className="px-4 py-4 text-center text-muted-foreground dark:text-muted-foreground bg-card dark:bg-gray-950">
-                          لا توجد نتائج
-                        </div>
-                      )}
-                    </div>
-                  )}
-                </div>
-                <Button 
-                  onClick={handleAddItem}
-                  disabled={!newAdjustment.warehouse_id || !selectedProduct}
-                >
-                  إضافة
-                </Button>
-              </div>
-            </div>
+            <StockAdjustmentProductPicker
+              warehouseId={newAdjustment.warehouse_id}
+              searchTerm={searchTerm}
+              showProductSearch={showProductSearch}
+              filteredProducts={filteredProducts}
+              selectedProduct={selectedProduct}
+              productUomStatus={productUomStatus}
+              productNeedsUomSetup={productNeedsUomSetup}
+              onSearchTermChange={(value) => {
+                setSearchTerm(value)
+                setShowProductSearch(true)
+              }}
+              onSearchFocus={() => setShowProductSearch(true)}
+              onProductSelect={(product) => {
+                setSelectedProduct(product)
+                setSearchTerm(product.name)
+                setShowProductSearch(false)
+              }}
+              onAddItem={handleAddItem}
+            />
 
             {/* Items Table */}
             {newAdjustment.items.length > 0 && (
@@ -1772,287 +1779,30 @@ function StockAdjustments() {
         </Card>
       )}
 
-      {/* View Mode - Display Adjustment Details */}
       {viewMode && selectedAdjustment && (
-        <Card className="p-6">
-          <div className="space-y-4">
-            <div className="flex justify-between items-center">
-              <h3 className="text-2xl font-bold flex items-center gap-2">
-                <span>
-                  {ADJUSTMENT_TYPES[selectedAdjustment.adjustment_type as keyof typeof ADJUSTMENT_TYPES]?.icon}
-                </span>
-                {' '}
-                تفاصيل التسوية
-              </h3>
-              <Button variant="outline" onClick={() => {
-                setViewMode(false)
-                setSelectedAdjustment(null)
-              }}>
-                ✕ إغلاق
-              </Button>
-            </div>
-
-            {/* Adjustment Header Info */}
-            <div className="grid grid-cols-2 gap-4 p-4 bg-muted/50 dark:bg-gray-900 rounded-lg">
-              <div>
-                <span className="text-sm text-muted-foreground">رقم التسوية:</span>
-                <p className="font-medium">{selectedAdjustment.adjustment_number}</p>
-              </div>
-              <div>
-                <span className="text-sm text-muted-foreground">التاريخ:</span>
-                <p className="font-medium">
-                  {new Date(selectedAdjustment.adjustment_date).toLocaleDateString('en-US')}
-                </p>
-              </div>
-              <div>
-                <span className="text-sm text-muted-foreground">النوع:</span>
-                <p className="font-medium">
-                  {ADJUSTMENT_TYPES[selectedAdjustment.adjustment_type as keyof typeof ADJUSTMENT_TYPES]?.label}
-                </p>
-              </div>
-              <div>
-                <span className="text-sm text-muted-foreground">الحالة:</span>
-                <Badge
-                  variant={
-                    selectedAdjustment.status === 'SUBMITTED'
-                      ? 'default'
-                      : selectedAdjustment.status === 'DRAFT'
-                      ? 'secondary'
-                      : 'destructive'
-                  }
-                >
-                  {selectedAdjustment.status === 'SUBMITTED'
-                    ? 'مرحل'
-                    : selectedAdjustment.status === 'DRAFT'
-                    ? 'مسودة'
-                    : 'ملغي'}
-                </Badge>
-              </div>
-              <div className="col-span-2">
-                <span className="text-sm text-muted-foreground">السبب:</span>
-                <p className="font-medium">{selectedAdjustment.reason}</p>
-              </div>
-              {selectedAdjustment.reference_number && (
-                <div className="col-span-2">
-                  <span className="text-sm text-muted-foreground">رقم المرجع:</span>
-                  <p className="font-medium">{selectedAdjustment.reference_number}</p>
-                </div>
-              )}
-            </div>
-
-            {/* Summary Statistics */}
-            <div className="grid grid-cols-4 gap-4">
-              <div className="p-4 bg-blue-50 dark:bg-blue-950 rounded-lg">
-                <p className="text-sm text-muted-foreground">إجمالي المنتجات</p>
-                <p className="text-2xl font-bold">{selectedAdjustment.total_items || 0}</p>
-              </div>
-              <div className="p-4 bg-purple-50 dark:bg-purple-950 rounded-lg">
-                <p className="text-sm text-muted-foreground">فرق الكمية</p>
-                <p className="text-2xl font-bold">{selectedAdjustment.total_qty_difference || 0}</p>
-              </div>
-              <div className="p-4 bg-green-50 dark:bg-green-950 rounded-lg">
-                <p className="text-sm text-muted-foreground">فرق القيمة</p>
-                <p className="text-2xl font-bold">
-                  {(selectedAdjustment.total_value_difference || 0).toFixed(2)} ر.س
-                </p>
-              </div>
-              <div className="p-4 bg-amber-50 dark:bg-amber-950 rounded-lg">
-                <p className="text-sm text-muted-foreground">يتطلب موافقة</p>
-                <p className="text-2xl font-bold">{selectedAdjustment.requires_approval ? 'نعم' : 'لا'}</p>
-              </div>
-            </div>
-
-            {/* Action Buttons */}
-            {selectedAdjustment.status === 'DRAFT' && (
-              <div className="flex justify-end gap-2">
-                {canUpdateAdjustment && canOpenAdjustmentForm && (
-                <Button variant="outline" onClick={async () => {
-                  if (!canUpdateAdjustment) return
-                  try {
-                    // Load adjustment items
-                    const supabase = getSupabase()
-                    const { data: items, error } = await supabase
-                      .from('stock_adjustment_items')
-                      .select('*, products(*)')
-                      .eq('adjustment_id', selectedAdjustment.id)
-                    
-                    if (error) throw error
-
-                    // Set form data for editing
-                    setNewAdjustment({
-                      adjustment_date: selectedAdjustment.adjustment_date,
-                      adjustment_type: selectedAdjustment.adjustment_type,
-                      reason: selectedAdjustment.reason || '',
-                      reference_number: selectedAdjustment.reference_number,
-                      warehouse_id: selectedAdjustment.warehouse_id,
-                      increase_account_id: selectedAdjustment.increase_account_id || '',
-                      decrease_account_id: selectedAdjustment.decrease_account_id || '',
-                      items: items?.map(item => ({
-                        id: item.id,
-                        product_id: item.product_id,
-                        product: item.products,
-                        warehouse_id: item.warehouse_id,
-                        current_qty: item.current_qty || 0,
-                        new_qty: item.new_qty || 0,
-                        difference_qty: item.difference_qty || 0,
-                        current_rate: item.current_rate || 0,
-                        value_difference: item.value_difference || 0,
-                        reason: item.reason || ''
-                      })) || []
-                    })
-
-                    // Switch to edit mode
-                    setViewMode(false)
-                    setSelectedAdjustment({ ...selectedAdjustment, isEditing: true })
-                    setShowNewForm(true)
-                  } catch (error: any) {
-                    toast.error('فشل تحميل بيانات التسوية: ' + error.message)
-                  }
-                }}>
-                  ✏️ تعديل
-                </Button>
-                )}
-                {canApproveAdjustment && (
-                <Button onClick={async () => {
-                  if (!canApproveAdjustment) return
-                  if (confirm('هل أنت متأكد من ترحيل هذه التسوية؟ سيتم تحديث أرصدة المخزون وإنشاء القيود المحاسبية.')) {
-                    await handleSubmitAdjustment(selectedAdjustment.id)
-                  }
-                }}>
-                  ✅ ترحيل
-                </Button>
-                )}
-                {canUpdateAdjustment && (
-                <Button variant="destructive" onClick={async () => {
-                  if (!canUpdateAdjustment) return
-                  if (confirm('هل أنت متأكد من إلغاء هذه التسوية؟')) {
-                    try {
-                      const supabase = getSupabase()
-                      const { error } = await supabase
-                        .from('stock_adjustments')
-                        .update({ status: 'CANCELLED' })
-                        .eq('id', selectedAdjustment.id)
-
-                      if (error) throw error
-
-                      toast.success('تم إلغاء التسوية بنجاح')
-                      setViewMode(false)
-                      setSelectedAdjustment(null)
-                      loadAdjustments()
-                    } catch (error: any) {
-                      toast.error('فشل إلغاء التسوية: ' + error.message)
-                    }
-                  }
-                }}>
-                  🗑️ إلغاء
-                </Button>
-                )}
-              </div>
-            )}
-          </div>
-        </Card>
+        <StockAdjustmentDetailsCard
+          adjustment={selectedAdjustment}
+          canUpdateAdjustment={canUpdateAdjustment}
+          canApproveAdjustment={canApproveAdjustment}
+          canOpenAdjustmentForm={canOpenAdjustmentForm}
+          onClose={handleCloseAdjustmentDetails}
+          onEdit={handleEditSelectedAdjustment}
+          onSubmit={handleSubmitSelectedAdjustment}
+          onCancel={handleCancelSelectedAdjustment}
+        />
       )}
 
-      {/* Filters */}
-      <Card className="p-4">
-        <div className="flex gap-4">
-          <div className="flex-1">
-            <label htmlFor="filter-status" className="block text-sm font-medium mb-1">الحالة</label>
-            <select
-              id="filter-status"
-              value={filterStatus}
-              onChange={(e) => setFilterStatus(e.target.value)}
-              className="w-full px-3 py-2 border border-border dark:border-gray-700 rounded-md bg-card dark:bg-gray-800 text-foreground dark:text-gray-100 hover:bg-muted/50 dark:hover:bg-gray-700 transition-colors focus:outline-none focus:ring-2 focus:ring-primary"
-            >
-              <option value="all">الكل</option>
-              <option value="DRAFT">مسودة</option>
-              <option value="SUBMITTED">مرحل</option>
-              <option value="CANCELLED">ملغي</option>
-            </select>
-          </div>
-          <div className="flex-1">
-            <label htmlFor="filter-type" className="block text-sm font-medium mb-1">النوع</label>
-            <select
-              id="filter-type"
-              value={filterType}
-              onChange={(e) => setFilterType(e.target.value)}
-              className="w-full px-3 py-2 border border-border dark:border-gray-700 rounded-md bg-card dark:bg-gray-800 text-foreground dark:text-gray-100 hover:bg-muted/50 dark:hover:bg-gray-700 transition-colors focus:outline-none focus:ring-2 focus:ring-primary"
-            >
-              <option value="all">الكل</option>
-              {Object.entries(ADJUSTMENT_TYPES).map(([key, value]) => (
-                <option key={key} value={key}>
-                  {value.icon} {value.label}
-                </option>
-              ))}
-            </select>
-          </div>
-        </div>
-      </Card>
+      <StockAdjustmentFilters
+        filterStatus={filterStatus}
+        filterType={filterType}
+        onStatusChange={setFilterStatus}
+        onTypeChange={setFilterType}
+      />
 
-      {/* Adjustments List */}
-      <div className="bg-card rounded-lg border">
-        {adjustments.length === 0 ? (
-          <EmptyState
-            icon={<ClipboardList aria-hidden="true" />}
-            title="لا توجد تسويات مخزون بعد"
-            description="ابدأ بإنشاء تسوية جديدة بالزر أعلاه"
-          />
-        ) : (
-          <div className="divide-y">
-            {adjustments.map((adj) => (
-              <button
-                key={adj.id}
-                type="button"
-                aria-label={`عرض تفاصيل تسوية المخزون ${adj.id}`}
-                className="w-full text-start p-4 hover:bg-muted/50 cursor-pointer transition-colors border-0 bg-transparent"
-                onClick={() => {
-                  setSelectedAdjustment(adj)
-                  setViewMode(true)
-                }}
-              >
-                <div className="flex justify-between items-start">
-                  <div>
-                    <div className="flex items-center gap-2">
-                      <span className="text-2xl">
-                        {ADJUSTMENT_TYPES[adj.adjustment_type as keyof typeof ADJUSTMENT_TYPES]?.icon}
-                      </span>
-                      <div>
-                        <h3 className="font-medium">
-                          {ADJUSTMENT_TYPES[adj.adjustment_type as keyof typeof ADJUSTMENT_TYPES]?.label}
-                        </h3>
-                        <p className="text-sm text-muted-foreground">
-                          {adj.reference_number || adj.id}
-                        </p>
-                      </div>
-                    </div>
-                    <p className="text-sm mt-2">{adj.reason}</p>
-                  </div>
-                  <div className="text-start">
-                    <Badge
-                      variant={
-                        adj.status === 'SUBMITTED'
-                          ? 'default'
-                          : adj.status === 'DRAFT'
-                          ? 'secondary'
-                          : 'destructive'
-                      }
-                    >
-                      {adj.status === 'SUBMITTED'
-                        ? 'مرحل'
-                        : adj.status === 'DRAFT'
-                        ? 'مسودة'
-                        : 'ملغي'}
-                    </Badge>
-                    <div className="text-sm text-muted-foreground mt-2">
-                      {new Date(adj.adjustment_date).toLocaleDateString('en-US')}
-                    </div>
-                  </div>
-                </div>
-              </button>
-            ))}
-          </div>
-        )}
-      </div>
+      <StockAdjustmentsList
+        adjustments={adjustments}
+        onSelect={handleSelectAdjustment}
+      />
     </div>
   )
 }
@@ -2438,7 +2188,3 @@ function StorageBinsPage() {
 function StockTransfersPage() {
   return <StockTransferManagement />
 }
-
-
-
-


### PR DESCRIPTION
## Summary
- extract stock-adjustment create action, details, filters, product picker, and list presentation into focused components
- keep authentication, permission rechecks, Supabase writes, and reload orchestration in the parent
- add component coverage plus integration behavior locks for closing and cancelling adjustment details
- reduce `StockAdjustments` cyclomatic complexity from 40 to 14 (ESLint)

## Verification
- focused Inventory tests: 42/42 passed
- full suite with coverage: 4,477/4,477 passed
- extracted presentation coverage: 100% statements, branches, functions, and lines
- TypeScript, production build, no-demo-password gate, and RBAC direct-write gate: passed
- ESLint: 0 errors (existing repository warnings only)
- CI/CD, SonarQube, UoM types, Vercel, and Netlify: passed
- CodeFactor: 1 fixed issue, 0 new issues
- SonarQube new-code issues: 0
- Codacy: 0 new issues

Refs #118