### PR TITLE
security(accounting): migration 178 journal RBAC database boundary

### DIFF
--- a/.github/workflows/journal-rbac-178-acceptance.yml
+++ b/.github/workflows/journal-rbac-178-acceptance.yml
@@ -1,0 +1,111 @@
+name: Journal RBAC 178 Acceptance
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'sql/migrations/178_journal_rbac_and_canonical_manual_lifecycle.sql'
+      - 'scripts/ci/fresh-db/acceptance_178_journal_rbac.sql'
+      - '.github/workflows/journal-rbac-178-acceptance.yml'
+      - 'src/services/accounting/journal-service.ts'
+      - 'src/services/accounting/posting-service.ts'
+      - 'src/features/accounting/journal-entries/**'
+      - 'src/features/inventory/helpers/stockAdjustmentSubmit.ts'
+  workflow_dispatch:
+
+jobs:
+  acceptance:
+    name: Confirm canonical journal permission boundaries
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      PGHOST: localhost
+      PGUSER: postgres
+      PGPASSWORD: postgres
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build fresh database through Migration 178
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          PAIR=$(bash scripts/ci/fresh-db/resolve_baseline_pair.sh sql/baseline)
+          pair_field() { printf '%s\n' "$PAIR" | sed -n "s/^$1=//p"; }
+          BASELINE=$(pair_field BASELINE_PATH)
+          REFERENCE=$(pair_field REFERENCE_PATH)
+          CUTOFF=$(pair_field BASELINE_CUTOFF)
+          CUTOFF=${CUTOFF:-0}
+
+          createdb wardah_fresh
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh -f scripts/ci/fresh-db/supabase_shim.sql -q
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh -f "$BASELINE" -q
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh -f "$REFERENCE" -q
+          python3 scripts/ci/fresh-db/build_apply_order.py sql/migrations "$CUTOFF" > /tmp/chain_order.txt
+          REPORT=/tmp/chain_report.txt PGDATABASE=wardah_fresh \
+            bash scripts/ci/fresh-db/run_chain.sh sql/migrations /tmp/chain_order.txt
+
+      - name: Run Migration 178 acceptance
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh \
+            -f scripts/ci/fresh-db/acceptance_178_journal_rbac.sql \
+            2>&1 | tee /tmp/journal-178.out
+          grep -q 'JOURNAL_RBAC_178_ACCEPTANCE_PASS' /tmp/journal-178.out
+
+      - name: Re-run sensitive-permission regression after 178
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh \
+            -f scripts/ci/fresh-db/acceptance_174_sensitive_permission_class.sql \
+            2>&1 | tee /tmp/rbac-174-after-178.out
+          grep -q 'SENSITIVE_PERMISSION_174_ACCEPTANCE_PASS' /tmp/rbac-174-after-178.out
+
+      - name: Verify legacy/internal journal execute surface is closed
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          psql -tA -v ON_ERROR_STOP=1 -d wardah_fresh <<'SQL' | tee /tmp/journal-178-grants.out
+          SELECT 'generic_create_auth=' || has_function_privilege('authenticated','public.rpc_create_journal_entry(jsonb)','EXECUTE');
+          SELECT 'event_post_auth=' || has_function_privilege('authenticated','public.rpc_post_event_journal(text,numeric,text,text,uuid,uuid,text,date)','EXECUTE');
+          SELECT 'legacy_batch_auth=' || has_function_privilege('authenticated','public.batch_post_journal_entries(uuid[])','EXECUTE');
+          SELECT 'legacy_post_anon=' || has_function_privilege('anon','public.post_journal_entry(uuid)','EXECUTE');
+          SELECT 'manual_create_auth=' || has_function_privilege('authenticated','public.rpc_create_manual_journal_entry(jsonb)','EXECUTE');
+          SELECT 'manual_post_auth=' || has_function_privilege('authenticated','public.rpc_post_manual_journal_entry(uuid)','EXECUTE');
+          SQL
+          grep -q '^generic_create_auth=false$' /tmp/journal-178-grants.out
+          grep -q '^event_post_auth=false$' /tmp/journal-178-grants.out
+          grep -q '^legacy_batch_auth=false$' /tmp/journal-178-grants.out
+          grep -q '^legacy_post_anon=false$' /tmp/journal-178-grants.out
+          grep -q '^manual_create_auth=true$' /tmp/journal-178-grants.out
+          grep -q '^manual_post_auth=true$' /tmp/journal-178-grants.out
+
+      - name: Upload acceptance evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: journal-rbac-178-${{ github.run_id }}
+          path: |
+            /tmp/journal-178.out
+            /tmp/rbac-174-after-178.out
+            /tmp/journal-178-grants.out
+            /tmp/chain_report.txt
+          retention-days: 30

--- a/scripts/ci/check_definer_guards.py
+++ b/scripts/ci/check_definer_guards.py
@@ -1,14 +1,22 @@
 #!/usr/bin/env python3
 """
-CI guard: prevent new SECURITY DEFINER functions without an org-member guard.
+CI guard: prevent new SECURITY DEFINER functions without a tenant/authorization guard.
 
 Scans all migration files numbered > BASELINE_CUTOFF for new/replaced DEFINER
-functions. Fails if any is callable by 'authenticated' without a body line that
-calls wardah_assert_org_member, wardah_assert_org_admin, or wardah_is_org_member.
+functions. Fails if any client-callable function lacks one of the reviewed
+server-boundary guards.
+
+Recognized guards:
+  - wardah_assert_org_member / wardah_assert_org_admin / wardah_is_org_member
+  - wardah_178_assert_permission: Migration 178's assertion wrapper around
+    wardah_has_exact_permission. Unlike matching a bare boolean permission
+    helper, this wrapper raises on denial and preserves the central Super Admin,
+    active-membership, role-org, role-active and expiry semantics.
 
 Exemptions:
   - Functions with REVOKE EXECUTE/ALL FROM PUBLIC immediately after definition
-  - Functions listed in KNOWN_EXEMPT (intentionally open or superseded, documented)
+  - Functions listed in KNOWN_EXEMPT (intentionally open/delegating/superseded,
+    with a documented reason)
 """
 
 import pathlib
@@ -34,12 +42,22 @@ KNOWN_EXEMPT = {
     # because this function's whole purpose is validating identity, not org
     # membership, for a caller checking their own permissions.
     "has_permission",
+    # Migration 178 assertion helper. It is an internal, non-client-callable
+    # wrapper around wardah_has_exact_permission and is itself the recognized
+    # authorization assertion used by the public manual-journal RPCs.
+    "wardah_178_assert_permission",
+    # Migration 178 batch wrapper performs no table mutation or privileged read;
+    # every entry is delegated to rpc_post_manual_journal_entry, which performs
+    # the exact-permission assertion against that entry's own organization.
+    "rpc_batch_post_manual_journal_entries",
 }
 
 GUARD_PATTERNS = [
     r"wardah_assert_org_member",
     r"wardah_assert_org_admin",
     r"wardah_is_org_member",
+    # Match only the assertion wrapper, never a bare boolean permission lookup.
+    r"wardah_178_assert_permission",
 ]
 GUARD_RE = re.compile("|".join(GUARD_PATTERNS))
 
@@ -84,12 +102,7 @@ def check_file(path: pathlib.Path) -> list[str]:
     errors = []
     sql = path.read_text(encoding="utf-8")
 
-    for m in re.finditer(
-        r"SECURITY\s+DEFINER",
-        sql,
-        re.IGNORECASE,
-    ):
-        # Walk back to find the CREATE FUNCTION
+    for m in re.finditer(r"SECURITY\s+DEFINER", sql, re.IGNORECASE):
         prefix = sql[: m.start()]
         func_m = None
         for fm in DEFINER_FUNC_RE.finditer(prefix):
@@ -103,7 +116,7 @@ def check_file(path: pathlib.Path) -> list[str]:
 
         body = extract_function_body(sql, func_m.start())
 
-        # Check for explicit REVOKE after definition
+        # Check for explicit REVOKE after definition and before the next CREATE.
         after = sql[func_m.end():]
         revoke_before_next_func = after.split("CREATE")[0] if "CREATE" in after else after
         if REVOKE_RE.search(revoke_before_next_func):
@@ -112,8 +125,7 @@ def check_file(path: pathlib.Path) -> list[str]:
         if not GUARD_RE.search(body):
             errors.append(
                 f"  ❌ {path.name}: function '{func_name}' is SECURITY DEFINER "
-                f"but has no org-member guard (wardah_assert_org_member / "
-                f"wardah_assert_org_admin / wardah_is_org_member)"
+                f"but has no recognized tenant/authorization assertion"
             )
 
     return errors
