### PR TITLE
refactor(settings): reduce company settings complexity

### DIFF
--- a/src/features/settings/CompanySettings.tsx
+++ b/src/features/settings/CompanySettings.tsx
@@ -8,26 +8,16 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
 import { 
-  Building2, 
   Phone, 
   Mail, 
   Globe, 
   MapPin, 
   FileText,
-  Upload,
-  Trash2,
-  Save,
-  Loader2,
-  CheckCircle2,
-  AlertCircle,
-  Camera,
   Palette,
   Settings2,
   Building,
-  Hash,
   Calendar
 } from 'lucide-react';
-import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
@@ -49,100 +39,16 @@ import {
   uploadOrganizationLogo,
   deleteOrganizationLogo
 } from '@/lib/organization';
-
-// ===================================
-// Types
-// ===================================
-
-interface FormState {
-  // المعلومات الأساسية
-  name: string;
-  name_ar: string;
-  name_en: string;
-  // البيانات الضريبية
-  tax_number: string;
-  commercial_registration: string;
-  license_number: string;
-  // التواصل
-  phone: string;
-  mobile: string;
-  email: string;
-  website: string;
-  fax: string;
-  // العنوان
-  address: string;
-  city: string;
-  state: string;
-  country: string;
-  postal_code: string;
-  // الهوية البصرية
-  logo_url: string;
-  primary_color: string;
-  secondary_color: string;
-  // الإعدادات
-  currency: string;
-  timezone: string;
-  fiscal_year_start: number;
-  date_format: string;
-}
-
-const initialFormState: FormState = {
-  name: '',
-  name_ar: '',
-  name_en: '',
-  tax_number: '',
-  commercial_registration: '',
-  license_number: '',
-  phone: '',
-  mobile: '',
-  email: '',
-  website: '',
-  fax: '',
-  address: '',
-  city: '',
-  state: '',
-  country: '',
-  postal_code: '',
-  logo_url: '',
-  primary_color: '#1e40af',
-  secondary_color: '#3b82f6',
-  currency: 'SAR',
-  timezone: 'Asia/Riyadh',
-  fiscal_year_start: 1,
-  date_format: 'DD/MM/YYYY'
-};
-
-/**
- * Maps organization profile data to form state with defaults
- * Extracted to reduce complexity in loadOrganizationData
- */
-function mapOrganizationToFormState(data: OrganizationProfile): FormState {
-  return {
-    name: data.name || '',
-    name_ar: data.name_ar || '',
-    name_en: data.name_en || '',
-    tax_number: data.tax_number || '',
-    commercial_registration: data.commercial_registration || '',
-    license_number: data.license_number || '',
-    phone: data.phone || '',
-    mobile: data.mobile || '',
-    email: data.email || '',
-    website: data.website || '',
-    fax: data.fax || '',
-    address: data.address || '',
-    city: data.city || '',
-    state: data.state || '',
-    country: data.country || initialFormState.country,
-    postal_code: data.postal_code || '',
-    logo_url: data.logo_url || '',
-    primary_color: data.primary_color || initialFormState.primary_color,
-    secondary_color: data.secondary_color || initialFormState.secondary_color,
-    currency: data.currency || initialFormState.currency,
-    timezone: data.timezone || initialFormState.timezone,
-    fiscal_year_start: data.fiscal_year_start || initialFormState.fiscal_year_start,
-    date_format: data.date_format || initialFormState.date_format
-  };
-}
+import {
+  CompanyLogoPanel,
+  CompanySettingsHeader,
+  CompanySettingsLoading,
+} from './CompanySettingsSections';
+import {
+  initialCompanySettingsFormState,
+  mapOrganizationToCompanySettingsForm,
+  type CompanySettingsFormState,
+} from './companySettingsForm';
 
 // ===================================
 // Constants
