### PR TITLE
security(accounting): make GL idempotency race-safe

### DIFF
--- a/.github/workflows/gl-idempotency-179-acceptance.yml
+++ b/.github/workflows/gl-idempotency-179-acceptance.yml
@@ -1,0 +1,243 @@
+name: GL Idempotency 179 Acceptance
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'sql/migrations/179_gl_journal_idempotency_race_safe.sql'
+      - 'scripts/ci/fresh-db/setup_179_pre_migration_fixture.sql'
+      - 'scripts/ci/fresh-db/acceptance_179_gl_idempotency.sql'
+      - '.github/workflows/gl-idempotency-179-acceptance.yml'
+  workflow_dispatch:
+
+jobs:
+  acceptance:
+    name: Confirm race-safe GL idempotency
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      PGHOST: localhost
+      PGUSER: postgres
+      PGPASSWORD: postgres
+      PGDATABASE: wardah_fresh
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build fresh database through Migration 178
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          PAIR=$(bash scripts/ci/fresh-db/resolve_baseline_pair.sh sql/baseline)
+          pair_field() { printf '%s\n' "$PAIR" | sed -n "s/^$1=//p"; }
+          BASELINE=$(pair_field BASELINE_PATH)
+          REFERENCE=$(pair_field REFERENCE_PATH)
+          CUTOFF=$(pair_field BASELINE_CUTOFF)
+          CUTOFF=${CUTOFF:-0}
+
+          createdb wardah_fresh
+          psql -v ON_ERROR_STOP=1 -f scripts/ci/fresh-db/supabase_shim.sql -q
+          psql -v ON_ERROR_STOP=1 -f "$BASELINE" -q
+          psql -v ON_ERROR_STOP=1 -f "$REFERENCE" -q
+
+          python3 scripts/ci/fresh-db/build_apply_order.py sql/migrations "$CUTOFF" > /tmp/full_order.txt
+          grep -v '^179_' /tmp/full_order.txt > /tmp/pre179_order.txt
+          REPORT=/tmp/pre179_chain_report.txt \
+            bash scripts/ci/fresh-db/run_chain.sh sql/migrations /tmp/pre179_order.txt
+
+      - name: Seed pre-179 legacy keyed row
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          psql -v ON_ERROR_STOP=1 \
+            -f scripts/ci/fresh-db/setup_179_pre_migration_fixture.sql \
+            2>&1 | tee /tmp/setup-179.out
+          grep -q 'SETUP_179_PRE_MIGRATION_PASS' /tmp/setup-179.out
+
+      - name: Apply Migration 179
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          psql -v ON_ERROR_STOP=1 \
+            -f sql/migrations/179_gl_journal_idempotency_race_safe.sql \
+            2>&1 | tee /tmp/migration-179.out
+
+      - name: Run deterministic replay acceptance
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          psql -v ON_ERROR_STOP=1 \
+            -f scripts/ci/fresh-db/acceptance_179_gl_idempotency.sql \
+            2>&1 | tee /tmp/acceptance-179.out
+          grep -q 'GL_IDEMPOTENCY_179_ACCEPTANCE_PASS' /tmp/acceptance-179.out
+
+      - name: Run real two-session idempotency race
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          # Test-only trigger: both RPC calls pass their SELECT pre-check, then block
+          # at INSERT on an advisory lock held by a third session. We verify both
+          # sessions are actually waiting before releasing the barrier.
+          psql -v ON_ERROR_STOP=1 <<'SQL'
+          CREATE OR REPLACE FUNCTION public.j179_test_insert_barrier()
+          RETURNS trigger LANGUAGE plpgsql AS $function$
+          BEGIN
+            IF NEW.idempotency_key = 'J179:race:key' THEN
+              PERFORM pg_advisory_xact_lock(179176);
+            END IF;
+            RETURN NEW;
+          END;
+          $function$;
+          CREATE TRIGGER aaa_j179_test_insert_barrier
+          BEFORE INSERT ON public.gl_entries
+          FOR EACH ROW EXECUTE FUNCTION public.j179_test_insert_barrier();
+          SQL
+
+          cat >/tmp/j179-race.sql <<'SQL'
+          SELECT public.rpc_create_journal_entry(jsonb_build_object(
+            'org_id','17900000-aaaa-aaaa-aaaa-000000000001',
+            'journal_id','17900000-2222-2222-2222-000000000001',
+            'entry_date','2026-08-24',
+            'description','J179 concurrent request',
+            'reference_type','J179_RACE',
+            'reference_number','race',
+            'idempotency_key','J179:race:key',
+            'auto_post',false,
+            'lines',jsonb_build_array(
+              jsonb_build_object('line_number',1,'account_id','17900000-3333-3333-3333-000000000001','debit',100,'credit',0,'currency_code','SAR'),
+              jsonb_build_object('line_number',2,'account_id','17900000-3333-3333-3333-000000000002','debit',0,'credit',100,'currency_code','SAR')
+            )
+          ));
+          SQL
+
+          rm -f /tmp/j179-holder.fifo
+          mkfifo /tmp/j179-holder.fifo
+          ( printf 'SELECT pg_advisory_lock(179176);\n'; cat /tmp/j179-holder.fifo ) \
+            | psql -qAt > /tmp/j179-holder.out 2>&1 &
+          holder_pid=$!
+
+          for _ in $(seq 1 50); do
+            held=$(psql -qAt -c "SELECT count(*) FROM pg_locks WHERE locktype='advisory' AND objid=179176 AND granted")
+            [ "$held" -ge 1 ] && break
+            sleep 0.1
+          done
+          [ "${held:-0}" -ge 1 ] || { echo 'Barrier holder did not acquire advisory lock'; exit 1; }
+
+          psql -qAt -v ON_ERROR_STOP=1 -f /tmp/j179-race.sql > /tmp/j179-race-1.out 2>&1 &
+          race1=$!
+          psql -qAt -v ON_ERROR_STOP=1 -f /tmp/j179-race.sql > /tmp/j179-race-2.out 2>&1 &
+          race2=$!
+
+          waiters=0
+          for _ in $(seq 1 100); do
+            waiters=$(psql -qAt -c "SELECT count(*) FROM pg_stat_activity WHERE datname=current_database() AND query LIKE '%J179:race:key%' AND wait_event='advisory'")
+            [ "$waiters" -ge 2 ] && break
+            sleep 0.1
+          done
+          if [ "$waiters" -lt 2 ]; then
+            echo "Expected two independently blocked RPC sessions, saw $waiters"
+            cat /tmp/j179-race-1.out || true
+            cat /tmp/j179-race-2.out || true
+            exit 1
+          fi
+
+          printf 'SELECT pg_advisory_unlock(179176);\n\\q\n' > /tmp/j179-holder.fifo
+          wait "$holder_pid"
+          wait "$race1"
+          wait "$race2"
+
+          cat /tmp/j179-race-1.out
+          cat /tmp/j179-race-2.out
+          ! grep -q '23505\|duplicate key value' /tmp/j179-race-1.out
+          ! grep -q '23505\|duplicate key value' /tmp/j179-race-2.out
+
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          vals=[]
+          for path in ('/tmp/j179-race-1.out','/tmp/j179-race-2.out'):
+              lines=[x.strip() for x in Path(path).read_text().splitlines() if x.strip().startswith('{')]
+              assert len(lines)==1, (path, lines)
+              vals.append(json.loads(lines[0]))
+          assert vals[0]['entry_id'] == vals[1]['entry_id'], vals
+          assert sorted(v['duplicate'] for v in vals) == [False, True], vals
+          assert all(v.get('payload_verified') is True for v in vals), vals
+          assert all(v.get('legacy_replay') is False for v in vals), vals
+          PY
+
+          psql -v ON_ERROR_STOP=1 <<'SQL'
+          DO $do$
+          DECLARE v_id uuid;
+          BEGIN
+            IF (SELECT count(*) FROM public.gl_entries
+                WHERE org_id='17900000-aaaa-aaaa-aaaa-000000000001'
+                  AND idempotency_key='J179:race:key') <> 1 THEN
+              RAISE EXCEPTION 'J179 race committed more than one header';
+            END IF;
+            SELECT id INTO v_id FROM public.gl_entries
+            WHERE org_id='17900000-aaaa-aaaa-aaaa-000000000001'
+              AND idempotency_key='J179:race:key';
+            IF (SELECT count(*) FROM public.gl_entry_lines WHERE entry_id=v_id) <> 2 THEN
+              RAISE EXCEPTION 'J179 race committed wrong line set';
+            END IF;
+            IF (SELECT request_hash FROM public.gl_entries WHERE id=v_id) IS NULL THEN
+              RAISE EXCEPTION 'J179 race winner lacks request_hash';
+            END IF;
+          END;
+          $do$;
+          DROP TRIGGER aaa_j179_test_insert_barrier ON public.gl_entries;
+          DROP FUNCTION public.j179_test_insert_barrier();
+          SQL
+
+      - name: Re-run Migration 178 journal boundary regression
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          psql -v ON_ERROR_STOP=1 \
+            -f scripts/ci/fresh-db/acceptance_178_journal_rbac.sql \
+            2>&1 | tee /tmp/journal-178-after-179.out
+          grep -q 'JOURNAL_RBAC_178_ACCEPTANCE_PASS' /tmp/journal-178-after-179.out
+
+      - name: Verify no legacy hash backfill occurred
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          psql -qAt -v ON_ERROR_STOP=1 <<'SQL' | tee /tmp/legacy-179.out
+          SELECT 'legacy_hash_is_null=' || (request_hash IS NULL)
+          FROM public.gl_entries
+          WHERE id='17900000-4444-4444-4444-000000000001';
+          SQL
+          grep -q '^legacy_hash_is_null=true$' /tmp/legacy-179.out
+
+      - name: Upload acceptance evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gl-idempotency-179-${{ github.run_id }}
+          path: |
+            /tmp/pre179_chain_report.txt
+            /tmp/setup-179.out
+            /tmp/migration-179.out
+            /tmp/acceptance-179.out
+            /tmp/j179-race-1.out
+            /tmp/j179-race-2.out
+            /tmp/journal-178-after-179.out
+            /tmp/legacy-179.out
+          retention-days: 30