@@ -135,15 +147,13 @@ def main() -> int:
 
     all_errors: list[str] = []
     for mig in sorted(new_migrations):
-        errors = check_file(mig)
-        all_errors.extend(errors)
+        all_errors.extend(check_file(mig))
 
     if all_errors:
         print("\n".join(all_errors), file=sys.stderr)
         print(
-            "\nأضف wardah_assert_org_member(v_org) أو wardah_assert_org_admin(v_org) "
-            "في أول جسم الدالة، أو اسحب EXECUTE/ALL من PUBLIC، أو أضف اسمها إلى "
-            "KNOWN_EXEMPT إن كانت مقصودة.",
+            "\nأضف tenant/authorization assertion معترفاً بها، أو اسحب EXECUTE/ALL "
+            "من PUBLIC فور تعريف الدالة، أو وثّق تفويضاً آمناً في KNOWN_EXEMPT.",
             file=sys.stderr,
         )
         return 1

--- a/scripts/ci/fresh-db/acceptance_178_journal_rbac.sql
+++ b/scripts/ci/fresh-db/acceptance_178_journal_rbac.sql
@@ -1,0 +1,247 @@
+-- Acceptance for Migration 178 — canonical manual-journal RBAC boundary (#150).
+\set ON_ERROR_STOP on
+BEGIN;
+
+CREATE OR REPLACE FUNCTION pg_temp.expect_error(p_sql text, p_needle text)
+RETURNS void LANGUAGE plpgsql AS $$
+DECLARE v_ok boolean := false;
+BEGIN
+  BEGIN
+    EXECUTE p_sql;
+    v_ok := true;
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM NOT LIKE '%' || p_needle || '%' THEN
+      RAISE EXCEPTION 'J178 expected [%], got [%] for [%]',p_needle,SQLERRM,p_sql;
+    END IF;
+  END;
+  IF v_ok THEN RAISE EXCEPTION 'J178 expected error [%], succeeded: %',p_needle,p_sql; END IF;
+END $$;
+
+CREATE OR REPLACE FUNCTION pg_temp.payload(p_org uuid,p_journal uuid,p_debit uuid,p_credit uuid,p_key text,p_auto boolean DEFAULT false)
+RETURNS jsonb LANGUAGE sql AS $$
+  SELECT jsonb_build_object(
+    'org_id',p_org,'journal_id',p_journal,'entry_date','2026-08-23',
+    'description','J178 manual fixture','reference_type','MANUAL_TEST',
+    'reference_number',p_key,'idempotency_key',p_key,'auto_post',p_auto,
+    'lines',jsonb_build_array(
+      jsonb_build_object('line_number',1,'account_id',p_debit,'debit',100,'credit',0,'description','D'),
+      jsonb_build_object('line_number',2,'account_id',p_credit,'debit',0,'credit',100,'description','C')
+    )
+  )
+$$;
+
+-- Fixtures.
+INSERT INTO auth.users(id,email) VALUES
+ ('17800000-0000-0000-0000-000000000001','j178-none@example.test'),
+ ('17800000-0000-0000-0000-000000000002','j178-member@example.test'),
+ ('17800000-0000-0000-0000-000000000003','j178-admin@example.test'),
+ ('17800000-0000-0000-0000-000000000004','j178-expired@example.test'),
+ ('17800000-0000-0000-0000-000000000005','j178-other@example.test');
+
+INSERT INTO public.organizations(id,name,code) VALUES
+ ('17800000-aaaa-aaaa-aaaa-000000000001','J178 Org A','J178-A'),
+ ('17800000-bbbb-bbbb-bbbb-000000000002','J178 Org B','J178-B');
+
+INSERT INTO public.user_organizations(user_id,org_id,is_active,is_org_admin) VALUES
+ ('17800000-0000-0000-0000-000000000001','17800000-aaaa-aaaa-aaaa-000000000001',true,false),
+ ('17800000-0000-0000-0000-000000000002','17800000-aaaa-aaaa-aaaa-000000000001',true,false),
+ ('17800000-0000-0000-0000-000000000003','17800000-aaaa-aaaa-aaaa-000000000001',true,true),
+ ('17800000-0000-0000-0000-000000000004','17800000-aaaa-aaaa-aaaa-000000000001',true,false),
+ ('17800000-0000-0000-0000-000000000005','17800000-bbbb-bbbb-bbbb-000000000002',true,true);
+
+INSERT INTO public.roles(id,org_id,name,name_ar,is_active) VALUES
+ ('17800000-1111-1111-1111-000000000001','17800000-aaaa-aaaa-aaaa-000000000001','J178 Journal Operator','مشغل قيود',true),
+ ('17800000-1111-1111-1111-000000000002','17800000-aaaa-aaaa-aaaa-000000000001','J178 Reverse Grant','عكس قيود',true);
+
+INSERT INTO public.role_permissions(role_id,permission_id)
+SELECT '17800000-1111-1111-1111-000000000001'::uuid,p.id
+FROM public.permissions p
+WHERE p.permission_key IN ('accounting.journals.create','accounting.journals.post','accounting.journals.update','accounting.journals.delete');
+INSERT INTO public.role_permissions(role_id,permission_id)
+SELECT '17800000-1111-1111-1111-000000000002'::uuid,p.id
+FROM public.permissions p WHERE p.permission_key='accounting.journals.reverse';
+
+INSERT INTO public.user_roles(user_id,role_id,org_id,expires_at) VALUES
+ ('17800000-0000-0000-0000-000000000002','17800000-1111-1111-1111-000000000001','17800000-aaaa-aaaa-aaaa-000000000001',NULL),
+ ('17800000-0000-0000-0000-000000000004','17800000-1111-1111-1111-000000000001','17800000-aaaa-aaaa-aaaa-000000000001','2020-01-01T00:00:00Z');
+
+INSERT INTO public.journals(id,org_id,code,name,journal_type,sequence_prefix,is_active) VALUES
+ ('17800000-2222-2222-2222-000000000001','17800000-aaaa-aaaa-aaaa-000000000001','J178','J178 Journal','general','J178',true),
+ ('17800000-2222-2222-2222-000000000002','17800000-bbbb-bbbb-bbbb-000000000002','J178B','J178 Journal B','general','J178B',true);
+
+INSERT INTO public.gl_accounts(id,org_id,code,name,category,subtype,normal_balance,allow_posting,is_active) VALUES
+ ('17800000-3333-3333-3333-000000000001','17800000-aaaa-aaaa-aaaa-000000000001','178101','J178 Debit','ASSET','CURRENT_ASSET','DEBIT',true,true),
+ ('17800000-3333-3333-3333-000000000002','17800000-aaaa-aaaa-aaaa-000000000001','178201','J178 Credit','LIABILITY','CURRENT_LIABILITY','CREDIT',true,true),
+ ('17800000-3333-3333-3333-000000000003','17800000-bbbb-bbbb-bbbb-000000000002','178301','J178 B Debit','ASSET','CURRENT_ASSET','DEBIT',true,true),
+ ('17800000-3333-3333-3333-000000000004','17800000-bbbb-bbbb-bbbb-000000000002','178401','J178 B Credit','LIABILITY','CURRENT_LIABILITY','CREDIT',true,true);
+
+-- Catalog/classifier and execute surface.
+DO $$
+BEGIN
+  IF NOT public.wardah_is_sensitive_permission('accounting.journals.reverse')
+     OR public.wardah_is_sensitive_permission('accounting.journals.post') THEN
+    RAISE EXCEPTION 'J178 sensitive classifier mismatch';
+  END IF;
+  IF NOT public.wardah_is_sensitive_permission('accounting.vouchers.cancel')
+     OR NOT public.wardah_is_sensitive_permission('accounting.vouchers.unpost') THEN
+    RAISE EXCEPTION 'J178 regressed 174 voucher sensitivity';
+  END IF;
+  IF has_function_privilege('authenticated','public.rpc_create_journal_entry(jsonb)','EXECUTE')
+     OR has_function_privilege('authenticated','public.rpc_post_event_journal(text,numeric,text,text,uuid,uuid,text,date)','EXECUTE')
+     OR has_function_privilege('authenticated','public.batch_post_journal_entries(uuid[])','EXECUTE')
+     OR has_function_privilege('authenticated','public.reverse_journal_entry_enhanced(uuid,text,date)','EXECUTE')
+     OR has_function_privilege('anon','public.post_journal_entry(uuid)','EXECUTE') THEN
+    RAISE EXCEPTION 'J178 internal/legacy function remains client executable';
+  END IF;
+  IF NOT has_function_privilege('authenticated','public.rpc_create_manual_journal_entry(jsonb)','EXECUTE')
+     OR NOT has_function_privilege('authenticated','public.rpc_post_manual_journal_entry(uuid)','EXECUTE')
+     OR NOT has_function_privilege('authenticated','public.rpc_reverse_manual_journal_entry(uuid,text,date)','EXECUTE') THEN
+    RAISE EXCEPTION 'J178 canonical public API not executable';
+  END IF;
+END $$;
+
+-- No-permission member denied create.
+SELECT set_config('request.jwt.claim.sub','17800000-0000-0000-0000-000000000001',false);
+SET LOCAL ROLE authenticated;
+SELECT pg_temp.expect_error(format('SELECT public.rpc_create_manual_journal_entry(%L::jsonb)',
+  pg_temp.payload('17800000-aaaa-aaaa-aaaa-000000000001','17800000-2222-2222-2222-000000000001',
+    '17800000-3333-3333-3333-000000000001','17800000-3333-3333-3333-000000000002','none',false)),
+  'PERMISSION_DENIED');
+RESET ROLE;
+
+-- Expired role denied.
+SELECT set_config('request.jwt.claim.sub','17800000-0000-0000-0000-000000000004',false);
+SET LOCAL ROLE authenticated;
+SELECT pg_temp.expect_error(format('SELECT public.rpc_create_manual_journal_entry(%L::jsonb)',
+  pg_temp.payload('17800000-aaaa-aaaa-aaaa-000000000001','17800000-2222-2222-2222-000000000001',
+    '17800000-3333-3333-3333-000000000001','17800000-3333-3333-3333-000000000002','expired',false)),
+  'PERMISSION_DENIED');
+RESET ROLE;
+
+-- Explicit operator: auto-post is forbidden; normal create succeeds as manual.
+SELECT set_config('request.jwt.claim.sub','17800000-0000-0000-0000-000000000002',false);
+SET LOCAL ROLE authenticated;
+SELECT pg_temp.expect_error(format('SELECT public.rpc_create_manual_journal_entry(%L::jsonb)',
+  pg_temp.payload('17800000-aaaa-aaaa-aaaa-000000000001','17800000-2222-2222-2222-000000000001',
+    '17800000-3333-3333-3333-000000000001','17800000-3333-3333-3333-000000000002','autopost',true)),
+  'JOURNAL_AUTO_POST_FORBIDDEN');
+
+CREATE TEMP TABLE t178_manual AS
+SELECT public.rpc_create_manual_journal_entry(pg_temp.payload(
+  '17800000-aaaa-aaaa-aaaa-000000000001','17800000-2222-2222-2222-000000000001',
+  '17800000-3333-3333-3333-000000000001','17800000-3333-3333-3333-000000000002','happy',false)) result;
+
+DO $$ DECLARE v jsonb; v_id uuid;
+BEGIN
+  SELECT result INTO v FROM t178_manual; v_id := (v->>'entry_id')::uuid;
+  IF NOT EXISTS (SELECT 1 FROM public.gl_entries
+                 WHERE id=v_id AND status='draft' AND journal_origin='manual'
+                   AND created_by='17800000-0000-0000-0000-000000000002') THEN
+    RAISE EXCEPTION 'J178 create provenance/status mismatch';
+  END IF;
+  IF (SELECT count(*) FROM public.gl_entry_lines WHERE entry_id=v_id) <> 2 THEN
+    RAISE EXCEPTION 'J178 create lines mismatch';
+  END IF;
+END $$;
+
+-- Cross-org entry cannot be posted with org-A role.
+RESET ROLE;
+INSERT INTO public.gl_entries(id,org_id,journal_id,entry_number,entry_date,entry_type,status,total_debit,total_credit,journal_origin)
+VALUES ('17800000-4444-4444-4444-000000000099','17800000-bbbb-bbbb-bbbb-000000000002',
+        '17800000-2222-2222-2222-000000000002','J178B-X','2026-08-23','manual','draft',10,10,'manual');
+SELECT set_config('request.jwt.claim.sub','17800000-0000-0000-0000-000000000002',false);
+SET LOCAL ROLE authenticated;
+SELECT pg_temp.expect_error(
+  'SELECT public.rpc_post_manual_journal_entry(''17800000-4444-4444-4444-000000000099''::uuid)',
+  'PERMISSION_DENIED');
+
+-- Post succeeds with exact post grant.
+CREATE TEMP TABLE t178_post AS
+SELECT public.rpc_post_manual_journal_entry((SELECT (result->>'entry_id')::uuid FROM t178_manual)) result;
+DO $$ DECLARE v_id uuid;
+BEGIN
+  SELECT (result->>'entry_id')::uuid INTO v_id FROM t178_post;
+  IF NOT EXISTS (SELECT 1 FROM public.gl_entries WHERE id=v_id AND status='posted'
+                 AND posted_by='17800000-0000-0000-0000-000000000002') THEN
+    RAISE EXCEPTION 'J178 post did not persist canonical actor/status';
+  END IF;
+END $$;
+
+-- A system-origin draft cannot be posted from the manual API even with post permission.
+RESET ROLE;
+INSERT INTO public.gl_entries(id,org_id,journal_id,entry_number,entry_date,entry_type,status,total_debit,total_credit,journal_origin)
+VALUES ('17800000-4444-4444-4444-000000000001','17800000-aaaa-aaaa-aaaa-000000000001',
+        '17800000-2222-2222-2222-000000000001','J178-SYS','2026-08-23','manual','draft',10,10,'system');
+SELECT set_config('request.jwt.claim.sub','17800000-0000-0000-0000-000000000002',false);
+SET LOCAL ROLE authenticated;
+SELECT pg_temp.expect_error(
+  'SELECT public.rpc_post_manual_journal_entry(''17800000-4444-4444-4444-000000000001''::uuid)',
+  'JOURNAL_SYSTEM_ENTRY_NOT_MANUAL_POSTABLE');
+
+-- Reverse is sensitive: org admin override alone is NOT enough.
+RESET ROLE;
+SELECT set_config('request.jwt.claim.sub','17800000-0000-0000-0000-000000000003',false);
+SET LOCAL ROLE authenticated;
+SELECT pg_temp.expect_error(format(
+  'SELECT public.rpc_reverse_manual_journal_entry(%L::uuid,%L,%L::date)',
+  (SELECT result->>'entry_id' FROM t178_post),'test reverse','2026-08-23'),
+  'PERMISSION_DENIED');
+RESET ROLE;
+
+-- Explicit reverse grant to the same org admin authorizes it.
+INSERT INTO public.user_roles(user_id,role_id,org_id,expires_at) VALUES
+ ('17800000-0000-0000-0000-000000000003','17800000-1111-1111-1111-000000000002','17800000-aaaa-aaaa-aaaa-000000000001',NULL);
+SELECT set_config('request.jwt.claim.sub','17800000-0000-0000-0000-000000000003',false);
+SET LOCAL ROLE authenticated;
+CREATE TEMP TABLE t178_reverse AS
+SELECT public.rpc_reverse_manual_journal_entry(
+ (SELECT (result->>'entry_id')::uuid FROM t178_post),'test reverse','2026-08-23') result;
+
+DO $$ DECLARE v jsonb; v_original uuid; v_reverse uuid; v_d numeric; v_c numeric;
+BEGIN
+  SELECT result INTO v FROM t178_reverse;
+  v_original := (v->>'original_entry_id')::uuid;
+  v_reverse := (v->>'reversal_entry_id')::uuid;
+  IF NOT EXISTS (SELECT 1 FROM public.gl_entries WHERE id=v_original AND status='reversed') THEN
+    RAISE EXCEPTION 'J178 original not marked reversed';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.gl_entries WHERE id=v_reverse AND status='posted'
+                 AND journal_origin='manual_reversal' AND reference_id=v_original
+                 AND posted_by='17800000-0000-0000-0000-000000000003') THEN
+    RAISE EXCEPTION 'J178 reversal provenance mismatch';
+  END IF;
+  SELECT sum(debit),sum(credit) INTO v_d,v_c FROM public.gl_entry_lines WHERE entry_id=v_reverse;
+  IF v_d<>100 OR v_c<>100 THEN RAISE EXCEPTION 'J178 reversal balance mismatch'; END IF;
+END $$;
+
+-- Reversal is idempotent after the original has already become reversed.
+DO $$ DECLARE v1 jsonb; v2 jsonb;
+BEGIN
+  SELECT result INTO v1 FROM t178_reverse;
+  v2 := public.rpc_reverse_manual_journal_entry((v1->>'original_entry_id')::uuid,'retry','2026-08-23');
+  IF NOT COALESCE((v2->>'duplicate')::boolean,false)
+     OR v2->>'reversal_entry_id' <> v1->>'reversal_entry_id' THEN
+    RAISE EXCEPTION 'J178 reversal replay mismatch';
+  END IF;
+END $$;
+RESET ROLE;
+
+-- Revocation is immediate for the sensitive permission.
+DELETE FROM public.role_permissions rp
+USING public.permissions p
+WHERE rp.permission_id=p.id
+  AND rp.role_id='17800000-1111-1111-1111-000000000002'
+  AND p.permission_key='accounting.journals.reverse';
+SELECT set_config('request.jwt.claim.sub','17800000-0000-0000-0000-000000000003',false);
+SET LOCAL ROLE authenticated;
+DO $$
+BEGIN
+  IF public.has_permission('17800000-0000-0000-0000-000000000003',
+      '17800000-aaaa-aaaa-aaaa-000000000001','accounting.journals.reverse') THEN
+    RAISE EXCEPTION 'J178 revoked reverse permission still effective';
+  END IF;
+END $$;
+RESET ROLE;
+
+ROLLBACK;
+\echo 'JOURNAL_RBAC_178_ACCEPTANCE_PASS'

