### PR TITLE
security(accounting): retire legacy journal approval surface

### DIFF
--- a/.github/workflows/legacy-journal-approval-180-acceptance.yml
+++ b/.github/workflows/legacy-journal-approval-180-acceptance.yml
@@ -1,0 +1,100 @@
+name: Legacy Journal Approval 180 Acceptance
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'sql/migrations/180_retire_legacy_journal_approval_surface.sql'
+      - 'scripts/ci/fresh-db/acceptance_180_legacy_journal_approval_retirement.sql'
+      - '.github/workflows/legacy-journal-approval-180-acceptance.yml'
+      - 'docs/db/LEGACY_JOURNAL_APPROVAL_180_RUNBOOK.md'
+  workflow_dispatch:
+
+jobs:
+  acceptance:
+    name: Confirm legacy approval surface is retired
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      PGHOST: localhost
+      PGUSER: postgres
+      PGPASSWORD: postgres
+      PGDATABASE: wardah_fresh
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build fresh database through Migration 179
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          PAIR=$(bash scripts/ci/fresh-db/resolve_baseline_pair.sh sql/baseline)
+          pair_field() { printf '%s\n' "$PAIR" | sed -n "s/^$1=//p"; }
+          BASELINE=$(pair_field BASELINE_PATH)
+          REFERENCE=$(pair_field REFERENCE_PATH)
+          CUTOFF=$(pair_field BASELINE_CUTOFF)
+          CUTOFF=${CUTOFF:-0}
+
+          createdb wardah_fresh
+          psql -v ON_ERROR_STOP=1 -f scripts/ci/fresh-db/supabase_shim.sql -q
+          psql -v ON_ERROR_STOP=1 -f "$BASELINE" -q
+          psql -v ON_ERROR_STOP=1 -f "$REFERENCE" -q
+
+          python3 scripts/ci/fresh-db/build_apply_order.py sql/migrations "$CUTOFF" > /tmp/full_order.txt
+          grep -v '^180_' /tmp/full_order.txt > /tmp/pre180_order.txt
+          REPORT=/tmp/pre180_chain_report.txt \
+            bash scripts/ci/fresh-db/run_chain.sh sql/migrations /tmp/pre180_order.txt
+
+      - name: Apply Migration 180
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          psql -v ON_ERROR_STOP=1 \
+            -f sql/migrations/180_retire_legacy_journal_approval_surface.sql \
+            2>&1 | tee /tmp/migration-180.out
+
+      - name: Run Migration 180 acceptance
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          psql -v ON_ERROR_STOP=1 \
+            -f scripts/ci/fresh-db/acceptance_180_legacy_journal_approval_retirement.sql \
+            2>&1 | tee /tmp/acceptance-180.out
+          grep -q 'LEGACY_JOURNAL_APPROVAL_180_ACCEPTANCE_PASS' /tmp/acceptance-180.out
+
+      - name: Re-run Migration 178 canonical journal regression
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          psql -v ON_ERROR_STOP=1 \
+            -f scripts/ci/fresh-db/acceptance_178_journal_rbac.sql \
+            2>&1 | tee /tmp/journal-178-after-180.out
+          grep -q 'JOURNAL_RBAC_178_ACCEPTANCE_PASS' /tmp/journal-178-after-180.out
+
+      - name: Upload acceptance evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: legacy-journal-approval-180-${{ github.run_id }}
+          path: |
+            /tmp/pre180_chain_report.txt
+            /tmp/migration-180.out
+            /tmp/acceptance-180.out
+            /tmp/journal-178-after-180.out
+          retention-days: 30