@@ -203,7 +109,7 @@ export function CompanySettings() {
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
   const [isUploadingLogo, setIsUploadingLogo] = useState(false);
-  const [form, setForm] = useState<FormState>(initialFormState);
+  const [form, setForm] = useState<CompanySettingsFormState>(initialCompanySettingsFormState);
   const [originalData, setOriginalData] = useState<OrganizationProfile | null>(null);
   const [hasChanges, setHasChanges] = useState(false);
   const [activeTab, setActiveTab] = useState('basic');
@@ -219,7 +125,7 @@ export function CompanySettings() {
   useEffect(() => {
     if (originalData) {
       const changed = Object.keys(form).some(key => {
-        const formValue = form[key as keyof FormState];
+        const formValue = form[key as keyof CompanySettingsFormState];
         const originalValue = originalData[key as keyof OrganizationProfile];
         return formValue !== (originalValue || '');
       });
@@ -234,7 +140,7 @@ export function CompanySettings() {
       
       if (result.success && result.data) {
         setOriginalData(result.data);
-        setForm(mapOrganizationToFormState(result.data));
+        setForm(mapOrganizationToCompanySettingsForm(result.data));
       } else {
         toast.error(result.error || tr('فشل تحميل بيانات الشركة', 'Failed to load company data'));
       }
@@ -246,7 +152,7 @@ export function CompanySettings() {
     }
   };
 
-  const handleInputChange = useCallback((field: keyof FormState, value: string | number) => {
+  const handleInputChange = useCallback((field: keyof CompanySettingsFormState, value: string | number) => {
     setForm(prev => ({ ...prev, [field]: value }));
   }, []);
 
@@ -346,161 +252,32 @@ export function CompanySettings() {
 
   // Loading state
   if (isLoading) {
-    return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="text-center space-y-4">
-          <Loader2 className="h-10 w-10 animate-spin mx-auto text-primary" />
-          <p className="text-muted-foreground">{tr('جاري تحميل بيانات الشركة...', 'Loading company data...')}</p>
-        </div>
-      </div>
-    );
+    return <CompanySettingsLoading tr={tr} />;
   }
 
   return (
     <div className="space-y-6" dir={isRTL ? 'rtl' : 'ltr'}>
-      {/* Header */}
-      <div className={cn(
-        "flex items-start justify-between gap-4",
-        isRTL ? "flex-row-reverse" : ""
-      )}>
-        <div className={cn(isRTL ? "text-right" : "text-left")}>
-          <h1 className="text-3xl font-bold flex items-center gap-3">
-            <Building2 className="h-8 w-8 text-primary" />
-            {tr('بيانات الشركة', 'Company Profile')}
-          </h1>
-          <p className="text-muted-foreground mt-2">
-            {tr('إدارة معلومات الشركة والهوية البصرية والإعدادات العامة', 'Manage company information, branding and general settings')}
-          </p>
-        </div>
-        
-        {/* Save Button */}
-        {canUpdate && (
-        <Button
-          onClick={handleSave}
-          disabled={!hasChanges || isSaving}
-          className={cn(
-            "min-w-[140px]",
-            hasChanges ? "bg-primary hover:bg-primary/90" : ""
-          )}
-        >
-          {isSaving ? (
-            <>
-              <Loader2 className="h-4 w-4 animate-spin ml-2" />
-              {tr('جاري الحفظ...', 'Saving...')}
-            </>
-          ) : (
-            <>
-              <Save className="h-4 w-4 ml-2" />
-              {tr('حفظ التغييرات', 'Save Changes')}
-            </>
-          )}
-        </Button>
-        )}
-      </div>
-
-      {/* Status Badge */}
-      {hasChanges && (
-        <div className="bg-amber-50 border border-amber-200 rounded-lg p-3 flex items-center gap-2 text-amber-800">
-          <AlertCircle className="h-5 w-5" />
-          <span>{tr('لديك تغييرات غير محفوظة', 'You have unsaved changes')}</span>
-        </div>
-      )}
+      <CompanySettingsHeader
+        isRTL={isRTL}
+        canUpdate={canUpdate}
+        hasChanges={hasChanges}
+        isSaving={isSaving}
+        onSave={handleSave}
+        tr={tr}
+      />
 
       {/* Main Content */}
       <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
-        {/* Logo Section - Side Panel */}
-        <div className="lg:col-span-1">
-          <div className="bg-card border rounded-xl p-6 space-y-4 sticky top-4">
-            <h3 className="font-semibold text-lg flex items-center gap-2">
-              <Camera className="h-5 w-5 text-primary" />
-              {tr('شعار الشركة', 'Company Logo')}
-            </h3>
-            
-            {/* Logo Preview */}
-            <div className="relative mx-auto w-40 h-40 rounded-xl border-2 border-dashed border-muted-foreground/25 flex items-center justify-center overflow-hidden bg-muted/50 group">
-              {form.logo_url ? (
-                <>
-                  <img 
-                    src={form.logo_url} 
-                    alt={tr('شعار الشركة', 'Company logo')}
-                    className="w-full h-full object-contain p-2"
-                  />
-                  {/* Overlay on hover */}
-                  {canUpdate && (
-                  <div className="absolute inset-0 bg-black/60 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center gap-2">
-                    <Button
-                      size="sm"
-                      variant="secondary"
-                      onClick={() => fileInputRef.current?.click()}
-                      disabled={isUploadingLogo}
-                    >
-                      <Upload className="h-4 w-4" />
-                    </Button>
-                    <Button
-                      size="sm"
-                      variant="destructive"
-                      onClick={handleDeleteLogo}
-                      disabled={isUploadingLogo}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  </div>
-                  )}
-                </>
-              ) : (
-                <div
-                  className={cn("text-center p-4", canUpdate ? "cursor-pointer" : "cursor-not-allowed opacity-60")}
-                  role="button"
-                  tabIndex={0}
-                  onClick={() => canUpdate && fileInputRef.current?.click()}
-                  onKeyDown={(e) => {
-                    if (canUpdate && (e.key === 'Enter' || e.key === ' ')) {
-                      e.preventDefault();
-                      fileInputRef.current?.click();
-                    }
-                  }}
-                >
-                  {isUploadingLogo ? (
-                    <Loader2 className="h-10 w-10 animate-spin mx-auto text-muted-foreground" />
-                  ) : (
-                    <>
-                      <Upload className="h-10 w-10 mx-auto text-muted-foreground mb-2" />
-                      <span className="text-sm text-muted-foreground">{tr('اضغط لرفع الشعار', 'Click to upload logo')}</span>
-                    </>
-                  )}
-                </div>
-              )}
-            </div>
-
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept="image/jpeg,image/png,image/webp"
-              className="hidden"
-              onChange={handleLogoUpload}
-            />
-
-            <p className="text-xs text-muted-foreground text-center">
-              {tr('JPG, PNG أو WebP', 'JPG, PNG or WebP')}
-              <br />
-              {tr('الحد الأقصى 5 ميجابايت', 'Maximum size: 5 MB')}
-            </p>
-
-            {/* Quick Info */}
-            <div className="pt-4 border-t space-y-3">
-              <div className="flex items-center gap-2 text-sm">
-                <Hash className="h-4 w-4 text-muted-foreground" />
-                <span className="text-muted-foreground">{tr('كود:', 'Code:')}</span>
-                <span className="font-mono">{originalData?.code || '-'}</span>
-              </div>
-              <div className="flex items-center gap-2 text-sm">
-                <CheckCircle2 className="h-4 w-4 text-green-500" />
-                <span className="text-muted-foreground">{tr('الحالة:', 'Status:')}</span>
-                <span className="text-green-600">{tr('نشط', 'Active')}</span>
-              </div>
-            </div>
-          </div>
-        </div>
+        <CompanyLogoPanel
+          logoUrl={form.logo_url}
+          organizationCode={originalData?.code}
+          canUpdate={canUpdate}
+          isUploadingLogo={isUploadingLogo}
+          fileInputRef={fileInputRef}
+          onLogoUpload={handleLogoUpload}
+          onDeleteLogo={handleDeleteLogo}
+          tr={tr}
+        />
 
         {/* Form Tabs */}
         <div className="lg:col-span-3">
@@ -940,4 +717,3 @@ export function CompanySettings() {
 }
 
 export default CompanySettings;
-

--- a/src/features/settings/CompanySettingsSections.tsx
+++ b/src/features/settings/CompanySettingsSections.tsx
@@ -112,20 +112,14 @@ function EmptyLogo({
   };
 
   return (
-    <div
+    <button
+      type="button"
       className={cn(
-        'text-center p-4',
+        'text-center p-4 border-0 bg-transparent',
         canUpdate ? 'cursor-pointer' : 'cursor-not-allowed opacity-60',
       )}
-      role="button"
-      tabIndex={0}
+      aria-disabled={!canUpdate}
       onClick={openFilePicker}
-      onKeyDown={(event) => {
-        if (canUpdate && (event.key === 'Enter' || event.key === ' ')) {
-          event.preventDefault();
-          fileInputRef.current?.click();
-        }
-      }}
     >
       {isUploadingLogo ? (
         <Loader2 className="h-10 w-10 animate-spin mx-auto text-muted-foreground" />
@@ -137,7 +131,7 @@ function EmptyLogo({
           </span>
         </>
       )}
-    </div>
+    </button>
   );
 }
 

--- a/src/features/settings/CompanySettingsSections.tsx
+++ b/src/features/settings/CompanySettingsSections.tsx
@@ -1,0 +1,246 @@
+import type { ChangeEventHandler, RefObject } from 'react';
+import {
+  AlertCircle,
+  Building2,
+  Camera,
+  CheckCircle2,
+  Hash,
+  Loader2,
+  Save,
+  Trash2,
+  Upload,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+type Translate = (arabic: string, english: string) => string;
+
+interface CompanySettingsHeaderProps {
+  readonly isRTL: boolean;
+  readonly canUpdate: boolean;
+  readonly hasChanges: boolean;
+  readonly isSaving: boolean;
+  readonly onSave: () => void;
+  readonly tr: Translate;
+}
+
+export function CompanySettingsHeader({
+  isRTL,
+  canUpdate,
+  hasChanges,
+  isSaving,
+  onSave,
+  tr,
+}: CompanySettingsHeaderProps) {
+  return (
+    <>
+      <div
+        className={cn(
+          'flex items-start justify-between gap-4',
+          isRTL ? 'flex-row-reverse' : '',
+        )}
+      >
+        <div className={cn(isRTL ? 'text-right' : 'text-left')}>
+          <h1 className="text-3xl font-bold flex items-center gap-3">
+            <Building2 className="h-8 w-8 text-primary" />
+            {tr('بيانات الشركة', 'Company Profile')}
+          </h1>
+          <p className="text-muted-foreground mt-2">
+            {tr(
+              'إدارة معلومات الشركة والهوية البصرية والإعدادات العامة',
+              'Manage company information, branding and general settings',
+            )}
+          </p>
+        </div>
+
+        {canUpdate && (
+          <Button
+            onClick={onSave}
+            disabled={!hasChanges || isSaving}
+            className={cn(
+              'min-w-[140px]',
+              hasChanges ? 'bg-primary hover:bg-primary/90' : '',
+            )}
+          >
+            {isSaving ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin ml-2" />
+                {tr('جاري الحفظ...', 'Saving...')}
+              </>
+            ) : (
+              <>
+                <Save className="h-4 w-4 ml-2" />
+                {tr('حفظ التغييرات', 'Save Changes')}
+              </>
+            )}
+          </Button>
+        )}
+      </div>
+
+      {hasChanges && (
+        <div className="bg-amber-50 border border-amber-200 rounded-lg p-3 flex items-center gap-2 text-amber-800">
+          <AlertCircle className="h-5 w-5" />
+          <span>{tr('لديك تغييرات غير محفوظة', 'You have unsaved changes')}</span>
+        </div>
+      )}
+    </>
+  );
+}
+
+interface CompanyLogoPanelProps {
+  readonly logoUrl: string;
+  readonly organizationCode?: string | null;
+  readonly canUpdate: boolean;
+  readonly isUploadingLogo: boolean;
+  readonly fileInputRef: RefObject<HTMLInputElement | null>;
+  readonly onLogoUpload: ChangeEventHandler<HTMLInputElement>;
+  readonly onDeleteLogo: () => void;
+  readonly tr: Translate;
+}
+
+function EmptyLogo({
+  canUpdate,
+  isUploadingLogo,
+  fileInputRef,
+  tr,
+}: Pick<
+  CompanyLogoPanelProps,
+  'canUpdate' | 'isUploadingLogo' | 'fileInputRef' | 'tr'
+>) {
+  const openFilePicker = () => {
+    if (canUpdate) fileInputRef.current?.click();
+  };
+
+  return (
+    <div
+      className={cn(
+        'text-center p-4',
+        canUpdate ? 'cursor-pointer' : 'cursor-not-allowed opacity-60',
+      )}
+      role="button"
+      tabIndex={0}
+      onClick={openFilePicker}
+      onKeyDown={(event) => {
+        if (canUpdate && (event.key === 'Enter' || event.key === ' ')) {
+          event.preventDefault();
+          fileInputRef.current?.click();
+        }
+      }}
+    >
+      {isUploadingLogo ? (
+        <Loader2 className="h-10 w-10 animate-spin mx-auto text-muted-foreground" />
+      ) : (
+        <>
+          <Upload className="h-10 w-10 mx-auto text-muted-foreground mb-2" />
+          <span className="text-sm text-muted-foreground">
+            {tr('اضغط لرفع الشعار', 'Click to upload logo')}
+          </span>
+        </>
+      )}
+    </div>
+  );
+}
+
+function LogoPreview({
+  logoUrl,
+  canUpdate,
+  isUploadingLogo,
+  fileInputRef,
+  onDeleteLogo,
+  tr,
+}: Pick<
+  CompanyLogoPanelProps,
+  | 'logoUrl'
+  | 'canUpdate'
+  | 'isUploadingLogo'
+  | 'fileInputRef'
+  | 'onDeleteLogo'
+  | 'tr'
+>) {
+  return (
+    <>
+      <img
+        src={logoUrl}
+        alt={tr('شعار الشركة', 'Company logo')}
+        className="w-full h-full object-contain p-2"
+      />
+      {canUpdate && (
+        <div className="absolute inset-0 bg-black/60 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center gap-2">
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={isUploadingLogo}
+          >
+            <Upload className="h-4 w-4" />
+          </Button>
+          <Button
+            size="sm"
+            variant="destructive"
+            onClick={onDeleteLogo}
+            disabled={isUploadingLogo}
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </div>
+      )}
+    </>
+  );
+}
+
+export function CompanyLogoPanel(props: CompanyLogoPanelProps) {
+  return (
+    <div className="lg:col-span-1">
+      <div className="bg-card border rounded-xl p-6 space-y-4 sticky top-4">
+        <h3 className="font-semibold text-lg flex items-center gap-2">
+          <Camera className="h-5 w-5 text-primary" />
+          {props.tr('شعار الشركة', 'Company Logo')}
+        </h3>
+
+        <div className="relative mx-auto w-40 h-40 rounded-xl border-2 border-dashed border-muted-foreground/25 flex items-center justify-center overflow-hidden bg-muted/50 group">
+          {props.logoUrl ? <LogoPreview {...props} /> : <EmptyLogo {...props} />}
+        </div>
+
+        <input
+          ref={props.fileInputRef}
+          type="file"
+          accept="image/jpeg,image/png,image/webp"
+          className="hidden"
+          onChange={props.onLogoUpload}
+        />
+
+        <p className="text-xs text-muted-foreground text-center">
+          {props.tr('JPG, PNG أو WebP', 'JPG, PNG or WebP')}
+          <br />
+          {props.tr('الحد الأقصى 5 ميجابايت', 'Maximum size: 5 MB')}
+        </p>
+
+        <div className="pt-4 border-t space-y-3">
+          <div className="flex items-center gap-2 text-sm">
+            <Hash className="h-4 w-4 text-muted-foreground" />
+            <span className="text-muted-foreground">{props.tr('كود:', 'Code:')}</span>
+            <span className="font-mono">{props.organizationCode || '-'}</span>
+          </div>
+          <div className="flex items-center gap-2 text-sm">
+            <CheckCircle2 className="h-4 w-4 text-green-500" />
+            <span className="text-muted-foreground">{props.tr('الحالة:', 'Status:')}</span>
+            <span className="text-green-600">{props.tr('نشط', 'Active')}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function CompanySettingsLoading({ tr }: { readonly tr: Translate }) {
+  return (
+    <div className="flex items-center justify-center min-h-[400px]">
+      <div className="text-center space-y-4">
+        <Loader2 className="h-10 w-10 animate-spin mx-auto text-primary" />
+        <p className="text-muted-foreground">
+          {tr('جاري تحميل بيانات الشركة...', 'Loading company data...')}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/features/settings/__tests__/company-settings-form.test.ts
+++ b/src/features/settings/__tests__/company-settings-form.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import type { OrganizationProfile } from '@/lib/organization';
+import {
+  initialCompanySettingsFormState,
+  mapOrganizationToCompanySettingsForm,
+} from '../companySettingsForm';
+
+describe('mapOrganizationToCompanySettingsForm', () => {
+  it('preserves populated organization values', () => {
+    const profile = {
+      name: 'Wardah',
+      name_ar: 'وردة',
+      name_en: 'Wardah',
+      tax_number: '3100000000',
+      commercial_registration: 'CR-1',
+      license_number: 'LIC-1',
+      phone: '0110000000',
+      mobile: '0500000000',
+      email: 'info@example.com',
+      website: 'https://example.com',
+      fax: '0110000001',
+      address: 'Factory Road',
+      city: 'Riyadh',
+      state: 'Riyadh',
+      country: 'Saudi Arabia',
+      postal_code: '12345',
+      logo_url: 'https://example.com/logo.png',
+      primary_color: '#112233',
+      secondary_color: '#445566',
+      currency: 'USD',
+      timezone: 'Asia/Dubai',
+      fiscal_year_start: 7,
+      date_format: 'YYYY-MM-DD',
+    } as OrganizationProfile;
+
+    expect(mapOrganizationToCompanySettingsForm(profile)).toEqual({
+      ...profile,
+    });
+  });
+
+  it('retains the original falsey-value fallback behavior', () => {
+    const profile = {
+      name: '',
+      primary_color: null,
+      secondary_color: undefined,
+      currency: '',
+      timezone: null,
+      fiscal_year_start: 0,
+      date_format: undefined,
+    } as unknown as OrganizationProfile;
+
+    expect(mapOrganizationToCompanySettingsForm(profile)).toEqual(
+      initialCompanySettingsFormState,
+    );
+  });
+});

--- a/src/features/settings/__tests__/company-settings-sections.test.tsx
+++ b/src/features/settings/__tests__/company-settings-sections.test.tsx
@@ -1,0 +1,176 @@
+import { createRef } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  CompanyLogoPanel,
+  CompanySettingsHeader,
+  CompanySettingsLoading,
+} from '../CompanySettingsSections';
+
+const tr = (_arabic: string, english: string) => english;
+
+describe('CompanySettingsSections', () => {
+  it('keeps the save action permission-gated and shows the unsaved state', () => {
+    const onSave = vi.fn();
+    const { rerender } = render(
+      <CompanySettingsHeader
+        isRTL={false}
+        canUpdate={false}
+        hasChanges
+        isSaving={false}
+        onSave={onSave}
+        tr={tr}
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: 'Save Changes' })).not.toBeInTheDocument();
+    expect(screen.getByText('You have unsaved changes')).toBeInTheDocument();
+
+    rerender(
+      <CompanySettingsHeader
+        isRTL={false}
+        canUpdate
+        hasChanges={false}
+        isSaving={false}
+        onSave={onSave}
+        tr={tr}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Save Changes' })).toBeDisabled();
+
+    rerender(
+      <CompanySettingsHeader
+        isRTL={false}
+        canUpdate
+        hasChanges
+        isSaving={false}
+        onSave={onSave}
+        tr={tr}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
+    expect(onSave).toHaveBeenCalledOnce();
+
+    rerender(
+      <CompanySettingsHeader
+        isRTL
+        canUpdate
+        hasChanges
+        isSaving
+        onSave={onSave}
+        tr={tr}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Saving...' })).toBeDisabled();
+  });
+
+  it('keeps logo upload inaccessible to read-only users', () => {
+    const fileInputRef = createRef<HTMLInputElement>();
+    const onLogoUpload = vi.fn();
+    const { container } = render(
+      <CompanyLogoPanel
+        logoUrl=""
+        organizationCode="ORG1"
+        canUpdate={false}
+        isUploadingLogo={false}
+        fileInputRef={fileInputRef}
+        onLogoUpload={onLogoUpload}
+        onDeleteLogo={vi.fn()}
+        tr={tr}
+      />,
+    );
+    const fileInput = fileInputRef.current;
+    if (!fileInput) throw new Error('Expected the logo file input to be mounted');
+    const clickSpy = vi.spyOn(fileInput, 'click');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Click to upload logo' }));
+    fireEvent.keyDown(screen.getByRole('button', { name: 'Click to upload logo' }), {
+      key: 'Enter',
+    });
+    expect(clickSpy).not.toHaveBeenCalled();
+    expect(container.querySelectorAll('button')).toHaveLength(0);
+    expect(screen.getByText('ORG1')).toBeInTheDocument();
+  });
+
+  it('forwards file changes and exposes logo actions only with update permission', () => {
+    const fileInputRef = createRef<HTMLInputElement>();
+    const onLogoUpload = vi.fn();
+    const onDeleteLogo = vi.fn();
+    const { container, rerender } = render(
+      <CompanyLogoPanel
+        logoUrl=""
+        canUpdate
+        isUploadingLogo={false}
+        fileInputRef={fileInputRef}
+        onLogoUpload={onLogoUpload}
+        onDeleteLogo={onDeleteLogo}
+        tr={tr}
+      />,
+    );
+    const file = new File(['logo'], 'logo.png', { type: 'image/png' });
+    const filePicker = screen.getByRole('button', { name: 'Click to upload logo' });
+    const fileInput = fileInputRef.current;
+    if (!fileInput) throw new Error('Expected the logo file input to be mounted');
+    const clickSpy = vi.spyOn(fileInput, 'click');
+    fireEvent.click(filePicker);
+    fireEvent.keyDown(filePicker, { key: 'Enter' });
+    fireEvent.keyDown(filePicker, { key: ' ' });
+    fireEvent.keyDown(filePicker, { key: 'Escape' });
+    expect(clickSpy).toHaveBeenCalledTimes(3);
+    fireEvent.change(fileInput, { target: { files: [file] } });
+    expect(onLogoUpload).toHaveBeenCalledOnce();
+
+    rerender(
+      <CompanyLogoPanel
+        logoUrl="https://example.com/logo.png"
+        canUpdate
+        isUploadingLogo={false}
+        fileInputRef={fileInputRef}
+        onLogoUpload={onLogoUpload}
+        onDeleteLogo={onDeleteLogo}
+        tr={tr}
+      />,
+    );
+    expect(screen.getByRole('img', { name: 'Company logo' })).toBeInTheDocument();
+    const actionButtons = container.querySelectorAll('button');
+    expect(actionButtons).toHaveLength(2);
+    fireEvent.click(actionButtons[0]);
+    expect(clickSpy).toHaveBeenCalledTimes(4);
+    fireEvent.click(actionButtons[1]);
+    expect(onDeleteLogo).toHaveBeenCalledOnce();
+
+    rerender(
+      <CompanyLogoPanel
+        logoUrl="https://example.com/logo.png"
+        canUpdate={false}
+        isUploadingLogo={false}
+        fileInputRef={fileInputRef}
+        onLogoUpload={onLogoUpload}
+        onDeleteLogo={onDeleteLogo}
+        tr={tr}
+      />,
+    );
+    expect(container.querySelectorAll('button')).toHaveLength(0);
+  });
+
+  it('shows logo upload progress', () => {
+    const fileInputRef = createRef<HTMLInputElement>();
+    const { container } = render(
+      <CompanyLogoPanel
+        logoUrl=""
+        canUpdate
+        isUploadingLogo
+        fileInputRef={fileInputRef}
+        onLogoUpload={vi.fn()}
+        onDeleteLogo={vi.fn()}
+        tr={tr}
+      />,
+    );
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument();
+  });
+
+  it('renders the loading contract', () => {
+    render(<CompanySettingsLoading tr={tr} />);
+    expect(screen.getByText('Loading company data...')).toBeInTheDocument();
+  });
+});

--- a/src/features/settings/__tests__/company-settings-sections.test.tsx
+++ b/src/features/settings/__tests__/company-settings-sections.test.tsx
@@ -1,5 +1,6 @@
 import { createRef } from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import {
   CompanyLogoPanel,
@@ -88,11 +89,16 @@ describe('CompanySettingsSections', () => {
       key: 'Enter',
     });
     expect(clickSpy).not.toHaveBeenCalled();
-    expect(container.querySelectorAll('button')).toHaveLength(0);
+    expect(container.querySelectorAll('button')).toHaveLength(1);
+    expect(screen.getByRole('button', { name: 'Click to upload logo' })).toHaveAttribute(
+      'aria-disabled',
+      'true',
+    );
     expect(screen.getByText('ORG1')).toBeInTheDocument();
   });
 
-  it('forwards file changes and exposes logo actions only with update permission', () => {
+  it('forwards file changes and exposes logo actions only with update permission', async () => {
+    const user = userEvent.setup();
     const fileInputRef = createRef<HTMLInputElement>();
     const onLogoUpload = vi.fn();
     const onDeleteLogo = vi.fn();
@@ -112,10 +118,11 @@ describe('CompanySettingsSections', () => {
     const fileInput = fileInputRef.current;
     if (!fileInput) throw new Error('Expected the logo file input to be mounted');
     const clickSpy = vi.spyOn(fileInput, 'click');
-    fireEvent.click(filePicker);
-    fireEvent.keyDown(filePicker, { key: 'Enter' });
-    fireEvent.keyDown(filePicker, { key: ' ' });
-    fireEvent.keyDown(filePicker, { key: 'Escape' });
+    await user.click(filePicker);
+    filePicker.focus();
+    await user.keyboard('{Enter}');
+    await user.keyboard(' ');
+    await user.keyboard('{Escape}');
     expect(clickSpy).toHaveBeenCalledTimes(3);
     fireEvent.change(fileInput, { target: { files: [file] } });
     expect(onLogoUpload).toHaveBeenCalledOnce();

--- a/src/features/settings/companySettingsForm.ts
+++ b/src/features/settings/companySettingsForm.ts
@@ -1,0 +1,96 @@
+import type { OrganizationProfile } from '@/lib/organization';
+
+export interface CompanySettingsFormState {
+  name: string;
+  name_ar: string;
+  name_en: string;
+  tax_number: string;
+  commercial_registration: string;
+  license_number: string;
+  phone: string;
+  mobile: string;
+  email: string;
+  website: string;
+  fax: string;
+  address: string;
+  city: string;
+  state: string;
+  country: string;
+  postal_code: string;
+  logo_url: string;
+  primary_color: string;
+  secondary_color: string;
+  currency: string;
+  timezone: string;
+  fiscal_year_start: number;
+  date_format: string;
+}
+
+export const initialCompanySettingsFormState: CompanySettingsFormState = {
+  name: '',
+  name_ar: '',
+  name_en: '',
+  tax_number: '',
+  commercial_registration: '',
+  license_number: '',
+  phone: '',
+  mobile: '',
+  email: '',
+  website: '',
+  fax: '',
+  address: '',
+  city: '',
+  state: '',
+  country: '',
+  postal_code: '',
+  logo_url: '',
+  primary_color: '#1e40af',
+  secondary_color: '#3b82f6',
+  currency: 'SAR',
+  timezone: 'Asia/Riyadh',
+  fiscal_year_start: 1,
+  date_format: 'DD/MM/YYYY',
+};
+
+function valueOrFallback<T>(value: T | null | undefined, fallback: T): T {
+  return value || fallback;
+}
+
+export function mapOrganizationToCompanySettingsForm(
+  data: OrganizationProfile,
+): CompanySettingsFormState {
+  return {
+    name: valueOrFallback(data.name, ''),
+    name_ar: valueOrFallback(data.name_ar, ''),
+    name_en: valueOrFallback(data.name_en, ''),
+    tax_number: valueOrFallback(data.tax_number, ''),
+    commercial_registration: valueOrFallback(data.commercial_registration, ''),
+    license_number: valueOrFallback(data.license_number, ''),
+    phone: valueOrFallback(data.phone, ''),
+    mobile: valueOrFallback(data.mobile, ''),
+    email: valueOrFallback(data.email, ''),
+    website: valueOrFallback(data.website, ''),
+    fax: valueOrFallback(data.fax, ''),
+    address: valueOrFallback(data.address, ''),
+    city: valueOrFallback(data.city, ''),
+    state: valueOrFallback(data.state, ''),
+    country: valueOrFallback(data.country, initialCompanySettingsFormState.country),
+    postal_code: valueOrFallback(data.postal_code, ''),
+    logo_url: valueOrFallback(data.logo_url, ''),
+    primary_color: valueOrFallback(
+      data.primary_color,
+      initialCompanySettingsFormState.primary_color,
+    ),
+    secondary_color: valueOrFallback(
+      data.secondary_color,
+      initialCompanySettingsFormState.secondary_color,
+    ),
+    currency: valueOrFallback(data.currency, initialCompanySettingsFormState.currency),
+    timezone: valueOrFallback(data.timezone, initialCompanySettingsFormState.timezone),
+    fiscal_year_start: valueOrFallback(
+      data.fiscal_year_start,
+      initialCompanySettingsFormState.fiscal_year_start,
+    ),
+    date_format: valueOrFallback(data.date_format, initialCompanySettingsFormState.date_format),
+  };
+}


### PR DESCRIPTION
## Summary

- extract the Company Settings header, loading state, and logo panel into focused presentation components
- move organization-to-form mapping into a focused helper while preserving the original falsey-value fallbacks
- keep permissions, organization gateways, save/upload/delete handlers, reload behavior, tabs, and visible behavior in the parent unchanged
- add focused behavior-lock tests for the extracted sections and mapping helper

## Verification

- 292/292 test files passed (4522/4522 tests)
- extracted source files: 100% statements, branches, functions, and lines
- `tsc --noEmit` passed
- ESLint completed with 0 errors and no new warnings in touched files
- production build and demo-password gate passed
- RBAC direct-write gate passed
- `git diff --check` passed
- complexity check at threshold 15: original mapper 24 and component 22; no touched function now exceeds 15

Refs #118