--- a/.github/workflows/gl-idempotency-179-acceptance.yml
+++ b/.github/workflows/gl-idempotency-179-acceptance.yml
@@ -7,6 +7,7 @@ on:
       - 'sql/migrations/179_gl_journal_idempotency_race_safe.sql'
       - 'scripts/ci/fresh-db/setup_179_pre_migration_fixture.sql'
       - 'scripts/ci/fresh-db/acceptance_179_gl_idempotency.sql'
+      - 'scripts/ci/check_definer_guards.py'
       - '.github/workflows/gl-idempotency-179-acceptance.yml'
   workflow_dispatch:
 
@@ -111,6 +112,11 @@ jobs:
           SQL
 
           cat >/tmp/j179-race.sql <<'SQL'
+          SELECT set_config(
+            'request.jwt.claim.sub',
+            '17900000-0000-0000-0000-000000000001',
+            false
+          );
           SELECT public.rpc_create_journal_entry(jsonb_build_object(
             'org_id','17900000-aaaa-aaaa-aaaa-000000000001',
             'journal_id','17900000-2222-2222-2222-000000000001',

--- a/docs/db/GL_IDEMPOTENCY_179_RUNBOOK.md
+++ b/docs/db/GL_IDEMPOTENCY_179_RUNBOOK.md
@@ -1,0 +1,93 @@
+# Migration 179 — Generic GL idempotency hardening
+
+Issue: #176  
+Parent security epic: #48
+
+## Scope
+
+Migration 179 is DB-only. It does not change application callers or widen the browser-executable journal surface established by Migration 178.
+
+The authoritative uniqueness boundary already exists from Migration 76:
+
+```sql
+CREATE UNIQUE INDEX uq_gl_entries_org_idem
+ON gl_entries (org_id, idempotency_key)
+WHERE idempotency_key IS NOT NULL;
+```
+
+179 preserves that index and changes the generic journal primitive from a best-effort pre-check into a deterministic request-identity contract.
+
+## Corrected diagnosis
+
+Before 179, two concurrent requests with the same `(org_id,idempotency_key)` can both pass the RPC's `SELECT` pre-check. The existing unique index prevents duplicate commits, but the loser can receive raw PostgreSQL `23505`.
+
+The old RPC also replays an existing key without comparing payload identity, so a materially changed request can silently receive an unrelated prior journal result.
+
+## Contract after 179
+
+For requests with a non-empty `idempotency_key`:
+
+- 179 computes SHA-256 over canonical `p_payload::text` using the same convention as Migration 150. The idempotency key is intentionally included.
+- A new keyed row stores the digest in `gl_entries.request_hash`.
+- Exact replay returns the same `entry_id` with `duplicate=true`, `payload_verified=true`, `legacy_replay=false`.
+- Reusing the key with a different hash fails `IDEMPOTENCY_KEY_CONFLICT`.
+- A concurrent loser handles `uq_gl_entries_org_idem` by re-reading the winner and applying the same hash comparison.
+- Any other unique violation, including `(org_id,entry_number)`, is re-raised unchanged.
+
+Requests without an idempotency key preserve the historical behavior and store `request_hash=NULL`.
+
+## Historical keyed rows
+
+Production inspection before implementation found existing keyed GL rows created before 179. Their original JSON payloads cannot be reconstructed losslessly from normalized ledger storage, so the migration does **not** backfill guessed hashes.
+
+A keyed row with `request_hash IS NULL` is treated as an explicitly unverified compatibility replay:
+
+```json
+{
+  "duplicate": true,
+  "payload_verified": false,
+  "legacy_replay": true
+}
+```
+
+The replay never fills `request_hash` opportunistically.
+
+## Acceptance evidence required before merge
+
+The dedicated `GL Idempotency 179 Acceptance` workflow must prove all of the following on PostgreSQL 17:
+
+1. Build a fresh database through 178.
+2. Seed a pre-179 keyed GL fixture before `request_hash` exists.
+3. Apply 179.
+4. Confirm legacy replay returns the original entry, is explicitly unverified, and leaves the hash NULL.
+5. Confirm a new keyed request stores SHA-256, exact replay returns the same entry, and changed payload fails closed.
+6. Force an unrelated `entry_number` unique collision and prove its original unique violation is not converted into idempotent replay.
+7. Run two independent PostgreSQL sessions against the same key. A third session holds an advisory-lock barrier at a test-only BEFORE INSERT trigger; the workflow must observe both RPC sessions waiting at that barrier before release. This proves both calls passed the pre-check before either insert completed.
+8. Assert the race commits exactly one GL header and one two-line set, both callers resolve to the same `entry_id`, and no raw `23505` leaks.
+9. Re-run Migration 178 journal-boundary acceptance after 179.
+10. Full repository CI/regression gates must remain green.
+
+## Production deployment
+
+Do not apply 179 before the DB-only PR is merged and all required checks are green.
+
+Deployment sequence:
+
+1. Read-only preflight:
+   - verify Production migration ledger does not contain 179;
+   - verify `uq_gl_entries_org_idem` still exists;
+   - verify no duplicate `(org_id,idempotency_key)` groups;
+   - verify `request_hash` is absent before application;
+   - record keyed-row count only; do not mutate rows.
+2. Apply the exact merged Migration 179 once.
+3. Post-apply read-only verification:
+   - migration ledger contains 179;
+   - `request_hash` exists and historical keyed rows remain NULL;
+   - existing unique index remains present;
+   - `authenticated` still cannot execute `rpc_create_journal_entry(jsonb)` directly;
+   - canonical public wrappers from 178 retain their grants.
+4. Do not create test/demo journal entries in Production for verification.
+
+## Rollback posture
+
+179 is additive at the schema level and replaces one function body. Historical data is not rewritten. If a deployment problem is discovered, do not delete the new column or historical data; ship a forward corrective migration.

--- a/scripts/ci/check_definer_guards.py
+++ b/scripts/ci/check_definer_guards.py
@@ -50,6 +50,11 @@ KNOWN_EXEMPT = {
     # every entry is delegated to rpc_post_manual_journal_entry, which performs
     # the exact-permission assertion against that entry's own organization.
     "rpc_batch_post_manual_journal_entries",
+    # Migration 179 redefines this internal primitive for idempotency only.
+    # Migration 178 already revoked PUBLIC/anon/authenticated EXECUTE and
+    # CREATE OR REPLACE preserves those ACLs; 179 acceptance independently
+    # verifies that authenticated still cannot execute it directly.
+    "rpc_create_journal_entry",
 }
 
 GUARD_PATTERNS = [

--- a/scripts/ci/check_definer_guards.py
+++ b/scripts/ci/check_definer_guards.py
@@ -50,11 +50,6 @@ KNOWN_EXEMPT = {
     # every entry is delegated to rpc_post_manual_journal_entry, which performs
     # the exact-permission assertion against that entry's own organization.
     "rpc_batch_post_manual_journal_entries",
-    # Migration 179 redefines this internal primitive for idempotency only.
-    # Migration 178 already revoked PUBLIC/anon/authenticated EXECUTE and
-    # CREATE OR REPLACE preserves those ACLs; 179 acceptance independently
-    # verifies that authenticated still cannot execute it directly.
-    "rpc_create_journal_entry",
 }
 
 GUARD_PATTERNS = [

--- a/scripts/ci/fresh-db/acceptance_179_gl_idempotency.sql
+++ b/scripts/ci/fresh-db/acceptance_179_gl_idempotency.sql
@@ -47,6 +47,15 @@ BEGIN
 END;
 $$;
 
+-- The generic primitive is internal after 178, but wardah_org_id(explicit)
+-- still enforces active organization membership through auth.uid(). Model the
+-- authenticated domain caller explicitly so the test reaches idempotency logic.
+SELECT set_config(
+  'request.jwt.claim.sub',
+  '17900000-0000-0000-0000-000000000001',
+  false
+);
+
 -- Schema and historical-row contract.
 DO $$
 BEGIN

--- a/scripts/ci/fresh-db/acceptance_179_gl_idempotency.sql
+++ b/scripts/ci/fresh-db/acceptance_179_gl_idempotency.sql
@@ -1,0 +1,176 @@
+-- Acceptance for Migration 179 — generic GL idempotency hardening (#176).
+\set ON_ERROR_STOP on
+BEGIN;
+
+CREATE OR REPLACE FUNCTION pg_temp.j179_payload(
+  p_key text,
+  p_description text DEFAULT 'J179 strict request'
+)
+RETURNS jsonb LANGUAGE sql AS $$
+  SELECT jsonb_build_object(
+    'org_id','17900000-aaaa-aaaa-aaaa-000000000001',
+    'journal_id','17900000-2222-2222-2222-000000000001',
+    'entry_date','2026-08-24',
+    'description',p_description,
+    'reference_type','J179_TEST',
+    'reference_number',p_key,
+    'idempotency_key',p_key,
+    'auto_post',false,
+    'lines',jsonb_build_array(
+      jsonb_build_object(
+        'line_number',1,
+        'account_id','17900000-3333-3333-3333-000000000001',
+        'debit',100,'credit',0,'currency_code','SAR','description','Debit'),
+      jsonb_build_object(
+        'line_number',2,
+        'account_id','17900000-3333-3333-3333-000000000002',
+        'debit',0,'credit',100,'currency_code','SAR','description','Credit')
+    )
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION pg_temp.expect_error(p_sql text, p_needle text)
+RETURNS void LANGUAGE plpgsql AS $$
+DECLARE v_succeeded boolean := false;
+BEGIN
+  BEGIN
+    EXECUTE p_sql;
+    v_succeeded := true;
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM NOT LIKE '%' || p_needle || '%' THEN
+      RAISE EXCEPTION 'J179 expected [%], got [%] for [%]', p_needle, SQLERRM, p_sql;
+    END IF;
+  END;
+  IF v_succeeded THEN
+    RAISE EXCEPTION 'J179 expected error [%], succeeded: %', p_needle, p_sql;
+  END IF;
+END;
+$$;
+
+-- Schema and historical-row contract.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema='public' AND table_name='gl_entries' AND column_name='request_hash'
+  ) THEN
+    RAISE EXCEPTION 'J179 request_hash column missing';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE schemaname='public' AND tablename='gl_entries'
+      AND indexname='uq_gl_entries_org_idem'
+  ) THEN
+    RAISE EXCEPTION 'J179 existing idempotency unique index missing';
+  END IF;
+
+  IF has_function_privilege('authenticated','public.rpc_create_journal_entry(jsonb)','EXECUTE') THEN
+    RAISE EXCEPTION 'J179 widened generic primitive execute surface';
+  END IF;
+END $$;
+
+CREATE TEMP TABLE t179_legacy AS
+SELECT public.rpc_create_journal_entry(
+  pg_temp.j179_payload('J179:legacy:key','Payload intentionally cannot verify legacy row')
+) AS result;
+
+DO $$
+DECLARE v jsonb;
+BEGIN
+  SELECT result INTO v FROM t179_legacy;
+  IF (v->>'entry_id')::uuid <> '17900000-4444-4444-4444-000000000001'::uuid
+     OR COALESCE((v->>'duplicate')::boolean,false) IS DISTINCT FROM true
+     OR COALESCE((v->>'payload_verified')::boolean,true) IS DISTINCT FROM false
+     OR COALESCE((v->>'legacy_replay')::boolean,false) IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'J179 legacy replay response mismatch: %', v;
+  END IF;
+
+  IF (SELECT request_hash FROM public.gl_entries
+      WHERE id='17900000-4444-4444-4444-000000000001') IS NOT NULL THEN
+    RAISE EXCEPTION 'J179 legacy replay opportunistically backfilled request_hash';
+  END IF;
+END $$;
+
+-- New keyed requests are strict and carry a SHA-256 request identity.
+CREATE TEMP TABLE t179_first AS
+SELECT public.rpc_create_journal_entry(pg_temp.j179_payload('J179:strict:key')) AS result;
+
+CREATE TEMP TABLE t179_replay AS
+SELECT public.rpc_create_journal_entry(pg_temp.j179_payload('J179:strict:key')) AS result;
+
+DO $$
+DECLARE v_first jsonb; v_replay jsonb; v_id uuid; v_hash text; v_expected text;
+BEGIN
+  SELECT result INTO v_first FROM t179_first;
+  SELECT result INTO v_replay FROM t179_replay;
+  v_id := (v_first->>'entry_id')::uuid;
+
+  IF v_id IS NULL OR (v_replay->>'entry_id')::uuid IS DISTINCT FROM v_id THEN
+    RAISE EXCEPTION 'J179 strict replay did not return same entry: first=% replay=%',v_first,v_replay;
+  END IF;
+  IF COALESCE((v_first->>'duplicate')::boolean,true) IS DISTINCT FROM false
+     OR COALESCE((v_replay->>'duplicate')::boolean,false) IS DISTINCT FROM true
+     OR COALESCE((v_replay->>'payload_verified')::boolean,false) IS DISTINCT FROM true
+     OR COALESCE((v_replay->>'legacy_replay')::boolean,true) IS DISTINCT FROM false THEN
+    RAISE EXCEPTION 'J179 strict response flags mismatch: first=% replay=%',v_first,v_replay;
+  END IF;
+
+  SELECT request_hash INTO v_hash FROM public.gl_entries WHERE id=v_id;
+  v_expected := encode(
+    extensions.digest(convert_to(pg_temp.j179_payload('J179:strict:key')::text,'UTF8'),'sha256'),
+    'hex'
+  );
+  IF v_hash IS DISTINCT FROM v_expected OR length(v_hash) <> 64 THEN
+    RAISE EXCEPTION 'J179 stored request hash mismatch: got=% expected=%',v_hash,v_expected;
+  END IF;
+  IF (SELECT count(*) FROM public.gl_entries
+      WHERE org_id='17900000-aaaa-aaaa-aaaa-000000000001'
+        AND idempotency_key='J179:strict:key') <> 1 THEN
+    RAISE EXCEPTION 'J179 strict key produced multiple headers';
+  END IF;
+  IF (SELECT count(*) FROM public.gl_entry_lines WHERE entry_id=v_id) <> 2 THEN
+    RAISE EXCEPTION 'J179 strict key produced wrong line count';
+  END IF;
+END $$;
+
+SELECT pg_temp.expect_error(
+  format('SELECT public.rpc_create_journal_entry(%L::jsonb)',
+         pg_temp.j179_payload('J179:strict:key','Changed material payload')),
+  'IDEMPOTENCY_KEY_CONFLICT'
+);
+
+-- An unrelated unique boundary must keep its original PostgreSQL violation.
+-- Test-only trigger forces entry_number to collide with the legacy fixture.
+CREATE OR REPLACE FUNCTION public.j179_force_unrelated_entry_number_collision()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF NEW.description = 'J179 force unrelated unique' THEN
+    NEW.entry_number := 'J179-LEGACY-001';
+  END IF;
+  RETURN NEW;
+END $$;
+
+CREATE TRIGGER zzz_j179_force_unrelated_entry_number_collision
+BEFORE INSERT ON public.gl_entries
+FOR EACH ROW EXECUTE FUNCTION public.j179_force_unrelated_entry_number_collision();
+
+SELECT pg_temp.expect_error(
+  format('SELECT public.rpc_create_journal_entry(%L::jsonb)',
+         pg_temp.j179_payload('J179:other-unique:key','J179 force unrelated unique')),
+  'gl_entries_org_number_unique'
+);
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM public.gl_entries
+    WHERE org_id='17900000-aaaa-aaaa-aaaa-000000000001'
+      AND idempotency_key='J179:other-unique:key'
+  ) THEN
+    RAISE EXCEPTION 'J179 unrelated unique violation was swallowed into a row';
+  END IF;
+END $$;
+
+ROLLBACK;
+SELECT 'GL_IDEMPOTENCY_179_ACCEPTANCE_PASS' AS result;

--- a/scripts/ci/fresh-db/setup_179_pre_migration_fixture.sql
+++ b/scripts/ci/fresh-db/setup_179_pre_migration_fixture.sql
@@ -21,6 +21,12 @@ VALUES
    '17900000-aaaa-aaaa-aaaa-000000000001',
    'J179', 'Journal 179', 'general', 'J179', true);
 
+-- generate_entry_number(uuid) executes CREATE SEQUENCE IF NOT EXISTS inside
+-- the caller transaction. Pre-create this test journal sequence so that the
+-- concurrency test is not serialized by unrelated transactional DDL before
+-- both calls reach the idempotency INSERT barrier.
+CREATE SEQUENCE IF NOT EXISTS public.seq_j179 START WITH 1;
+
 INSERT INTO public.gl_accounts
   (id, org_id, code, name, category, subtype, normal_balance, allow_posting, is_active)
 VALUES

--- a/scripts/ci/fresh-db/setup_179_pre_migration_fixture.sql
+++ b/scripts/ci/fresh-db/setup_179_pre_migration_fixture.sql
@@ -1,0 +1,54 @@
+\set ON_ERROR_STOP on
+
+-- Pre-179 fixture: model a historical keyed GL entry after Migration 178 but
+-- before request_hash exists. Migration 179 must preserve it as an explicitly
+-- unverified legacy replay and must never invent/backfill a request hash.
+
+INSERT INTO public.organizations (id, code, name) VALUES
+  ('17900000-aaaa-aaaa-aaaa-000000000001', 'J179-A', 'Journal 179 Org A');
+
+INSERT INTO public.journals
+  (id, org_id, code, name, journal_type, sequence_prefix, is_active)
+VALUES
+  ('17900000-2222-2222-2222-000000000001',
+   '17900000-aaaa-aaaa-aaaa-000000000001',
+   'J179', 'Journal 179', 'general', 'J179', true);
+
+INSERT INTO public.gl_accounts
+  (id, org_id, code, name, category, subtype, normal_balance, allow_posting, is_active)
+VALUES
+  ('17900000-3333-3333-3333-000000000001',
+   '17900000-aaaa-aaaa-aaaa-000000000001',
+   '179101', 'J179 Debit', 'ASSET', 'CURRENT_ASSET', 'DEBIT', true, true),
+  ('17900000-3333-3333-3333-000000000002',
+   '17900000-aaaa-aaaa-aaaa-000000000001',
+   '179201', 'J179 Credit', 'LIABILITY', 'CURRENT_LIABILITY', 'CREDIT', true, true);
+
+INSERT INTO public.gl_entries
+  (id, org_id, journal_id, entry_number, entry_date, entry_type,
+   description, reference_type, reference_number, status,
+   total_debit, total_credit, idempotency_key, journal_origin)
+VALUES
+  ('17900000-4444-4444-4444-000000000001',
+   '17900000-aaaa-aaaa-aaaa-000000000001',
+   '17900000-2222-2222-2222-000000000001',
+   'J179-LEGACY-001', '2026-08-24', 'manual',
+   'Pre-179 keyed system entry', 'J179_FIXTURE', 'legacy', 'draft',
+   100, 100, 'J179:legacy:key', 'system');
+
+INSERT INTO public.gl_entry_lines
+  (id, org_id, tenant_id, entry_id, line_number, account_id,
+   debit, credit, currency_code, description)
+VALUES
+  ('17900000-5555-5555-5555-000000000001',
+   '17900000-aaaa-aaaa-aaaa-000000000001',
+   '17900000-aaaa-aaaa-aaaa-000000000001',
+   '17900000-4444-4444-4444-000000000001', 1,
+   '17900000-3333-3333-3333-000000000001', 100, 0, 'SAR', 'Legacy debit'),
+  ('17900000-5555-5555-5555-000000000002',
+   '17900000-aaaa-aaaa-aaaa-000000000001',
+   '17900000-aaaa-aaaa-aaaa-000000000001',
+   '17900000-4444-4444-4444-000000000001', 2,
+   '17900000-3333-3333-3333-000000000002', 0, 100, 'SAR', 'Legacy credit');
+
+SELECT 'SETUP_179_PRE_MIGRATION_PASS' AS result;

--- a/scripts/ci/fresh-db/setup_179_pre_migration_fixture.sql
+++ b/scripts/ci/fresh-db/setup_179_pre_migration_fixture.sql
@@ -4,8 +4,15 @@
 -- before request_hash exists. Migration 179 must preserve it as an explicitly
 -- unverified legacy replay and must never invent/backfill a request hash.
 
+INSERT INTO auth.users (id, email) VALUES
+  ('17900000-0000-0000-0000-000000000001', 'j179-member@example.test');
+
 INSERT INTO public.organizations (id, code, name) VALUES
   ('17900000-aaaa-aaaa-aaaa-000000000001', 'J179-A', 'Journal 179 Org A');
+
+INSERT INTO public.user_organizations (user_id, org_id, is_active, is_org_admin) VALUES
+  ('17900000-0000-0000-0000-000000000001',
+   '17900000-aaaa-aaaa-aaaa-000000000001', true, false);
 
 INSERT INTO public.journals
   (id, org_id, code, name, journal_type, sequence_prefix, is_active)

--- a/sql/migrations/179_gl_journal_idempotency_race_safe.sql
+++ b/sql/migrations/179_gl_journal_idempotency_race_safe.sql
@@ -219,7 +219,12 @@ EXCEPTION
 END;
 $function$;
 
--- 178 deliberately revoked browser execution of this generic primitive.
--- CREATE OR REPLACE preserves those existing ACLs; do not widen them here.
+-- Re-assert the internal-only execute surface in this migration itself. This is
+-- intentionally redundant with Migration 178: it makes the safety property
+-- local to the SECURITY DEFINER redefinition and keeps future per-file CI strict.
+REVOKE ALL ON FUNCTION public.rpc_create_journal_entry(jsonb) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.rpc_create_journal_entry(jsonb) FROM anon;
+REVOKE ALL ON FUNCTION public.rpc_create_journal_entry(jsonb) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.rpc_create_journal_entry(jsonb) TO service_role;
 
 COMMIT;

--- a/sql/migrations/179_gl_journal_idempotency_race_safe.sql
+++ b/sql/migrations/179_gl_journal_idempotency_race_safe.sql
@@ -1,0 +1,225 @@
+-- Migration 179 — race-safe generic GL journal idempotency (Issue #176)
+--
+-- Migration 76 already created the authoritative partial unique index:
+--   uq_gl_entries_org_idem (org_id, idempotency_key) WHERE idempotency_key IS NOT NULL
+-- This migration does NOT replace that boundary. It adds request identity and makes
+-- rpc_create_journal_entry handle the already-existing uniqueness race deterministically.
+--
+-- Historical keyed rows intentionally keep request_hash NULL. Their original JSON
+-- payload cannot be reconstructed losslessly from normalized ledger rows, so 179
+-- never invents/backfills a hash for them. Legacy replay is explicit in the RPC result.
+
+BEGIN;
+
+ALTER TABLE public.gl_entries
+  ADD COLUMN IF NOT EXISTS request_hash text;
+
+COMMENT ON COLUMN public.gl_entries.request_hash IS
+  'SHA-256 of canonical jsonb request text for 179+ keyed journal creation. NULL on historical keyed rows by design.';
+
+CREATE OR REPLACE FUNCTION public.rpc_create_journal_entry(p_payload jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $function$
+DECLARE
+    v_org uuid;
+    v_journal_id uuid;
+    v_entry_id uuid;
+    v_entry_number text;
+    v_entry_date date;
+    v_total_debit numeric := 0;
+    v_total_credit numeric := 0;
+    v_line_count integer := 0;
+    v_idem text;
+    v_hash text;
+    v_auto_post boolean := COALESCE((p_payload ->> 'auto_post')::boolean, false);
+    v_existing record;
+    v_constraint text;
+BEGIN
+    -- Preserve the Migration 76 tenant contract.
+    v_org := public.wardah_org_id(NULLIF(p_payload ->> 'org_id', '')::uuid);
+    IF v_org IS NULL THEN
+        RAISE EXCEPTION 'TENANT_MISSING: تعذر تحديد هوية المؤسسة';
+    END IF;
+
+    v_entry_date := COALESCE(NULLIF(p_payload ->> 'entry_date', '')::date, CURRENT_DATE);
+    PERFORM public.assert_period_open(v_org, v_entry_date);
+
+    v_idem := NULLIF(p_payload ->> 'idempotency_key', '');
+    IF v_idem IS NOT NULL THEN
+        -- Match Migration 150's newer convention: canonical jsonb::text, SHA-256,
+        -- with idempotency_key intentionally included in request identity.
+        v_hash := encode(extensions.digest(convert_to(p_payload::text, 'UTF8'), 'sha256'), 'hex');
+
+        SELECT ge.id, ge.entry_number, ge.request_hash
+          INTO v_existing
+        FROM public.gl_entries ge
+        WHERE ge.org_id = v_org
+          AND ge.idempotency_key = v_idem
+        LIMIT 1;
+
+        IF FOUND THEN
+            IF v_existing.request_hash IS NULL THEN
+                RETURN jsonb_build_object(
+                    'success', true,
+                    'entry_id', v_existing.id,
+                    'entry_number', v_existing.entry_number,
+                    'duplicate', true,
+                    'payload_verified', false,
+                    'legacy_replay', true
+                );
+            END IF;
+
+            IF v_existing.request_hash IS DISTINCT FROM v_hash THEN
+                RAISE EXCEPTION
+                  'IDEMPOTENCY_KEY_CONFLICT: المفتاح استُخدم سابقًا مع حمولة مختلفة';
+            END IF;
+
+            RETURN jsonb_build_object(
+                'success', true,
+                'entry_id', v_existing.id,
+                'entry_number', v_existing.entry_number,
+                'duplicate', true,
+                'payload_verified', true,
+                'legacy_replay', false
+            );
+        END IF;
+    END IF;
+
+    SELECT COALESCE(SUM(COALESCE((l ->> 'debit')::numeric, 0)), 0),
+           COALESCE(SUM(COALESCE((l ->> 'credit')::numeric, 0)), 0),
+           COUNT(*)
+    INTO v_total_debit, v_total_credit, v_line_count
+    FROM jsonb_array_elements(p_payload -> 'lines') l;
+
+    IF v_line_count < 2 THEN
+        RAISE EXCEPTION 'EMPTY_ENTRY: القيد يحتاج سطرين على الأقل';
+    END IF;
+    IF round(v_total_debit, 2) <> round(v_total_credit, 2) THEN
+        RAISE EXCEPTION 'UNBALANCED_ENTRY: مدين=% دائن=%', v_total_debit, v_total_credit;
+    END IF;
+    IF round(v_total_debit, 2) = 0 THEN
+        RAISE EXCEPTION 'ZERO_ENTRY: قيمة القيد صفر';
+    END IF;
+
+    v_journal_id := NULLIF(p_payload ->> 'journal_id', '')::uuid;
+    IF v_journal_id IS NULL AND to_regclass('public.journals') IS NOT NULL THEN
+        SELECT id INTO v_journal_id
+        FROM public.journals
+        WHERE org_id = v_org AND is_active = true
+        ORDER BY created_at ASC
+        LIMIT 1;
+    END IF;
+
+    BEGIN
+        v_entry_number := public.generate_entry_number(v_journal_id);
+    EXCEPTION WHEN OTHERS THEN
+        BEGIN
+            v_entry_number := public.generate_entry_number(v_org, v_entry_date);
+        EXCEPTION WHEN OTHERS THEN
+            v_entry_number := 'JE-' || to_char(v_entry_date, 'YYYY') || '-' ||
+                              lpad(floor(random() * 1000000)::text, 6, '0');
+        END;
+    END;
+
+    INSERT INTO public.gl_entries (
+        org_id, journal_id, entry_number, entry_date, entry_type,
+        description, description_ar, reference_type, reference_number,
+        status, total_debit, total_credit, idempotency_key, request_hash
+    ) VALUES (
+        v_org, v_journal_id, v_entry_number, v_entry_date, 'manual',
+        NULLIF(p_payload ->> 'description', ''),
+        NULLIF(p_payload ->> 'description_ar', ''),
+        NULLIF(p_payload ->> 'reference_type', ''),
+        NULLIF(p_payload ->> 'reference_number', ''),
+        'draft', v_total_debit, v_total_credit, v_idem, v_hash
+    )
+    RETURNING id INTO v_entry_id;
+
+    INSERT INTO public.gl_entry_lines (
+        org_id, tenant_id, entry_id, line_number, account_id,
+        debit, credit, currency_code, description, description_ar
+    )
+    SELECT
+        v_org, v_org, v_entry_id,
+        COALESCE((l.value ->> 'line_number')::int, l.ord::int),
+        (l.value ->> 'account_id')::uuid,
+        COALESCE((l.value ->> 'debit')::numeric, 0),
+        COALESCE((l.value ->> 'credit')::numeric, 0),
+        COALESCE(NULLIF(l.value ->> 'currency_code', ''), 'SAR'),
+        NULLIF(l.value ->> 'description', ''),
+        NULLIF(l.value ->> 'description_ar', '')
+    FROM jsonb_array_elements(p_payload -> 'lines') WITH ORDINALITY AS l(value, ord);
+
+    IF v_auto_post THEN
+        UPDATE public.gl_entries
+        SET status = 'posted', posted_at = NOW()
+        WHERE id = v_entry_id;
+    END IF;
+
+    RETURN jsonb_build_object(
+        'success', true,
+        'entry_id', v_entry_id,
+        'entry_number', v_entry_number,
+        'total_debit', v_total_debit,
+        'total_credit', v_total_credit,
+        'status', CASE WHEN v_auto_post THEN 'posted' ELSE 'draft' END,
+        'duplicate', false,
+        'payload_verified', (v_idem IS NOT NULL),
+        'legacy_replay', false
+    );
+
+EXCEPTION
+    WHEN unique_violation THEN
+        -- gl_entries has more than one unique boundary. Only the Migration 76
+        -- idempotency index is eligible for replay handling; all others keep the
+        -- original PostgreSQL error unchanged.
+        GET STACKED DIAGNOSTICS v_constraint = CONSTRAINT_NAME;
+        IF v_idem IS NULL OR v_constraint IS DISTINCT FROM 'uq_gl_entries_org_idem' THEN
+            RAISE;
+        END IF;
+
+        SELECT ge.id, ge.entry_number, ge.request_hash
+          INTO v_existing
+        FROM public.gl_entries ge
+        WHERE ge.org_id = v_org
+          AND ge.idempotency_key = v_idem
+        LIMIT 1;
+
+        IF NOT FOUND THEN
+            RAISE;
+        END IF;
+
+        IF v_existing.request_hash IS NULL THEN
+            -- Compatibility only for a historical keyed row. 179 never fills it.
+            RETURN jsonb_build_object(
+                'success', true,
+                'entry_id', v_existing.id,
+                'entry_number', v_existing.entry_number,
+                'duplicate', true,
+                'payload_verified', false,
+                'legacy_replay', true
+            );
+        END IF;
+
+        IF v_existing.request_hash IS DISTINCT FROM v_hash THEN
+            RAISE EXCEPTION
+              'IDEMPOTENCY_KEY_CONFLICT: المفتاح استُخدم سابقًا مع حمولة مختلفة';
+        END IF;
+
+        RETURN jsonb_build_object(
+            'success', true,
+            'entry_id', v_existing.id,
+            'entry_number', v_existing.entry_number,
+            'duplicate', true,
+            'payload_verified', true,
+            'legacy_replay', false
+        );
+END;
+$function$;
+
+-- 178 deliberately revoked browser execution of this generic primitive.
+-- CREATE OR REPLACE preserves those existing ACLs; do not widen them here.
+
+COMMIT;

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -2219,6 +2219,7 @@ export type Database = {
           reference_id: string | null
           reference_number: string | null
           reference_type: string | null
+          request_hash: string | null
           status: string | null
           total_credit: number
           total_debit: number
@@ -2242,6 +2243,7 @@ export type Database = {
           reference_id?: string | null
           reference_number?: string | null
           reference_type?: string | null
+          request_hash?: string | null
           status?: string | null
           total_credit?: number
           total_debit?: number
@@ -2265,6 +2267,7 @@ export type Database = {
           reference_id?: string | null
           reference_number?: string | null
           reference_type?: string | null
+          request_hash?: string | null
           status?: string | null
           total_credit?: number
           total_debit?: number


### PR DESCRIPTION
Closes #176
Parent: #48

## What this fixes
Migration 76 already created `uq_gl_entries_org_idem`; the original #176 diagnosis incorrectly said the unique boundary was missing. The real gap is that `rpc_create_journal_entry(jsonb)` still does a `SELECT` pre-check followed by `INSERT`, so a concurrent loser can leak raw `23505`. The RPC also replays the same key without validating payload identity.

## Scope
DB-only Migration 179. No application/UI changes.

- adds nullable `gl_entries.request_hash` for 179+ keyed requests;
- uses SHA-256 over canonical `p_payload::text`, intentionally including `idempotency_key`, matching Migration 150's newer convention;
- exact replay returns the same entry with `payload_verified=true`;
- changed payload under the same key fails `IDEMPOTENCY_KEY_CONFLICT`;
- pre-179 keyed rows remain `request_hash IS NULL` and replay only as explicitly unverified legacy compatibility (`payload_verified=false`, `legacy_replay=true`);
- never backfills guessed hashes into historical keyed rows;
- catches only the existing idempotency unique index race and re-reads the winner;
- unrelated unique violations such as `(org_id,entry_number)` are re-raised unchanged;
- preserves Migration 178's closed browser execute surface for the generic primitive.

## Acceptance
Dedicated PostgreSQL 17 workflow:
- builds Fresh DB through 178;
- seeds a pre-179 keyed fixture before the hash column exists;
- applies 179 and verifies strict + legacy replay semantics;
- forces an unrelated entry-number collision to prove it is not swallowed;
- runs a real two-session race with an explicit third-session advisory-lock barrier and verifies both RPC sessions reached the INSERT boundary before release;
- asserts one header/two lines, same `entry_id`, and no raw `23505`;
- re-runs Migration 178 journal-boundary acceptance after 179.

See `docs/db/GL_IDEMPOTENCY_179_RUNBOOK.md` for deployment and no-backfill policy.

## Production safety
Preparation/review performs no Production writes. Do not apply 179 until this PR is merged and all gates are green. Post-merge verification must be read-only except for the one migration application, and must not create test/demo accounting entries in Production.