--- a/scripts/ci/fresh-db/acceptance_178_journal_rbac.sql
+++ b/scripts/ci/fresh-db/acceptance_178_journal_rbac.sql
@@ -144,7 +144,9 @@ BEGIN
   END IF;
 END $$;
 
--- Cross-org entry cannot be posted with org-A role.
+-- Cross-org UUIDs are indistinguishable from missing UUIDs for every public
+-- row-addressed mutation. This closes the tenant-existence oracle before the
+-- exact-permission check is reached.
 RESET ROLE;
 INSERT INTO public.gl_entries(id,org_id,journal_id,entry_number,entry_date,entry_type,status,total_debit,total_credit,journal_origin)
 VALUES ('17800000-4444-4444-4444-000000000099','17800000-bbbb-bbbb-bbbb-000000000002',
@@ -153,7 +155,22 @@ SELECT set_config('request.jwt.claim.sub','17800000-0000-0000-0000-000000000002'
 SET LOCAL ROLE authenticated;
 SELECT pg_temp.expect_error(
   'SELECT public.rpc_post_manual_journal_entry(''17800000-4444-4444-4444-000000000099''::uuid)',
-  'PERMISSION_DENIED');
+  'JOURNAL_ENTRY_NOT_FOUND');
+SELECT pg_temp.expect_error(
+  'SELECT public.rpc_delete_manual_journal_entry(''17800000-4444-4444-4444-000000000099''::uuid)',
+  'JOURNAL_ENTRY_NOT_FOUND');
+SELECT pg_temp.expect_error(format(
+  'SELECT public.rpc_update_manual_journal_entry(%L::uuid,%L::jsonb)',
+  '17800000-4444-4444-4444-000000000099',
+  pg_temp.payload('17800000-aaaa-aaaa-aaaa-000000000001','17800000-2222-2222-2222-000000000001',
+    '17800000-3333-3333-3333-000000000001','17800000-3333-3333-3333-000000000002','foreign-update',false)),
+  'JOURNAL_ENTRY_NOT_FOUND');
+SELECT pg_temp.expect_error(
+  'SELECT public.rpc_reverse_manual_journal_entry(''17800000-4444-4444-4444-000000000099''::uuid,''foreign'',''2026-08-23''::date)',
+  'JOURNAL_ENTRY_NOT_FOUND');
+SELECT pg_temp.expect_error(
+  'SELECT public.rpc_post_manual_journal_entry(''17800000-4444-4444-4444-000000000098''::uuid)',
+  'JOURNAL_ENTRY_NOT_FOUND');
 
 -- Post succeeds with exact post grant.
 CREATE TEMP TABLE t178_post AS

--- a/sql/migrations/178_journal_rbac_and_canonical_manual_lifecycle.sql
+++ b/sql/migrations/178_journal_rbac_and_canonical_manual_lifecycle.sql
@@ -6,6 +6,8 @@
 --   * add first-class post/reverse permissions;
 --   * make reverse sensitive (explicit grant required for org admins);
 --   * close legacy/internal journal primitives to authenticated clients;
+--   * scope entry lookup before authorization so foreign UUIDs do not become
+--     a cross-tenant existence oracle;
 --   * provide permission-guarded create/update/delete/post/reverse RPCs for
 --     manually maintained journals only.
 --
@@ -296,7 +298,22 @@ DECLARE
 BEGIN
   IF v_uid IS NULL THEN RAISE EXCEPTION 'NOT_AUTHENTICATED'; END IF;
 
-  SELECT * INTO v_old FROM public.gl_entries WHERE id = p_entry_id FOR UPDATE;
+  SELECT ge.* INTO v_old
+  FROM public.gl_entries ge
+  WHERE ge.id = p_entry_id
+    AND (
+      EXISTS (
+        SELECT 1 FROM public.super_admins sa
+        WHERE sa.user_id = v_uid AND sa.is_active = true
+      )
+      OR EXISTS (
+        SELECT 1 FROM public.user_organizations uo
+        WHERE uo.user_id = v_uid
+          AND uo.org_id = ge.org_id
+          AND COALESCE(uo.is_active, true)
+      )
+    )
+  FOR UPDATE;
   IF NOT FOUND THEN RAISE EXCEPTION 'JOURNAL_ENTRY_NOT_FOUND'; END IF;
 
   PERFORM public.wardah_178_assert_permission(v_old.org_id, 'accounting.journals.update');
@@ -373,7 +390,22 @@ DECLARE
   v_entry public.gl_entries%rowtype;
 BEGIN
   IF v_uid IS NULL THEN RAISE EXCEPTION 'NOT_AUTHENTICATED'; END IF;
-  SELECT * INTO v_entry FROM public.gl_entries WHERE id=p_entry_id FOR UPDATE;
+  SELECT ge.* INTO v_entry
+  FROM public.gl_entries ge
+  WHERE ge.id = p_entry_id
+    AND (
+      EXISTS (
+        SELECT 1 FROM public.super_admins sa
+        WHERE sa.user_id = v_uid AND sa.is_active = true
+      )
+      OR EXISTS (
+        SELECT 1 FROM public.user_organizations uo
+        WHERE uo.user_id = v_uid
+          AND uo.org_id = ge.org_id
+          AND COALESCE(uo.is_active, true)
+      )
+    )
+  FOR UPDATE;
   IF NOT FOUND THEN RAISE EXCEPTION 'JOURNAL_ENTRY_NOT_FOUND'; END IF;
 
   PERFORM public.wardah_178_assert_permission(v_entry.org_id,'accounting.journals.delete');
@@ -407,7 +439,22 @@ DECLARE
   v_lines integer;
 BEGIN
   IF v_uid IS NULL THEN RAISE EXCEPTION 'NOT_AUTHENTICATED'; END IF;
-  SELECT * INTO v_entry FROM public.gl_entries WHERE id=p_entry_id FOR UPDATE;
+  SELECT ge.* INTO v_entry
+  FROM public.gl_entries ge
+  WHERE ge.id = p_entry_id
+    AND (
+      EXISTS (
+        SELECT 1 FROM public.super_admins sa
+        WHERE sa.user_id = v_uid AND sa.is_active = true
+      )
+      OR EXISTS (
+        SELECT 1 FROM public.user_organizations uo
+        WHERE uo.user_id = v_uid
+          AND uo.org_id = ge.org_id
+          AND COALESCE(uo.is_active, true)
+      )
+    )
+  FOR UPDATE;
   IF NOT FOUND THEN RAISE EXCEPTION 'JOURNAL_ENTRY_NOT_FOUND'; END IF;
 
   PERFORM public.wardah_178_assert_permission(v_entry.org_id,'accounting.journals.post');
@@ -494,7 +541,22 @@ DECLARE
   v_reversal uuid;
 BEGIN
   IF v_uid IS NULL THEN RAISE EXCEPTION 'NOT_AUTHENTICATED'; END IF;
-  SELECT * INTO v_original FROM public.gl_entries WHERE id=p_entry_id FOR UPDATE;
+  SELECT ge.* INTO v_original
+  FROM public.gl_entries ge
+  WHERE ge.id = p_entry_id
+    AND (
+      EXISTS (
+        SELECT 1 FROM public.super_admins sa
+        WHERE sa.user_id = v_uid AND sa.is_active = true
+      )
+      OR EXISTS (
+        SELECT 1 FROM public.user_organizations uo
+        WHERE uo.user_id = v_uid
+          AND uo.org_id = ge.org_id
+          AND COALESCE(uo.is_active, true)
+      )
+    )
+  FOR UPDATE;
   IF NOT FOUND THEN RAISE EXCEPTION 'JOURNAL_ENTRY_NOT_FOUND'; END IF;
 
   PERFORM public.wardah_178_assert_permission(v_original.org_id,'accounting.journals.reverse');

--- a/sql/migrations/178_journal_rbac_and_canonical_manual_lifecycle.sql
+++ b/sql/migrations/178_journal_rbac_and_canonical_manual_lifecycle.sql
@@ -1,0 +1,660 @@
+-- Migration 178 — canonical manual-journal RBAC boundary (Issue #150)
+--
+-- Goals:
+--   * keep gl_entries/gl_entry_lines as the canonical ledger;
+--   * separate manual Journal UI authorization from trusted domain posting;
+--   * add first-class post/reverse permissions;
+--   * make reverse sensitive (explicit grant required for org admins);
+--   * close legacy/internal journal primitives to authenticated clients;
+--   * provide permission-guarded create/update/delete/post/reverse RPCs for
+--     manually maintained journals only.
+--
+-- Production deployment is intentionally NOT part of this migration file's
+-- preparation. Validate on Fresh DB first.
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- 1. Permission catalog: posting and reversal are not CRUD aliases.
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE
+  v_module uuid;
+BEGIN
+  SELECT id INTO v_module
+  FROM public.modules
+  WHERE name = 'accounting' AND COALESCE(is_active, true)
+  ORDER BY created_at NULLS LAST
+  LIMIT 1;
+
+  IF v_module IS NULL THEN
+    RAISE EXCEPTION 'JOURNAL_178_ACCOUNTING_MODULE_MISSING';
+  END IF;
+
+  INSERT INTO public.permissions (
+    module_id, resource, resource_ar, action, action_ar, permission_key,
+    description, description_ar
+  )
+  SELECT v_module, x.resource, x.resource_ar, x.action, x.action_ar,
+         x.permission_key, x.description, x.description_ar
+  FROM (VALUES
+    ('journals'::varchar, 'القيود'::varchar, 'post'::varchar, 'ترحيل'::varchar,
+     'accounting.journals.post'::varchar,
+     'Post manual journal entries to the general ledger'::text,
+     'ترحيل القيود اليومية اليدوية إلى الأستاذ العام'::text),
+    ('journals'::varchar, 'القيود'::varchar, 'reverse'::varchar, 'عكس'::varchar,
+     'accounting.journals.reverse'::varchar,
+     'Reverse posted manual journal entries'::text,
+     'عكس القيود اليومية اليدوية المرحلة'::text)
+  ) AS x(resource, resource_ar, action, action_ar, permission_key, description, description_ar)
+  WHERE NOT EXISTS (
+    SELECT 1 FROM public.permissions p WHERE p.permission_key = x.permission_key
+  );
+
+  IF (SELECT count(*) FROM public.permissions
+      WHERE permission_key IN ('accounting.journals.post','accounting.journals.reverse')) <> 2 THEN
+    RAISE EXCEPTION 'JOURNAL_178_PERMISSION_CATALOG_INCOMPLETE';
+  END IF;
+END;
+$$;
+
+-- Reverse is deliberately sensitive: unlike ordinary post/create/update,
+-- an org-admin override alone must not authorize financial reversal.
+CREATE OR REPLACE FUNCTION public.wardah_is_sensitive_permission(p_permission_key text)
+RETURNS boolean
+LANGUAGE sql
+IMMUTABLE
+STRICT
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+  SELECT p_permission_key IN (
+    'accounting.vouchers.unpost',
+    'accounting.vouchers.cancel',
+    'accounting.journals.reverse'
+  );
+$function$;
+
+REVOKE ALL ON FUNCTION public.wardah_is_sensitive_permission(text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.wardah_is_sensitive_permission(text) TO authenticated, service_role;
+
+-- ---------------------------------------------------------------------------
+-- 2. Canonical-ledger provenance and status contract.
+--    The old entry_type='manual' value cannot distinguish manual UI entries
+--    from system entries because the historical generic posting primitive used
+--    it for both. journal_origin becomes the authoritative discriminator.
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.gl_entries
+  ADD COLUMN IF NOT EXISTS journal_origin text;
+
+UPDATE public.gl_entries
+SET journal_origin = CASE
+  WHEN reference_type IS NULL AND status = 'draft' THEN 'manual_legacy'
+  ELSE 'system'
+END
+WHERE journal_origin IS NULL;
+
+ALTER TABLE public.gl_entries
+  ALTER COLUMN journal_origin SET DEFAULT 'system',
+  ALTER COLUMN journal_origin SET NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.gl_entries'::regclass
+      AND conname = 'gl_entries_journal_origin_check'
+  ) THEN
+    ALTER TABLE public.gl_entries
+      ADD CONSTRAINT gl_entries_journal_origin_check
+      CHECK (journal_origin IN ('system','manual','manual_legacy','manual_reversal'));
+  END IF;
+END;
+$$;
+
+-- The protection trigger already understands "reversed", but the historical
+-- CHECK constraint did not. Align the declarative constraint with the trigger.
+ALTER TABLE public.gl_entries DROP CONSTRAINT IF EXISTS gl_entries_status_check;
+ALTER TABLE public.gl_entries
+  ADD CONSTRAINT gl_entries_status_check
+  CHECK (status IN ('draft','posted','cancelled','reversed'));
+
+CREATE INDEX IF NOT EXISTS idx_gl_entries_manual_lifecycle
+  ON public.gl_entries(org_id, journal_origin, status);
+
+-- ---------------------------------------------------------------------------
+-- 3. Internal helpers. They are never client-callable.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.wardah_178_assert_permission(
+  p_org uuid,
+  p_permission_key text
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_uid uuid := auth.uid();
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'NOT_AUTHENTICATED';
+  END IF;
+  IF p_org IS NULL THEN
+    RAISE EXCEPTION 'ORG_UNRESOLVED';
+  END IF;
+  IF NOT public.wardah_has_exact_permission(v_uid, p_org, p_permission_key) THEN
+    RAISE EXCEPTION 'PERMISSION_DENIED: %', p_permission_key;
+  END IF;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.wardah_178_validate_manual_lines(
+  p_org uuid,
+  p_lines jsonb
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_count integer;
+  v_bad integer;
+BEGIN
+  IF p_lines IS NULL OR jsonb_typeof(p_lines) <> 'array' THEN
+    RAISE EXCEPTION 'JOURNAL_LINES_REQUIRED';
+  END IF;
+
+  SELECT count(*) INTO v_count FROM jsonb_array_elements(p_lines);
+  IF v_count < 2 THEN
+    RAISE EXCEPTION 'EMPTY_ENTRY: at least two lines are required';
+  END IF;
+
+  SELECT count(*) INTO v_bad
+  FROM jsonb_array_elements(p_lines) l
+  WHERE NULLIF(l->>'account_id','') IS NULL
+     OR COALESCE((l->>'debit')::numeric, 0) < 0
+     OR COALESCE((l->>'credit')::numeric, 0) < 0
+     OR (COALESCE((l->>'debit')::numeric, 0) > 0
+         AND COALESCE((l->>'credit')::numeric, 0) > 0)
+     OR (COALESCE((l->>'debit')::numeric, 0) = 0
+         AND COALESCE((l->>'credit')::numeric, 0) = 0);
+  IF v_bad > 0 THEN
+    RAISE EXCEPTION 'JOURNAL_INVALID_LINE_SHAPE';
+  END IF;
+
+  SELECT count(*) INTO v_bad
+  FROM jsonb_array_elements(p_lines) l
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM public.gl_accounts a
+    WHERE a.id = (l->>'account_id')::uuid
+      AND a.org_id = p_org
+      AND COALESCE(a.is_active, true)
+      AND COALESCE(a.allow_posting, true)
+  );
+  IF v_bad > 0 THEN
+    RAISE EXCEPTION 'JOURNAL_ACCOUNT_NOT_POSTABLE_IN_ORG';
+  END IF;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.wardah_178_assert_permission(uuid,text) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.wardah_178_validate_manual_lines(uuid,jsonb) FROM PUBLIC, anon, authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 4. Public canonical manual-journal lifecycle.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_create_manual_journal_entry(p_payload jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_uid uuid := auth.uid();
+  v_org uuid;
+  v_payload jsonb;
+  v_result jsonb;
+  v_entry uuid;
+  v_client_idem text;
+  v_internal_idem text;
+  v_existing_origin text;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'NOT_AUTHENTICATED'; END IF;
+
+  v_org := public.wardah_org_id(NULLIF(p_payload->>'org_id','')::uuid);
+  PERFORM public.wardah_178_assert_permission(v_org, 'accounting.journals.create');
+
+  IF COALESCE((p_payload->>'auto_post')::boolean, false) THEN
+    RAISE EXCEPTION 'JOURNAL_AUTO_POST_FORBIDDEN: use rpc_post_manual_journal_entry';
+  END IF;
+
+  PERFORM public.wardah_178_validate_manual_lines(v_org, p_payload->'lines');
+
+  v_client_idem := NULLIF(p_payload->>'idempotency_key','');
+  IF v_client_idem IS NOT NULL THEN
+    v_internal_idem := 'manual:' || v_org::text || ':' || v_client_idem;
+    SELECT journal_origin INTO v_existing_origin
+    FROM public.gl_entries
+    WHERE org_id = v_org AND idempotency_key = v_internal_idem
+    LIMIT 1;
+    IF v_existing_origin IS NOT NULL
+       AND v_existing_origin NOT IN ('manual','manual_legacy') THEN
+      RAISE EXCEPTION 'JOURNAL_IDEMPOTENCY_NAMESPACE_COLLISION';
+    END IF;
+  END IF;
+
+  v_payload := p_payload || jsonb_build_object(
+    'org_id', v_org::text,
+    'auto_post', false
+  );
+  IF v_internal_idem IS NOT NULL THEN
+    v_payload := v_payload || jsonb_build_object('idempotency_key', v_internal_idem);
+  ELSE
+    v_payload := v_payload - 'idempotency_key';
+  END IF;
+
+  v_result := public.rpc_create_journal_entry(v_payload);
+  v_entry := NULLIF(v_result->>'entry_id','')::uuid;
+  IF v_entry IS NULL THEN RAISE EXCEPTION 'JOURNAL_CREATE_RETURNED_NO_ENTRY'; END IF;
+
+  UPDATE public.gl_entries
+  SET journal_origin = 'manual',
+      created_by = COALESCE(created_by, v_uid),
+      updated_at = now()
+  WHERE id = v_entry AND org_id = v_org
+    AND journal_origin IN ('system','manual','manual_legacy');
+
+  IF NOT FOUND THEN RAISE EXCEPTION 'JOURNAL_CREATE_ORIGIN_MISMATCH'; END IF;
+
+  INSERT INTO public.audit_logs(org_id,user_id,action,entity_type,entity_id,metadata)
+  VALUES (v_org,v_uid,'journal.manual.create','gl_entry',v_entry::text,
+          jsonb_build_object('migration',178));
+
+  RETURN v_result || jsonb_build_object('journal_origin','manual');
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.rpc_update_manual_journal_entry(
+  p_entry_id uuid,
+  p_payload jsonb
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_uid uuid := auth.uid();
+  v_old public.gl_entries%rowtype;
+  v_entry_date date;
+  v_journal uuid;
+  v_total_debit numeric;
+  v_total_credit numeric;
+  v_line_count integer;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'NOT_AUTHENTICATED'; END IF;
+
+  SELECT * INTO v_old FROM public.gl_entries WHERE id = p_entry_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'JOURNAL_ENTRY_NOT_FOUND'; END IF;
+
+  PERFORM public.wardah_178_assert_permission(v_old.org_id, 'accounting.journals.update');
+  IF v_old.journal_origin NOT IN ('manual','manual_legacy') THEN
+    RAISE EXCEPTION 'JOURNAL_SYSTEM_ENTRY_NOT_MANUAL_EDITABLE';
+  END IF;
+  IF v_old.status <> 'draft' THEN
+    RAISE EXCEPTION 'JOURNAL_ONLY_DRAFT_EDITABLE';
+  END IF;
+
+  PERFORM public.wardah_178_validate_manual_lines(v_old.org_id, p_payload->'lines');
+
+  SELECT COALESCE(sum(COALESCE((l->>'debit')::numeric,0)),0),
+         COALESCE(sum(COALESCE((l->>'credit')::numeric,0)),0), count(*)
+  INTO v_total_debit,v_total_credit,v_line_count
+  FROM jsonb_array_elements(p_payload->'lines') l;
+  IF round(v_total_debit,2) <> round(v_total_credit,2) OR round(v_total_debit,2)=0 THEN
+    RAISE EXCEPTION 'UNBALANCED_ENTRY';
+  END IF;
+
+  v_entry_date := COALESCE(NULLIF(p_payload->>'entry_date','')::date, v_old.entry_date);
+  PERFORM public.assert_period_open(v_old.org_id, v_entry_date);
+
+  v_journal := COALESCE(NULLIF(p_payload->>'journal_id','')::uuid, v_old.journal_id);
+  IF v_journal IS NOT NULL AND NOT EXISTS (
+    SELECT 1 FROM public.journals j
+    WHERE j.id=v_journal AND j.org_id=v_old.org_id AND COALESCE(j.is_active,true)
+  ) THEN
+    RAISE EXCEPTION 'JOURNAL_NOT_ACTIVE_IN_ORG';
+  END IF;
+
+  UPDATE public.gl_entries
+  SET journal_id=v_journal,
+      entry_date=v_entry_date,
+      description=NULLIF(p_payload->>'description',''),
+      description_ar=NULLIF(p_payload->>'description_ar',''),
+      reference_type=NULLIF(p_payload->>'reference_type',''),
+      reference_number=NULLIF(p_payload->>'reference_number',''),
+      total_debit=v_total_debit,
+      total_credit=v_total_credit,
+      updated_at=now()
+  WHERE id=p_entry_id;
+
+  DELETE FROM public.gl_entry_lines WHERE entry_id=p_entry_id;
+  INSERT INTO public.gl_entry_lines(
+    org_id,tenant_id,entry_id,line_number,account_id,debit,credit,
+    currency_code,description,description_ar
+  )
+  SELECT v_old.org_id,v_old.org_id,p_entry_id,
+         COALESCE((l.value->>'line_number')::int,l.ord::int),
+         (l.value->>'account_id')::uuid,
+         COALESCE((l.value->>'debit')::numeric,0),
+         COALESCE((l.value->>'credit')::numeric,0),
+         COALESCE(NULLIF(l.value->>'currency_code',''),'SAR'),
+         NULLIF(l.value->>'description',''),NULLIF(l.value->>'description_ar','')
+  FROM jsonb_array_elements(p_payload->'lines') WITH ORDINALITY AS l(value,ord);
+
+  INSERT INTO public.audit_logs(org_id,user_id,action,entity_type,entity_id,metadata)
+  VALUES (v_old.org_id,v_uid,'journal.manual.update','gl_entry',p_entry_id::text,
+          jsonb_build_object('migration',178));
+
+  RETURN jsonb_build_object('success',true,'entry_id',p_entry_id,'status','draft');
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.rpc_delete_manual_journal_entry(p_entry_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_uid uuid := auth.uid();
+  v_entry public.gl_entries%rowtype;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'NOT_AUTHENTICATED'; END IF;
+  SELECT * INTO v_entry FROM public.gl_entries WHERE id=p_entry_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'JOURNAL_ENTRY_NOT_FOUND'; END IF;
+
+  PERFORM public.wardah_178_assert_permission(v_entry.org_id,'accounting.journals.delete');
+  IF v_entry.journal_origin NOT IN ('manual','manual_legacy') THEN
+    RAISE EXCEPTION 'JOURNAL_SYSTEM_ENTRY_NOT_MANUAL_DELETABLE';
+  END IF;
+  IF v_entry.status <> 'draft' THEN RAISE EXCEPTION 'JOURNAL_ONLY_DRAFT_DELETABLE'; END IF;
+
+  DELETE FROM public.gl_entry_lines WHERE entry_id=p_entry_id;
+  DELETE FROM public.gl_entries WHERE id=p_entry_id;
+
+  INSERT INTO public.audit_logs(org_id,user_id,action,entity_type,entity_id,metadata)
+  VALUES (v_entry.org_id,v_uid,'journal.manual.delete','gl_entry',p_entry_id::text,
+          jsonb_build_object('migration',178,'entry_number',v_entry.entry_number));
+
+  RETURN jsonb_build_object('success',true,'entry_id',p_entry_id,'deleted',true);
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.rpc_post_manual_journal_entry(p_entry_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_uid uuid := auth.uid();
+  v_entry public.gl_entries%rowtype;
+  v_debit numeric;
+  v_credit numeric;
+  v_lines integer;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'NOT_AUTHENTICATED'; END IF;
+  SELECT * INTO v_entry FROM public.gl_entries WHERE id=p_entry_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'JOURNAL_ENTRY_NOT_FOUND'; END IF;
+
+  PERFORM public.wardah_178_assert_permission(v_entry.org_id,'accounting.journals.post');
+  IF v_entry.journal_origin NOT IN ('manual','manual_legacy') THEN
+    RAISE EXCEPTION 'JOURNAL_SYSTEM_ENTRY_NOT_MANUAL_POSTABLE';
+  END IF;
+  IF v_entry.status='posted' THEN
+    RETURN jsonb_build_object('success',true,'entry_id',p_entry_id,'status','posted','duplicate',true);
+  END IF;
+  IF v_entry.status <> 'draft' THEN RAISE EXCEPTION 'JOURNAL_ONLY_DRAFT_POSTABLE'; END IF;
+
+  SELECT COALESCE(sum(debit),0),COALESCE(sum(credit),0),count(*)
+  INTO v_debit,v_credit,v_lines
+  FROM public.gl_entry_lines WHERE entry_id=p_entry_id AND org_id=v_entry.org_id;
+  IF v_lines < 2 OR round(v_debit,2) <> round(v_credit,2) OR round(v_debit,2)=0 THEN
+    RAISE EXCEPTION 'JOURNAL_ENTRY_NOT_BALANCED';
+  END IF;
+  IF round(v_debit,2) <> round(v_entry.total_debit,2)
+     OR round(v_credit,2) <> round(v_entry.total_credit,2) THEN
+    RAISE EXCEPTION 'JOURNAL_HEADER_LINE_TOTAL_MISMATCH';
+  END IF;
+
+  PERFORM public.assert_period_open(v_entry.org_id,v_entry.entry_date);
+
+  UPDATE public.gl_entries
+  SET status='posted',posted_at=now(),posted_by=v_uid,updated_at=now()
+  WHERE id=p_entry_id;
+
+  INSERT INTO public.audit_logs(org_id,user_id,action,entity_type,entity_id,metadata)
+  VALUES (v_entry.org_id,v_uid,'journal.manual.post','gl_entry',p_entry_id::text,
+          jsonb_build_object('migration',178,'entry_number',v_entry.entry_number));
+
+  RETURN jsonb_build_object('success',true,'entry_id',p_entry_id,'status','posted');
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.rpc_batch_post_manual_journal_entries(p_entry_ids uuid[])
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_id uuid;
+  v_result jsonb;
+  v_results jsonb := '[]'::jsonb;
+  v_success integer := 0;
+  v_failed integer := 0;
+BEGIN
+  IF auth.uid() IS NULL THEN RAISE EXCEPTION 'NOT_AUTHENTICATED'; END IF;
+  FOREACH v_id IN ARRAY COALESCE(p_entry_ids,ARRAY[]::uuid[]) LOOP
+    BEGIN
+      v_result := public.rpc_post_manual_journal_entry(v_id);
+      v_success := v_success + 1;
+      v_results := v_results || jsonb_build_array(v_result);
+    EXCEPTION WHEN OTHERS THEN
+      v_failed := v_failed + 1;
+      v_results := v_results || jsonb_build_array(jsonb_build_object(
+        'entry_id',v_id,'success',false,'error',SQLERRM));
+    END;
+  END LOOP;
+  RETURN jsonb_build_object(
+    'success',v_failed=0,'total',COALESCE(array_length(p_entry_ids,1),0),
+    'success_count',v_success,'fail_count',v_failed,'results',v_results);
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.rpc_reverse_manual_journal_entry(
+  p_entry_id uuid,
+  p_reversal_reason text DEFAULT NULL,
+  p_reversal_date date DEFAULT CURRENT_DATE
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_uid uuid := auth.uid();
+  v_original public.gl_entries%rowtype;
+  v_existing uuid;
+  v_lines jsonb;
+  v_result jsonb;
+  v_reversal uuid;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'NOT_AUTHENTICATED'; END IF;
+  SELECT * INTO v_original FROM public.gl_entries WHERE id=p_entry_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'JOURNAL_ENTRY_NOT_FOUND'; END IF;
+
+  PERFORM public.wardah_178_assert_permission(v_original.org_id,'accounting.journals.reverse');
+  IF v_original.journal_origin NOT IN ('manual','manual_legacy') THEN
+    RAISE EXCEPTION 'JOURNAL_SYSTEM_ENTRY_REQUIRES_SOURCE_DOCUMENT_REVERSAL';
+  END IF;
+
+  SELECT id INTO v_existing
+  FROM public.gl_entries
+  WHERE org_id=v_original.org_id
+    AND reference_type='JOURNAL_REVERSAL'
+    AND reference_id=p_entry_id
+    AND status='posted'
+  LIMIT 1;
+  IF v_existing IS NOT NULL THEN
+    RETURN jsonb_build_object('success',true,'original_entry_id',p_entry_id,
+      'reversal_entry_id',v_existing,'duplicate',true);
+  END IF;
+
+  IF v_original.status <> 'posted' THEN
+    RAISE EXCEPTION 'JOURNAL_ONLY_POSTED_REVERSIBLE';
+  END IF;
+  PERFORM public.assert_period_open(v_original.org_id,p_reversal_date);
+
+  SELECT jsonb_agg(jsonb_build_object(
+    'line_number',line_number,'account_id',account_id,
+    'debit',credit,'credit',debit,'currency_code',COALESCE(currency_code,'SAR'),
+    'description',COALESCE(description,'Reversal')
+  ) ORDER BY line_number)
+  INTO v_lines
+  FROM public.gl_entry_lines
+  WHERE entry_id=p_entry_id AND org_id=v_original.org_id;
+
+  IF v_lines IS NULL OR jsonb_array_length(v_lines)<2 THEN
+    RAISE EXCEPTION 'JOURNAL_REVERSAL_LINES_MISSING';
+  END IF;
+
+  v_result := public.rpc_create_journal_entry(jsonb_build_object(
+    'org_id',v_original.org_id::text,
+    'journal_id',v_original.journal_id,
+    'entry_date',p_reversal_date,
+    'description','Reversal: ' || COALESCE(v_original.description,v_original.entry_number),
+    'description_ar','عكس: ' || COALESCE(v_original.description_ar,v_original.entry_number),
+    'reference_type','JOURNAL_REVERSAL',
+    'reference_number','REV-' || v_original.entry_number,
+    'idempotency_key','manual-reversal:' || p_entry_id::text,
+    'auto_post',true,
+    'lines',v_lines
+  ));
+  v_reversal := NULLIF(v_result->>'entry_id','')::uuid;
+  IF v_reversal IS NULL THEN RAISE EXCEPTION 'JOURNAL_REVERSAL_CREATE_FAILED'; END IF;
+
+  UPDATE public.gl_entries
+  SET journal_origin='manual_reversal',reference_id=p_entry_id,
+      created_by=COALESCE(created_by,v_uid),posted_by=v_uid,updated_at=now()
+  WHERE id=v_reversal AND org_id=v_original.org_id;
+
+  UPDATE public.gl_entries
+  SET status='reversed',updated_at=now()
+  WHERE id=p_entry_id;
+
+  INSERT INTO public.audit_logs(org_id,user_id,action,entity_type,entity_id,metadata)
+  VALUES (v_original.org_id,v_uid,'journal.manual.reverse','gl_entry',p_entry_id::text,
+          jsonb_build_object('migration',178,'reversal_entry_id',v_reversal,
+                             'reason',p_reversal_reason));
+
+  RETURN jsonb_build_object('success',true,'original_entry_id',p_entry_id,
+    'reversal_entry_id',v_reversal,'reversal_number',v_result->>'entry_number');
+END;
+$function$;
+
+-- Guarded public adapters for UI-driven event posting. Domain SECURITY DEFINER
+-- functions continue calling the underlying internal primitives as owner.
+CREATE OR REPLACE FUNCTION public.rpc_post_manual_event_journal(
+  p_event text,
+  p_amount numeric,
+  p_memo text,
+  p_ref_type text DEFAULT NULL,
+  p_ref_id uuid DEFAULT NULL,
+  p_tenant uuid DEFAULT NULL,
+  p_idempotency_key text DEFAULT NULL,
+  p_jv_date date DEFAULT CURRENT_DATE
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE v_org uuid;
+BEGIN
+  v_org := public.wardah_org_id(p_tenant);
+  PERFORM public.wardah_178_assert_permission(v_org,'accounting.journals.create');
+  PERFORM public.wardah_178_assert_permission(v_org,'accounting.journals.post');
+  RETURN public.rpc_post_event_journal(
+    p_event,p_amount,p_memo,p_ref_type,p_ref_id,v_org,p_idempotency_key,p_jv_date);
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.rpc_post_manual_work_center_oh(
+  p_work_center text,
+  p_amount numeric,
+  p_memo text,
+  p_ref_type text DEFAULT NULL,
+  p_ref_id uuid DEFAULT NULL,
+  p_tenant uuid DEFAULT NULL,
+  p_idempotency_key text DEFAULT NULL,
+  p_jv_date date DEFAULT CURRENT_DATE
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE v_org uuid;
+BEGIN
+  v_org := public.wardah_org_id(p_tenant);
+  PERFORM public.wardah_178_assert_permission(v_org,'accounting.journals.create');
+  PERFORM public.wardah_178_assert_permission(v_org,'accounting.journals.post');
+  RETURN public.rpc_post_work_center_oh(
+    p_work_center,p_amount,p_memo,p_ref_type,p_ref_id,v_org,p_idempotency_key,p_jv_date);
+END;
+$function$;
+
+-- ---------------------------------------------------------------------------
+-- 5. Grants: trusted primitives/legacy model are not public client APIs.
+-- ---------------------------------------------------------------------------
+REVOKE ALL ON FUNCTION public.rpc_create_journal_entry(jsonb) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.rpc_post_event_journal(text,numeric,text,text,uuid,uuid,text,date) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.rpc_post_work_center_oh(text,numeric,text,text,uuid,uuid,text,date) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.generate_entry_number(uuid) FROM PUBLIC, anon, authenticated;
+
+-- Preserve trusted server automation without exposing the primitives to users.
+GRANT EXECUTE ON FUNCTION public.rpc_create_journal_entry(jsonb) TO service_role;
+GRANT EXECUTE ON FUNCTION public.rpc_post_event_journal(text,numeric,text,text,uuid,uuid,text,date) TO service_role;
+GRANT EXECUTE ON FUNCTION public.rpc_post_work_center_oh(text,numeric,text,text,uuid,uuid,text,date) TO service_role;
+GRANT EXECUTE ON FUNCTION public.generate_entry_number(uuid) TO service_role;
+
+-- Legacy journal_entries model: permanently fail closed for browser clients.
+REVOKE ALL ON FUNCTION public.batch_post_journal_entries(uuid[]) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.approve_journal_entry(uuid,integer,text) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.reverse_journal_entry_enhanced(uuid,text,date) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.post_journal_entry(uuid) FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.rpc_create_manual_journal_entry(jsonb) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.rpc_update_manual_journal_entry(uuid,jsonb) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.rpc_delete_manual_journal_entry(uuid) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.rpc_post_manual_journal_entry(uuid) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.rpc_batch_post_manual_journal_entries(uuid[]) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.rpc_reverse_manual_journal_entry(uuid,text,date) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.rpc_post_manual_event_journal(text,numeric,text,text,uuid,uuid,text,date) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.rpc_post_manual_work_center_oh(text,numeric,text,text,uuid,uuid,text,date) TO authenticated, service_role;
+
+-- Ensure PUBLIC/anon never inherit the new API accidentally.
+REVOKE ALL ON FUNCTION public.rpc_create_manual_journal_entry(jsonb) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.rpc_update_manual_journal_entry(uuid,jsonb) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.rpc_delete_manual_journal_entry(uuid) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.rpc_post_manual_journal_entry(uuid) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.rpc_batch_post_manual_journal_entries(uuid[]) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.rpc_reverse_manual_journal_entry(uuid,text,date) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.rpc_post_manual_event_journal(text,numeric,text,text,uuid,uuid,text,date) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.rpc_post_manual_work_center_oh(text,numeric,text,text,uuid,uuid,text,date) FROM PUBLIC, anon;
+
+COMMIT;

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -2212,6 +2212,7 @@ export type Database = {
           id: string
           idempotency_key: string | null
           journal_id: string | null
+          journal_origin: string
           org_id: string
           posted_at: string | null
           posted_by: string | null
@@ -2234,6 +2235,7 @@ export type Database = {
           id?: string
           idempotency_key?: string | null
           journal_id?: string | null
+          journal_origin?: string
           org_id: string
           posted_at?: string | null
           posted_by?: string | null
@@ -2256,6 +2258,7 @@ export type Database = {
           id?: string
           idempotency_key?: string | null
           journal_id?: string | null
+          journal_origin?: string
           org_id?: string
           posted_at?: string | null
           posted_by?: string | null
@@ -10960,6 +10963,10 @@ export type Database = {
         Args: { p_org_id: string; p_product_id: string; p_uom_id: string }
         Returns: Json
       }
+      rpc_batch_post_manual_journal_entries: {
+        Args: { p_entry_ids: string[] }
+        Returns: Json
+      }
       rpc_cancel_customer_receipt: {
         Args: { p_reason: string; p_receipt_id: string }
         Returns: Json
@@ -11007,6 +11014,10 @@ export type Database = {
       }
       rpc_create_customer_receipt: { Args: { p_payload: Json }; Returns: Json }
       rpc_create_journal_entry: { Args: { p_payload: Json }; Returns: Json }
+      rpc_create_manual_journal_entry: {
+        Args: { p_payload: Json }
+        Returns: Json
+      }
       rpc_create_matched_supplier_invoice: {
         Args: { p_payload: Json }
         Returns: Json
@@ -11038,6 +11049,10 @@ export type Database = {
       rpc_create_supplier_payment: { Args: { p_payload: Json }; Returns: Json }
       rpc_create_uom_purchase_order: {
         Args: { p_payload: Json }
+        Returns: Json
+      }
+      rpc_delete_manual_journal_entry: {
+        Args: { p_entry_id: string }
         Returns: Json
       }
       rpc_delete_org_role: { Args: { p_payload: Json }; Returns: Json }
@@ -11135,6 +11150,36 @@ export type Database = {
         Returns: string
       }
       rpc_post_goods_receipt: { Args: { p_payload: Json }; Returns: Json }
+      rpc_post_manual_event_journal: {
+        Args: {
+          p_amount: number
+          p_event: string
+          p_idempotency_key?: string
+          p_jv_date?: string
+          p_memo: string
+          p_ref_id?: string
+          p_ref_type?: string
+          p_tenant?: string
+        }
+        Returns: string
+      }
+      rpc_post_manual_journal_entry: {
+        Args: { p_entry_id: string }
+        Returns: Json
+      }
+      rpc_post_manual_work_center_oh: {
+        Args: {
+          p_amount: number
+          p_idempotency_key?: string
+          p_jv_date?: string
+          p_memo: string
+          p_ref_id?: string
+          p_ref_type?: string
+          p_tenant?: string
+          p_work_center: string
+        }
+        Returns: string
+      }
       rpc_post_payroll_run: { Args: { p_payload: Json }; Returns: Json }
       rpc_post_settlement: { Args: { p_payload: Json }; Returns: Json }
       rpc_post_supplier_payment: {
@@ -11170,6 +11215,14 @@ export type Database = {
           p_note?: string
           p_org_id: string
           p_resolved_uom_id?: string
+        }
+        Returns: Json
+      }
+      rpc_reverse_manual_journal_entry: {
+        Args: {
+          p_entry_id: string
+          p_reversal_date?: string
+          p_reversal_reason?: string
         }
         Returns: Json
       }
@@ -11233,6 +11286,10 @@ export type Database = {
       }
       rpc_update_customer_receipt_draft: {
         Args: { p_payload: Json; p_receipt_id: string }
+        Returns: Json
+      }
+      rpc_update_manual_journal_entry: {
+        Args: { p_entry_id: string; p_payload: Json }
         Returns: Json
       }
       rpc_update_supplier_payment_draft: {
@@ -11636,6 +11693,14 @@ export type Database = {
       wardah_175_internal_replace_user_roles: {
         Args: { p_payload: Json }
         Returns: Json
+      }
+      wardah_178_assert_permission: {
+        Args: { p_org: string; p_permission_key: string }
+        Returns: undefined
+      }
+      wardah_178_validate_manual_lines: {
+        Args: { p_lines: Json; p_org: string }
+        Returns: undefined
       }
       wardah_apply_stock_incoming: {
         Args: {


### PR DESCRIPTION
Database-first half of #150. This PR intentionally contains only Migration 178 and its database/CI support. The dependent UI/service changes remain in #177 and must not be merged until this PR is merged, applied to Production, and verified.

Scope:
- Migration 178: canonical `gl_entries` manual-journal lifecycle and exact `accounting.journals.post` / sensitive `accounting.journals.reverse` permissions.
- Close authenticated access to legacy/internal journal primitives.
- Add `journal_origin` provenance and align canonical status contract.
- Harden row-addressed manual journal RPCs so foreign-tenant UUIDs are filtered before permission evaluation; cross-tenant existing UUIDs and missing UUIDs both return `JOURNAL_ENTRY_NOT_FOUND`.
- Dedicated Fresh DB acceptance, including cross-tenant existence-oracle negatives for update/delete/post/reverse.
- Static DEFINER guard support and regenerated DB types.

Governance:
- DB-only by design per the repository DB-first deployment rule. No dependent UI/service files are included.
- Do not apply to Production before merge into `main` and green acceptance.
- After merge, apply/verify Migration 178 in Production; only then rebase/retarget and merge dependent UI PR #177.

Safety: no Production write was performed while preparing this PR.