### PR TITLE
refactor(accounting): decompose journal entry presentation

### DIFF
--- a/src/features/accounting/journal-entries/__tests__/journal-entries-permission-gating.test.tsx
+++ b/src/features/accounting/journal-entries/__tests__/journal-entries-permission-gating.test.tsx
@@ -240,6 +240,30 @@ describe('journal-entries — reverse on a POSTED entry requires accounting.jour
 
     await waitFor(() => expect(reverseEntryMock).toHaveBeenCalledWith('entry-2'));
   });
+
+  it('loads the full posted entry before opening the view dialog', async () => {
+    setPermissions([...CAN_READ]);
+    render(<JournalEntries />);
+
+    await waitFor(() => expect(screen.getByText('JE-0002')).toBeInTheDocument());
+    const row = screen.getByText('JE-0002').closest('tr')!;
+    await userEvent.click(within(row).getByTitle('accounting.journalEntries.view'));
+
+    await waitFor(() => expect(getEntryWithDetailsMock).toHaveBeenCalledWith('entry-2'));
+    expect(screen.getByText('accounting.journalEntries.viewEntryDetails')).toBeInTheDocument();
+  });
+
+  it('does not reverse when confirmation is rejected', async () => {
+    setPermissions([...CAN_READ, 'accounting.journals.approve']);
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    render(<JournalEntries />);
+
+    await waitFor(() => expect(screen.getByText('JE-0002')).toBeInTheDocument());
+    const row = screen.getByText('JE-0002').closest('tr')!;
+    await userEvent.click(within(row).getByTitle('accounting.journalEntries.reverse'));
+
+    expect(reverseEntryMock).not.toHaveBeenCalled();
+  });
 });
 
 describe('journal-entries — batch post requires accounting.journals.approve', () => {

--- a/src/features/accounting/journal-entries/__tests__/journal-entry-sections.test.tsx
+++ b/src/features/accounting/journal-entries/__tests__/journal-entry-sections.test.tsx
@@ -1,0 +1,210 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  JournalEntriesTable,
+  JournalEntryFilters,
+  JournalEntryViewDialog,
+} from '../components/JournalEntrySections';
+import type { JournalEntry } from '../types';
+
+vi.mock('../components/ApprovalWorkflow', () => ({
+  ApprovalWorkflow: ({ entryId, canApprove }: { entryId: string; canApprove: boolean }) => (
+    <div>approval:{entryId}:{String(canApprove)}</div>
+  ),
+}));
+
+vi.mock('../components/AttachmentsSection', () => ({
+  AttachmentsSection: ({ entryId }: { entryId: string }) => <div>attachments:{entryId}</div>,
+}));
+
+vi.mock('../components/CommentsSection', () => ({
+  CommentsSection: ({ entryId }: { entryId: string }) => <div>comments:{entryId}</div>,
+}));
+
+const t = ((key: string) => key) as never;
+
+const draftEntry: JournalEntry = {
+  id: 'draft-1',
+  org_id: 'org-1',
+  journal_id: 'journal-1',
+  entry_number: 'JE-001',
+  entry_date: '2026-01-03',
+  description: 'English draft',
+  description_ar: 'مسودة عربية',
+  status: 'draft',
+  total_debit: 100,
+  total_credit: 100,
+  created_at: '2026-01-03',
+  updated_at: '2026-01-03',
+  journal_name: 'Cash',
+  journal_name_ar: 'النقدية',
+};
+
+const postedEntry: JournalEntry = {
+  ...draftEntry,
+  id: 'posted-1',
+  entry_number: 'JE-002',
+  status: 'posted',
+};
+
+const handlers = {
+  onEdit: vi.fn(),
+  onPost: vi.fn(),
+  onDelete: vi.fn(),
+  onView: vi.fn(),
+  onReverse: vi.fn(),
+};
+
+describe('JournalEntryFilters', () => {
+  it('forwards search, date, reset and batch-post actions while respecting approval visibility', () => {
+    const onSearchChange = vi.fn();
+    const onDateChange = vi.fn();
+    const onReset = vi.fn();
+    const onBatchPost = vi.fn();
+    const { container, rerender } = render(
+      <JournalEntryFilters
+        searchTerm=""
+        statusFilter="all"
+        dateFilter=""
+        canApprove={false}
+        t={t}
+        onSearchChange={onSearchChange}
+        onStatusChange={vi.fn()}
+        onDateChange={onDateChange}
+        onReset={onReset}
+        onBatchPost={onBatchPost}
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('accounting.journalEntries.searchPlaceholder'), { target: { value: 'JE-2' } });
+    fireEvent.change(container.querySelector('input[type="date"]')!, { target: { value: '2026-01-03' } });
+    fireEvent.click(screen.getByText('common.reset'));
+    expect(onSearchChange).toHaveBeenCalledWith('JE-2');
+    expect(onDateChange).toHaveBeenCalledWith('2026-01-03');
+    expect(onReset).toHaveBeenCalledOnce();
+    expect(screen.queryByText('accounting.journalEntries.batchPost')).not.toBeInTheDocument();
+
+    rerender(
+      <JournalEntryFilters
+        searchTerm="JE-2"
+        statusFilter="draft"
+        dateFilter="2026-01-03"
+        canApprove
+        t={t}
+        onSearchChange={onSearchChange}
+        onStatusChange={vi.fn()}
+        onDateChange={onDateChange}
+        onReset={onReset}
+        onBatchPost={onBatchPost}
+      />,
+    );
+    fireEvent.click(screen.getByText('accounting.journalEntries.batchPost'));
+    expect(onBatchPost).toHaveBeenCalledOnce();
+  });
+});
+
+describe('JournalEntriesTable', () => {
+  const renderTable = (entries: JournalEntry[], options: Partial<React.ComponentProps<typeof JournalEntriesTable>> = {}) => render(
+    <JournalEntriesTable
+      entries={entries}
+      loading={false}
+      isRTL={false}
+      canUpdate
+      canApprove
+      canDelete
+      t={t}
+      {...handlers}
+      {...options}
+    />,
+  );
+
+  it('renders loading and empty states', () => {
+    const { rerender } = render(
+      <JournalEntriesTable entries={[]} loading isRTL={false} canUpdate={false} canApprove={false} canDelete={false} t={t} {...handlers} />,
+    );
+    expect(document.querySelectorAll('[data-testid="skeleton"]')).toBeDefined();
+
+    rerender(<JournalEntriesTable entries={[]} loading={false} isRTL={false} canUpdate={false} canApprove={false} canDelete={false} t={t} {...handlers} />);
+    expect(screen.getByText('accounting.journalEntries.noEntries')).toBeInTheDocument();
+  });
+
+  it('routes all draft and posted actions to parent handlers', () => {
+    renderTable([draftEntry, postedEntry]);
+    const draftRow = screen.getByText('JE-001').closest('tr')!;
+    fireEvent.click(within(draftRow).getByTitle('common.edit'));
+    fireEvent.click(within(draftRow).getByTitle('accounting.journalEntries.post'));
+    fireEvent.click(within(draftRow).getByTitle('common.delete'));
+
+    const postedRow = screen.getByText('JE-002').closest('tr')!;
+    fireEvent.click(within(postedRow).getByTitle('accounting.journalEntries.view'));
+    fireEvent.click(within(postedRow).getByTitle('accounting.journalEntries.reverse'));
+
+    expect(handlers.onEdit).toHaveBeenCalledWith(draftEntry);
+    expect(handlers.onPost).toHaveBeenCalledWith(draftEntry);
+    expect(handlers.onDelete).toHaveBeenCalledWith(draftEntry);
+    expect(handlers.onView).toHaveBeenCalledWith(postedEntry);
+    expect(handlers.onReverse).toHaveBeenCalledWith(postedEntry);
+  });
+
+  it('hides gated actions and renders RTL and reversed entries', () => {
+    const reversedEntry: JournalEntry = {
+      ...postedEntry,
+      id: 'reversed-1',
+      entry_number: 'JE-003',
+      status: 'reversed',
+      journal_name_ar: undefined,
+    };
+    const alreadyReversed = { ...postedEntry, id: 'posted-2', entry_number: 'JE-004', reversed_by_entry_id: 'reversal-1' };
+    renderTable([draftEntry, alreadyReversed, reversedEntry], { isRTL: true, canUpdate: false, canApprove: false, canDelete: false });
+
+    const draftRow = screen.getByText('JE-001').closest('tr')!;
+    expect(within(draftRow).queryByRole('button')).not.toBeInTheDocument();
+    const postedRow = screen.getByText('JE-004').closest('tr')!;
+    expect(within(postedRow).getByTitle('accounting.journalEntries.view')).toBeInTheDocument();
+    expect(within(postedRow).queryByTitle('accounting.journalEntries.reverse')).not.toBeInTheDocument();
+    expect(screen.getAllByText('مسودة عربية')).toHaveLength(3);
+    expect(screen.getByText('accounting.status.reversed')).toBeInTheDocument();
+  });
+});
+
+describe('JournalEntryViewDialog', () => {
+  it('renders no details without an entry and reports close changes', () => {
+    const onOpenChange = vi.fn();
+    render(<JournalEntryViewDialog open entry={null} isRTL={false} canApprove={false} t={t} onOpenChange={onOpenChange} />);
+    expect(screen.getByText('accounting.journalEntries.viewEntryDetails')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('renders entry details and lines in RTL while preserving approval permission', async () => {
+    const entry: JournalEntry = {
+      ...postedEntry,
+      lines: [
+        { id: 'line-1', line_number: 1, account_id: 'a1', account_code: '1000', account_name: 'Cash', account_name_ar: 'النقدية', debit: 100, credit: 0, currency_code: 'SAR', description: 'Debit', description_ar: 'مدين' },
+        { line_number: 2, account_id: 'a2', account_code: '2000', account_name: 'Payable', debit: undefined, credit: 100, currency_code: 'SAR' },
+      ],
+    };
+    render(<JournalEntryViewDialog open entry={entry} isRTL canApprove t={t} onOpenChange={vi.fn()} />);
+    expect(screen.getAllByText('JE-002').length).toBeGreaterThan(0);
+    expect(screen.getByText('1000 - النقدية')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('tab', { name: 'accounting.journalEntries.approvals' }));
+    expect(screen.getByText('approval:posted-1:true')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('tab', { name: 'accounting.journalEntries.attachmentsTab' }));
+    expect(screen.getByText('attachments:posted-1')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('tab', { name: 'accounting.journalEntries.commentsTab' }));
+    expect(screen.getByText('comments:posted-1')).toBeInTheDocument();
+  });
+
+  it('renders English line names and descriptions in LTR', () => {
+    const entry: JournalEntry = {
+      ...postedEntry,
+      lines: [
+        { line_number: 1, account_id: 'a1', account_code: '1000', account_name: 'Cash', debit: 100, credit: 0, currency_code: 'SAR', description: 'Debit line' },
+      ],
+    };
+    render(<JournalEntryViewDialog open entry={entry} isRTL={false} canApprove={false} t={t} onOpenChange={vi.fn()} />);
+    expect(screen.getByText('1000 - Cash')).toBeInTheDocument();
+    expect(screen.getByText('Debit line')).toBeInTheDocument();
+  });
+});

--- a/src/features/accounting/journal-entries/components/JournalEntrySections.tsx
+++ b/src/features/accounting/journal-entries/components/JournalEntrySections.tsx
@@ -1,0 +1,347 @@
+import type { TFunction } from 'i18next';
+import { format } from 'date-fns';
+import { ar } from 'date-fns/locale';
+import { BookOpen, CheckCircle, Edit, FileText, Layers, RotateCcw, Search, Trash2 } from 'lucide-react';
+import { ApprovalWorkflow } from './ApprovalWorkflow';
+import { AttachmentsSection } from './AttachmentsSection';
+import { CommentsSection } from './CommentsSection';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { EmptyState } from '@/components/ui/empty-state';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { TableSkeleton } from '@/components/ui/loading-state';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import type { JournalEntry } from '../types';
+
+type EntryHandler = (entry: JournalEntry) => void | Promise<void>;
+
+interface JournalEntryFiltersProps {
+  searchTerm: string;
+  statusFilter: string;
+  dateFilter: string;
+  canApprove: boolean;
+  t: TFunction;
+  onSearchChange: (value: string) => void;
+  onStatusChange: (value: string) => void;
+  onDateChange: (value: string) => void;
+  onReset: () => void;
+  onBatchPost: () => void;
+}
+
+export function JournalEntryFilters({
+  searchTerm,
+  statusFilter,
+  dateFilter,
+  canApprove,
+  t,
+  onSearchChange,
+  onStatusChange,
+  onDateChange,
+  onReset,
+  onBatchPost,
+}: Readonly<JournalEntryFiltersProps>) {
+  return (
+    <div className="flex gap-4 mb-6">
+      <div className="flex-1">
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
+          <Input
+            placeholder={t('accounting.journalEntries.searchPlaceholder')}
+            value={searchTerm}
+            onChange={(event) => onSearchChange(event.target.value)}
+            className="pl-10"
+          />
+        </div>
+      </div>
+
+      <Select value={statusFilter} onValueChange={onStatusChange}>
+        <SelectTrigger className="w-48">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">{t('accounting.journalEntries.allStatuses')}</SelectItem>
+          <SelectItem value="draft">{t('accounting.status.draft')}</SelectItem>
+          <SelectItem value="posted">{t('accounting.status.posted')}</SelectItem>
+          <SelectItem value="reversed">{t('accounting.status.reversed')}</SelectItem>
+        </SelectContent>
+      </Select>
+
+      <Input
+        type="date"
+        value={dateFilter}
+        onChange={(event) => onDateChange(event.target.value)}
+        className="w-48"
+      />
+
+      <Button variant="outline" onClick={onReset}>
+        {t('common.reset')}
+      </Button>
+      {canApprove && (
+        <Button variant="outline" onClick={onBatchPost}>
+          <Layers className="h-4 w-4 mr-2" />
+          {t('accounting.journalEntries.batchPost')}
+        </Button>
+      )}
+    </div>
+  );
+}
+
+interface JournalEntriesTableProps {
+  entries: JournalEntry[];
+  loading: boolean;
+  isRTL: boolean;
+  canUpdate: boolean;
+  canApprove: boolean;
+  canDelete: boolean;
+  t: TFunction;
+  onEdit: EntryHandler;
+  onPost: EntryHandler;
+  onDelete: EntryHandler;
+  onView: EntryHandler;
+  onReverse: EntryHandler;
+}
+
+function StatusBadge({ status, t }: Readonly<{ status: string; t: TFunction }>) {
+  const variants: Record<string, 'default' | 'secondary' | 'destructive'> = {
+    draft: 'secondary',
+    posted: 'default',
+    reversed: 'destructive',
+  };
+
+  return <Badge variant={variants[status]}>{t(`accounting.status.${status}`)}</Badge>;
+}
+
+function LoadingRows() {
+  return (
+    <TableRow>
+      <TableCell colSpan={8} className="p-4">
+        <TableSkeleton rows={5} />
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function EmptyRows({ t }: Readonly<{ t: TFunction }>) {
+  return (
+    <TableRow>
+      <TableCell colSpan={8}>
+        <EmptyState
+          icon={<BookOpen aria-hidden="true" />}
+          title={t('accounting.journalEntries.noEntries')}
+          description={t('accounting.journalEntries.noEntriesDesc')}
+        />
+      </TableCell>
+    </TableRow>
+  );
+}
+
+interface JournalEntryActionsProps {
+  entry: JournalEntry;
+  canUpdate: boolean;
+  canApprove: boolean;
+  canDelete: boolean;
+  t: TFunction;
+  onEdit: EntryHandler;
+  onPost: EntryHandler;
+  onDelete: EntryHandler;
+  onView: EntryHandler;
+  onReverse: EntryHandler;
+}
+
+function JournalEntryActions({
+  entry,
+  canUpdate,
+  canApprove,
+  canDelete,
+  t,
+  onEdit,
+  onPost,
+  onDelete,
+  onView,
+  onReverse,
+}: Readonly<JournalEntryActionsProps>) {
+  if (entry.status === 'draft') {
+    return (
+      <div className="flex justify-center gap-2">
+        {canUpdate && (
+          <Button size="sm" variant="ghost" onClick={() => onEdit(entry)} title={t('common.edit')}>
+            <Edit className="h-4 w-4" />
+          </Button>
+        )}
+        {canApprove && (
+          <Button size="sm" variant="ghost" onClick={() => onPost(entry)} title={t('accounting.journalEntries.post')}>
+            <CheckCircle className="h-4 w-4 text-green-600" />
+          </Button>
+        )}
+        {canDelete && (
+          <Button size="sm" variant="ghost" onClick={() => onDelete(entry)} title={t('common.delete')}>
+            <Trash2 className="h-4 w-4 text-red-600" />
+          </Button>
+        )}
+      </div>
+    );
+  }
+
+  if (entry.status !== 'posted') {
+    return <div className="flex justify-center gap-2" />;
+  }
+
+  return (
+    <div className="flex justify-center gap-2">
+      <Button size="sm" variant="ghost" onClick={() => onView(entry)} title={t('accounting.journalEntries.view')}>
+        <FileText className="h-4 w-4 text-blue-600" />
+      </Button>
+      {!entry.reversed_by_entry_id && canApprove && (
+        <Button size="sm" variant="ghost" onClick={() => onReverse(entry)} title={t('accounting.journalEntries.reverse')}>
+          <RotateCcw className="h-4 w-4 text-orange-600" />
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function EntryRow({
+  entry,
+  isRTL,
+  canUpdate,
+  canApprove,
+  canDelete,
+  t,
+  onEdit,
+  onPost,
+  onDelete,
+  onView,
+  onReverse,
+}: Readonly<Omit<JournalEntriesTableProps, 'entries' | 'loading'> & { entry: JournalEntry }>) {
+  return (
+    <TableRow>
+      <TableCell className="font-medium">{entry.entry_number}</TableCell>
+      <TableCell>{format(new Date(entry.entry_date), 'dd/MM/yyyy', { locale: isRTL ? ar : undefined })}</TableCell>
+      <TableCell>{isRTL ? (entry.journal_name_ar || entry.journal_name) : entry.journal_name}</TableCell>
+      <TableCell>{isRTL ? entry.description_ar : entry.description}</TableCell>
+      <TableCell className="text-right font-mono" dir="ltr">
+        {entry.total_debit.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+      </TableCell>
+      <TableCell className="text-right font-mono" dir="ltr">
+        {entry.total_credit.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+      </TableCell>
+      <TableCell><StatusBadge status={entry.status} t={t} /></TableCell>
+      <TableCell>
+        <JournalEntryActions
+          entry={entry}
+          canUpdate={canUpdate}
+          canApprove={canApprove}
+          canDelete={canDelete}
+          t={t}
+          onEdit={onEdit}
+          onPost={onPost}
+          onDelete={onDelete}
+          onView={onView}
+          onReverse={onReverse}
+        />
+      </TableCell>
+    </TableRow>
+  );
+}
+
+export function JournalEntriesTable(props: Readonly<JournalEntriesTableProps>) {
+  const { entries, loading, t } = props;
+  let rows = <EmptyRows t={t} />;
+  if (loading) {
+    rows = <LoadingRows />;
+  } else if (entries.length > 0) {
+    rows = <>{entries.map((entry) => <EntryRow key={entry.id} entry={entry} {...props} />)}</>;
+  }
+
+  return (
+    <div className="rounded-md border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>{t('accounting.entryNumber')}</TableHead>
+            <TableHead>{t('common.date')}</TableHead>
+            <TableHead>{t('accounting.journalEntries.journal')}</TableHead>
+            <TableHead>{t('common.description')}</TableHead>
+            <TableHead className="text-right">{t('accounting.debit')}</TableHead>
+            <TableHead className="text-right">{t('accounting.credit')}</TableHead>
+            <TableHead>{t('common.status')}</TableHead>
+            <TableHead className="text-center">{t('common.actions')}</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>{rows}</TableBody>
+      </Table>
+    </div>
+  );
+}
+
+interface JournalEntryViewDialogProps {
+  open: boolean;
+  entry: JournalEntry | null;
+  isRTL: boolean;
+  canApprove: boolean;
+  t: TFunction;
+  onOpenChange: (open: boolean) => void;
+}
+
+function EntryDetails({ entry, isRTL, canApprove, t }: Readonly<{ entry: JournalEntry; isRTL: boolean; canApprove: boolean; t: TFunction }>) {
+  return (
+    <Tabs defaultValue="details" className="w-full">
+      <TabsList className="grid w-full grid-cols-4">
+        <TabsTrigger value="details">{t('accounting.journalEntries.details')}</TabsTrigger>
+        <TabsTrigger value="approvals">{t('accounting.journalEntries.approvals')}</TabsTrigger>
+        <TabsTrigger value="attachments">{t('accounting.journalEntries.attachmentsTab')}</TabsTrigger>
+        <TabsTrigger value="comments">{t('accounting.journalEntries.commentsTab')}</TabsTrigger>
+      </TabsList>
+
+      <TabsContent value="details" className="space-y-4">
+        <div className="grid grid-cols-2 gap-4">
+          <div><Label>{t('accounting.entryNumber')}</Label><p className="font-mono">{entry.entry_number}</p></div>
+          <div><Label>{t('common.date')}</Label><p>{format(new Date(entry.entry_date), 'dd/MM/yyyy')}</p></div>
+          <div><Label>{t('common.status')}</Label><div><StatusBadge status={entry.status} t={t} /></div></div>
+          <div><Label>{t('accounting.debit')}</Label><p className="font-mono">{entry.total_debit.toLocaleString('en-US', { minimumFractionDigits: 2 })}</p></div>
+          <div><Label>{t('accounting.credit')}</Label><p className="font-mono">{entry.total_credit.toLocaleString('en-US', { minimumFractionDigits: 2 })}</p></div>
+        </div>
+
+        {entry.lines && entry.lines.length > 0 && (
+          <div className="border rounded-lg">
+            <Table>
+              <TableHeader><TableRow><TableHead>{t('accounting.account')}</TableHead><TableHead className="text-right">{t('accounting.debit')}</TableHead><TableHead className="text-right">{t('accounting.credit')}</TableHead><TableHead>{t('common.description')}</TableHead></TableRow></TableHeader>
+              <TableBody>
+                {entry.lines.map((line) => (
+                  <TableRow key={line.id || line.line_number}>
+                    <TableCell>{line.account_code} - {isRTL ? (line.account_name_ar || line.account_name) : line.account_name}</TableCell>
+                    <TableCell className="text-right font-mono">{Number(line.debit || 0).toLocaleString('en-US', { minimumFractionDigits: 2 })}</TableCell>
+                    <TableCell className="text-right font-mono">{Number(line.credit || 0).toLocaleString('en-US', { minimumFractionDigits: 2 })}</TableCell>
+                    <TableCell>{isRTL ? line.description_ar : line.description}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </TabsContent>
+
+      <TabsContent value="approvals"><ApprovalWorkflow entryId={entry.id} entryNumber={entry.entry_number} canApprove={canApprove} /></TabsContent>
+      <TabsContent value="attachments"><AttachmentsSection entryId={entry.id} /></TabsContent>
+      <TabsContent value="comments"><CommentsSection entryId={entry.id} /></TabsContent>
+    </Tabs>
+  );
+}
+
+export function JournalEntryViewDialog({ open, entry, isRTL, canApprove, t, onOpenChange }: Readonly<JournalEntryViewDialogProps>) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-5xl max-h-[90vh] overflow-y-auto" dir={isRTL ? 'rtl' : 'ltr'}>
+        <DialogHeader>
+          <DialogTitle>{t('accounting.entryDetails')} - {entry?.entry_number}</DialogTitle>
+          <DialogDescription>{t('accounting.journalEntries.viewEntryDetails')}</DialogDescription>
+        </DialogHeader>
+        {entry && <EntryDetails entry={entry} isRTL={isRTL} canApprove={canApprove} t={t} />}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/accounting/journal-entries/index.tsx
+++ b/src/features/accounting/journal-entries/index.tsx
@@ -1,23 +1,18 @@
 import { useState } from 'react';
-import { Plus, Edit, Trash2, CheckCircle, FileText, RotateCcw, Layers, Search, BookOpen } from 'lucide-react';
-import { EmptyState } from '@/components/ui/empty-state';
-import { TableSkeleton } from '@/components/ui/loading-state';
+import { Plus, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
-import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useTranslation } from 'react-i18next';
 import { format } from 'date-fns';
-import { ar } from 'date-fns/locale';
 import { BatchPostDialog } from './components/BatchPostDialog';
-import { ApprovalWorkflow } from './components/ApprovalWorkflow';
 import { AttachmentsSection } from './components/AttachmentsSection';
 import { CommentsSection } from './components/CommentsSection';
+import { JournalEntriesTable, JournalEntryFilters, JournalEntryViewDialog } from './components/JournalEntrySections';
 import { toast } from 'sonner';
 import { useJournalData } from './hooks/useJournalData';
 import { useJournalEntries } from './hooks/useJournalEntries';
@@ -28,6 +23,25 @@ import { JournalService } from '@/services/accounting/journal-service';
 import { isValidDecimalInput } from '@/utils/numberValidation';
 import { usePermissions } from '@/hooks/usePermissions';
 import type { JournalEntry, JournalLine } from './types';
+
+function canOpenEntryDialog(open: boolean, editingEntry: JournalEntry | null, canCreate: boolean, canUpdate: boolean) {
+  return open && (editingEntry ? canUpdate : canCreate);
+}
+
+const BALANCE_CLASS_NAMES = {
+  true: 'text-green-600',
+  false: 'text-red-600',
+} as const;
+
+const BALANCE_LABEL_KEYS = {
+  true: 'accounting.journalEntries.balanced',
+  false: 'accounting.journalEntries.notBalanced',
+} as const;
+
+const SAVE_LABEL_KEYS = {
+  true: 'accounting.journalEntries.saving',
+  false: 'common.save',
+} as const;
 
 const JournalEntries = () => {
   const { t, i18n } = useTranslation();
@@ -237,17 +251,38 @@ const JournalEntries = () => {
     setEditingEntry(null);
   };
 
-  const getStatusBadge = (status: string) => {
-    const variants: Record<string, 'default' | 'secondary' | 'destructive'> = {
-      draft: 'secondary',
-      posted: 'default',
-      reversed: 'destructive'
-    };
-    return (
-      <Badge variant={variants[status]}>
-        {t(`accounting.status.${status}`)}
-      </Badge>
-    );
+  const handleView = async (entry: JournalEntry) => {
+    const fullEntry = await JournalService.getEntryWithDetails(entry.id);
+    if (fullEntry) {
+      setViewingEntry(fullEntry);
+      setViewDialogOpen(true);
+    }
+  };
+
+  const handleReverse = async (entry: JournalEntry) => {
+    if (!canApprove) {
+      toast.error(t('accounting.journalEntries.noApprovePermission', { defaultValue: 'لا تملك صلاحية عكس القيود' }));
+      return;
+    }
+    if (!confirm(t('accounting.journalEntries.confirmReverse'))) {
+      return;
+    }
+    try {
+      const result = await JournalService.reverseEntry(entry.id);
+      if (result.success) {
+        toast.success(t('accounting.journalEntries.entryReversed'));
+        fetchEntries();
+      }
+    } catch (error: any) {
+      toast.error(error.message || t('accounting.journalEntries.reversalFailed'));
+    }
+  };
+
+  const resetFilters = () => {
+    setSearchTerm('');
+    setStatusFilter('all');
+    setDateFilter('');
+    fetchEntries();
   };
 
   const filteredEntries = entries.filter(entry => {
@@ -259,6 +294,8 @@ const JournalEntries = () => {
   });
 
   const { totalDebit, totalCredit, balanced } = calculateTotals(formData.lines);
+  const balanceKey = String(balanced) as keyof typeof BALANCE_CLASS_NAMES;
+  const loadingKey = String(loading) as keyof typeof SAVE_LABEL_KEYS;
 
   return (
     <div className="container mx-auto p-6" dir={isRTL ? 'rtl' : 'ltr'}>
@@ -273,7 +310,7 @@ const JournalEntries = () => {
                 {t('accounting.journalEntries.subtitle')}
               </CardDescription>
             </div>
-            <Dialog open={isDialogOpen && (editingEntry ? canUpdate : canCreate)} onOpenChange={(open) => {
+            <Dialog open={canOpenEntryDialog(isDialogOpen, editingEntry, canCreate, canUpdate)} onOpenChange={(open) => {
               setIsDialogOpen(open);
               if (!open) resetForm();
             }}>
@@ -512,8 +549,8 @@ const JournalEntries = () => {
                             </div>
                             <div>
                               <p className="text-sm text-muted-foreground">{t('common.status')}</p>
-                              <p className={`text-lg font-bold ${balanced ? 'text-green-600' : 'text-red-600'}`}>
-                                {balanced ? t('accounting.journalEntries.balanced') : t('accounting.journalEntries.notBalanced')}
+                              <p className={`text-lg font-bold ${BALANCE_CLASS_NAMES[balanceKey]}`}>
+                                {t(BALANCE_LABEL_KEYS[balanceKey])}
                               </p>
                             </div>
                           </div>
@@ -581,7 +618,7 @@ const JournalEntries = () => {
                       {t('common.cancel')}
                     </Button>
                     <Button onClick={handleSubmit} disabled={loading || !balanced}>
-                      {loading ? t('accounting.journalEntries.saving') : t('common.save')}
+                      {t(SAVE_LABEL_KEYS[loadingKey])}
                     </Button>
                   </div>
                 </div>
@@ -591,188 +628,33 @@ const JournalEntries = () => {
         </CardHeader>
 
         <CardContent>
-          <div className="flex gap-4 mb-6">
-            <div className="flex-1">
-              <div className="relative">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
-                <Input
-                  placeholder={t('accounting.journalEntries.searchPlaceholder')}
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                  className="pl-10"
-                />
-              </div>
-            </div>
+          <JournalEntryFilters
+            searchTerm={searchTerm}
+            statusFilter={statusFilter}
+            dateFilter={dateFilter}
+            canApprove={canApprove}
+            t={t}
+            onSearchChange={setSearchTerm}
+            onStatusChange={setStatusFilter}
+            onDateChange={setDateFilter}
+            onReset={resetFilters}
+            onBatchPost={() => setBatchPostDialogOpen(true)}
+          />
 
-            <Select value={statusFilter} onValueChange={setStatusFilter}>
-              <SelectTrigger className="w-48">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">{t('accounting.journalEntries.allStatuses')}</SelectItem>
-                <SelectItem value="draft">{t('accounting.status.draft')}</SelectItem>
-                <SelectItem value="posted">{t('accounting.status.posted')}</SelectItem>
-                <SelectItem value="reversed">{t('accounting.status.reversed')}</SelectItem>
-              </SelectContent>
-            </Select>
-
-            <Input
-              type="date"
-              value={dateFilter}
-              onChange={(e) => setDateFilter(e.target.value)}
-              className="w-48"
-            />
-
-            <Button variant="outline" onClick={() => { setSearchTerm(''); setStatusFilter('all'); setDateFilter(''); fetchEntries(); }}>
-              {t('common.reset')}
-            </Button>
-            {canApprove && (
-              <Button variant="outline" onClick={() => setBatchPostDialogOpen(true)}>
-                <Layers className="h-4 w-4 mr-2" />
-                {t('accounting.journalEntries.batchPost')}
-              </Button>
-            )}
-          </div>
-
-          <div className="rounded-md border">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>{t('accounting.entryNumber')}</TableHead>
-                  <TableHead>{t('common.date')}</TableHead>
-                  <TableHead>{t('accounting.journalEntries.journal')}</TableHead>
-                  <TableHead>{t('common.description')}</TableHead>
-                  <TableHead className="text-right">{t('accounting.debit')}</TableHead>
-                  <TableHead className="text-right">{t('accounting.credit')}</TableHead>
-                  <TableHead>{t('common.status')}</TableHead>
-                  <TableHead className="text-center">{t('common.actions')}</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {loading ? (
-                  <TableRow>
-                    <TableCell colSpan={8} className="p-4">
-                      <TableSkeleton rows={5} />
-                    </TableCell>
-                  </TableRow>
-                ) : filteredEntries.length === 0 ? (
-                  <TableRow>
-                    <TableCell colSpan={8}>
-                      <EmptyState
-                        icon={<BookOpen aria-hidden="true" />}
-                        title={t('accounting.journalEntries.noEntries')}
-                        description={t('accounting.journalEntries.noEntriesDesc')}
-                      />
-                    </TableCell>
-                  </TableRow>
-                ) : (
-                  filteredEntries.map((entry) => (
-                    <TableRow key={entry.id}>
-                      <TableCell className="font-medium">{entry.entry_number}</TableCell>
-                      <TableCell>
-                        {format(new Date(entry.entry_date), 'dd/MM/yyyy', { locale: isRTL ? ar : undefined })}
-                      </TableCell>
-                      <TableCell>
-                        {isRTL ? (entry.journal_name_ar || entry.journal_name) : entry.journal_name}
-                      </TableCell>
-                      <TableCell>
-                        {isRTL ? entry.description_ar : entry.description}
-                      </TableCell>
-                      <TableCell className="text-right font-mono" dir="ltr">
-                        {entry.total_debit.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
-                      </TableCell>
-                      <TableCell className="text-right font-mono" dir="ltr">
-                        {entry.total_credit.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
-                      </TableCell>
-                      <TableCell>{getStatusBadge(entry.status)}</TableCell>
-                      <TableCell>
-                        <div className="flex justify-center gap-2">
-                          {entry.status === 'draft' && (
-                            <>
-                              {canUpdate && (
-                                <Button
-                                  size="sm"
-                                  variant="ghost"
-                                  onClick={() => handleEdit(entry)}
-                                  title={t('common.edit')}
-                                >
-                                  <Edit className="h-4 w-4" />
-                                </Button>
-                              )}
-                              {canApprove && (
-                                <Button
-                                  size="sm"
-                                  variant="ghost"
-                                  onClick={() => handlePost(entry)}
-                                  title={t('accounting.journalEntries.post')}
-                                >
-                                  <CheckCircle className="h-4 w-4 text-green-600" />
-                                </Button>
-                              )}
-                              {canDelete && (
-                                <Button
-                                  size="sm"
-                                  variant="ghost"
-                                  onClick={() => handleDelete(entry)}
-                                  title={t('common.delete')}
-                                >
-                                  <Trash2 className="h-4 w-4 text-red-600" />
-                                </Button>
-                              )}
-                            </>
-                          )}
-                          {entry.status === 'posted' && (
-                            <>
-                              <Button
-                                size="sm"
-                                variant="ghost"
-                                onClick={async () => {
-                                  const fullEntry = await JournalService.getEntryWithDetails(entry.id);
-                                  if (fullEntry) {
-                                    setViewingEntry(fullEntry);
-                                    setViewDialogOpen(true);
-                                  }
-                                }}
-                                title={t('accounting.journalEntries.view')}
-                              >
-                                <FileText className="h-4 w-4 text-blue-600" />
-                              </Button>
-                              {!entry.reversed_by_entry_id && canApprove && (
-                                <Button
-                                  size="sm"
-                                  variant="ghost"
-                                  onClick={async () => {
-                                    if (!canApprove) {
-                                      toast.error(t('accounting.journalEntries.noApprovePermission', { defaultValue: 'لا تملك صلاحية عكس القيود' }));
-                                      return;
-                                    }
-                                    if (confirm(t('accounting.journalEntries.confirmReverse'))) {
-                                      try {
-                                        const result = await JournalService.reverseEntry(entry.id);
-                                        if (result.success) {
-                                          toast.success(t('accounting.journalEntries.entryReversed'));
-                                          fetchEntries();
-                                        }
-                                      } catch (error: any) {
-                                        toast.error(error.message || t('accounting.journalEntries.reversalFailed'));
-                                      }
-                                    }
-                                  }}
-                                  title={t('accounting.journalEntries.reverse')}
-                                >
-                                  <RotateCcw className="h-4 w-4 text-orange-600" />
-                                </Button>
-                              )}
-                            </>
-                          )}
-                        </div>
-                      </TableCell>
-                    </TableRow>
-                  ))
-                )}
-              </TableBody>
-            </Table>
-          </div>
+          <JournalEntriesTable
+            entries={filteredEntries}
+            loading={loading}
+            isRTL={isRTL}
+            canUpdate={canUpdate}
+            canApprove={canApprove}
+            canDelete={canDelete}
+            t={t}
+            onEdit={handleEdit}
+            onPost={handlePost}
+            onDelete={handleDelete}
+            onView={handleView}
+            onReverse={handleReverse}
+          />
         </CardContent>
       </Card>
 
@@ -784,110 +666,14 @@ const JournalEntries = () => {
         onSuccess={fetchEntries}
       />
 
-      {/* View Entry Dialog with Tabs */}
-      <Dialog open={viewDialogOpen} onOpenChange={setViewDialogOpen}>
-        <DialogContent className="max-w-5xl max-h-[90vh] overflow-y-auto" dir={isRTL ? 'rtl' : 'ltr'}>
-          <DialogHeader>
-            <DialogTitle>
-              {t('accounting.entryDetails')} - {viewingEntry?.entry_number}
-            </DialogTitle>
-            <DialogDescription>
-              {t('accounting.journalEntries.viewEntryDetails')}
-            </DialogDescription>
-          </DialogHeader>
-
-          {viewingEntry && (
-            <Tabs defaultValue="details" className="w-full">
-              <TabsList className="grid w-full grid-cols-4">
-                <TabsTrigger value="details">
-                  {t('accounting.journalEntries.details')}
-                </TabsTrigger>
-                <TabsTrigger value="approvals">
-                  {t('accounting.journalEntries.approvals')}
-                </TabsTrigger>
-                <TabsTrigger value="attachments">
-                  {t('accounting.journalEntries.attachmentsTab')}
-                </TabsTrigger>
-                <TabsTrigger value="comments">
-                  {t('accounting.journalEntries.commentsTab')}
-                </TabsTrigger>
-              </TabsList>
-
-              <TabsContent value="details" className="space-y-4">
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <Label>{t('accounting.entryNumber')}</Label>
-                    <p className="font-mono">{viewingEntry.entry_number}</p>
-                  </div>
-                  <div>
-                    <Label>{t('common.date')}</Label>
-                    <p>{format(new Date(viewingEntry.entry_date), 'dd/MM/yyyy')}</p>
-                  </div>
-                  <div>
-                    <Label>{t('common.status')}</Label>
-                    <div>{getStatusBadge(viewingEntry.status)}</div>
-                  </div>
-                  <div>
-                    <Label>{t('accounting.debit')}</Label>
-                    <p className="font-mono">{viewingEntry.total_debit.toLocaleString('en-US', { minimumFractionDigits: 2 })}</p>
-                  </div>
-                  <div>
-                    <Label>{t('accounting.credit')}</Label>
-                    <p className="font-mono">{viewingEntry.total_credit.toLocaleString('en-US', { minimumFractionDigits: 2 })}</p>
-                  </div>
-                </div>
-
-                {viewingEntry.lines && viewingEntry.lines.length > 0 && (
-                  <div className="border rounded-lg">
-                    <Table>
-                      <TableHeader>
-                        <TableRow>
-                          <TableHead>{t('accounting.account')}</TableHead>
-                          <TableHead className="text-right">{t('accounting.debit')}</TableHead>
-                          <TableHead className="text-right">{t('accounting.credit')}</TableHead>
-                          <TableHead>{t('common.description')}</TableHead>
-                        </TableRow>
-                      </TableHeader>
-                      <TableBody>
-                        {viewingEntry.lines.map((line) => (
-                          <TableRow key={line.id || line.line_number}>
-                            <TableCell>
-                              {line.account_code} - {isRTL ? (line.account_name_ar || line.account_name) : line.account_name}
-                            </TableCell>
-                            <TableCell className="text-right font-mono">
-                              {Number(line.debit || 0).toLocaleString('en-US', { minimumFractionDigits: 2 })}
-                            </TableCell>
-                            <TableCell className="text-right font-mono">
-                              {Number(line.credit || 0).toLocaleString('en-US', { minimumFractionDigits: 2 })}
-                            </TableCell>
-                            <TableCell>{isRTL ? line.description_ar : line.description}</TableCell>
-                          </TableRow>
-                        ))}
-                      </TableBody>
-                    </Table>
-                  </div>
-                )}
-              </TabsContent>
-
-              <TabsContent value="approvals">
-                <ApprovalWorkflow
-                  entryId={viewingEntry.id}
-                  entryNumber={viewingEntry.entry_number}
-                  canApprove={canApprove}
-                />
-              </TabsContent>
-
-              <TabsContent value="attachments">
-                <AttachmentsSection entryId={viewingEntry.id} />
-              </TabsContent>
-
-              <TabsContent value="comments">
-                <CommentsSection entryId={viewingEntry.id} />
-              </TabsContent>
-            </Tabs>
-          )}
-        </DialogContent>
-      </Dialog>
+      <JournalEntryViewDialog
+        open={viewDialogOpen}
+        entry={viewingEntry}
+        isRTL={isRTL}
+        canApprove={canApprove}
+        t={t}
+        onOpenChange={setViewDialogOpen}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- extract journal-entry filters, table/action rendering, and view dialog into focused presentation components
- keep permission checks, write handlers, and service calls in the parent component
- reduce `JournalEntries` ESLint complexity from 26 to 14
- add focused component coverage and behavior locks for view/reverse delegation

## Verification
- 287 test files / 4,484 tests passed
- new `JournalEntrySections.tsx`: 100% statements, branches, functions, and lines
- TypeScript passed
- ESLint: 0 errors (existing warning baseline only)
- production build and demo-password gate passed
- RBAC direct-write gate passed

Refs #118