### PR TITLE
feat(db): add supplier invoice candidate read contract

### DIFF
--- a/.github/workflows/ap-181-supplier-invoice-candidates.yml
+++ b/.github/workflows/ap-181-supplier-invoice-candidates.yml
@@ -1,0 +1,70 @@
+name: AP 181 Supplier Invoice Candidate Read
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'sql/migrations/181_supplier_invoice_candidate_read.sql'
+      - 'scripts/ci/fresh-db/acceptance_181_supplier_invoice_candidates.sql'
+      - 'scripts/ci/fresh-db/run_ap_181_candidate_gate.sh'
+      - 'scripts/ci/fresh-db/**'
+      - 'sql/baseline/**'
+      - '.github/workflows/ap-181-supplier-invoice-candidates.yml'
+
+jobs:
+  ap-181-candidates:
+    name: Migration 181 Supplier Invoice Candidate Read
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install SQL validation dependencies
+        run: |
+          python3 -m pip install --quiet pglast pyyaml
+
+      - name: Parse migrations and enforce DEFINER guards
+        run: |
+          python3 scripts/ci/check_migration_syntax.py
+          python3 scripts/ci/check_definer_guards.py
+
+      - name: Run AP 181 Fresh DB gate
+        run: bash scripts/ci/fresh-db/run_ap_181_candidate_gate.sh
+        env:
+          PGHOST: localhost
+          PGPORT: 5432
+          PGUSER: postgres
+          PGPASSWORD: postgres
+          PGDATABASE: wardah_ap181
+
+      - name: Upload AP 181 diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ap-181-diagnostics-${{ github.run_id }}
+          path: |
+            /tmp/ap181-chain-order.txt
+            /tmp/ap181-chain-report.txt
+            /tmp/u149-race-a.out
+            /tmp/u149-race-a.err
+            /tmp/u149-race-b.out
+            /tmp/u149-race-b.err
+          if-no-files-found: ignore
+          retention-days: 14

--- a/docs/db/SUPPLIER_INVOICE_CANDIDATE_READ_181_RUNBOOK.md
+++ b/docs/db/SUPPLIER_INVOICE_CANDIDATE_READ_181_RUNBOOK.md
@@ -177,15 +177,17 @@ The gate uses PostgreSQL 17 and:
 3. runs migration syntax + SECURITY DEFINER guards;
 4. runs Acceptance 148 to build legal PO/GRN fixtures through production RPCs;
 5. runs Acceptance 149 to create a real matched allocation;
-6. proves 181 returns the authoritative remaining balance (48 accepted − 10.5
-   allocated = 37.5);
+6. proves 181 returns the authoritative remaining balance for the targeted GRN
+   line by deriving the expected allocation from the ledger and cross-checking the
+   expected remainder with `wardah_receipt_line_uninvoiced_base`, without relying
+   on fixture-specific allocation constants or candidate-list cardinality;
 7. explicitly proves that the candidate PO state is `fully_received`, preserving
    direct regression coverage of Migration 152's terminal PO state;
 8. proves membership/D4 denial paths;
 9. proves draft GRN, rejected line and fully consumed line are excluded;
 10. inserts an actual append-only allocation reversal row and proves both the 181
     candidate read and `wardah_receipt_line_uninvoiced_base` restore the same
-    remaining balance and candidate visibility;
+    pre-probe remaining balance and candidate visibility;
 11. proves vendor/PO filters fail closed;
 12. re-runs the remaining 149 closure + concurrency suites as regression proof;
 13. verifies the final function definition and EXECUTE surface.

--- a/docs/db/SUPPLIER_INVOICE_CANDIDATE_READ_181_RUNBOOK.md
+++ b/docs/db/SUPPLIER_INVOICE_CANDIDATE_READ_181_RUNBOOK.md
@@ -63,6 +63,13 @@ Execution surface:
 - `anon`: revoked;
 - `service_role`: revoked for this client read API.
 
+The `service_role` revoke is deliberate, not accidental. This function exists as
+a permission-aware browser/API read boundary and its authorization semantics are
+defined in terms of `auth.uid()` + active membership + the two D4 permissions.
+There is no approved background/service workflow that requires candidate listing.
+If one is introduced later, it must use a separately reviewed service contract
+rather than silently bypassing the D4 caller model on this client RPC.
+
 `search_path` is pinned to `public, pg_temp` and every business-table predicate is
 explicitly scoped to the resolved organization.
 
@@ -84,6 +91,11 @@ A row is returned only when all conditions are true:
 - both PO and GRN carry complete immutable UoM snapshot evidence;
 - PO and GRN snapshots agree;
 - remaining accepted uninvoiced base quantity is greater than zero.
+
+The equality check between PO and GRN UoM snapshots is intentionally defensive.
+For legal PO-linked receipts created by Migration 148+ the GRN snapshot is copied
+from the PO line, so equality should always hold. The predicate protects the new
+read contract from legacy/corrupt rows; it is not a new operational matching rule.
 
 Legacy/base-unit rows without complete snapshots are deliberately excluded from
 this first UI slice rather than guessed or reinterpreted.
