### PR TITLE
fix(ui): keep long dialogs reachable within viewport

### DIFF
--- a/src/components/ui/__tests__/dialog-scroll.test.tsx
+++ b/src/components/ui/__tests__/dialog-scroll.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog';
+
+describe('DialogContent viewport reachability', () => {
+  it('keeps oversized dialog content scrollable within the viewport', () => {
+    render(
+      <Dialog open>
+        <DialogContent data-testid="dialog-content">
+          <DialogTitle>Test dialog</DialogTitle>
+          <DialogDescription>Viewport overflow regression guard</DialogDescription>
+          <div>Long content</div>
+        </DialogContent>
+      </Dialog>
+    );
+
+    const dialog = screen.getByTestId('dialog-content');
+
+    expect(dialog.className).toContain('max-h-[calc(100vh-2rem)]');
+    expect(dialog.className).toContain('overflow-y-auto');
+  });
+});

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -29,7 +29,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid max-h-[calc(100vh-2rem)] w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       {...props}


### PR DESCRIPTION
Closes #146.

## Summary
- cap shared `DialogContent` height to the viewport with a safe 1rem margin on each side;
- enable vertical scrolling when dialog content exceeds that height;
- add a regression test asserting both reachability classes stay on the shared dialog primitive.

## Why this fixes the observed role-assignment bug
The user-role dialog uses the shared `DialogContent`. With a long role list, the dialog previously had no max-height/overflow contract, so the footer could render below the viewport at 100% zoom. The shared primitive now remains bounded to the viewport and scrolls vertically, keeping all actions keyboard/scroll reachable without changing role-assignment logic.

## Scope
UI primitive + focused regression test only. No RBAC logic, database, permission, or API changes.