--- a/docs/db/LEGACY_JOURNAL_APPROVAL_180_RUNBOOK.md
+++ b/docs/db/LEGACY_JOURNAL_APPROVAL_180_RUNBOOK.md
@@ -1,0 +1,76 @@
+# Migration 180 — Retire legacy journal approval surface
+
+Issue: #175  
+Parent security epic: #48
+
+## Decision
+
+The active journal lifecycle is `gl_entries` / `gl_entry_lines` and the canonical manual-journal RPC surface introduced by Migration 178. The historical approval model (`journal_entries`, `journal_entry_approvals`, `approve_journal_entry`) is not revived.
+
+Production evidence before this migration shows:
+
+- `journal_entry_approvals` has no active rows;
+- `approve_journal_entry` is already not executable by `authenticated`;
+- `check_entry_approval_required` returns `false` and contains a TODO rather than an active approval policy;
+- the client `JournalService.approveEntry()` is intentionally fail-closed pending #175.
+
+A future multi-level approval feature, if required, must be designed explicitly against canonical `gl_entries`, with assigned-approver and segregation-of-duties rules. It must not reuse the legacy `journal_entries` workflow.
+
+## Scope
+
+Migration 180 is DB-only and non-destructive.
+
+It:
+
+- preserves the legacy table, functions, rows, and schema history;
+- revokes `journal_entry_approvals` access from `PUBLIC`, `anon`, `authenticated`, and `service_role`;
+- revokes execution of `check_entry_approval_required(uuid)` and `approve_journal_entry(uuid,integer,text)` from those roles;
+- does not change `gl_entries`, `gl_entry_lines`, canonical journal statuses, posting, reversal, permissions, or idempotency.
+
+## Preflight — read only
+
+Before applying to Production, confirm:
+
+1. the merged migration is exactly the reviewed `main` version;
+2. Production migration ledger ends at or beyond 179 and does not already contain 180;
+3. `journal_entry_approvals` still exists;
+4. legacy approval row count is recorded without modifying rows;
+5. canonical manual journal RPC grants match the post-178 contract;
+6. generic `rpc_create_journal_entry(jsonb)` remains closed to `anon` and `authenticated` per 178/179.
+
+Do not create test journal entries or approval rows in Production for this migration.
+
+## Deployment order
+
+1. Review DB-only PR.
+2. Require normal CI/quality gates plus `Legacy Journal Approval 180 Acceptance` green.
+3. Merge to `main`.
+4. Re-fetch the exact merged migration from `main` and compare it with the reviewed file.
+5. Apply Migration 180 once to Production.
+6. Run the read-only postflight below.
+7. Only after DB verification may a separate application PR remove the dormant approval UI/service calls.
+
+## Postflight — read only
+
+Verify:
+
+- migration ledger contains `180_retire_legacy_journal_approval_surface` exactly once;
+- legacy table and both legacy functions still exist;
+- `anon`, `authenticated`, and `service_role` have no table privileges on `journal_entry_approvals`;
+- those roles cannot execute either legacy approval function;
+- `authenticated` still has EXECUTE on canonical manual journal create/post/reverse RPCs;
+- `anon` and `authenticated` still cannot execute generic `rpc_create_journal_entry(jsonb)`.
+
+## Rollback policy
+
+There is no destructive rollback. If an unexpected supported legacy dependency is discovered after deployment, stop and document it before restoring any grant. Do not re-grant broad table DML or browser EXECUTE as an emergency shortcut. Any compatibility restoration must be a reviewed additive migration with a narrowly defined authorization boundary.
+
+## Follow-up application round
+
+After Production 180 is verified, a separate PR may:
+
+- remove the dormant Approvals tab/component from the active canonical Journal Entries UI;
+- remove `JournalService.checkApprovalRequired`, `approveEntry`, and legacy approval reads from active application code where no other supported caller exists;
+- update behavior-lock tests so the UI cannot accidentally reintroduce the retired legacy workflow.
+
+That application PR must contain no database migration and must not redefine approval semantics.

--- a/docs/db/LEGACY_JOURNAL_APPROVAL_180_RUNBOOK.md
+++ b/docs/db/LEGACY_JOURNAL_APPROVAL_180_RUNBOOK.md
@@ -10,8 +10,8 @@ The active journal lifecycle is `gl_entries` / `gl_entry_lines` and the canonica
 Production evidence before this migration shows:
 
 - `journal_entry_approvals` has no active rows;
-- `approve_journal_entry` is already not executable by `authenticated`;
-- `check_entry_approval_required` returns `false` and contains a TODO rather than an active approval policy;
+- `approve_journal_entry` is already not executable by `authenticated`, while `service_role` still retains EXECUTE before 180;
+- `check_entry_approval_required` remains executable by `authenticated` and `service_role`, returns `false`, and contains a TODO rather than an active approval policy;
 - the client `JournalService.approveEntry()` is intentionally fail-closed pending #175.
 
 A future multi-level approval feature, if required, must be designed explicitly against canonical `gl_entries`, with assigned-approver and segregation-of-duties rules. It must not reuse the legacy `journal_entries` workflow.
@@ -36,7 +36,8 @@ Before applying to Production, confirm:
 3. `journal_entry_approvals` still exists;
 4. legacy approval row count is recorded without modifying rows;
 5. canonical manual journal RPC grants match the post-178 contract;