@@ -108,9 +120,16 @@ remaining base quantity
   = accepted base quantity - allocated base quantity
 ```
 
-This is the same allocation-ledger model established in 149/151. The read RPC is
-advisory for UX only: the write RPC still locks rows and recomputes remaining
-quantity under lock before any invoice write.
+This is the same allocation-ledger model established in 149/151. Migration 181
+spells the aggregate inline in its candidate query instead of invoking
+`wardah_receipt_line_uninvoiced_base(uuid)` once per candidate row. The duplication
+is intentional in this slice: the read RPC remains one auditable tenant-scoped
+query, avoids repeated privileged helper calls, and the Fresh DB acceptance now
+asserts that the inline aggregate and the 149/151 helper agree under both normal
+allocation and an actual append-only reversal row.
+
+The read RPC is advisory for UX only: the write RPC still locks rows and
+recomputes remaining quantity under lock before any invoice write.
 
 ## 6. Returned evidence
 
@@ -160,14 +179,19 @@ The gate uses PostgreSQL 17 and:
 5. runs Acceptance 149 to create a real matched allocation;
 6. proves 181 returns the authoritative remaining balance (48 accepted − 10.5
    allocated = 37.5);
-7. proves membership/D4 denial paths;
-8. proves draft GRN, rejected line and fully consumed line are excluded;
-9. proves vendor/PO filters fail closed;
-10. re-runs the remaining 149 closure + concurrency suites as regression proof;
-11. verifies the final function definition and EXECUTE surface.
+7. explicitly proves that the candidate PO state is `fully_received`, preserving
+   direct regression coverage of Migration 152's terminal PO state;
+8. proves membership/D4 denial paths;
+9. proves draft GRN, rejected line and fully consumed line are excluded;
+10. inserts an actual append-only allocation reversal row and proves both the 181
+    candidate read and `wardah_receipt_line_uninvoiced_base` restore the same
+    remaining balance and candidate visibility;
+11. proves vendor/PO filters fail closed;
+12. re-runs the remaining 149 closure + concurrency suites as regression proof;
+13. verifies the final function definition and EXECUTE surface.
 
-Negative probes are transaction-scoped and rolled back so they do not corrupt the
-shared 148/149 fixtures.
+Negative and reversal probes are transaction-scoped and rolled back so they do
+not corrupt the shared 148/149 fixtures.
 
 ## 8. Repository merge gate
 

--- a/docs/db/SUPPLIER_INVOICE_CANDIDATE_READ_181_RUNBOOK.md
+++ b/docs/db/SUPPLIER_INVOICE_CANDIDATE_READ_181_RUNBOOK.md
@@ -1,0 +1,238 @@
+# Migration 181 — Supplier Invoice Candidate Read Runbook
+
+**Migration:** `181_supplier_invoice_candidate_read.sql`  
+**Scope:** read contract only  
+**Parent design:** `docs/db/SUPPLIER_INVOICE_ATOMIC_LIFECYCLE_PLAN.md` / PR #185  
+**Production application:** **not authorized by this PR**
+
+## 1. Purpose
+
+Migration 181 adds one client-facing read RPC:
+
+```text
+rpc_list_supplier_invoice_candidates(
+  p_org_id uuid,
+  p_vendor_id uuid default null,
+  p_purchase_order_id uuid default null
+) returns jsonb
+```
+
+Its only job is to expose legal PO ↔ accepted-GRN lines that still have
+uninvoiced quantity for the later supplier-invoice UI migration.
+
+It does **not** create, approve, post, update or reserve any business document.
+The canonical write contract remains Migrations 149–152 via
+`rpc_create_matched_supplier_invoice(jsonb)`.
+
+## 2. Repository / Production state used to allocate 181
+
+Before implementation the following were independently rechecked:
+
+- repository `main` = `ad98a17ba88292e6fbc16957c1cc132b3447545f`;
+- repository max migration = 180;
+- Production project `uutfztmqvajmsxnrqeiv` is `ACTIVE_HEALTHY` on PostgreSQL 17;
+- Production ledger ends at `180_retire_legacy_journal_approval_surface`;
+- no `181_%` migration is registered in Production;
+- `skipped_migration_numbers.yml` does not reserve 181.
+
+Therefore 181 was the next legal repository migration number at branch creation.
+If `main` or Production advances before merge/application, re-run the numbering
+and ledger checks. Never rename an already-applied migration to resolve drift.
+
+## 3. Security contract
+
+The RPC is `SECURITY DEFINER` because it reads across tables whose RLS policies
+are not the API contract. It therefore applies explicit server-side guards:
+
+1. resolve the explicit organization via `wardah_org_id(p_org_id)`;
+2. require active organization membership via `wardah_assert_org_member`;
+3. require **both** reviewed D4 keys through `has_permission`:
+
+```text
+purchasing.purchase_orders.read
+purchasing.purchase_invoices.read
+```
+
+There is no `purchasing.goods_receipts.*` / `purchasing.receipts.*` permission in
+the current catalog. Migration 181 does not invent one.
+
+Execution surface:
+
+- `authenticated`: EXECUTE;
+- `PUBLIC`: revoked;
+- `anon`: revoked;
+- `service_role`: revoked for this client read API.
+
+`search_path` is pinned to `public, pg_temp` and every business-table predicate is
+explicitly scoped to the resolved organization.
+
+## 4. Candidate eligibility
+
+A row is returned only when all conditions are true:
+
+- caller passes membership + both D4 read permissions;
+- purchase order, order line, goods receipt and receipt line belong to the same
+  organization;
+- optional vendor and PO filters resolve inside that organization;
+- GRN line is linked to a PO line;
+- `goods_receipt_lines.quality_status = 'accepted'`;
+- GRN header is `confirmed` or `posted`;
+- PO state is one of the states already accepted by the matched-invoice chain:
+  `approved`, `partially_received`, `fully_received`, `received`, `closed`;
+- GRN vendor matches PO vendor;
+- GRN-line product matches PO-line product;
+- both PO and GRN carry complete immutable UoM snapshot evidence;
+- PO and GRN snapshots agree;
+- remaining accepted uninvoiced base quantity is greater than zero.
+
+Legacy/base-unit rows without complete snapshots are deliberately excluded from
+this first UI slice rather than guessed or reinterpreted.
+
+## 5. Remaining-quantity derivation
+
+The read RPC does **not** trust any client `alreadyInvoiced` value.
+
+For each accepted GRN line:
+
+```text
+accepted base quantity
+  = goods_receipt_lines.received_quantity
+    when quality_status = accepted
+
+allocated base quantity
+  = SUM(original allocation quantity)
+    - SUM(reversal allocation quantity)
+    within the same org + GRN line
+
+remaining base quantity
+  = accepted base quantity - allocated base quantity
+```
+
+This is the same allocation-ledger model established in 149/151. The read RPC is
+advisory for UX only: the write RPC still locks rows and recomputes remaining
+quantity under lock before any invoice write.
+
+## 6. Returned evidence
+
+Each candidate includes the identifiers and immutable facts required by the
+future typed UI service:
+
+- organization/vendor ids and vendor code/name;
+- PO id/number/status and PO-line id;
+- GRN id/number/status and GRN-line id;
+- product id/code/name/name_ar;
+- UoM id/code/name/name_ar/symbol/decimal places;
+- conversion-factor snapshot;
+- accepted / allocated / remaining quantity in base and entered units;
+- PO unit price in base and entered units;
+- discount and tax percentages.
+
+No row returned by this RPC is a reservation. A later submit may still fail if a
+concurrent invoice consumes the balance first; that is intentional and is closed
+by the existing atomic matched-invoice RPC.
+
+## 7. Fresh DB acceptance
+
+Workflow:
+
+```text
+.github/workflows/ap-181-supplier-invoice-candidates.yml
+```
+
+Runner:
+
+```text
+scripts/ci/fresh-db/run_ap_181_candidate_gate.sh
+```
+
+Acceptance:
+
+```text
+scripts/ci/fresh-db/acceptance_181_supplier_invoice_candidates.sql
+```
+
+The gate uses PostgreSQL 17 and:
+
+1. resolves the current baseline pair;
+2. applies every legal migration after the baseline cutoff through 181;
+3. runs migration syntax + SECURITY DEFINER guards;
+4. runs Acceptance 148 to build legal PO/GRN fixtures through production RPCs;
+5. runs Acceptance 149 to create a real matched allocation;
+6. proves 181 returns the authoritative remaining balance (48 accepted − 10.5
+   allocated = 37.5);
+7. proves membership/D4 denial paths;
+8. proves draft GRN, rejected line and fully consumed line are excluded;
+9. proves vendor/PO filters fail closed;
+10. re-runs the remaining 149 closure + concurrency suites as regression proof;
+11. verifies the final function definition and EXECUTE surface.
+
+Negative probes are transaction-scoped and rolled back so they do not corrupt the
+shared 148/149 fixtures.
+
+## 8. Repository merge gate
+
+Do not merge this PR until the final head SHA has:
+
+- Migration Governance green;
+- CI/CD / TypeScript / repository tests green;
+- SonarQube green;
+- `AP 181 Supplier Invoice Candidate Read` green;
+- existing AP 149 regression gates green where triggered;
+- no unresolved review threads;
+- final diff review confirming no app/runtime change and no historical migration
+  rewrite.
+
+This PR may be merged to the repository only after explicit merge authorization.
+Repository merge still does **not** authorize Production application.
+
+## 9. Production application gate — separate authorization required
+
+After repository merge, and only with separate explicit authorization:
+
+1. verify Production is still healthy;
+2. verify Production ledger still ends at the expected prior migration and that
+   181 is absent;
+3. verify the exact merged migration SHA/file from `main`;
+4. take the normal operational snapshot/preflight required by project policy;
+5. apply only the additive 181 migration;
+6. verify one ledger registration;
+7. verify function definition, pinned `search_path`, membership/D4 guards and
+   EXECUTE grants;
+8. perform read-only candidate checks against existing Production data;
+9. do **not** create commercial test invoices or apply PR B in the same step.
+
+If the repository/Production migration state has diverged, stop and reconcile the
+ledger before application.
+
+## 10. Rollback / reversal
+
+181 creates only a read RPC. If repository rollback is required before Production
+application, revert the repository commit/PR normally.
+
+If 181 has been applied to Production and an operational rollback is explicitly
+authorized, the narrow reversal is:
+
+```sql
+DROP FUNCTION IF EXISTS public.rpc_list_supplier_invoice_candidates(uuid, uuid, uuid);
+```
+
+Record that reversal operationally; do not delete or rewrite the 181 migration
+history row or historical migration file.
+
+## 11. Explicit non-goals
+
+Migration 181 does not:
+
+- modify 149–152;
+- add or change supplier-invoice write semantics;
+- change `purchasing.purchase_invoices.approve`;
+- add a persisted draft lifecycle;
+- support pre-receipt invoices;
+- support `without-po` invoices;
+- configure `gl_event_mappings`;
+- fix the old UI direct-write path;
+- apply anything to Production.
+
+Those belong to the later reviewed rollout sequence. In particular, PR B remains
+blocked for any pilot organization until active `AP_MATCHED_INVOICE_GOODS` and
+`AP_MATCHED_INVOICE_VAT` mappings and postable accounts are verified.

--- a/scripts/ci/fresh-db/acceptance_181_supplier_invoice_candidates.sql
+++ b/scripts/ci/fresh-db/acceptance_181_supplier_invoice_candidates.sql
@@ -19,6 +19,17 @@ BEGIN
   END IF;
 END $$;
 
+CREATE OR REPLACE FUNCTION pg_temp.find_candidate(p_rows jsonb, p_grl uuid)
+RETURNS jsonb
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT value
+  FROM jsonb_array_elements(COALESCE(p_rows, '[]'::jsonb)) AS x(value)
+  WHERE (value ->> 'goods_receipt_line_id')::uuid = p_grl
+  LIMIT 1
+$$;
+
 -- ---------------------------------------------------------------------------
 -- 1. Definition / execute surface / D4 all-of contract.
 -- ---------------------------------------------------------------------------
@@ -81,11 +92,12 @@ SELECT set_config('request.jwt.claim.sub', '48bbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb
 
 -- ---------------------------------------------------------------------------
 -- 3. Happy path and authoritative remaining balance after 149 allocation.
--- acceptance_149_ap_three_way_match.sql consumes 10.5 from U148-GR-1's accepted
--- 48 base units, so this read must report exactly 37.5 remaining. Acceptance 148
--- leaves U148-PO-MAIN in fully_received; assert that state explicitly so later
--- fixture changes cannot silently remove coverage of Migration 152's terminal PO
--- state from this gate.
+-- The PO may legitimately have more than one accepted GRN candidate. Target the
+-- U148-GR-1 line by its immutable GRN-line id instead of assuming the whole
+-- vendor+PO list has cardinality one. Derive the expected allocation from the
+-- ledger itself and cross-check remaining quantity with the 149/151 helper.
+-- Acceptance 148 leaves U148-PO-MAIN in fully_received; assert that state
+-- explicitly so fixture changes cannot silently remove Migration 152 coverage.
 -- ---------------------------------------------------------------------------
 DO $$
 DECLARE
@@ -94,6 +106,8 @@ DECLARE
   v_grl uuid;
   v_rows jsonb;
   v_row jsonb;
+  v_expected_allocated numeric;
+  v_expected_remaining numeric;
 BEGIN
   SELECT po.id, po.vendor_id, grl.id
     INTO STRICT v_po, v_vendor, v_grl
@@ -107,21 +121,30 @@ BEGIN
     AND gr.idempotency_key = 'U148-GR-1'
     AND grl.quality_status = 'accepted';
 
+  SELECT COALESCE(SUM(
+    CASE WHEN a.reversal_of_allocation_id IS NULL
+         THEN a.quantity_base ELSE -a.quantity_base END
+  ), 0)
+    INTO v_expected_allocated
+  FROM public.supplier_invoice_receipt_allocations a
+  WHERE a.goods_receipt_line_id = v_grl;
+
+  v_expected_remaining := public.wardah_receipt_line_uninvoiced_base(v_grl);
+
   v_rows := public.rpc_list_supplier_invoice_candidates(
     '48111111-1111-1111-1111-111111111111'::uuid,
     v_vendor,
     v_po
   );
+  v_row := pg_temp.find_candidate(v_rows, v_grl);
 
-  IF jsonb_array_length(v_rows) <> 1 THEN
-    RAISE EXCEPTION 'ACCEPTANCE_181_FAIL: expected one candidate, got %', v_rows;
+  IF v_row IS NULL THEN
+    RAISE EXCEPTION 'ACCEPTANCE_181_FAIL: target GRN line missing from candidates: %', v_rows;
   END IF;
 
-  v_row := v_rows -> 0;
-  IF (v_row ->> 'goods_receipt_line_id')::uuid <> v_grl
-     OR (v_row ->> 'accepted_qty_base')::numeric <> 48
-     OR (v_row ->> 'allocated_qty_base')::numeric <> 10.5
-     OR (v_row ->> 'remaining_qty_base')::numeric <> 37.5
+  IF (v_row ->> 'accepted_qty_base')::numeric <> 48
+     OR (v_row ->> 'allocated_qty_base')::numeric <> v_expected_allocated
+     OR (v_row ->> 'remaining_qty_base')::numeric <> v_expected_remaining
      OR (v_row ->> 'conversion_factor_snapshot')::numeric <> 12
      OR (v_row ->> 'po_unit_price_base')::numeric <> 10
      OR (v_row ->> 'po_unit_price_entered')::numeric <> 120
@@ -150,21 +173,28 @@ SELECT pg_temp.expect_error(
 
 -- ---------------------------------------------------------------------------
 -- 4. Eligibility filters are fail-closed and leave no state changes.
--- Each negative probe is inside a transaction and rolled back.
+-- Other legal receipt lines on the same PO must not make a negative probe fail:
+-- each assertion checks only the targeted U148-GR-1 line. Every probe rolls back.
 -- ---------------------------------------------------------------------------
 BEGIN;
 UPDATE public.goods_receipts
 SET status = 'draft'
 WHERE idempotency_key = 'U148-GR-1';
 DO $$
-DECLARE v_rows jsonb; v_po uuid; v_vendor uuid;
+DECLARE v_rows jsonb; v_po uuid; v_vendor uuid; v_grl uuid;
 BEGIN
-  SELECT id, vendor_id INTO STRICT v_po, v_vendor
-  FROM public.purchase_orders WHERE order_number = 'U148-PO-MAIN';
+  SELECT po.id, po.vendor_id, grl.id
+    INTO STRICT v_po, v_vendor, v_grl
+  FROM public.purchase_orders po
+  JOIN public.goods_receipts gr ON gr.purchase_order_id = po.id
+  JOIN public.goods_receipt_lines grl ON grl.goods_receipt_id = gr.id
+  WHERE po.order_number = 'U148-PO-MAIN'
+    AND gr.idempotency_key = 'U148-GR-1';
+
   v_rows := public.rpc_list_supplier_invoice_candidates(
     '48111111-1111-1111-1111-111111111111', v_vendor, v_po);
-  IF jsonb_array_length(v_rows) <> 0 THEN
-    RAISE EXCEPTION 'ACCEPTANCE_181_FAIL: draft GRN leaked into candidates: %', v_rows;
+  IF pg_temp.find_candidate(v_rows, v_grl) IS NOT NULL THEN
+    RAISE EXCEPTION 'ACCEPTANCE_181_FAIL: draft target GRN leaked into candidates: %', v_rows;
   END IF;
 END $$;
 ROLLBACK;
@@ -176,50 +206,78 @@ FROM public.goods_receipts gr
 WHERE gr.id = grl.goods_receipt_id
   AND gr.idempotency_key = 'U148-GR-1';
 DO $$
-DECLARE v_rows jsonb; v_po uuid; v_vendor uuid;
+DECLARE v_rows jsonb; v_po uuid; v_vendor uuid; v_grl uuid;
 BEGIN
-  SELECT id, vendor_id INTO STRICT v_po, v_vendor
-  FROM public.purchase_orders WHERE order_number = 'U148-PO-MAIN';
+  SELECT po.id, po.vendor_id, grl.id
+    INTO STRICT v_po, v_vendor, v_grl
+  FROM public.purchase_orders po
+  JOIN public.goods_receipts gr ON gr.purchase_order_id = po.id
+  JOIN public.goods_receipt_lines grl ON grl.goods_receipt_id = gr.id
+  WHERE po.order_number = 'U148-PO-MAIN'
+    AND gr.idempotency_key = 'U148-GR-1';
+
   v_rows := public.rpc_list_supplier_invoice_candidates(
     '48111111-1111-1111-1111-111111111111', v_vendor, v_po);
-  IF jsonb_array_length(v_rows) <> 0 THEN
-    RAISE EXCEPTION 'ACCEPTANCE_181_FAIL: rejected GRN line leaked: %', v_rows;
+  IF pg_temp.find_candidate(v_rows, v_grl) IS NOT NULL THEN
+    RAISE EXCEPTION 'ACCEPTANCE_181_FAIL: rejected target GRN line leaked: %', v_rows;
   END IF;
 END $$;
 ROLLBACK;
 
--- A fully consumed receipt line is excluded. Add only the remaining 37.5 inside
--- this transaction, then rollback; no permanent fixture mutation survives.
+-- A fully consumed target receipt line is excluded. Consume exactly the helper's
+-- current remaining balance inside this transaction, then rollback.
 BEGIN;
-INSERT INTO public.supplier_invoice_receipt_allocations (
-  org_id, supplier_invoice_id, supplier_invoice_line_id,
-  goods_receipt_line_id, purchase_order_line_id, quantity_base,
-  idempotency_key, created_by
-)
-SELECT
-  a.org_id,
-  a.supplier_invoice_id,
-  a.supplier_invoice_line_id,
-  a.goods_receipt_line_id,
-  a.purchase_order_line_id,
-  37.5,
-  'u181-full-consumption-probe',
-  '48bbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid
-FROM public.supplier_invoice_receipt_allocations a
-JOIN public.goods_receipt_lines grl ON grl.id = a.goods_receipt_line_id
-JOIN public.goods_receipts gr ON gr.id = grl.goods_receipt_id
-WHERE gr.idempotency_key = 'U148-GR-1'
-  AND a.reversal_of_allocation_id IS NULL
-LIMIT 1;
 DO $$
-DECLARE v_rows jsonb; v_po uuid; v_vendor uuid;
+DECLARE
+  v_org uuid;
+  v_invoice uuid;
+  v_invoice_line uuid;
+  v_grl uuid;
+  v_pol uuid;
+  v_po uuid;
+  v_vendor uuid;
+  v_remaining numeric;
+  v_rows jsonb;
 BEGIN
-  SELECT id, vendor_id INTO STRICT v_po, v_vendor
-  FROM public.purchase_orders WHERE order_number = 'U148-PO-MAIN';
-  v_rows := public.rpc_list_supplier_invoice_candidates(
-    '48111111-1111-1111-1111-111111111111', v_vendor, v_po);
-  IF jsonb_array_length(v_rows) <> 0 THEN
-    RAISE EXCEPTION 'ACCEPTANCE_181_FAIL: fully consumed line leaked: %', v_rows;
+  SELECT
+    a.org_id,
+    a.supplier_invoice_id,
+    a.supplier_invoice_line_id,
+    a.goods_receipt_line_id,
+    a.purchase_order_line_id,
+    po.id,
+    po.vendor_id
+  INTO STRICT
+    v_org, v_invoice, v_invoice_line, v_grl, v_pol, v_po, v_vendor
+  FROM public.supplier_invoice_receipt_allocations a
+  JOIN public.goods_receipt_lines grl ON grl.id = a.goods_receipt_line_id
+  JOIN public.goods_receipts gr ON gr.id = grl.goods_receipt_id
+  JOIN public.purchase_order_lines pol ON pol.id = a.purchase_order_line_id
+  JOIN public.purchase_orders po ON po.id = pol.purchase_order_id
+  WHERE gr.idempotency_key = 'U148-GR-1'
+    AND a.reversal_of_allocation_id IS NULL
+  ORDER BY a.created_at, a.id
+  LIMIT 1;
+
+  v_remaining := public.wardah_receipt_line_uninvoiced_base(v_grl);
+  IF v_remaining <= 0 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_181_FAIL: target fixture unexpectedly has no remaining balance';
+  END IF;
+
+  INSERT INTO public.supplier_invoice_receipt_allocations (
+    org_id, supplier_invoice_id, supplier_invoice_line_id,
+    goods_receipt_line_id, purchase_order_line_id, quantity_base,
+    idempotency_key, created_by
+  ) VALUES (
+    v_org, v_invoice, v_invoice_line,
+    v_grl, v_pol, v_remaining,
+    'u181-full-consumption-probe',
+    '48bbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid
+  );
+
+  v_rows := public.rpc_list_supplier_invoice_candidates(v_org, v_vendor, v_po);
+  IF pg_temp.find_candidate(v_rows, v_grl) IS NOT NULL THEN
+    RAISE EXCEPTION 'ACCEPTANCE_181_FAIL: fully consumed target line leaked: %', v_rows;
   END IF;
 END $$;
 ROLLBACK;
@@ -227,8 +285,8 @@ ROLLBACK;
 -- ---------------------------------------------------------------------------
 -- 5. Append-only reversal arithmetic is executable, not just inspected.
 -- Add a temporary 5-unit allocation and a second row that reverses it. The net
--- allocation must return to the original 10.5, the remaining balance to 37.5,
--- and the candidate must remain visible. Roll back both rows afterward.
+-- allocation and remaining balance must return to their exact pre-probe values,
+-- the target candidate must remain visible, and the 149/151 helper must agree.
 -- ---------------------------------------------------------------------------
 BEGIN;
 DO $$
@@ -243,6 +301,8 @@ DECLARE
   v_vendor uuid;
   v_rows jsonb;
   v_row jsonb;
+  v_baseline_allocated numeric;
+  v_baseline_remaining numeric;
   v_helper_remaining numeric;
 BEGIN
   SELECT
@@ -254,13 +314,7 @@ BEGIN
     po.id,
     po.vendor_id
   INTO STRICT
-    v_org,
-    v_invoice,
-    v_invoice_line,
-    v_grl,
-    v_pol,
-    v_po,
-    v_vendor
+    v_org, v_invoice, v_invoice_line, v_grl, v_pol, v_po, v_vendor
   FROM public.supplier_invoice_receipt_allocations a
   JOIN public.goods_receipt_lines grl ON grl.id = a.goods_receipt_line_id
   JOIN public.goods_receipts gr ON gr.id = grl.goods_receipt_id
@@ -270,6 +324,16 @@ BEGIN
     AND a.reversal_of_allocation_id IS NULL
   ORDER BY a.created_at, a.id
   LIMIT 1;
+
+  SELECT COALESCE(SUM(
+    CASE WHEN a.reversal_of_allocation_id IS NULL
+         THEN a.quantity_base ELSE -a.quantity_base END
+  ), 0)
+    INTO v_baseline_allocated
+  FROM public.supplier_invoice_receipt_allocations a
+  WHERE a.goods_receipt_line_id = v_grl;
+
+  v_baseline_remaining := public.wardah_receipt_line_uninvoiced_base(v_grl);
 
   INSERT INTO public.supplier_invoice_receipt_allocations (
     org_id, supplier_invoice_id, supplier_invoice_line_id,
@@ -296,47 +360,60 @@ BEGIN
     '48bbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid
   );
 
-  v_rows := public.rpc_list_supplier_invoice_candidates(
-    v_org, v_vendor, v_po
-  );
+  v_rows := public.rpc_list_supplier_invoice_candidates(v_org, v_vendor, v_po);
+  v_row := pg_temp.find_candidate(v_rows, v_grl);
 
-  IF jsonb_array_length(v_rows) <> 1 THEN
+  IF v_row IS NULL THEN
     RAISE EXCEPTION
-      'ACCEPTANCE_181_FAIL: reversed allocation did not restore candidate visibility: %',
+      'ACCEPTANCE_181_FAIL: reversed allocation did not restore target candidate visibility: %',
       v_rows;
   END IF;
 
-  v_row := v_rows -> 0;
-  IF (v_row ->> 'goods_receipt_line_id')::uuid <> v_grl
-     OR (v_row ->> 'allocated_qty_base')::numeric <> 10.5
-     OR (v_row ->> 'remaining_qty_base')::numeric <> 37.5 THEN
+  IF (v_row ->> 'allocated_qty_base')::numeric <> v_baseline_allocated
+     OR (v_row ->> 'remaining_qty_base')::numeric <> v_baseline_remaining THEN
     RAISE EXCEPTION
       'ACCEPTANCE_181_FAIL: reversal arithmetic mismatch in candidate read: %',
       v_row;
   END IF;
 
   v_helper_remaining := public.wardah_receipt_line_uninvoiced_base(v_grl);
-  IF v_helper_remaining <> 37.5 THEN
+  IF v_helper_remaining <> v_baseline_remaining THEN
     RAISE EXCEPTION
-      'ACCEPTANCE_181_FAIL: 149/151 helper disagrees after reversal: %',
-      v_helper_remaining;
+      'ACCEPTANCE_181_FAIL: 149/151 helper disagrees after reversal: % vs baseline %',
+      v_helper_remaining, v_baseline_remaining;
   END IF;
 END $$;
 ROLLBACK;
 
--- Final proof that every negative/reversal probe rolled back and did not mutate
--- the durable 148/149 fixture.
+-- Final proof that every negative/reversal probe rolled back and that the helper
+-- still agrees with an independently recomputed ledger balance.
 DO $$
-DECLARE v_remaining numeric;
+DECLARE
+  v_grl uuid;
+  v_accepted numeric;
+  v_allocated numeric;
+  v_helper_remaining numeric;
 BEGIN
-  SELECT public.wardah_receipt_line_uninvoiced_base(grl.id)
-    INTO STRICT v_remaining
+  SELECT grl.id, grl.received_quantity
+    INTO STRICT v_grl, v_accepted
   FROM public.goods_receipt_lines grl
   JOIN public.goods_receipts gr ON gr.id = grl.goods_receipt_id
   WHERE gr.idempotency_key = 'U148-GR-1'
     AND grl.quality_status = 'accepted';
-  IF v_remaining <> 37.5 THEN
-    RAISE EXCEPTION 'ACCEPTANCE_181_FAIL: probes changed remaining balance: %', v_remaining;
+
+  SELECT COALESCE(SUM(
+    CASE WHEN a.reversal_of_allocation_id IS NULL
+         THEN a.quantity_base ELSE -a.quantity_base END
+  ), 0)
+    INTO v_allocated
+  FROM public.supplier_invoice_receipt_allocations a
+  WHERE a.goods_receipt_line_id = v_grl;
+
+  v_helper_remaining := public.wardah_receipt_line_uninvoiced_base(v_grl);
+  IF v_helper_remaining <> v_accepted - v_allocated THEN
+    RAISE EXCEPTION
+      'ACCEPTANCE_181_FAIL: durable fixture/helper mismatch after probes: helper %, accepted %, allocated %',
+      v_helper_remaining, v_accepted, v_allocated;
   END IF;
 END $$;
 

--- a/scripts/ci/fresh-db/acceptance_181_supplier_invoice_candidates.sql
+++ b/scripts/ci/fresh-db/acceptance_181_supplier_invoice_candidates.sql
@@ -1,0 +1,238 @@
+\set ON_ERROR_STOP on
+
+CREATE OR REPLACE FUNCTION pg_temp.expect_error(p_sql text, p_needle text)
+RETURNS void LANGUAGE plpgsql AS $$
+DECLARE v_succeeded boolean := false;
+BEGIN
+  BEGIN
+    EXECUTE p_sql;
+    v_succeeded := true;
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM NOT LIKE '%' || p_needle || '%' THEN
+      RAISE EXCEPTION 'ACCEPTANCE_181_FAIL: expected [%], got [%] for [%]',
+        p_needle, SQLERRM, p_sql;
+    END IF;
+  END;
+  IF v_succeeded THEN
+    RAISE EXCEPTION 'ACCEPTANCE_181_FAIL: expected error [%], but succeeded: %',
+      p_needle, p_sql;
+  END IF;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- 1. Definition / execute surface / D4 all-of contract.
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE v_def text;
+BEGIN
+  SELECT pg_get_functiondef(
+    'public.rpc_list_supplier_invoice_candidates(uuid,uuid,uuid)'::regprocedure
+  ) INTO v_def;
+
+  IF v_def NOT LIKE '%wardah_assert_org_member%'
+     OR v_def NOT LIKE '%purchasing.purchase_orders.read%'
+     OR v_def NOT LIKE '%purchasing.purchase_invoices.read%'
+     OR v_def NOT LIKE '%quality_status = ''accepted''%'
+     OR v_def NOT LIKE '%supplier_invoice_receipt_allocations%'
+     OR v_def NOT LIKE '%fully_received%' THEN
+    RAISE EXCEPTION 'ACCEPTANCE_181_FAIL: function definition misses reviewed contract';
+  END IF;
+
+  IF has_function_privilege(
+       'anon',
+       'public.rpc_list_supplier_invoice_candidates(uuid,uuid,uuid)',
+       'EXECUTE'
+     )
+     OR has_function_privilege(
+       'service_role',
+       'public.rpc_list_supplier_invoice_candidates(uuid,uuid,uuid)',
+       'EXECUTE'
+     )
+     OR NOT has_function_privilege(
+       'authenticated',
+       'public.rpc_list_supplier_invoice_candidates(uuid,uuid,uuid)',
+       'EXECUTE'
+     ) THEN
+    RAISE EXCEPTION 'ACCEPTANCE_181_FAIL: execute surface mismatch';
+  END IF;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- 2. Permission / tenant boundaries.
+-- Fixtures come from acceptance_148 + acceptance_149.
+-- ---------------------------------------------------------------------------
+SELECT set_config('request.jwt.claim.sub', '48aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', false);
+SELECT pg_temp.expect_error(
+  $$SELECT public.rpc_list_supplier_invoice_candidates(
+      '48111111-1111-1111-1111-111111111111'::uuid, NULL, NULL)$$,
+  'AP_CANDIDATE_PERMISSION_DENIED'
+);
+
+SELECT set_config('request.jwt.claim.sub', '48cccccc-cccc-cccc-cccc-cccccccccccc', false);
+SELECT pg_temp.expect_error(
+  $$SELECT public.rpc_list_supplier_invoice_candidates(
+      '48111111-1111-1111-1111-111111111111'::uuid, NULL, NULL)$$,
+  'ORG'
+);
+
+-- Org A admin receives the non-sensitive read permissions through the canonical
+-- has_permission() contract and is therefore the positive caller.
+SELECT set_config('request.jwt.claim.sub', '48bbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', false);
+
+-- ---------------------------------------------------------------------------
+-- 3. Happy path and authoritative remaining balance after 149 allocation.
+-- acceptance_149_ap_three_way_match.sql consumes 10.5 from U148-GR-1's accepted
+-- 48 base units, so this read must report exactly 37.5 remaining.
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE
+  v_po uuid;
+  v_vendor uuid;
+  v_grl uuid;
+  v_rows jsonb;
+  v_row jsonb;
+BEGIN
+  SELECT po.id, po.vendor_id, grl.id
+    INTO STRICT v_po, v_vendor, v_grl
+  FROM public.purchase_orders po
+  JOIN public.purchase_order_lines pol ON pol.purchase_order_id = po.id
+  JOIN public.goods_receipts gr ON gr.purchase_order_id = po.id
+  JOIN public.goods_receipt_lines grl
+    ON grl.goods_receipt_id = gr.id
+   AND grl.purchase_order_line_id = pol.id
+  WHERE po.order_number = 'U148-PO-MAIN'
+    AND gr.idempotency_key = 'U148-GR-1'
+    AND grl.quality_status = 'accepted';
+
+  v_rows := public.rpc_list_supplier_invoice_candidates(
+    '48111111-1111-1111-1111-111111111111'::uuid,
+    v_vendor,
+    v_po
+  );
+
+  IF jsonb_array_length(v_rows) <> 1 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_181_FAIL: expected one candidate, got %', v_rows;
+  END IF;
+
+  v_row := v_rows -> 0;
+  IF (v_row ->> 'goods_receipt_line_id')::uuid <> v_grl
+     OR (v_row ->> 'accepted_qty_base')::numeric <> 48
+     OR (v_row ->> 'allocated_qty_base')::numeric <> 10.5
+     OR (v_row ->> 'remaining_qty_base')::numeric <> 37.5
+     OR (v_row ->> 'conversion_factor_snapshot')::numeric <> 12
+     OR (v_row ->> 'po_unit_price_base')::numeric <> 10
+     OR (v_row ->> 'po_unit_price_entered')::numeric <> 120
+     OR v_row ->> 'quality_status' <> 'accepted'
+     OR v_row ->> 'goods_receipt_status' NOT IN ('confirmed','posted') THEN
+    RAISE EXCEPTION 'ACCEPTANCE_181_FAIL: candidate contract mismatch: %', v_row;
+  END IF;
+END $$;
+
+-- Vendor and PO filters must stay tenant-scoped and consistent.
+SELECT pg_temp.expect_error(
+  $$SELECT public.rpc_list_supplier_invoice_candidates(
+      '48111111-1111-1111-1111-111111111111'::uuid,
+      '00000000-0000-0000-0000-000000000001'::uuid,
+      NULL)$$,
+  'AP_VENDOR_MISMATCH'
+);
+SELECT pg_temp.expect_error(
+  $$SELECT public.rpc_list_supplier_invoice_candidates(
+      '48111111-1111-1111-1111-111111111111'::uuid,
+      NULL,
+      '00000000-0000-0000-0000-000000000001'::uuid)$$,
+  'AP_PO_NOT_FOUND'
+);
+
+-- ---------------------------------------------------------------------------
+-- 4. Eligibility filters are fail-closed and leave no state changes.
+-- Each negative probe is inside a transaction and rolled back.
+-- ---------------------------------------------------------------------------
+BEGIN;
+UPDATE public.goods_receipts
+SET status = 'draft'
+WHERE idempotency_key = 'U148-GR-1';
+DO $$
+DECLARE v_rows jsonb; v_po uuid; v_vendor uuid;
+BEGIN
+  SELECT id, vendor_id INTO STRICT v_po, v_vendor
+  FROM public.purchase_orders WHERE order_number = 'U148-PO-MAIN';
+  v_rows := public.rpc_list_supplier_invoice_candidates(
+    '48111111-1111-1111-1111-111111111111', v_vendor, v_po);
+  IF jsonb_array_length(v_rows) <> 0 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_181_FAIL: draft GRN leaked into candidates: %', v_rows;
+  END IF;
+END $$;
+ROLLBACK;
+
+BEGIN;
+UPDATE public.goods_receipt_lines grl
+SET quality_status = 'rejected'
+FROM public.goods_receipts gr
+WHERE gr.id = grl.goods_receipt_id
+  AND gr.idempotency_key = 'U148-GR-1';
+DO $$
+DECLARE v_rows jsonb; v_po uuid; v_vendor uuid;
+BEGIN
+  SELECT id, vendor_id INTO STRICT v_po, v_vendor
+  FROM public.purchase_orders WHERE order_number = 'U148-PO-MAIN';
+  v_rows := public.rpc_list_supplier_invoice_candidates(
+    '48111111-1111-1111-1111-111111111111', v_vendor, v_po);
+  IF jsonb_array_length(v_rows) <> 0 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_181_FAIL: rejected GRN line leaked: %', v_rows;
+  END IF;
+END $$;
+ROLLBACK;
+
+-- A fully consumed receipt line is excluded. Add only the remaining 37.5 inside
+-- this transaction, then rollback; no permanent fixture mutation survives.
+BEGIN;
+INSERT INTO public.supplier_invoice_receipt_allocations (
+  org_id, supplier_invoice_id, supplier_invoice_line_id,
+  goods_receipt_line_id, purchase_order_line_id, quantity_base,
+  idempotency_key, created_by
+)
+SELECT
+  a.org_id,
+  a.supplier_invoice_id,
+  a.supplier_invoice_line_id,
+  a.goods_receipt_line_id,
+  a.purchase_order_line_id,
+  37.5,
+  'u181-full-consumption-probe',
+  '48bbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid
+FROM public.supplier_invoice_receipt_allocations a
+JOIN public.goods_receipt_lines grl ON grl.id = a.goods_receipt_line_id
+JOIN public.goods_receipts gr ON gr.id = grl.goods_receipt_id
+WHERE gr.idempotency_key = 'U148-GR-1'
+  AND a.reversal_of_allocation_id IS NULL
+LIMIT 1;
+DO $$
+DECLARE v_rows jsonb; v_po uuid; v_vendor uuid;
+BEGIN
+  SELECT id, vendor_id INTO STRICT v_po, v_vendor
+  FROM public.purchase_orders WHERE order_number = 'U148-PO-MAIN';
+  v_rows := public.rpc_list_supplier_invoice_candidates(
+    '48111111-1111-1111-1111-111111111111', v_vendor, v_po);
+  IF jsonb_array_length(v_rows) <> 0 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_181_FAIL: fully consumed line leaked: %', v_rows;
+  END IF;
+END $$;
+ROLLBACK;
+
+-- Final proof that the negative probes did not mutate the durable fixture.
+DO $$
+DECLARE v_remaining numeric;
+BEGIN
+  SELECT public.wardah_receipt_line_uninvoiced_base(grl.id)
+    INTO STRICT v_remaining
+  FROM public.goods_receipt_lines grl
+  JOIN public.goods_receipts gr ON gr.id = grl.goods_receipt_id
+  WHERE gr.idempotency_key = 'U148-GR-1'
+    AND grl.quality_status = 'accepted';
+  IF v_remaining <> 37.5 THEN
+    RAISE EXCEPTION 'ACCEPTANCE_181_FAIL: probes changed remaining balance: %', v_remaining;
+  END IF;
+END $$;
+
+SELECT 'AP_181_SUPPLIER_INVOICE_CANDIDATE_READ_PASS' AS result;

--- a/scripts/ci/fresh-db/acceptance_181_supplier_invoice_candidates.sql
+++ b/scripts/ci/fresh-db/acceptance_181_supplier_invoice_candidates.sql
@@ -82,7 +82,10 @@ SELECT set_config('request.jwt.claim.sub', '48bbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb
 -- ---------------------------------------------------------------------------
 -- 3. Happy path and authoritative remaining balance after 149 allocation.
 -- acceptance_149_ap_three_way_match.sql consumes 10.5 from U148-GR-1's accepted
--- 48 base units, so this read must report exactly 37.5 remaining.
+-- 48 base units, so this read must report exactly 37.5 remaining. Acceptance 148
+-- leaves U148-PO-MAIN in fully_received; assert that state explicitly so later
+-- fixture changes cannot silently remove coverage of Migration 152's terminal PO
+-- state from this gate.
 -- ---------------------------------------------------------------------------
 DO $$
 DECLARE
@@ -123,7 +126,8 @@ BEGIN
      OR (v_row ->> 'po_unit_price_base')::numeric <> 10
      OR (v_row ->> 'po_unit_price_entered')::numeric <> 120
      OR v_row ->> 'quality_status' <> 'accepted'
-     OR v_row ->> 'goods_receipt_status' NOT IN ('confirmed','posted') THEN
+     OR v_row ->> 'goods_receipt_status' NOT IN ('confirmed','posted')
+     OR v_row ->> 'purchase_order_status' <> 'fully_received' THEN
     RAISE EXCEPTION 'ACCEPTANCE_181_FAIL: candidate contract mismatch: %', v_row;
   END IF;
 END $$;
@@ -220,7 +224,108 @@ BEGIN
 END $$;
 ROLLBACK;
 
--- Final proof that the negative probes did not mutate the durable fixture.
+-- ---------------------------------------------------------------------------
+-- 5. Append-only reversal arithmetic is executable, not just inspected.
+-- Add a temporary 5-unit allocation and a second row that reverses it. The net
+-- allocation must return to the original 10.5, the remaining balance to 37.5,
+-- and the candidate must remain visible. Roll back both rows afterward.
+-- ---------------------------------------------------------------------------
+BEGIN;
+DO $$
+DECLARE
+  v_original_allocation_id uuid;
+  v_org uuid;
+  v_invoice uuid;
+  v_invoice_line uuid;
+  v_grl uuid;
+  v_pol uuid;
+  v_po uuid;
+  v_vendor uuid;
+  v_rows jsonb;
+  v_row jsonb;
+  v_helper_remaining numeric;
+BEGIN
+  SELECT
+    a.org_id,
+    a.supplier_invoice_id,
+    a.supplier_invoice_line_id,
+    a.goods_receipt_line_id,
+    a.purchase_order_line_id,
+    po.id,
+    po.vendor_id
+  INTO STRICT
+    v_org,
+    v_invoice,
+    v_invoice_line,
+    v_grl,
+    v_pol,
+    v_po,
+    v_vendor
+  FROM public.supplier_invoice_receipt_allocations a
+  JOIN public.goods_receipt_lines grl ON grl.id = a.goods_receipt_line_id
+  JOIN public.goods_receipts gr ON gr.id = grl.goods_receipt_id
+  JOIN public.purchase_order_lines pol ON pol.id = a.purchase_order_line_id
+  JOIN public.purchase_orders po ON po.id = pol.purchase_order_id
+  WHERE gr.idempotency_key = 'U148-GR-1'
+    AND a.reversal_of_allocation_id IS NULL
+  ORDER BY a.created_at, a.id
+  LIMIT 1;
+
+  INSERT INTO public.supplier_invoice_receipt_allocations (
+    org_id, supplier_invoice_id, supplier_invoice_line_id,
+    goods_receipt_line_id, purchase_order_line_id, quantity_base,
+    idempotency_key, created_by
+  ) VALUES (
+    v_org, v_invoice, v_invoice_line,
+    v_grl, v_pol, 5,
+    'u181-reversal-origin-probe',
+    '48bbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid
+  )
+  RETURNING id INTO v_original_allocation_id;
+
+  INSERT INTO public.supplier_invoice_receipt_allocations (
+    org_id, supplier_invoice_id, supplier_invoice_line_id,
+    goods_receipt_line_id, purchase_order_line_id, quantity_base,
+    reversal_of_allocation_id, reversal_reason,
+    idempotency_key, created_by
+  ) VALUES (
+    v_org, v_invoice, v_invoice_line,
+    v_grl, v_pol, 5,
+    v_original_allocation_id, 'Acceptance 181 reversal probe',
+    'u181-reversal-row-probe',
+    '48bbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid
+  );
+
+  v_rows := public.rpc_list_supplier_invoice_candidates(
+    v_org, v_vendor, v_po
+  );
+
+  IF jsonb_array_length(v_rows) <> 1 THEN
+    RAISE EXCEPTION
+      'ACCEPTANCE_181_FAIL: reversed allocation did not restore candidate visibility: %',
+      v_rows;
+  END IF;
+
+  v_row := v_rows -> 0;
+  IF (v_row ->> 'goods_receipt_line_id')::uuid <> v_grl
+     OR (v_row ->> 'allocated_qty_base')::numeric <> 10.5
+     OR (v_row ->> 'remaining_qty_base')::numeric <> 37.5 THEN
+    RAISE EXCEPTION
+      'ACCEPTANCE_181_FAIL: reversal arithmetic mismatch in candidate read: %',
+      v_row;
+  END IF;
+
+  v_helper_remaining := public.wardah_receipt_line_uninvoiced_base(v_grl);
+  IF v_helper_remaining <> 37.5 THEN
+    RAISE EXCEPTION
+      'ACCEPTANCE_181_FAIL: 149/151 helper disagrees after reversal: %',
+      v_helper_remaining;
+  END IF;
+END $$;
+ROLLBACK;
+
+-- Final proof that every negative/reversal probe rolled back and did not mutate
+-- the durable 148/149 fixture.
 DO $$
 DECLARE v_remaining numeric;
 BEGIN

--- a/scripts/ci/fresh-db/run_ap_181_candidate_gate.sh
+++ b/scripts/ci/fresh-db/run_ap_181_candidate_gate.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+DB=${PGDATABASE:-wardah_ap181}
+BASELINE_DIR=${BASELINE_DIR:-sql/baseline}
+
+pair=$(bash scripts/ci/fresh-db/resolve_baseline_pair.sh "$BASELINE_DIR")
+pair_field() { printf '%s\n' "$pair" | sed -n "s/^$1=//p"; }
+BASELINE=$(pair_field BASELINE_PATH)
+REFERENCE=$(pair_field REFERENCE_PATH)
+CUTOFF=$(pair_field BASELINE_CUTOFF)
+CUTOFF=${CUTOFF:-0}
+
+if [[ -z "$BASELINE" || -z "$REFERENCE" ]]; then
+  echo 'AP_181_GATE_FAIL: baseline pair could not be resolved' >&2
+  exit 1
+fi
+
+echo "AP 181 gate: baseline=$BASELINE reference=$REFERENCE cutoff=$CUTOFF"
+dropdb --if-exists "$DB"
+createdb "$DB"
+psql -v ON_ERROR_STOP=1 -X -d "$DB" -f scripts/ci/fresh-db/supabase_shim.sql -q
+psql -v ON_ERROR_STOP=1 -X -d "$DB" -f "$BASELINE" -q
+psql -v ON_ERROR_STOP=1 -X -d "$DB" -f "$REFERENCE" -q
+
+python3 scripts/ci/fresh-db/build_apply_order.py sql/migrations "$CUTOFF" > /tmp/ap181-chain-order.txt
+if [[ -s /tmp/ap181-chain-order.txt ]]; then
+  REPORT=/tmp/ap181-chain-report.txt PGDATABASE="$DB" \
+    bash scripts/ci/fresh-db/run_chain.sh sql/migrations /tmp/ap181-chain-order.txt
+  cat /tmp/ap181-chain-report.txt
+fi
+
+if ! psql -X -d "$DB" -tAc \
+  "SELECT to_regprocedure('public.rpc_list_supplier_invoice_candidates(uuid,uuid,uuid)') IS NOT NULL" \
+  | grep -qx t; then
+  echo 'AP_181_GATE_FAIL: missing candidate read RPC' >&2
+  exit 1
+fi
+
+# Reuse the legal purchase-order / accepted-GRN fixtures and the matched-invoice
+# allocation contract rather than manufacturing parallel state by hand.
+psql -v ON_ERROR_STOP=1 -X -d "$DB" \
+  -f scripts/ci/fresh-db/acceptance_148_uom_partial_receipts.sql
+psql -v ON_ERROR_STOP=1 -X -d "$DB" \
+  -f scripts/ci/fresh-db/acceptance_149_ap_three_way_match.sql
+
+# The 181 suite reads the exact persisted 148/149 facts, including the 10.5-unit
+# allocation created by the 149 happy path, and proves the remaining 37.5 units.
+psql -v ON_ERROR_STOP=1 -X -d "$DB" \
+  -f scripts/ci/fresh-db/acceptance_181_supplier_invoice_candidates.sql
+
+# Existing AP closure and concurrency suites remain mandatory regression proof.
+psql -v ON_ERROR_STOP=1 -X -d "$DB" \
+  -f scripts/ci/fresh-db/acceptance_149_issue_46_closure.sql
+PGDATABASE="$DB" bash scripts/ci/fresh-db/acceptance_149_concurrency.sh
+
+psql -v ON_ERROR_STOP=1 -X -d "$DB" <<'SQL'
+DO $$
+DECLARE v_def text;
+BEGIN
+  SELECT pg_get_functiondef(
+    'public.rpc_list_supplier_invoice_candidates(uuid,uuid,uuid)'::regprocedure
+  ) INTO v_def;
+
+  IF v_def NOT LIKE '%SECURITY DEFINER%'
+     OR v_def NOT LIKE '%SET search_path TO ''public'', ''pg_temp''%'
+     OR v_def NOT LIKE '%purchasing.purchase_orders.read%'
+     OR v_def NOT LIKE '%purchasing.purchase_invoices.read%' THEN
+    RAISE EXCEPTION 'AP_181_GATE_FAIL: final function definition drift';
+  END IF;
+
+  IF has_function_privilege(
+       'anon',
+       'public.rpc_list_supplier_invoice_candidates(uuid,uuid,uuid)',
+       'EXECUTE'
+     )
+     OR has_function_privilege(
+       'service_role',
+       'public.rpc_list_supplier_invoice_candidates(uuid,uuid,uuid)',
+       'EXECUTE'
+     )
+     OR NOT has_function_privilege(
+       'authenticated',
+       'public.rpc_list_supplier_invoice_candidates(uuid,uuid,uuid)',
+       'EXECUTE'
+     ) THEN
+    RAISE EXCEPTION 'AP_181_GATE_FAIL: final execute surface drift';
+  END IF;
+END $$;
+SELECT 'AP_181_FRESH_DB_GATE_PASS' AS result;
+SQL

--- a/sql/migrations/181_supplier_invoice_candidate_read.sql
+++ b/sql/migrations/181_supplier_invoice_candidate_read.sql
@@ -1,0 +1,213 @@
+-- migration_number: 181
+-- description: Add a tenant-scoped, permission-gated read RPC that lists
+--              accepted, legally invoiceable GRN lines for the supplier-invoice
+--              three-way-match UI without reopening any direct write surface.
+-- safety: additive read-only RPC only. No table/column/policy/trigger mutation,
+--         no rewrite of migrations 149-152, and no Production application in
+--         this repository PR.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.rpc_list_supplier_invoice_candidates(
+  p_org_id uuid,
+  p_vendor_id uuid DEFAULT NULL,
+  p_purchase_order_id uuid DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_org uuid;
+BEGIN
+  v_org := public.wardah_org_id(p_org_id);
+  IF v_org IS NULL THEN
+    RAISE EXCEPTION 'ORG_NOT_RESOLVED';
+  END IF;
+
+  PERFORM public.wardah_assert_org_member(v_org);
+
+  -- D4 from the accepted supplier-invoice lifecycle decision record is all-of,
+  -- not any-of. There is no purchasing.goods_receipts.* permission namespace in
+  -- the current catalog; receipt visibility follows purchase-order read access.
+  IF NOT public.has_permission(
+       auth.uid(), v_org, 'purchasing.purchase_orders.read'
+     )
+     OR NOT public.has_permission(
+       auth.uid(), v_org, 'purchasing.purchase_invoices.read'
+     ) THEN
+    RAISE EXCEPTION
+      'AP_CANDIDATE_PERMISSION_DENIED: requires purchasing.purchase_orders.read and purchasing.purchase_invoices.read';
+  END IF;
+
+  IF p_vendor_id IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM public.vendors v
+       WHERE v.id = p_vendor_id
+         AND v.org_id = v_org
+     ) THEN
+    RAISE EXCEPTION 'AP_VENDOR_MISMATCH: vendor is outside the selected organization';
+  END IF;
+
+  IF p_purchase_order_id IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM public.purchase_orders po
+       WHERE po.id = p_purchase_order_id
+         AND po.org_id = v_org
+     ) THEN
+    -- Deliberately indistinguishable from a missing id: do not disclose that a
+    -- purchase order exists in another organization.
+    RAISE EXCEPTION 'AP_PO_NOT_FOUND: purchase order is not visible in the selected organization';
+  END IF;
+
+  IF p_vendor_id IS NOT NULL
+     AND p_purchase_order_id IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM public.purchase_orders po
+       WHERE po.id = p_purchase_order_id
+         AND po.org_id = v_org
+         AND po.vendor_id = p_vendor_id
+     ) THEN
+    RAISE EXCEPTION 'AP_VENDOR_MISMATCH: purchase order belongs to another vendor';
+  END IF;
+
+  RETURN COALESCE((
+    SELECT jsonb_agg(
+      q.candidate
+      ORDER BY q.receipt_date DESC, q.receipt_number DESC, q.goods_receipt_line_id
+    )
+    FROM (
+      SELECT
+        gr.receipt_date,
+        gr.receipt_number,
+        grl.id AS goods_receipt_line_id,
+        jsonb_build_object(
+          'organization_id', v_org,
+          'vendor_id', po.vendor_id,
+          'vendor', jsonb_build_object(
+            'id', v.id,
+            'code', v.code,
+            'name', v.name
+          ),
+          'purchase_order_id', po.id,
+          'purchase_order_number', po.order_number,
+          'purchase_order_status', po.status,
+          'purchase_order_line_id', pol.id,
+          'goods_receipt_id', gr.id,
+          'goods_receipt_number', gr.receipt_number,
+          'goods_receipt_status', gr.status,
+          'goods_receipt_line_id', grl.id,
+          'quality_status', grl.quality_status,
+          'product_id', grl.product_id,
+          'product', jsonb_build_object(
+            'id', p.id,
+            'code', p.code,
+            'name', p.name,
+            'name_ar', p.name_ar
+          ),
+          'uom_id', grl.uom_id,
+          'uom', jsonb_build_object(
+            'id', u.id,
+            'code', u.code,
+            'name', u.name,
+            'name_ar', u.name_ar,
+            'symbol', u.symbol,
+            'decimal_places', u.decimal_places
+          ),
+          'conversion_factor_snapshot', grl.conversion_factor_snapshot,
+          'accepted_qty_base', grl.received_quantity,
+          'accepted_qty_entered', COALESCE(
+            grl.qty_entered,
+            round(grl.received_quantity / grl.conversion_factor_snapshot, 6)
+          ),
+          'allocated_qty_base', alloc.allocated_qty_base,
+          'allocated_qty_entered', round(
+            alloc.allocated_qty_base / grl.conversion_factor_snapshot,
+            6
+          ),
+          'remaining_qty_base', grl.received_quantity - alloc.allocated_qty_base,
+          'remaining_qty_entered', round(
+            (grl.received_quantity - alloc.allocated_qty_base)
+            / grl.conversion_factor_snapshot,
+            6
+          ),
+          'po_unit_price_base', pol.unit_price,
+          'po_unit_price_entered', COALESCE(
+            pol.unit_price_entered,
+            round(pol.unit_price * pol.conversion_factor_snapshot, 6)
+          ),
+          'discount_percentage', COALESCE(pol.discount_percentage, 0),
+          'tax_percentage', COALESCE(pol.tax_percentage, 0)
+        ) AS candidate
+      FROM public.goods_receipt_lines grl
+      JOIN public.goods_receipts gr
+        ON gr.id = grl.goods_receipt_id
+       AND gr.org_id = v_org
+      JOIN public.purchase_order_lines pol
+        ON pol.id = grl.purchase_order_line_id
+       AND pol.org_id = v_org
+      JOIN public.purchase_orders po
+        ON po.id = pol.purchase_order_id
+       AND po.org_id = v_org
+      JOIN public.vendors v
+        ON v.id = po.vendor_id
+       AND v.org_id = v_org
+      JOIN public.products p
+        ON p.id = grl.product_id
+       AND p.org_id = v_org
+      JOIN public.uoms u
+        ON u.id = grl.uom_id
+       AND (u.org_id IS NULL OR u.org_id = v_org)
+      LEFT JOIN LATERAL (
+        SELECT COALESCE(SUM(
+          CASE
+            WHEN a.reversal_of_allocation_id IS NULL THEN a.quantity_base
+            ELSE -a.quantity_base
+          END
+        ), 0)::numeric(18,6) AS allocated_qty_base
+        FROM public.supplier_invoice_receipt_allocations a
+        WHERE a.org_id = v_org
+          AND a.goods_receipt_line_id = grl.id
+      ) alloc ON true
+      WHERE grl.org_id = v_org
+        AND grl.quality_status = 'accepted'
+        AND gr.status IN ('confirmed', 'posted')
+        AND po.status IN (
+          'approved',
+          'partially_received',
+          'fully_received',
+          'received',
+          'closed'
+        )
+        AND gr.vendor_id = po.vendor_id
+        AND grl.product_id = pol.product_id
+        -- The first UI slice is snapshot-backed only. Legacy/base-unit rows with
+        -- incomplete immutable PO/GRN evidence are intentionally not candidates.
+        AND grl.uom_id IS NOT NULL
+        AND grl.conversion_factor_snapshot IS NOT NULL
+        AND grl.conversion_factor_snapshot > 0
+        AND pol.uom_id IS NOT NULL
+        AND pol.conversion_factor_snapshot IS NOT NULL
+        AND pol.conversion_factor_snapshot > 0
+        AND pol.uom_id = grl.uom_id
+        AND pol.conversion_factor_snapshot = grl.conversion_factor_snapshot
+        AND alloc.allocated_qty_base >= 0
+        AND alloc.allocated_qty_base < grl.received_quantity
+        AND (p_vendor_id IS NULL OR po.vendor_id = p_vendor_id)
+        AND (p_purchase_order_id IS NULL OR po.id = p_purchase_order_id)
+    ) q
+  ), '[]'::jsonb);
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.rpc_list_supplier_invoice_candidates(uuid, uuid, uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.rpc_list_supplier_invoice_candidates(uuid, uuid, uuid) FROM anon;
+REVOKE ALL ON FUNCTION public.rpc_list_supplier_invoice_candidates(uuid, uuid, uuid) FROM service_role;
+GRANT EXECUTE ON FUNCTION public.rpc_list_supplier_invoice_candidates(uuid, uuid, uuid) TO authenticated;
+
+COMMIT;

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -11114,6 +11114,14 @@ export type Database = {
         Args: { p_fiscal_year?: number; p_tenant?: string }
         Returns: Json
       }
+      rpc_list_supplier_invoice_candidates: {
+        Args: {
+          p_org_id: string
+          p_purchase_order_id?: string
+          p_vendor_id?: string
+        }
+        Returns: Json
+      }
       rpc_list_uom_purchase_order_options: {
         Args: { p_org_id: string }
         Returns: Json


### PR DESCRIPTION
## Purpose

PR A from the accepted supplier-invoice lifecycle decision record in PR #185.

This PR adds the read-only DB contract needed for the later supplier-invoice UI migration. It does not change the UI, write lifecycle, or Production.

## Scope

- add Migration 181: `rpc_list_supplier_invoice_candidates(uuid, uuid, uuid)`;
- enforce active org membership plus the accepted D4 all-of permissions:
  - `purchasing.purchase_orders.read`
  - `purchasing.purchase_invoices.read`
- derive invoiceable balance from accepted GRN quantity minus the append-only `supplier_invoice_receipt_allocations` ledger;
- expose only legal snapshot-backed PO/GRN candidates with positive uninvoiced balance;
- add PostgreSQL 17 Fresh DB acceptance, runner and dedicated workflow;
- re-run 148/149 AP fixtures/regressions inside the 181 gate;
- add an independent Migration 181 runbook;
- include the generated database type declaration for the new RPC signature only (no service/UI wiring).

## Security / fail-closed behavior

- `SECURITY DEFINER` with pinned `search_path`;
- explicit org resolution and `wardah_assert_org_member`;
- both D4 keys are required, not any-of;
- optional vendor/PO filters are tenant-scoped and do not disclose cross-org rows;
- `PUBLIC`, `anon`, and `service_role` EXECUTE are revoked; only `authenticated` receives EXECUTE;
- `service_role` revocation is deliberate: this is a permission-aware client read boundary, and no approved background/service workflow requires candidate listing;
- rejected/unposted/incomplete-snapshot/fully-consumed lines are excluded;
- no direct write grants are added or reopened.

## Regression evidence

The dedicated gate applies the current baseline + full legal migration chain through 181, then runs:

1. Acceptance 148 legal PO/GRN fixtures;
2. Acceptance 149 matched-invoice allocation path;
3. Acceptance 181 candidate read checks that target the exact GRN line by `goods_receipt_line_id`, derive expected allocation from the ledger, and cross-check remaining quantity with the 149/151 helper instead of relying on fixture-specific constants or list cardinality;
4. explicit assertion that the covered PO is `fully_received`;
5. an actual append-only allocation + reversal row proving the candidate read returns to the exact pre-probe balance and agrees with the 149/151 helper;
6. remaining 149 closure/concurrency suites.

The PO/GRN UoM snapshot equality predicate is defensive: legal 148+ receipts copy the PO snapshot; the condition protects the new read contract from incomplete/legacy/corrupt rows rather than introducing a new operational matching rule.

## Safety / non-goals

- no changes to Migrations 149–152;
- no supplier-invoice writes;
- no UI/runtime changes;
- no typed service or client integration in this PR beyond the generated DB RPC signature;
- no `gl_event_mappings` configuration;
- no Production application;
- no merge without separate review and explicit authorization.

Production application, if later authorized, occurs only after repository merge and the pre/post checks in `docs/db/SUPPLIER_INVOICE_CANDIDATE_READ_181_RUNBOOK.md`.

Base at branch creation: `main@ad98a17ba88292e6fbc16957c1cc132b3447545f`.