### PR TITLE
refactor(general-ledger): reduce account method complexity

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -89,6 +89,7 @@ sonar.coverage.exclusions=\
   **/src/features/accounting/journal-entries/hooks/**,\
   **/src/features/accounting/journal-entries/services/**,\
   **/src/features/accounting/journal-entries/utils/**,\
+  **/src/features/general-ledger/index.tsx,\
   **/src/features/manufacturing/capacity/**,\
   **/src/features/manufacturing/efficiency/**,\
   **/src/features/manufacturing/index.tsx,\

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -89,7 +89,6 @@ sonar.coverage.exclusions=\
   **/src/features/accounting/journal-entries/hooks/**,\
   **/src/features/accounting/journal-entries/services/**,\
   **/src/features/accounting/journal-entries/utils/**,\
-  **/src/features/general-ledger/**,\
   **/src/features/manufacturing/capacity/**,\
   **/src/features/manufacturing/efficiency/**,\
   **/src/features/manufacturing/index.tsx,\

--- a/src/features/general-ledger/__tests__/account-tree-item.test.tsx
+++ b/src/features/general-ledger/__tests__/account-tree-item.test.tsx
@@ -1,0 +1,189 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  AccountTreeItem,
+  accountMatchesFilters,
+  hasMatchingAccount,
+  type AccountTreeItemProps,
+  type AccountTreeNode,
+} from '../components/AccountTreeItem';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const child: AccountTreeNode = {
+  id: 'child-1',
+  code: '1100',
+  name: 'Petty Cash',
+  name_ar: 'العهد النقدية',
+  name_en: 'Petty Cash',
+  category: 'ASSET',
+  normal_balance: 'Debit',
+  allow_posting: true,
+  is_active: true,
+  org_id: 'org-1',
+  children: [],
+};
+
+const account: AccountTreeNode = {
+  id: 'account-1',
+  code: '1000',
+  name: 'Cash',
+  name_ar: 'النقدية',
+  name_en: 'Cash',
+  category: 'ASSET',
+  normal_balance: 'Debit',
+  allow_posting: false,
+  is_active: true,
+  org_id: 'org-1',
+  children: [child],
+};
+
+function createProps(overrides: Partial<AccountTreeItemProps> = {}): AccountTreeItemProps {
+  return {
+    account,
+    level: 0,
+    isRTL: false,
+    expandedNodes: new Set<string>(),
+    onToggleNode: vi.fn(),
+    onOpenModal: vi.fn(),
+    onDeleteAccount: vi.fn(),
+    searchTerm: '',
+    categoryFilter: 'all',
+    showInactiveAccounts: false,
+    canCreate: false,
+    canEdit: false,
+    canDelete: false,
+    ...overrides,
+  };
+}
+
+describe('general-ledger account tree filters', () => {
+  it('matches search, category, and active filters with the original AND semantics', () => {
+    expect(accountMatchesFilters(account, {
+      searchTerm: 'cash',
+      categoryFilter: 'ASSET',
+      showInactiveAccounts: false,
+    })).toBe(true);
+    expect(accountMatchesFilters({ ...account, is_active: false }, {
+      searchTerm: '',
+      categoryFilter: 'LIABILITY',
+      showInactiveAccounts: false,
+    })).toBe(false);
+  });
+
+  it('keeps a parent visible when only a descendant matches', () => {
+    expect(hasMatchingAccount(account, {
+      searchTerm: 'petty',
+      categoryFilter: 'all',
+      showInactiveAccounts: false,
+    })).toBe(true);
+  });
+
+  it('returns false for a leaf with no matching filters', () => {
+    expect(hasMatchingAccount({ ...child, children: undefined }, {
+      searchTerm: 'missing',
+      categoryFilter: 'all',
+      showInactiveAccounts: false,
+    })).toBe(false);
+  });
+});
+
+describe('AccountTreeItem', () => {
+  it('renders the localized identity and status badges', () => {
+    render(<AccountTreeItem {...createProps({ isRTL: true })} />);
+
+    expect(screen.getByText('النقدية')).toBeInTheDocument();
+    expect(screen.getByText('gl.asset')).toBeInTheDocument();
+    expect(screen.getByText('gl.debitShort')).toBeInTheDocument();
+  });
+
+  it('renders a matching descendant only after its parent is expanded', () => {
+    render(<AccountTreeItem {...createProps({
+      expandedNodes: new Set(['1000']),
+      searchTerm: 'petty',
+    })} />);
+
+    expect(screen.getByText('Cash')).toBeInTheDocument();
+    expect(screen.getByText('Petty Cash')).toBeInTheDocument();
+  });
+
+  it('hides a tree with no matching account or descendant', () => {
+    const { container } = render(<AccountTreeItem {...createProps({ searchTerm: 'missing' })} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('preserves create, edit, and delete permission gates and callbacks', async () => {
+    const onOpenModal = vi.fn();
+    const onDeleteAccount = vi.fn();
+    render(<AccountTreeItem {...createProps({
+      canCreate: true,
+      canEdit: true,
+      canDelete: true,
+      onOpenModal,
+      onDeleteAccount,
+    })} />);
+
+    await userEvent.click(screen.getByTitle('gl.addSubAccount'));
+    await userEvent.click(screen.getByTitle('gl.editAccountBtn'));
+    await userEvent.click(screen.getByTitle('gl.deleteAccountBtn'));
+
+    expect(onOpenModal).toHaveBeenNthCalledWith(1, 'add', undefined, account);
+    expect(onOpenModal).toHaveBeenNthCalledWith(2, 'edit', account);
+    expect(onDeleteAccount).toHaveBeenCalledWith(account);
+  });
+
+  it('hides every action without its exact permission', () => {
+    render(<AccountTreeItem {...createProps()} />);
+    expect(screen.queryByTitle('gl.addSubAccount')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('gl.editAccountBtn')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('gl.deleteAccountBtn')).not.toBeInTheDocument();
+  });
+
+  it('toggles a parent while a leaf toggle stays disabled', async () => {
+    const onToggleNode = vi.fn();
+    const { rerender } = render(<AccountTreeItem {...createProps({ onToggleNode })} />);
+    await userEvent.click(screen.getByRole('button'));
+    expect(onToggleNode).toHaveBeenCalledWith('1000');
+
+    rerender(<AccountTreeItem {...createProps({ account: child, onToggleNode })} />);
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('renders inactive, postable, credit, and unknown-category fallbacks', () => {
+    render(<AccountTreeItem {...createProps({
+      account: {
+        ...child,
+        category: 'OTHER',
+        normal_balance: 'Credit',
+        is_active: false,
+      },
+      showInactiveAccounts: true,
+    })} />);
+
+    expect(screen.getByText('OTHER')).toBeInTheDocument();
+    expect(screen.getByText('gl.creditShort')).toBeInTheDocument();
+    expect(screen.getByText('gl.postable')).toBeInTheDocument();
+    expect(screen.getByText('common.inactive')).toBeInTheDocument();
+  });
+
+  it('falls back to the base name in both directions and tolerates a missing category', () => {
+    const fallbackAccount = {
+      ...child,
+      name: 'Fallback Name',
+      name_ar: undefined,
+      name_en: undefined,
+      category: undefined,
+    };
+    render(
+      <>
+        <AccountTreeItem {...createProps({ account: fallbackAccount, isRTL: true })} />
+        <AccountTreeItem {...createProps({ account: fallbackAccount, isRTL: false })} />
+      </>,
+    );
+
+    expect(screen.getAllByText('Fallback Name')).toHaveLength(2);
+  });
+});

--- a/src/features/general-ledger/__tests__/general-ledger-permission-gating.test.tsx
+++ b/src/features/general-ledger/__tests__/general-ledger-permission-gating.test.tsx
@@ -30,6 +30,7 @@ const getAllGLAccounts = vi.fn();
 const createGLAccount = vi.fn();
 const updateGLAccount = vi.fn();
 const deleteGLAccount = vi.fn();
+const checkAccountCodeExists = vi.fn();
 
 vi.mock('@/lib/supabase', () => ({
   getAllGLAccounts: (...args: unknown[]) => getAllGLAccounts(...args),
@@ -37,7 +38,7 @@ vi.mock('@/lib/supabase', () => ({
   createGLAccount: (...args: unknown[]) => createGLAccount(...args),
   updateGLAccount: (...args: unknown[]) => updateGLAccount(...args),
   deleteGLAccount: (...args: unknown[]) => deleteGLAccount(...args),
-  checkAccountCodeExists: vi.fn().mockResolvedValue(false),
+  checkAccountCodeExists: (...args: unknown[]) => checkAccountCodeExists(...args),
 }));
 
 vi.mock('@/lib/export-libs', () => ({
@@ -83,6 +84,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   hasPermissionKeyMock.mockReturnValue(false);
   getAllGLAccounts.mockResolvedValue(accounts);
+  checkAccountCodeExists.mockResolvedValue(false);
 });
 
 describe('ChartOfAccounts — screen view vs. general_ledger.chart_of_accounts.create/.edit/.delete', () => {
@@ -155,6 +157,41 @@ describe('ChartOfAccounts — screen view vs. general_ledger.chart_of_accounts.c
     await userEvent.click(screen.getByText('common.save'));
 
     await waitFor(() => expect(createGLAccount).toHaveBeenCalled());
+  });
+
+  it('keeps the create form open and performs no write when the code already exists', async () => {
+    checkAccountCodeExists.mockResolvedValue(true);
+    setPermissions([
+      'general_ledger.chart_of_accounts.view',
+      'general_ledger.chart_of_accounts.create',
+    ]);
+    renderAt('/general-ledger/accounts');
+    await waitFor(() => expect(screen.getByText('1000')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByText('gl.addAccount'));
+    await userEvent.type(await screen.findByPlaceholderText('gl.accountCode'), '2000');
+    await userEvent.type(screen.getByPlaceholderText('gl.accountNameEn'), 'Bank');
+    await userEvent.click(screen.getByText('common.save'));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('gl.duplicateCode'));
+    expect(screen.getByPlaceholderText('gl.accountCode')).toBeInTheDocument();
+    expect(createGLAccount).not.toHaveBeenCalled();
+  });
+
+  it('a full edit grant preserves the update gateway and closes after success', async () => {
+    updateGLAccount.mockResolvedValue({ success: true });
+    setPermissions([
+      'general_ledger.chart_of_accounts.view',
+      'general_ledger.chart_of_accounts.edit',
+    ]);
+    renderAt('/general-ledger/accounts');
+    await waitFor(() => expect(screen.getByText('1000')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByTitle('gl.editAccountBtn'));
+    await userEvent.click(await screen.findByText('common.save'));
+
+    await waitFor(() => expect(updateGLAccount).toHaveBeenCalled());
+    expect(screen.queryByPlaceholderText('gl.accountCode')).not.toBeInTheDocument();
   });
 
   it('hides subaccount creation for a non-posting account without the create key', async () => {

--- a/src/features/general-ledger/__tests__/save-account.test.ts
+++ b/src/features/general-ledger/__tests__/save-account.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GLAccount } from '@/lib/supabase';
+import { saveGeneralLedgerAccount } from '../helpers/saveAccount';
+
+const selectedAccount: GLAccount = {
+  id: 'account-1',
+  code: '1000',
+  name: 'Cash',
+  name_ar: 'النقدية',
+  name_en: 'Cash',
+  category: 'ASSET',
+  normal_balance: 'Debit',
+  allow_posting: true,
+  is_active: true,
+  org_id: 'org-1',
+};
+
+const formData: Partial<GLAccount> = {
+  code: '2000',
+  name: 'Bank',
+  name_ar: 'البنك',
+  name_en: 'Bank',
+  category: 'ASSET',
+  parent_id: 'parent-1',
+  is_active: true,
+};
+
+const getEffectiveTenantId = vi.fn();
+const checkAccountCodeExists = vi.fn();
+const createGLAccount = vi.fn();
+const updateGLAccount = vi.fn();
+const t = vi.fn((key: string, options?: Record<string, unknown>) => (
+  options?.code ? `${key}:${options.code}` : key
+));
+
+const dependencies = {
+  getEffectiveTenantId,
+  checkAccountCodeExists,
+  createGLAccount,
+  updateGLAccount,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getEffectiveTenantId.mockResolvedValue('org-1');
+  checkAccountCodeExists.mockResolvedValue(false);
+  createGLAccount.mockResolvedValue({ success: true });
+  updateGLAccount.mockResolvedValue({ success: true });
+});
+
+describe('saveGeneralLedgerAccount', () => {
+  it('fails before validation or persistence when the active organization is missing', async () => {
+    getEffectiveTenantId.mockResolvedValue(null);
+
+    await expect(saveGeneralLedgerAccount({ formData, modalType: 'add', selectedAccount: null, t }, dependencies))
+      .rejects.toThrow('gl.orgIdNotFound');
+    expect(checkAccountCodeExists).not.toHaveBeenCalled();
+    expect(createGLAccount).not.toHaveBeenCalled();
+  });
+
+  it('rejects missing required fields before checking duplicate codes', async () => {
+    const outcome = await saveGeneralLedgerAccount(
+      { formData: { code: '2000' }, modalType: 'add', selectedAccount: null, t },
+      dependencies,
+    );
+
+    expect(outcome).toEqual({ status: 'rejected', message: 'gl.requiredFields' });
+    expect(checkAccountCodeExists).not.toHaveBeenCalled();
+  });
+
+  it('rejects a duplicate create code using the existing tenant argument contract', async () => {
+    checkAccountCodeExists.mockResolvedValue(true);
+
+    const outcome = await saveGeneralLedgerAccount(
+      { formData, modalType: 'add', selectedAccount: null, t },
+      dependencies,
+    );
+
+    expect(checkAccountCodeExists).toHaveBeenCalledWith('2000', 'org-1');
+    expect(outcome).toEqual({ status: 'rejected', message: 'gl.duplicateCode:2000' });
+    expect(createGLAccount).not.toHaveBeenCalled();
+  });
+
+  it('creates the exact existing payload and defaults an undefined active flag to true', async () => {
+    const outcome = await saveGeneralLedgerAccount(
+      {
+        formData: { ...formData, parent_id: undefined, is_active: undefined },
+        modalType: 'add',
+        selectedAccount: null,
+        t,
+      },
+      dependencies,
+    );
+
+    expect(createGLAccount).toHaveBeenCalledWith({
+      code: '2000',
+      name: 'Bank',
+      name_ar: 'البنك',
+      name_en: 'Bank',
+      account_type: 'ASSET',
+      parent_id: null,
+      is_active: true,
+    });
+    expect(updateGLAccount).not.toHaveBeenCalled();
+    expect(outcome).toEqual({ status: 'saved', message: 'gl.createdSuccess' });
+  });
+
+  it('updates the exact existing payload and skips duplicate lookup when the code is unchanged', async () => {
+    const outcome = await saveGeneralLedgerAccount(
+      {
+        formData: { ...formData, code: selectedAccount.code },
+        modalType: 'edit',
+        selectedAccount,
+        t,
+      },
+      dependencies,
+    );
+
+    expect(checkAccountCodeExists).not.toHaveBeenCalled();
+    expect(updateGLAccount).toHaveBeenCalledWith({
+      id: 'account-1',
+      code: '1000',
+      name: 'Bank',
+      name_ar: 'البنك',
+      name_en: 'Bank',
+      account_type: 'ASSET',
+      parent_id: 'parent-1',
+      is_active: true,
+    });
+    expect(outcome).toEqual({ status: 'saved', message: 'gl.updatedSuccess' });
+  });
+
+  it('checks a changed edit code before updating', async () => {
+    await saveGeneralLedgerAccount(
+      { formData: { ...formData, parent_id: undefined }, modalType: 'edit', selectedAccount, t },
+      dependencies,
+    );
+
+    expect(checkAccountCodeExists).toHaveBeenCalledWith('2000', 'org-1');
+    expect(updateGLAccount).toHaveBeenCalledWith(expect.objectContaining({ parent_id: null }));
+  });
+
+  it.each([
+    ['add', null, createGLAccount, 'Create failed'],
+    ['edit', selectedAccount, updateGLAccount, 'Update failed'],
+  ] as const)('propagates the existing fallback error for a failed %s result', async (
+    modalType,
+    account,
+    persistenceMock,
+    expectedMessage,
+  ) => {
+    persistenceMock.mockResolvedValueOnce({ success: false });
+
+    await expect(saveGeneralLedgerAccount(
+      { formData, modalType, selectedAccount: account, t },
+      dependencies,
+    )).rejects.toThrow(expectedMessage);
+  });
+});

--- a/src/features/general-ledger/components/AccountTreeItem.tsx
+++ b/src/features/general-ledger/components/AccountTreeItem.tsx
@@ -1,0 +1,293 @@
+import { useTranslation } from 'react-i18next';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import type { GLAccount } from '@/lib/supabase';
+import { ChevronDown, ChevronRight, Pencil, Plus, Trash2 } from 'lucide-react';
+
+export interface AccountTreeNode extends GLAccount {
+  children?: AccountTreeNode[];
+}
+
+export interface AccountTreeItemProps {
+  account: AccountTreeNode;
+  level: number;
+  isRTL: boolean;
+  expandedNodes: Set<string>;
+  onToggleNode: (code: string) => void;
+  onOpenModal: (type: 'add' | 'edit', account?: GLAccount, parent?: GLAccount) => void;
+  onDeleteAccount: (account: GLAccount) => void;
+  searchTerm: string;
+  categoryFilter: string;
+  showInactiveAccounts: boolean;
+  canCreate: boolean;
+  canEdit: boolean;
+  canDelete: boolean;
+}
+
+interface AccountFilter {
+  searchTerm: string;
+  categoryFilter: string;
+  showInactiveAccounts: boolean;
+}
+
+export function accountMatchesFilters(account: AccountTreeNode, filter: AccountFilter) {
+  const normalizedSearch = filter.searchTerm.toLowerCase();
+  const matchesSearch = !filter.searchTerm
+    || account.code.toLowerCase().includes(normalizedSearch)
+    || Boolean(account.name && account.name.toLowerCase().includes(normalizedSearch))
+    || Boolean(account.name_ar && account.name_ar.toLowerCase().includes(normalizedSearch));
+  const matchesCategory = filter.categoryFilter === 'all'
+    || account.category === filter.categoryFilter;
+  const matchesActive = filter.showInactiveAccounts || account.is_active;
+
+  return matchesSearch && matchesCategory && matchesActive;
+}
+
+export function hasMatchingAccount(account: AccountTreeNode, filter: AccountFilter): boolean {
+  if (accountMatchesFilters(account, filter)) return true;
+  return account.children?.some((child) => hasMatchingAccount(child, filter)) ?? false;
+}
+
+const CATEGORY_CLASS_NAMES: Record<string, string> = {
+  ASSET: 'bg-blue-100 text-blue-800 border-blue-200',
+  LIABILITY: 'bg-red-100 text-red-800 border-red-200',
+  EQUITY: 'bg-purple-100 text-purple-800 border-purple-200',
+  REVENUE: 'bg-green-100 text-green-800 border-green-200',
+  EXPENSE: 'bg-orange-100 text-orange-800 border-orange-200',
+};
+
+const CATEGORY_LABEL_KEYS: Record<string, string> = {
+  ASSET: 'gl.asset',
+  LIABILITY: 'gl.liability',
+  EQUITY: 'gl.equity',
+  REVENUE: 'gl.revenue',
+  EXPENSE: 'gl.expense',
+};
+
+function CategoryBadge({ category }: { readonly category?: string }) {
+  const { t } = useTranslation();
+  const categoryValue = category || '';
+  const labelKey = CATEGORY_LABEL_KEYS[categoryValue];
+  const label = labelKey ? t(labelKey) : categoryValue;
+
+  return (
+    <Badge
+      variant="outline"
+      className={`text-xs ${CATEGORY_CLASS_NAMES[categoryValue] || ''}`}
+    >
+      {label}
+    </Badge>
+  );
+}
+
+function NormalBalanceBadge({ normalBalance }: { readonly normalBalance?: string }) {
+  const { t } = useTranslation();
+  const isDebit = normalBalance === 'Debit';
+  const className = isDebit
+    ? 'text-xs bg-sky-50 text-sky-700 border-sky-200'
+    : 'text-xs bg-amber-50 text-amber-700 border-amber-200';
+
+  return (
+    <Badge variant="outline" className={className}>
+      {t(isDebit ? 'gl.debitShort' : 'gl.creditShort')}
+    </Badge>
+  );
+}
+
+function AccountBadges({ account }: { readonly account: AccountTreeNode }) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex items-center gap-2">
+      <CategoryBadge category={account.category} />
+      <NormalBalanceBadge normalBalance={account.normal_balance} />
+      {account.allow_posting && (
+        <Badge variant="outline" className="text-xs bg-green-50 text-green-700 border-green-200">
+          {t('gl.postable')}
+        </Badge>
+      )}
+      {!account.is_active && (
+        <Badge variant="outline" className="text-xs bg-gray-100 text-gray-600 border-gray-300">
+          {t('common.inactive')}
+        </Badge>
+      )}
+    </div>
+  );
+}
+
+function TreeToggle({
+  accountCode,
+  hasChildren,
+  isExpanded,
+  onToggleNode,
+}: {
+  readonly accountCode: string;
+  readonly hasChildren: boolean;
+  readonly isExpanded: boolean;
+  readonly onToggleNode: (code: string) => void;
+}) {
+  let icon = (
+    <span className="w-4 h-4 flex items-center justify-center">
+      <span className="w-1.5 h-1.5 rounded-full bg-muted-foreground/40" />
+    </span>
+  );
+  if (hasChildren) {
+    icon = isExpanded
+      ? <ChevronDown className="h-4 w-4 text-primary" />
+      : <ChevronRight className="h-4 w-4 text-muted-foreground" />;
+  }
+
+  return (
+    <button
+      type="button"
+      disabled={!hasChildren}
+      className="cursor-pointer flex items-center hover:bg-accent/30 rounded-md p-1 transition-colors disabled:cursor-default disabled:opacity-50 border-0 bg-transparent"
+      onClick={() => onToggleNode(accountCode)}
+    >
+      {icon}
+    </button>
+  );
+}
+
+function AccountIdentity({
+  account,
+  isRTL,
+  level,
+}: {
+  readonly account: AccountTreeNode;
+  readonly isRTL: boolean;
+  readonly level: number;
+}) {
+  const codeClassName = level === 0 ? 'font-bold' : '';
+  const nameClassName = level === 0 ? 'text-base font-bold' : 'text-sm';
+  const displayName = isRTL
+    ? (account.name_ar || account.name)
+    : (account.name_en || account.name);
+
+  return (
+    <div className="flex items-center gap-2 flex-1">
+      <code className={`text-sm font-mono px-2 py-0.5 rounded bg-muted/50 ${codeClassName}`}>
+        {account.code}
+      </code>
+      <span className={`${nameClassName} flex-1`}>{displayName}</span>
+    </div>
+  );
+}
+
+function AccountActions({
+  account,
+  canCreate,
+  canEdit,
+  canDelete,
+  onOpenModal,
+  onDeleteAccount,
+}: Pick<
+  AccountTreeItemProps,
+  'account' | 'canCreate' | 'canEdit' | 'canDelete' | 'onOpenModal' | 'onDeleteAccount'
+>) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity ml-4">
+      {!account.allow_posting && canCreate && (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8 hover:bg-primary/10 hover:text-primary"
+          title={t('gl.addSubAccount')}
+          onClick={() => onOpenModal('add', undefined, account)}
+        >
+          <Plus className="h-4 w-4" />
+        </Button>
+      )}
+      {canEdit && (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8 hover:bg-blue-100 hover:text-blue-700"
+          title={t('gl.editAccountBtn')}
+          onClick={() => onOpenModal('edit', account)}
+        >
+          <Pencil className="h-4 w-4" />
+        </Button>
+      )}
+      {canDelete && (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8 hover:bg-red-100 hover:text-red-700"
+          title={t('gl.deleteAccountBtn')}
+          onClick={() => onDeleteAccount(account)}
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function AccountChildren(props: AccountTreeItemProps & { readonly isExpanded: boolean }) {
+  if (!props.isExpanded || !props.account.children?.length) return null;
+
+  return (
+    <div className="border-l-2 border-primary/20 ml-4">
+      {props.account.children.map((child) => (
+        <AccountTreeItem
+          {...props}
+          key={child.code}
+          account={child}
+          level={props.level + 1}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function AccountTreeItem(props: AccountTreeItemProps) {
+  const filter = {
+    searchTerm: props.searchTerm,
+    categoryFilter: props.categoryFilter,
+    showInactiveAccounts: props.showInactiveAccounts,
+  };
+  if (!hasMatchingAccount(props.account, filter)) return null;
+
+  const isExpanded = props.expandedNodes.has(props.account.code);
+  const hasChildren = Boolean(props.account.children?.length);
+  const rowClassName = [
+    'flex justify-between items-center transition-all duration-150 group border-b border-border/40 hover:bg-accent/50 hover:shadow-sm',
+    props.account.is_active ? '' : 'opacity-50',
+    props.level === 0 ? 'font-semibold' : '',
+  ].filter(Boolean).join(' ');
+  const rowStyle = {
+    paddingRight: props.isRTL ? `${props.level * 24 + 12}px` : '12px',
+    paddingLeft: props.isRTL ? '12px' : `${props.level * 24 + 12}px`,
+    paddingTop: '10px',
+    paddingBottom: '10px',
+  };
+
+  return (
+    <div>
+      <div className={rowClassName} style={rowStyle}>
+        <div className="flex items-center gap-3 flex-1">
+          <TreeToggle
+            accountCode={props.account.code}
+            hasChildren={hasChildren}
+            isExpanded={isExpanded}
+            onToggleNode={props.onToggleNode}
+          />
+          <AccountIdentity account={props.account} isRTL={props.isRTL} level={props.level} />
+          <AccountBadges account={props.account} />
+        </div>
+        <AccountActions
+          account={props.account}
+          canCreate={props.canCreate}
+          canEdit={props.canEdit}
+          canDelete={props.canDelete}
+          onOpenModal={props.onOpenModal}
+          onDeleteAccount={props.onDeleteAccount}
+        />
+      </div>
+      <AccountChildren {...props} isExpanded={isExpanded} />
+    </div>
+  );
+}

--- a/src/features/general-ledger/components/AccountTreeItem.tsx
+++ b/src/features/general-ledger/components/AccountTreeItem.tsx
@@ -9,19 +9,19 @@ export interface AccountTreeNode extends GLAccount {
 }
 
 export interface AccountTreeItemProps {
-  account: AccountTreeNode;
-  level: number;
-  isRTL: boolean;
-  expandedNodes: Set<string>;
-  onToggleNode: (code: string) => void;
-  onOpenModal: (type: 'add' | 'edit', account?: GLAccount, parent?: GLAccount) => void;
-  onDeleteAccount: (account: GLAccount) => void;
-  searchTerm: string;
-  categoryFilter: string;
-  showInactiveAccounts: boolean;
-  canCreate: boolean;
-  canEdit: boolean;
-  canDelete: boolean;
+  readonly account: AccountTreeNode;
+  readonly level: number;
+  readonly isRTL: boolean;
+  readonly expandedNodes: Set<string>;
+  readonly onToggleNode: (code: string) => void;
+  readonly onOpenModal: (type: 'add' | 'edit', account?: GLAccount, parent?: GLAccount) => void;
+  readonly onDeleteAccount: (account: GLAccount) => void;
+  readonly searchTerm: string;
+  readonly categoryFilter: string;
+  readonly showInactiveAccounts: boolean;
+  readonly canCreate: boolean;
+  readonly canEdit: boolean;
+  readonly canDelete: boolean;
 }
 
 interface AccountFilter {
@@ -34,8 +34,8 @@ export function accountMatchesFilters(account: AccountTreeNode, filter: AccountF
   const normalizedSearch = filter.searchTerm.toLowerCase();
   const matchesSearch = !filter.searchTerm
     || account.code.toLowerCase().includes(normalizedSearch)
-    || Boolean(account.name && account.name.toLowerCase().includes(normalizedSearch))
-    || Boolean(account.name_ar && account.name_ar.toLowerCase().includes(normalizedSearch));
+    || Boolean(account.name?.toLowerCase().includes(normalizedSearch))
+    || Boolean(account.name_ar?.toLowerCase().includes(normalizedSearch));
   const matchesCategory = filter.categoryFilter === 'all'
     || account.category === filter.categoryFilter;
   const matchesActive = filter.showInactiveAccounts || account.is_active;

--- a/src/features/general-ledger/helpers/saveAccount.ts
+++ b/src/features/general-ledger/helpers/saveAccount.ts
@@ -1,0 +1,114 @@
+import type {
+  CreateGLAccountInput,
+  GLAccount,
+  UpdateGLAccountInput,
+} from '@/lib/supabase';
+
+type AccountType = CreateGLAccountInput['account_type'];
+type ModalType = 'add' | 'edit';
+type Translate = (key: string, options?: Record<string, unknown>) => string;
+
+interface SaveAccountDependencies {
+  getEffectiveTenantId: () => Promise<string | null>;
+  checkAccountCodeExists: (code: string, excludeId?: string) => Promise<boolean>;
+  createGLAccount: (input: CreateGLAccountInput) => Promise<{ success: boolean; error?: string }>;
+  updateGLAccount: (input: UpdateGLAccountInput) => Promise<{ success: boolean; error?: string }>;
+}
+
+interface SaveAccountInput {
+  formData: Partial<GLAccount>;
+  modalType: ModalType;
+  selectedAccount: GLAccount | null;
+  t: Translate;
+}
+
+export type SaveAccountOutcome =
+  | { status: 'rejected'; message: string }
+  | { status: 'saved'; message: string };
+
+function requiredFieldsAreMissing(formData: Partial<GLAccount>) {
+  return !formData.code || !formData.name || !formData.category;
+}
+
+function shouldCheckDuplicateCode(
+  modalType: ModalType,
+  selectedAccount: GLAccount | null,
+  code: string,
+) {
+  if (modalType === 'add') return true;
+  return Boolean(selectedAccount && code !== selectedAccount.code);
+}
+
+function buildCreateInput(formData: Partial<GLAccount>, accountType: AccountType): CreateGLAccountInput {
+  return {
+    code: formData.code as string,
+    name: formData.name as string,
+    name_ar: formData.name_ar,
+    name_en: formData.name_en,
+    account_type: accountType,
+    parent_id: formData.parent_id || null,
+    is_active: formData.is_active !== false,
+  };
+}
+
+function buildUpdateInput(
+  formData: Partial<GLAccount>,
+  selectedAccount: GLAccount,
+  accountType: AccountType,
+): UpdateGLAccountInput {
+  return {
+    id: selectedAccount.id,
+    code: formData.code,
+    name: formData.name,
+    name_ar: formData.name_ar,
+    name_en: formData.name_en,
+    account_type: accountType,
+    parent_id: formData.parent_id || null,
+    is_active: formData.is_active,
+  };
+}
+
+async function persistAccount(
+  input: SaveAccountInput,
+  accountType: AccountType,
+  dependencies: SaveAccountDependencies,
+) {
+  if (input.modalType === 'edit' && input.selectedAccount) {
+    const result = await dependencies.updateGLAccount(
+      buildUpdateInput(input.formData, input.selectedAccount, accountType),
+    );
+    if (!result.success) throw new Error(result.error || 'Update failed');
+    return input.t('gl.updatedSuccess');
+  }
+
+  const result = await dependencies.createGLAccount(buildCreateInput(input.formData, accountType));
+  if (!result.success) throw new Error(result.error || 'Create failed');
+  return input.t('gl.createdSuccess');
+}
+
+export async function saveGeneralLedgerAccount(
+  input: SaveAccountInput,
+  dependencies: SaveAccountDependencies,
+): Promise<SaveAccountOutcome> {
+  const orgId = await dependencies.getEffectiveTenantId();
+  if (!orgId) throw new Error(input.t('gl.orgIdNotFound'));
+
+  if (requiredFieldsAreMissing(input.formData)) {
+    return { status: 'rejected', message: input.t('gl.requiredFields') };
+  }
+
+  const code = input.formData.code as string;
+  if (shouldCheckDuplicateCode(input.modalType, input.selectedAccount, code)) {
+    const codeExists = await dependencies.checkAccountCodeExists(code, orgId);
+    if (codeExists) {
+      return {
+        status: 'rejected',
+        message: input.t('gl.duplicateCode', { code }),
+      };
+    }
+  }
+
+  const accountType = input.formData.category as AccountType;
+  const message = await persistAccount(input, accountType, dependencies);
+  return { status: 'saved', message };
+}

--- a/src/features/general-ledger/index.tsx
+++ b/src/features/general-ledger/index.tsx
@@ -6,7 +6,6 @@ import { Input } from '@/components/ui/input';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogClose } from '@/components/ui/dialog';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Checkbox } from '@/components/ui/checkbox';
-import { Badge } from '@/components/ui/badge';
 import { EmptyState } from '@/components/ui/empty-state';
 import {
     GLAccount,
@@ -22,12 +21,10 @@ import { toast } from 'sonner';
 import { loadXLSX, loadJsPDF } from '@/lib/export-libs';
 import { AccountStatement } from '@/features/accounting/account-statement';
 import { usePermissions } from '@/hooks/usePermissions';
+import { AccountTreeItem } from './components/AccountTreeItem';
+import { saveGeneralLedgerAccount } from './helpers/saveAccount';
 import {
   Plus,
-  Pencil,
-  Trash2,
-  ChevronRight,
-  ChevronDown,
   FileDown,
   Search,
   Filter,
@@ -134,196 +131,6 @@ function AccountFormModal({ isOpen, onClose, onSave, account, parentAccount }: {
     );
 }
 
-// New AccountTreeItem Component for Collapsible Tree with Enhanced Design
-const AccountTreeItem = ({ account, level, isRTL, expandedNodes, onToggleNode, onOpenModal, onDeleteAccount, searchTerm, categoryFilter, showInactiveAccounts, canCreate, canEdit, canDelete }: {
-  account: any,
-  level: number,
-  isRTL: boolean,
-  expandedNodes: Set<string>,
-  onToggleNode: (code: string) => void,
-  onOpenModal: (type: 'add' | 'edit', account?: any, parent?: any) => void,
-  onDeleteAccount: (account: any) => void,
-  searchTerm: string,
-  categoryFilter: string,
-  showInactiveAccounts: boolean,
-  canCreate: boolean,
-  canEdit: boolean,
-  canDelete: boolean
-}) => {
-    const { t } = useTranslation();
-    const isExpanded = expandedNodes.has(account.code);
-    const hasChildren = account.children && account.children.length > 0;
-
-    // Helper function to check if account or any child matches filters
-    const matchesFilters = (acc: any): boolean => {
-        // Check search term
-        const matchesSearch = !searchTerm ||
-            acc.code.toLowerCase().includes(searchTerm.toLowerCase()) ||
-            (acc.name && acc.name.toLowerCase().includes(searchTerm.toLowerCase())) ||
-            (acc.name_ar && acc.name_ar.toLowerCase().includes(searchTerm.toLowerCase()));
-
-        // Check category filter
-        const matchesCategory = categoryFilter === 'all' || acc.category === categoryFilter;
-
-        // Check active status
-        const matchesActive = showInactiveAccounts || acc.is_active;
-
-        return matchesSearch && matchesCategory && matchesActive;
-    };
-
-    // Check if this account or any child matches
-    const hasMatchingChild = (acc: any): boolean => {
-        if (matchesFilters(acc)) return true;
-        if (acc.children && acc.children.length > 0) {
-            return acc.children.some((child: any) => hasMatchingChild(child));
-        }
-        return false;
-    };
-
-    if (!hasMatchingChild(account)) {
-        return null;
-    }
-
-    const getCategoryBadge = (category: string) => {
-        const badges: any = {
-            'ASSET': { label: t('gl.asset'), variant: 'default', className: 'bg-blue-100 text-blue-800 border-blue-200' },
-            'LIABILITY': { label: t('gl.liability'), variant: 'secondary', className: 'bg-red-100 text-red-800 border-red-200' },
-            'EQUITY': { label: t('gl.equity'), variant: 'outline', className: 'bg-purple-100 text-purple-800 border-purple-200' },
-            'REVENUE': { label: t('gl.revenue'), variant: 'default', className: 'bg-green-100 text-green-800 border-green-200' },
-            'EXPENSE': { label: t('gl.expense'), variant: 'destructive', className: 'bg-orange-100 text-orange-800 border-orange-200' }
-        };
-        const badge = badges[category] || { label: category, variant: 'outline', className: '' };
-        return <Badge variant="outline" className={`text-xs ${badge.className}`}>{badge.label}</Badge>;
-    };
-
-    const getNormalBalanceBadge = (normalBalance: string) => {
-        if (normalBalance === 'Debit') {
-            return <Badge variant="outline" className="text-xs bg-sky-50 text-sky-700 border-sky-200">{t('gl.debitShort')}</Badge>;
-        } else {
-            return <Badge variant="outline" className="text-xs bg-amber-50 text-amber-700 border-amber-200">{t('gl.creditShort')}</Badge>;
-        }
-    };
-
-    return (
-        <div key={account.code}>
-            <div
-                className={`flex justify-between items-center transition-all duration-150 group border-b border-border/40 hover:bg-accent/50 hover:shadow-sm ${
-                    !account.is_active ? 'opacity-50' : ''
-                } ${
-                    level === 0 ? 'font-semibold' : ''
-                }`}
-                style={{
-                    paddingRight: isRTL ? `${level * 24 + 12}px` : '12px',
-                    paddingLeft: isRTL ? '12px' : `${level * 24 + 12}px`,
-                    paddingTop: '10px',
-                    paddingBottom: '10px'
-                }}
-            >
-                <div className="flex items-center gap-3 flex-1">
-                    <button
-                        type="button"
-                        disabled={!hasChildren}
-                        className="cursor-pointer flex items-center hover:bg-accent/30 rounded-md p-1 transition-colors disabled:cursor-default disabled:opacity-50 border-0 bg-transparent"
-                        onClick={() => hasChildren && onToggleNode(account.code)}
-                    >
-                        {hasChildren ? (
-                            isExpanded ?
-                                <ChevronDown className="h-4 w-4 text-primary" /> :
-                                <ChevronRight className="h-4 w-4 text-muted-foreground" />
-                        ) : (
-                            <span className="w-4 h-4 flex items-center justify-center">
-                                <span className="w-1.5 h-1.5 rounded-full bg-muted-foreground/40"></span>
-                            </span>
-                        )}
-                    </button>
-
-                    <div className="flex items-center gap-2 flex-1">
-                        <code className={`text-sm font-mono px-2 py-0.5 rounded bg-muted/50 ${level === 0 ? 'font-bold' : ''}`}>
-                            {account.code}
-                        </code>
-                        <span className={`${level === 0 ? 'text-base font-bold' : 'text-sm'} flex-1`}>
-                            {isRTL ? (account.name_ar || account.name) : (account.name_en || account.name)}
-                        </span>
-                    </div>
-
-                    <div className="flex items-center gap-2">
-                        {getCategoryBadge(account.category)}
-                        {getNormalBalanceBadge(account.normal_balance)}
-                        {account.allow_posting && (
-                            <Badge variant="outline" className="text-xs bg-green-50 text-green-700 border-green-200">
-                                {t('gl.postable')}
-                            </Badge>
-                        )}
-                        {!account.is_active && (
-                            <Badge variant="outline" className="text-xs bg-gray-100 text-gray-600 border-gray-300">
-                                {t('common.inactive')}
-                            </Badge>
-                        )}
-                    </div>
-                </div>
-
-                <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity ml-4">
-                    {!account.allow_posting && canCreate && (
-                        <Button
-                            variant="ghost"
-                            size="icon"
-                            className="h-8 w-8 hover:bg-primary/10 hover:text-primary"
-                            title={t('gl.addSubAccount')}
-                            onClick={() => onOpenModal('add', undefined, account)}
-                        >
-                            <Plus className="h-4 w-4" />
-                        </Button>
-                    )}
-                    {canEdit && (
-                        <Button
-                            variant="ghost"
-                            size="icon"
-                            className="h-8 w-8 hover:bg-blue-100 hover:text-blue-700"
-                            title={t('gl.editAccountBtn')}
-                            onClick={() => onOpenModal('edit', account)}
-                        >
-                            <Pencil className="h-4 w-4" />
-                        </Button>
-                    )}
-                    {canDelete && (
-                        <Button
-                            variant="ghost"
-                            size="icon"
-                            className="h-8 w-8 hover:bg-red-100 hover:text-red-700"
-                            title={t('gl.deleteAccountBtn')}
-                            onClick={() => onDeleteAccount(account)}
-                        >
-                            <Trash2 className="h-4 w-4" />
-                        </Button>
-                    )}
-                </div>
-            </div>
-            {isExpanded && hasChildren && (
-                <div className="border-l-2 border-primary/20 ml-4">
-                    {account.children.map((child: any) => (
-                        <AccountTreeItem
-                            key={child.code}
-                            account={child}
-                            level={level + 1}
-                            isRTL={isRTL}
-                            expandedNodes={expandedNodes}
-                            onToggleNode={onToggleNode}
-                            onOpenModal={onOpenModal}
-                            onDeleteAccount={onDeleteAccount}
-                            searchTerm={searchTerm}
-                            categoryFilter={categoryFilter}
-                            showInactiveAccounts={showInactiveAccounts}
-                            canCreate={canCreate}
-                            canEdit={canEdit}
-                            canDelete={canDelete}
-                        />
-                    ))}
-                </div>
-            )}
-        </div>
-    );
-};
-
 function ChartOfAccounts() {
     const { t, i18n } = useTranslation();
     const isRTL = i18n.language === 'ar';
@@ -405,67 +212,25 @@ function ChartOfAccounts() {
             return;
         }
         try {
-            const org_id = await getEffectiveTenantId();
-            if (!org_id) throw new Error(t('gl.orgIdNotFound'));
-
-            // Validate required fields
-            if (!formData.code || !formData.name || !formData.category) {
-                toast.error(t('gl.requiredFields'));
+            const outcome = await saveGeneralLedgerAccount(
+                {
+                    formData,
+                    modalType,
+                    selectedAccount,
+                    t: (key, options) => t(key, options) as string,
+                },
+                {
+                    getEffectiveTenantId,
+                    checkAccountCodeExists,
+                    createGLAccount,
+                    updateGLAccount,
+                },
+            );
+            if (outcome.status === 'rejected') {
+                toast.error(outcome.message);
                 return;
             }
-
-            // Check for duplicate account code (only on create or if code changed)
-            if (modalType === 'add' || (modalType === 'edit' && selectedAccount && formData.code !== selectedAccount.code)) {
-                const codeExists = await checkAccountCodeExists(formData.code as string, org_id);
-                if (codeExists) {
-                    toast.error(t('gl.duplicateCode', { code: formData.code }));
-                    return;
-                }
-            }
-
-            // Convert category to account_type for CreateGLAccountInput
-            const accountType = formData.category as 'ASSET' | 'LIABILITY' | 'EQUITY' | 'REVENUE' | 'EXPENSE' | undefined;
-            if (!accountType) {
-                toast.error(t('gl.accountTypeRequired'));
-                return;
-            }
-
-            if (modalType === 'edit' && selectedAccount) {
-                // Update existing account - UpdateGLAccountInput needs { id, ...updates }
-                const updateData: any = {
-                    id: selectedAccount.id,
-                    code: formData.code,
-                    name: formData.name,
-                    name_ar: formData.name_ar,
-                    name_en: formData.name_en,
-                    account_type: accountType,
-                    parent_id: formData.parent_id || null,
-                    is_active: formData.is_active,
-                };
-                const result = await updateGLAccount(updateData);
-                if (result.success) {
-                    toast.success(t('gl.updatedSuccess'));
-                } else {
-                    throw new Error(result.error || 'Update failed');
-                }
-            } else {
-                // Create new account - CreateGLAccountInput needs account_type (required)
-                const createData: any = {
-                    code: formData.code as string,
-                    name: formData.name as string,
-                    name_ar: formData.name_ar,
-                    name_en: formData.name_en,
-                    account_type: accountType,
-                    parent_id: formData.parent_id || null,
-                    is_active: formData.is_active !== false,
-                };
-                const result = await createGLAccount(createData);
-                if (result.success) {
-                    toast.success(t('gl.createdSuccess'));
-                } else {
-                    throw new Error(result.error || 'Create failed');
-                }
-            }
+            toast.success(outcome.message);
 
             handleCloseModal();
             await loadAccounts();


### PR DESCRIPTION
## Summary

- extract the recursive account-tree presentation into `AccountTreeItem.tsx`
- extract create/update validation and persistence into `saveAccount.ts`
- preserve the existing permission gates, duplicate-code behavior, gateway payloads, toasts, modal lifecycle, and account reload
- remove the stale broad General Ledger Sonar coverage exclusion so the generic new-source gate can enforce the added files
- add focused component, helper, and integration coverage

## Verification

- General Ledger tests: 4 files, 70/70 tests passed
- new component/helper: 100% statements, branches, functions, and lines
- TypeScript: `tsc --noEmit` clean
- ESLint: 0 errors; both targeted complex methods are below complexity 15
- production Vite build: passed
- demo-password build gate: passed
- RBAC direct-write gate: passed
- `git diff --check`: clean
- full repository run: 4511/4515 passed under parallel load; the 4 unrelated 5-second timeout failures were rerun in their 3 files with one worker and passed 27/27

No SQL, migrations, RPC, or schema changes.

Addresses the General Ledger complex-method group in #118.

Refs #118