-6. generic `rpc_create_journal_entry(jsonb)` remains closed to `anon` and `authenticated` per 178/179.
+6. generic `rpc_create_journal_entry(jsonb)` remains closed to `anon` and `authenticated` per 178/179;
+7. no supported backend caller depends on `service_role` access to `approve_journal_entry` or `check_entry_approval_required` — explicitly search `supabase/functions`, scheduled/background jobs, and server-side scripts before applying 180.
 
 Do not create test journal entries or approval rows in Production for this migration.
 

--- a/scripts/ci/fresh-db/acceptance_180_legacy_journal_approval_retirement.sql
+++ b/scripts/ci/fresh-db/acceptance_180_legacy_journal_approval_retirement.sql
@@ -1,0 +1,63 @@
+\set ON_ERROR_STOP on
+
+DO $do$
+BEGIN
+  IF to_regclass('public.journal_entry_approvals') IS NULL THEN
+    RAISE EXCEPTION 'J180 legacy approval table was removed';
+  END IF;
+  IF to_regprocedure('public.check_entry_approval_required(uuid)') IS NULL THEN
+    RAISE EXCEPTION 'J180 legacy approval check function was removed';
+  END IF;
+  IF to_regprocedure('public.approve_journal_entry(uuid,integer,text)') IS NULL THEN
+    RAISE EXCEPTION 'J180 legacy approval mutation function was removed';
+  END IF;
+
+  IF has_table_privilege('anon','public.journal_entry_approvals','SELECT')
+     OR has_table_privilege('anon','public.journal_entry_approvals','INSERT')
+     OR has_table_privilege('anon','public.journal_entry_approvals','UPDATE')
+     OR has_table_privilege('anon','public.journal_entry_approvals','DELETE') THEN
+    RAISE EXCEPTION 'J180 anon still has legacy approval table access';
+  END IF;
+
+  IF has_table_privilege('authenticated','public.journal_entry_approvals','SELECT')
+     OR has_table_privilege('authenticated','public.journal_entry_approvals','INSERT')
+     OR has_table_privilege('authenticated','public.journal_entry_approvals','UPDATE')
+     OR has_table_privilege('authenticated','public.journal_entry_approvals','DELETE') THEN
+    RAISE EXCEPTION 'J180 authenticated still has legacy approval table access';
+  END IF;
+
+  IF has_table_privilege('service_role','public.journal_entry_approvals','SELECT')
+     OR has_table_privilege('service_role','public.journal_entry_approvals','INSERT')
+     OR has_table_privilege('service_role','public.journal_entry_approvals','UPDATE')
+     OR has_table_privilege('service_role','public.journal_entry_approvals','DELETE') THEN
+    RAISE EXCEPTION 'J180 service_role still has legacy approval table access';
+  END IF;
+
+  IF has_function_privilege('anon','public.check_entry_approval_required(uuid)','EXECUTE')
+     OR has_function_privilege('authenticated','public.check_entry_approval_required(uuid)','EXECUTE')
+     OR has_function_privilege('service_role','public.check_entry_approval_required(uuid)','EXECUTE') THEN
+    RAISE EXCEPTION 'J180 legacy approval check is still executable';
+  END IF;
+
+  IF has_function_privilege('anon','public.approve_journal_entry(uuid,integer,text)','EXECUTE')
+     OR has_function_privilege('authenticated','public.approve_journal_entry(uuid,integer,text)','EXECUTE')
+     OR has_function_privilege('service_role','public.approve_journal_entry(uuid,integer,text)','EXECUTE') THEN
+    RAISE EXCEPTION 'J180 legacy approval mutation is still executable';
+  END IF;
+
+  -- Canonical lifecycle remains the client-facing journal boundary.
+  IF NOT has_function_privilege('authenticated','public.rpc_create_manual_journal_entry(jsonb)','EXECUTE')
+     OR NOT has_function_privilege('authenticated','public.rpc_post_manual_journal_entry(uuid)','EXECUTE')
+     OR NOT has_function_privilege('authenticated','public.rpc_reverse_manual_journal_entry(uuid,text,date)','EXECUTE') THEN
+    RAISE EXCEPTION 'J180 changed canonical manual journal EXECUTE surface';
+  END IF;
+
+  -- The trusted generic primitive hardened in 178/179 must remain closed.
+  IF has_function_privilege('authenticated','public.rpc_create_journal_entry(jsonb)','EXECUTE')
+     OR has_function_privilege('anon','public.rpc_create_journal_entry(jsonb)','EXECUTE') THEN
+    RAISE EXCEPTION 'J180 reopened generic journal primitive';
+  END IF;
+END;
+$do$;
+
+SELECT 'LEGACY_JOURNAL_APPROVAL_180_ACCEPTANCE_PASS';

--- a/sql/migrations/180_retire_legacy_journal_approval_surface.sql
+++ b/sql/migrations/180_retire_legacy_journal_approval_surface.sql
@@ -1,0 +1,37 @@
+-- Migration 180 — retire legacy journal approval surface (Issue #175)
+--
+-- The canonical ledger is public.gl_entries / public.gl_entry_lines after 178.
+-- The historical journal_entries approval model is retained for history only.
+-- This migration is intentionally additive/non-destructive: no table, row,
+-- function, baseline, or historical migration is deleted.
+--
+-- Scope:
+--   * remove browser/client access to journal_entry_approvals;
+--   * remove client/service execution of the two legacy approval functions;
+--   * preserve all legacy objects and rows in place;
+--   * do not change canonical manual journal create/post/reverse behavior.
+
+BEGIN;
+
+-- The legacy approval table previously retained broad table-level grants even
+-- though its RLS depends on historical app.current_tenant_id context. Do not
+-- treat that stale RLS contract as an authorization boundary.
+REVOKE ALL ON TABLE public.journal_entry_approvals FROM PUBLIC;
+REVOKE ALL ON TABLE public.journal_entry_approvals FROM anon;
+REVOKE ALL ON TABLE public.journal_entry_approvals FROM authenticated;
+REVOKE ALL ON TABLE public.journal_entry_approvals FROM service_role;
+
+-- Keep definitions for historical/schema compatibility, but retire every
+-- non-owner execution path. A future canonical approval workflow must be
+-- designed explicitly against gl_entries rather than reviving these RPCs.
+REVOKE ALL ON FUNCTION public.check_entry_approval_required(uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.check_entry_approval_required(uuid) FROM anon;
+REVOKE ALL ON FUNCTION public.check_entry_approval_required(uuid) FROM authenticated;
+REVOKE ALL ON FUNCTION public.check_entry_approval_required(uuid) FROM service_role;
+
+REVOKE ALL ON FUNCTION public.approve_journal_entry(uuid, integer, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.approve_journal_entry(uuid, integer, text) FROM anon;
+REVOKE ALL ON FUNCTION public.approve_journal_entry(uuid, integer, text) FROM authenticated;
+REVOKE ALL ON FUNCTION public.approve_journal_entry(uuid, integer, text) FROM service_role;
+
+COMMIT;


### PR DESCRIPTION
Refs #175
Parent: #48

## Scope
DB-only retirement of the historical journal approval surface after the canonical `gl_entries` lifecycle introduced by #178/#177 and the GL idempotency hardening in #179.

This PR intentionally does **not** implement a new approval workflow and does not change the active Journal Entries UI.

- preserves legacy `journal_entries` / `journal_entry_approvals` objects and history;
- revokes all `journal_entry_approvals` table access from PUBLIC/anon/authenticated/service_role;
- revokes execution of `check_entry_approval_required(uuid)` and `approve_journal_entry(uuid,integer,text)` from those roles;
- leaves canonical manual journal create/post/reverse permissions and behavior unchanged;
- leaves generic `rpc_create_journal_entry(jsonb)` closed to browser roles;
- adds dedicated PostgreSQL 17 Fresh DB acceptance and re-runs Migration 178 journal-boundary acceptance;
- documents preflight, deployment, postflight, rollback policy, and the later application-only cleanup round.

## Why retire instead of revive
Production read-only audit found the legacy approval model dormant: zero approval rows, the legacy mutation already closed to authenticated users, the approval-check function returns `false` with a TODO, and the client approval mutation is explicitly fail-closed pending #175. A future multi-level approval design must target canonical `gl_entries` with explicit assigned-approver/SoD rules rather than reviving the historical `journal_entries` model.

## Production safety
No Production mutation is performed by PR preparation/review. Do not apply Migration 180 until this PR is reviewed, all gates are green, merged to `main`, and the exact merged migration is re-fetched and verified per the runbook. No test/demo accounting or approval rows should be created in Production for this change.