### PR TITLE
feat(navigation): ALIGN-P1 — Product Catalog as sidebar source of truth

### DIFF
--- a/src/components/layout/__tests__/sidebar-i18n.test.tsx
+++ b/src/components/layout/__tests__/sidebar-i18n.test.tsx
@@ -15,8 +15,8 @@ import { MemoryRouter } from 'react-router-dom'
 import arTranslation from '@/locales/ar/translation.json'
 import enTranslation from '@/locales/en/translation.json'
 
-// مصدر المكوّن كنص خام — لاستخراج المفاتيح آلياً بدل قائمة يدوية
-import sidebarSource from '@/components/layout/sidebar.tsx?raw'
+// مصدر التنقل الحي — الكتالوج هو مصدر الحقيقة بعد ALIGN-P1، لا sidebar.tsx
+import { PRODUCT_CATALOG, type ProductCatalogItem } from '@/config/product-catalog'
 
 import i18n from '@/i18n'
 import { Sidebar } from '@/components/layout/sidebar'
@@ -30,7 +30,7 @@ vi.mock('@/hooks/usePermissions', () => ({
   usePermissions: vi.fn(() => ({
     isOrgAdmin: false,
     isSuperAdmin: false,
-    hasModuleAccess: () => false,
+    hasPermissionKey: () => false,
     permissions: [],
     loading: false,
     error: null,
@@ -50,30 +50,34 @@ vi.mock('@/contexts/AuthContext', () => ({
 }))
 
 // ----------------------------------------------------------------
-// استخراج مفاتيح التنقل آلياً من مصدر sidebar
+// استخراج مفاتيح التنقل آلياً من الكتالوج الحي (مصدر الحقيقة بعد ALIGN-P1)
 // ----------------------------------------------------------------
 
-/** مفاتيح القوائم الرئيسية: key: 'X', يتبعها icon: (بنية عناصر التنقل) */
-function extractTopLevelKeys(src: string): string[] {
-  const re = /key:\s*'([^']+)',\s*[\r\n]+\s*icon:/g
+function navKeyOf(item: ProductCatalogItem): string {
+  return item.labelKey.replace(/^navigation\./, '')
+}
+
+/** مفاتيح المنتجات الجذرية (موديولات + dashboard + org-admin/super-admin). */
+function extractTopLevelKeys(catalog: readonly ProductCatalogItem[]): string[] {
+  return catalog.map(item => item.key)
+}
+
+/** مفاتيح ترجمة كل القوائم الفرعية (children) عبر الكتالوج بالكامل. */
+function extractSubItemNavKeys(catalog: readonly ProductCatalogItem[]): string[] {
   const out = new Set<string>()
-  let m: RegExpExecArray | null
-  while ((m = re.exec(src)) !== null) out.add(m[1])
+  const walk = (items: readonly ProductCatalogItem[]) => {
+    for (const item of items) {
+      out.add(navKeyOf(item))
+      if (item.children) walk(item.children)
+    }
+  }
+  for (const item of catalog) if (item.children) walk(item.children)
   return [...out]
 }
 
-/** مفاتيح ترجمة القوائم الفرعية: labelKey: 'navigation.X' */
-function extractSubItemNavKeys(src: string): string[] {
-  const re = /labelKey:\s*'navigation\.([^']+)'/g
-  const out = new Set<string>()
-  let m: RegExpExecArray | null
-  while ((m = re.exec(src)) !== null) out.add(m[1])
-  return [...out]
-}
-
-const TOP_LEVEL_KEYS = extractTopLevelKeys(sidebarSource)
-const SUBITEM_KEYS = extractSubItemNavKeys(sidebarSource)
-const ALL_NAV_KEYS = [...new Set([...TOP_LEVEL_KEYS, ...SUBITEM_KEYS])]
+const TOP_LEVEL_KEYS = extractTopLevelKeys(PRODUCT_CATALOG)
+const SUBITEM_KEYS = extractSubItemNavKeys(PRODUCT_CATALOG)
+const ALL_NAV_KEYS = [...new Set([...TOP_LEVEL_KEYS, ...PRODUCT_CATALOG.map(navKeyOf), ...SUBITEM_KEYS])]
 
 const ARABIC = /[؀-ۿ]/
 
@@ -94,7 +98,7 @@ describe('Sidebar — i18n', () => {
     ;(usePermissions as any).mockReturnValue({
       isOrgAdmin: false,
       isSuperAdmin: false,
-      hasModuleAccess: () => false,
+      hasPermissionKey: () => false,
       permissions: [],
       loading: false,
       error: null,
@@ -171,7 +175,7 @@ describe('Sidebar — i18n', () => {
     ;(usePermissions as any).mockReturnValue({
       isOrgAdmin: true,
       isSuperAdmin: true,
-      hasModuleAccess: () => true,
+      hasPermissionKey: () => true,
       permissions: [],
       loading: false,
       error: null,
@@ -204,7 +208,7 @@ describe('Sidebar — i18n', () => {
     ;(usePermissions as any).mockReturnValue({
       isOrgAdmin: false,
       isSuperAdmin: false,
-      hasModuleAccess: (moduleCode: string) => moduleCode === 'sales',
+      hasPermissionKey: (key: string) => key === 'sales.customers.read',
       permissions: [],
       loading: false,
       error: null,
@@ -221,7 +225,7 @@ describe('Sidebar — i18n', () => {
     ;(usePermissions as any).mockReturnValue({
       isOrgAdmin: true,
       isSuperAdmin: false,
-      hasModuleAccess: () => true,
+      hasPermissionKey: () => true,
       permissions: [],
       loading: false,
       error: null,

--- a/src/components/layout/__tests__/sidebar-landing-href.test.tsx
+++ b/src/components/layout/__tests__/sidebar-landing-href.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * ALIGN-P1 review follow-up: two real functional-authorization dead ends
+ * caught in independent review of PR #193 (head d357a2a).
+ *
+ * 1. Collapsed sidebar always linked a visible GROUP to item.href, even when
+ *    the caller was only permitted a CHILD route (e.g. General Ledger-only
+ *    access to Accounting) — clicking sent them to a root ModuleGuard would
+ *    reject. Fixed by landingHref: falls back to the first visible child.
+ * 2. Expanded/mobile rendered a childless-but-visible group (e.g. Settings
+ *    for a settings.users.read-only caller, whose only children require
+ *    settings.organization.read) as a plain button/div with no navigation
+ *    at all — a dead end even though /settings itself is directly
+ *    enterable. Fixed by rendering a real link to landingHref when there
+ *    are no visible children left to expand into.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+import { Sidebar } from '@/components/layout/sidebar'
+import { usePermissions } from '@/hooks/usePermissions'
+import { useUIStore } from '@/store/ui-store'
+import i18n from '@/i18n'
+
+vi.mock('@/hooks/usePermissions', () => ({
+  usePermissions: vi.fn(),
+}))
+
+vi.mock('@/store/ui-store', () => ({
+  useUIStore: vi.fn(),
+}))
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: vi.fn(() => ({
+    user: { id: 'u1', email: 'test@test.com' },
+    session: null,
+    organizations: [],
+    currentOrgId: 'org-1',
+    setCurrentOrgId: vi.fn(),
+    signOut: vi.fn(),
+    isLoading: false,
+  })),
+}))
+
+function mockPermissions(hasPermissionKey: (key: string) => boolean) {
+  ;(usePermissions as any).mockReturnValue({
+    isOrgAdmin: false,
+    isSuperAdmin: false,
+    hasPermissionKey,
+    permissions: [],
+    loading: false,
+    error: null,
+  })
+}
+
+function mockUiStore(sidebarCollapsed: boolean) {
+  ;(useUIStore as any).mockReturnValue({
+    sidebarCollapsed,
+    sidebarOpen: false,
+    setSidebarOpen: vi.fn(),
+  })
+}
+
+function renderSidebar() {
+  return render(
+    <MemoryRouter initialEntries={['/dashboard']}>
+      <Sidebar />
+    </MemoryRouter>,
+  )
+}
+
+describe('Sidebar — landingHref (ALIGN-P1 review fixes)', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('collapsed: General Ledger-only caller lands on /general-ledger/accounts, never on /accounting', () => {
+    mockPermissions(key => key === 'general_ledger.chart_of_accounts.view')
+    mockUiStore(true)
+
+    const { container } = renderSidebar()
+    const hrefs = [...container.querySelectorAll('a')].map(a => a.getAttribute('href'))
+
+    expect(hrefs).toContain('/general-ledger/accounts')
+    expect(hrefs).not.toContain('/accounting')
+  })
+
+  it('collapsed: a caller who genuinely satisfies the Accounting root still lands on /accounting', () => {
+    mockPermissions(key => key === 'accounting.journals.read')
+    mockUiStore(true)
+
+    const { container } = renderSidebar()
+    const hrefs = [...container.querySelectorAll('a')].map(a => a.getAttribute('href'))
+
+    expect(hrefs).toContain('/accounting')
+  })
+
+  it('expanded: settings.users.read-only caller gets a real /settings link, not a dead button', () => {
+    mockPermissions(key => key === 'settings.users.read')
+    mockUiStore(false)
+
+    renderSidebar()
+
+    const settingsLink = screen.getByRole('link', { name: i18n.t('navigation.settings') })
+    expect(settingsLink).toHaveAttribute('href', '/settings')
+    expect(screen.queryByRole('button', { name: i18n.t('navigation.settings') })).not.toBeInTheDocument()
+  })
+
+  it('expanded: a caller with a visible child still gets an expandable group, not a direct link', () => {
+    mockPermissions(key => key === 'settings.organization.read')
+    mockUiStore(false)
+
+    renderSidebar()
+
+    expect(screen.getByRole('button', { name: i18n.t('navigation.settings') })).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: i18n.t('navigation.settings') })).not.toBeInTheDocument()
+  })
+})

--- a/src/components/layout/__tests__/sidebar-product-catalog-ratchet.test.ts
+++ b/src/components/layout/__tests__/sidebar-product-catalog-ratchet.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import sidebarSource from '@/components/layout/sidebar.tsx?raw';
+
+describe('Sidebar product catalog ratchet', () => {
+  it('consumes the product catalog instead of owning a duplicate module map', () => {
+    expect(sidebarSource).toContain("from '@/config/product-catalog'");
+    expect(sidebarSource).toContain('getVisibleProductNavigation');
+    expect(sidebarSource).not.toContain('const MODULE_CODES =');
+    expect(sidebarSource).not.toContain('const allNavigationItems =');
+  });
+
+  it('does not restore decorative static badges', () => {
+    expect(sidebarSource).not.toContain("badge: '2'");
+    expect(sidebarSource).not.toContain("badge: '3'");
+    expect(sidebarSource).not.toContain("from '@/components/ui/badge'");
+  });
+
+  it('filters navigation with exact backend permission keys', () => {
+    expect(sidebarSource).toContain('hasPermissionKey');
+    expect(sidebarSource).not.toContain('hasModuleAccess');
+  });
+});

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -1,13 +1,13 @@
-import { useState } from 'react'
+import { useState, type KeyboardEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import { NavLink, useLocation } from 'react-router-dom'
-import { 
-  LayoutDashboard, 
-  Factory, 
-  Package, 
-  ShoppingCart, 
-  DollarSign, 
-  BarChart3, 
+import {
+  LayoutDashboard,
+  Factory,
+  Package,
+  ShoppingCart,
+  DollarSign,
+  BarChart3,
   Settings,
   ChevronRight,
   ChevronLeft,
@@ -15,111 +15,139 @@ import {
   BookOpen,
   Users,
   Building2,
-  Shield
+  Shield,
+  type LucideIcon,
 } from 'lucide-react'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import { Badge } from '@/components/ui/badge'
 import { cn } from '@/lib/utils'
 import { useUIStore } from '@/store/ui-store'
 import { usePermissions } from '@/hooks/usePermissions'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { getGlassClasses } from '@/lib/wardah-ui-utils'
+import {
+  getVisibleProductNavigation,
+  type ProductCatalogItem,
+  type ProductIconKey,
+} from '@/config/product-catalog'
 
-// تعريف أكواد الموديولات للصلاحيات
-const MODULE_CODES = {
-  DASHBOARD: 'dashboard',
-  MANUFACTURING: 'manufacturing',
-  INVENTORY: 'inventory',
-  PURCHASING: 'purchasing',
-  SALES: 'sales',
-  ACCOUNTING: 'accounting',
-  GENERAL_LEDGER: 'general_ledger',
-  HR: 'hr',
-  REPORTS: 'reports',
-  SETTINGS: 'settings',
-  ORG_ADMIN: 'org_admin',
-  SUPER_ADMIN: 'super_admin',
-} as const;
-
-// Helper functions to reduce cognitive complexity
-const shouldShowNavigationItem = (
-  item: {
-    key: string;
-    moduleCode: string;
-    moduleCodes?: readonly string[];
-    requireSuperAdmin?: boolean;
-    requireOrgAdmin?: boolean;
-  },
-  isOrgAdmin: boolean,
-  isSuperAdmin: boolean,
-  hasModuleAccess: (moduleCode: string) => boolean
-): boolean => {
-  if (item.key === 'dashboard') return true
-  if (item.requireSuperAdmin) return isSuperAdmin
-  if (item.requireOrgAdmin) return isOrgAdmin || isSuperAdmin
-  return (item.moduleCodes ?? [item.moduleCode]).some(hasModuleAccess)
+const PRODUCT_ICONS: Record<ProductIconKey, LucideIcon> = {
+  LayoutDashboard,
+  Factory,
+  Package,
+  ShoppingCart,
+  DollarSign,
+  BookOpen,
+  Users,
+  BarChart3,
+  Settings,
+  Building2,
+  Shield,
 }
 
-// Helper function to render collapsed sidebar item
-const renderCollapsedItem = (
-  item: { key: string; icon: any; href: string; badge: string | null },
+function getItemIcon(item: ProductCatalogItem): LucideIcon {
+  return item.icon ? PRODUCT_ICONS[item.icon] : LayoutDashboard
+}
+
+function isItemActive(item: ProductCatalogItem, pathname: string): boolean {
+  if (pathname.startsWith(item.href)) return true
+  return item.children?.some(child => pathname.startsWith(child.href)) ?? false
+}
+
+function renderCollapsedItem(
+  item: ProductCatalogItem,
   isActive: boolean,
   isRTL: boolean,
   t: (key: string) => string,
-  handleItemClick: () => void
-) => {
-  const Icon = item.icon
+  handleItemClick: () => void,
+) {
+  const Icon = getItemIcon(item)
   return (
     <Tooltip>
       <TooltipTrigger asChild>
         <NavLink
           to={item.href}
           className={cn(
-            "flex items-center justify-center p-3 rounded-lg text-sm font-medium transition-all duration-200",
-            "hover:bg-accent/50 hover:scale-105",
-            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-            isActive && "bg-primary text-primary-foreground shadow-md hover:bg-primary/90"
+            'flex items-center justify-center p-3 rounded-lg text-sm font-medium transition-all duration-200',
+            'hover:bg-accent/50 hover:scale-105',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+            isActive && 'bg-primary text-primary-foreground shadow-md hover:bg-primary/90',
           )}
           onClick={handleItemClick}
         >
           <Icon className="h-5 w-5 shrink-0" />
-          {item.badge && (
-            <span className="absolute top-1 right-1 h-2 w-2 rounded-full bg-destructive" />
-          )}
         </NavLink>
       </TooltipTrigger>
-      <TooltipContent side={isRTL ? "left" : "right"} className="font-medium">
-        {t(`navigation.${item.key}`)}
-        {item.badge && (
-          <Badge variant="secondary" className="ml-2 text-xs">
-            {item.badge}
-          </Badge>
-        )}
+      <TooltipContent side={isRTL ? 'left' : 'right'} className="font-medium">
+        {t(item.labelKey)}
       </TooltipContent>
     </Tooltip>
   )
 }
 
-// Helper function to render expanded sidebar item
-const renderExpandedItem = (
-  item: { key: string; icon: any; href: string; badge: string | null; subItems?: Array<{ key: string; href: string; labelKey: string }> },
-  isActive: boolean,
+function renderChildren(
+  item: ProductCatalogItem,
   isExpanded: boolean,
-  hasSubItems: boolean,
   isRTL: boolean,
   t: (key: string) => string,
-  ChevronIcon: any,
+  ChevronIcon: LucideIcon,
+  handleItemClick: () => void,
+  pathname: string,
+) {
+  if (!item.children?.length) return null
+
+  return (
+    <div
+      className={cn(
+        'overflow-hidden transition-all duration-300 ease-in-out',
+        isExpanded ? 'max-h-[42rem] opacity-100' : 'max-h-0 opacity-0',
+        isRTL ? 'mr-4 pr-3 border-r-2 border-border/30' : 'ml-4 pl-3 border-l-2 border-border/30',
+      )}
+    >
+      <div className="space-y-0.5 py-1">
+        {item.children.map(child => {
+          const isSubActive = pathname === child.href || pathname.startsWith(`${child.href}/`)
+          return (
+            <NavLink
+              key={`${child.moduleCode}:${child.key}:${child.href}`}
+              to={child.href}
+              className={cn(
+                'flex items-center gap-2 px-3 py-2 rounded-md text-xs transition-all duration-150',
+                'text-muted-foreground hover:text-foreground hover:bg-accent/30 hover:translate-x-1',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                isSubActive && 'text-primary font-semibold bg-primary/10 border-l-2 border-primary',
+                isRTL && 'hover:-translate-x-1',
+              )}
+              onClick={handleItemClick}
+            >
+              <ChevronIcon className="h-3 w-3 shrink-0 opacity-60" />
+              <span className={cn('flex-1 truncate', isRTL ? 'text-right' : 'text-left')}>
+                {t(child.labelKey)}
+              </span>
+            </NavLink>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function renderExpandedItem(
+  item: ProductCatalogItem,
+  isActive: boolean,
+  isExpanded: boolean,
+  isRTL: boolean,
+  t: (key: string) => string,
+  ChevronIcon: LucideIcon,
   toggleExpanded: (key: string) => void,
   handleItemClick: () => void,
-  location: { pathname: string }
-) => {
-  const Icon = item.icon
+  pathname: string,
+) {
+  const Icon = getItemIcon(item)
+  const hasChildren = Boolean(item.children?.length)
+
   const handleItemAction = () => {
-    if (hasSubItems) {
-      toggleExpanded(item.key)
-    } else {
-      handleItemClick()
-    }
+    if (hasChildren) toggleExpanded(item.key)
+    else handleItemClick()
   }
 
   return (
@@ -127,110 +155,55 @@ const renderExpandedItem = (
       <button
         type="button"
         className={cn(
-          "w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-all duration-200 group border-0",
-          "hover:bg-accent/50 hover:shadow-sm",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-          isActive && "bg-primary text-primary-foreground shadow-md hover:bg-primary/90",
-          isRTL ? "text-right" : "text-left"
+          'w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-all duration-200 group border-0',
+          'hover:bg-accent/50 hover:shadow-sm',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+          isActive && 'bg-primary text-primary-foreground shadow-md hover:bg-primary/90',
+          isRTL ? 'text-right' : 'text-left',
         )}
         onClick={handleItemAction}
       >
         <Icon className="h-5 w-5 shrink-0 transition-transform group-hover:scale-110" />
-        <span className={cn(
-          "flex-1 truncate",
-          isRTL ? "text-right" : "text-left"
-        )}>
-          {t(`navigation.${item.key}`)}
+        <span className={cn('flex-1 truncate', isRTL ? 'text-right' : 'text-left')}>
+          {t(item.labelKey)}
         </span>
-        {item.badge && (
-          <Badge 
-            variant={isActive ? "outline" : "secondary"} 
+        {hasChildren && (
+          <ChevronDown
             className={cn(
-              "text-xs font-semibold px-2 py-0.5",
-              isActive && "border-primary-foreground/20"
+              'h-4 w-4 shrink-0 transition-transform duration-200',
+              isExpanded && 'rotate-180',
+              isRTL && 'rotate-180',
             )}
-          >
-            {item.badge}
-          </Badge>
-        )}
-        {hasSubItems && (
-          <ChevronDown 
-            className={cn(
-              "h-4 w-4 shrink-0 transition-transform duration-200",
-              isExpanded && "rotate-180",
-              isRTL && "rotate-180"
-            )} 
           />
         )}
       </button>
-      
-      {/* Sub-items with animation */}
-      {hasSubItems && (
-        <div
-          className={cn(
-            "overflow-hidden transition-all duration-300 ease-in-out",
-            isExpanded ? "max-h-96 opacity-100" : "max-h-0 opacity-0",
-            isRTL ? "mr-4 pr-3 border-r-2 border-border/30" : "ml-4 pl-3 border-l-2 border-border/30"
-          )}
-        >
-          <div className="space-y-0.5 py-1">
-            {item.subItems?.map((subItem) => {
-              const isSubActive = location.pathname === subItem.href
-              return (
-                <NavLink
-                  key={subItem.key}
-                  to={subItem.href}
-                  className={cn(
-                    "flex items-center gap-2 px-3 py-2 rounded-md text-xs transition-all duration-150",
-                    "text-muted-foreground hover:text-foreground hover:bg-accent/30 hover:translate-x-1",
-                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                    isSubActive && "text-primary font-semibold bg-primary/10 border-l-2 border-primary",
-                    isRTL && "hover:-translate-x-1"
-                  )}
-                  onClick={handleItemClick}
-                >
-                  <ChevronIcon className="h-3 w-3 shrink-0 opacity-60" />
-                  <span className={cn(
-                    "flex-1 truncate",
-                    isRTL ? "text-right" : "text-left"
-                  )}>
-                    {t(subItem.labelKey)}
-                  </span>
-                </NavLink>
-              )
-            })}
-          </div>
-        </div>
-      )}
+      {renderChildren(item, isExpanded, isRTL, t, ChevronIcon, handleItemClick, pathname)}
     </>
   )
 }
 
-// Helper function to render mobile sidebar item
-const renderMobileItem = (
-  item: { key: string; icon: any; href: string; badge: string | null; subItems?: Array<{ key: string; href: string; labelKey: string }> },
+function renderMobileItem(
+  item: ProductCatalogItem,
   isActive: boolean,
   isExpanded: boolean,
-  hasSubItems: boolean,
   isRTL: boolean,
   t: (key: string) => string,
-  ChevronIcon: any,
+  ChevronIcon: LucideIcon,
   toggleExpanded: (key: string) => void,
   handleItemClick: () => void,
-  location: { pathname: string }
-) => {
-  const Icon = item.icon
+  pathname: string,
+) {
+  const Icon = getItemIcon(item)
+  const hasChildren = Boolean(item.children?.length)
+
   const handleItemAction = () => {
-    if (hasSubItems) {
-      toggleExpanded(item.key)
-    } else {
-      handleItemClick()
-    }
+    if (hasChildren) toggleExpanded(item.key)
+    else handleItemClick()
   }
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault()
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
       handleItemAction()
     }
   }
@@ -241,82 +214,30 @@ const renderMobileItem = (
         role="menuitem"
         tabIndex={0}
         className={cn(
-          "flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-all duration-200 cursor-pointer group",
-          "hover:bg-accent/50 hover:shadow-sm",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-          isActive && "bg-primary text-primary-foreground shadow-md hover:bg-primary/90",
-          isRTL ? "text-right" : "text-left"
+          'flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-all duration-200 cursor-pointer group',
+          'hover:bg-accent/50 hover:shadow-sm',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+          isActive && 'bg-primary text-primary-foreground shadow-md hover:bg-primary/90',
+          isRTL ? 'text-right' : 'text-left',
         )}
         onClick={handleItemAction}
         onKeyDown={handleKeyDown}
       >
         <Icon className="h-5 w-5 shrink-0 transition-transform group-hover:scale-110" />
-        <span className={cn(
-          "flex-1 truncate",
-          isRTL ? "text-right" : "text-left"
-        )}>
-          {t(`navigation.${item.key}`)}
+        <span className={cn('flex-1 truncate', isRTL ? 'text-right' : 'text-left')}>
+          {t(item.labelKey)}
         </span>
-        {item.badge && (
-          <Badge 
-            variant={isActive ? "outline" : "secondary"} 
+        {hasChildren && (
+          <ChevronDown
             className={cn(
-              "text-xs font-semibold px-2 py-0.5",
-              isActive && "border-primary-foreground/20"
+              'h-4 w-4 shrink-0 transition-transform duration-200',
+              isExpanded && 'rotate-180',
+              isRTL && 'rotate-180',
             )}
-          >
-            {item.badge}
-          </Badge>
-        )}
-        {hasSubItems && (
-          <ChevronDown 
-            className={cn(
-              "h-4 w-4 shrink-0 transition-transform duration-200",
-              isExpanded && "rotate-180",
-              isRTL && "rotate-180"
-            )} 
           />
         )}
       </div>
-      
-      {/* Sub-items with animation */}
-      {hasSubItems && (
-        <div
-          className={cn(
-            "overflow-hidden transition-all duration-300 ease-in-out",
-            isExpanded ? "max-h-96 opacity-100" : "max-h-0 opacity-0",
-            isRTL ? "mr-4 pr-3 border-r-2 border-border/30" : "ml-4 pl-3 border-l-2 border-border/30"
-          )}
-        >
-          <div className="space-y-0.5 py-1">
-            {item.subItems?.map((subItem) => {
-              const isSubActive = location.pathname === subItem.href
-              return (
-                <NavLink
-                  key={subItem.key}
-                  to={subItem.href}
-                  className={cn(
-                    "flex items-center gap-2 px-3 py-2 rounded-md text-xs transition-all duration-150",
-                    "text-muted-foreground hover:text-foreground hover:bg-accent/30 hover:translate-x-1",
-                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                    isSubActive && "text-primary font-semibold bg-primary/10 border-l-2 border-primary",
-                    isRTL && "hover:-translate-x-1"
-                  )}
-                  onClick={handleItemClick}
-                >
-                  <ChevronIcon className="h-3 w-3 shrink-0 opacity-60" />
-                  <span className={cn(
-                    "flex-1 truncate",
-                    isRTL ? "text-right" : "text-left"
-                  )}>
-                    {t(subItem.labelKey)}
-                  </span>
-                </NavLink>
-              )
-            })}
-          </div>
-        </div>
-      )}
+      {renderChildren(item, isExpanded, isRTL, t, ChevronIcon, handleItemClick, pathname)}
     </div>
   )
 }
@@ -326,253 +247,59 @@ export function Sidebar() {
   const location = useLocation()
   const { sidebarCollapsed, sidebarOpen, setSidebarOpen } = useUIStore()
   const [expandedItems, setExpandedItems] = useState<string[]>([])
-  
-      // 🔐 استخدام صلاحيات المستخدم
-      const { isOrgAdmin, isSuperAdmin, hasModuleAccess } = usePermissions()
+  const { isOrgAdmin, isSuperAdmin, hasPermissionKey } = usePermissions()
 
   const isRTL = (i18n.resolvedLanguage ?? i18n.language).toLowerCase().startsWith('ar')
   const ChevronIcon = isRTL ? ChevronLeft : ChevronRight
 
+  const navigationItems = getVisibleProductNavigation({
+    isOrgAdmin,
+    isSuperAdmin,
+    hasPermissionKey,
+  })
+
   const toggleExpanded = (key: string) => {
-    setExpandedItems(prev => 
-      prev.includes(key) 
-        ? prev.filter(k => k !== key) 
-        : [...prev, key]
+    setExpandedItems(previous =>
+      previous.includes(key) ? previous.filter(itemKey => itemKey !== key) : [...previous, key],
     )
   }
 
-  // تعريف عناصر التنقل مع الصلاحيات
-  const allNavigationItems = [
-    {
-      key: 'dashboard',
-      icon: LayoutDashboard,
-      href: '/dashboard',
-      badge: null,
-      moduleCode: MODULE_CODES.DASHBOARD, // لا يحتاج صلاحية - متاح للجميع
-      subItems: [
-        { key: 'overview', href: '/dashboard/overview', labelKey: 'navigation.overview' },
-        { key: 'analytics', href: '/dashboard/analytics', labelKey: 'navigation.analytics' },
-        { key: 'performance', href: '/dashboard/performance', labelKey: 'navigation.performance' }
-      ]
-    },
-    {
-      key: 'manufacturing',
-      icon: Factory,
-      href: '/manufacturing',
-      badge: '2',
-      moduleCode: MODULE_CODES.MANUFACTURING,
-      subItems: [
-        { key: 'overview', href: '/manufacturing/overview', labelKey: 'navigation.overview' },
-        { key: 'orders', href: '/manufacturing/orders', labelKey: 'navigation.orders' },
-        { key: 'mes', href: '/manufacturing/mes', labelKey: 'navigation.mes' },
-        // 'routing' intentionally removed: /manufacturing/routing now fails
-        // closed for everyone (route-permissions.ts — no manufacturing.routing.*
-        // catalog resource exists), so a nav entry pointing at it would only
-        // ever land on AccessDeniedPage.
-        { key: 'capacity', href: '/manufacturing/capacity', labelKey: 'navigation.capacity' },
-        { key: 'efficiency', href: '/manufacturing/efficiency', labelKey: 'navigation.efficiency' },
-        { key: 'process-costing', href: '/manufacturing/process-costing', labelKey: 'navigation.process-costing' },
-        { key: 'equivalent-units', href: '/manufacturing/equivalent-units', labelKey: 'navigation.equivalent-units' },
-        { key: 'cost-of-production', href: '/manufacturing/cost-of-production', labelKey: 'navigation.cost-of-production' },
-        { key: 'variance-alerts', href: '/manufacturing/variance-alerts', labelKey: 'navigation.variance-alerts' },
-        { key: 'stages', href: '/manufacturing/stages', labelKey: 'navigation.stages' },
-        { key: 'wip-log', href: '/manufacturing/wip-log', labelKey: 'navigation.wipLog' },
-        { key: 'standard-costs', href: '/manufacturing/standard-costs', labelKey: 'navigation.standardCosts' },
-        { key: 'workcenters', href: '/manufacturing/workcenters', labelKey: 'navigation.workcenters' },
-        { key: 'bom', href: '/manufacturing/bom', labelKey: 'navigation.bom' },
-        { key: 'quality', href: '/manufacturing/quality', labelKey: 'navigation.quality' }
-      ]
-    },
-    {
-      key: 'inventory',
-      icon: Package,
-      href: '/inventory',
-      badge: null,
-      moduleCode: MODULE_CODES.INVENTORY,
-      subItems: [
-        { key: 'overview', href: '/inventory/overview', labelKey: 'navigation.overview' },
-        { key: 'items', href: '/inventory/items', labelKey: 'navigation.items' },
-        { key: 'categories', href: '/inventory/categories', labelKey: 'navigation.categories' },
-        { key: 'movements', href: '/inventory/movements', labelKey: 'navigation.movements' },
-        { key: 'adjustments', href: '/inventory/adjustments', labelKey: 'navigation.adjustments' },
-        { key: 'valuation', href: '/inventory/valuation', labelKey: 'navigation.valuation' },
-        { key: 'warehouses', href: '/inventory/warehouses', labelKey: 'navigation.warehouses' },
-        { key: 'locations', href: '/inventory/locations', labelKey: 'navigation.locations' },
-        { key: 'bins', href: '/inventory/bins', labelKey: 'navigation.bins' },
-        { key: 'transfers', href: '/inventory/transfers', labelKey: 'navigation.transfers' }
-      ]
-    },
-    {
-      key: 'purchasing',
-      icon: ShoppingCart,
-      href: '/purchasing',
-      badge: '3',
-      moduleCode: MODULE_CODES.PURCHASING,
-      subItems: [
-        { key: 'overview', href: '/purchasing/overview', labelKey: 'navigation.overview' },
-        { key: 'suppliers', href: '/purchasing/suppliers', labelKey: 'navigation.suppliers' },
-        { key: 'orders', href: '/purchasing/orders', labelKey: 'navigation.orders' },
-        { key: 'receipts', href: '/purchasing/receipts', labelKey: 'navigation.receipts' },
-        { key: 'invoices', href: '/purchasing/invoices', labelKey: 'navigation.invoices' },
-        { key: 'payments', href: '/purchasing/payments', labelKey: 'navigation.payments' }
-      ]
-    },
-    {
-      key: 'sales',
-      icon: DollarSign,
-      href: '/sales',
-      badge: null,
-      moduleCode: MODULE_CODES.SALES,
-      subItems: [
-        { key: 'overview', href: '/sales/overview', labelKey: 'navigation.overview' },
-        { key: 'customers', href: '/sales/customers', labelKey: 'navigation.customers' },
-        { key: 'orders', href: '/sales/orders', labelKey: 'navigation.orders' },
-        { key: 'invoices', href: '/sales/invoices', labelKey: 'navigation.invoices' },
-        { key: 'delivery', href: '/sales/delivery', labelKey: 'navigation.delivery' },
-        { key: 'collections', href: '/sales/collections', labelKey: 'navigation.collections' }
-      ]
-    },
-    {
-      key: 'accounting',
-      icon: BookOpen,
-      href: '/accounting',
-      badge: null,
-      moduleCode: MODULE_CODES.ACCOUNTING,
-      // The Accounting menu owns both accounting/* and general-ledger/* links.
-      // Either backend module grant makes the group relevant.
-      moduleCodes: [MODULE_CODES.ACCOUNTING, MODULE_CODES.GENERAL_LEDGER],
-      subItems: [
-        { key: 'overview', href: '/accounting/overview', labelKey: 'navigation.overview' },
-        { key: 'chart-of-accounts', href: '/general-ledger/accounts', labelKey: 'navigation.chart-of-accounts' },
-        { key: 'journal-entries', href: '/accounting/journal-entries', labelKey: 'navigation.journal-entries' },
-        { key: 'trial-balance', href: '/accounting/trial-balance', labelKey: 'navigation.trial-balance' },
-        { key: 'account-statement', href: '/accounting/account-statement', labelKey: 'navigation.account-statement' },
-        { key: 'posting', href: '/accounting/posting', labelKey: 'navigation.posting' },
-        { key: 'reconciliation', href: '/accounting/reconciliation', labelKey: 'navigation.reconciliation' }
-      ]
-    },
-    // قائمة «دفتر الأستاذ» المكرّرة حُذفت: عنصراها موجودان في قائمة المحاسبة،
-    // ومسارات /general-ledger/* تبقى عاملة (توافق URLs).
-    {
-      key: 'hr',
-      icon: Users,
-      href: '/hr',
-      badge: null,
-      moduleCode: MODULE_CODES.HR,
-      subItems: [
-        { key: 'overview', href: '/hr/overview', labelKey: 'navigation.hr-dashboard' },
-        { key: 'employees', href: '/hr/employees', labelKey: 'navigation.employees' },
-        { key: 'attendance', href: '/hr/attendance', labelKey: 'navigation.attendance' },
-        { key: 'payroll', href: '/hr/payroll', labelKey: 'navigation.payroll' },
-        { key: 'leaves', href: '/hr/leaves', labelKey: 'navigation.leaves' },
-        { key: 'settlements', href: '/hr/settlements', labelKey: 'navigation.settlements' },
-        { key: 'reports', href: '/hr/reports', labelKey: 'navigation.reports' }
-        // 'settings' (/hr/settings) removed: route-permissions.ts no longer
-        // registers it (fails closed for everyone — see the comment there),
-        // so a sidebar link that only leads to a denied route is dead UI.
-      ]
-    },
-    {
-      key: 'reports',
-      icon: BarChart3,
-      href: '/reports',
-      badge: null,
-      moduleCode: MODULE_CODES.REPORTS,
-      subItems: [
-        { key: 'financial', href: '/reports/financial', labelKey: 'navigation.financial' },
-        { key: 'inventory', href: '/reports/inventory', labelKey: 'navigation.inventory' },
-        { key: 'manufacturing', href: '/reports/manufacturing', labelKey: 'navigation.manufacturing' },
-        { key: 'process-costing-dashboard', href: '/reports/process-costing-dashboard', labelKey: 'navigation.process-costing-dashboard' },
-        { key: 'sales', href: '/reports/sales', labelKey: 'navigation.sales' },
-        { key: 'purchasing', href: '/reports/purchasing', labelKey: 'navigation.purchasing' },
-        { key: 'advanced', href: '/reports/advanced', labelKey: 'navigation.advanced' },
-        { key: 'analytics', href: '/reports/analytics', labelKey: 'navigation.analytics' },
-        { key: 'reports-insights', href: '/reports/insights', labelKey: 'navigation.reports-insights' }
-      ]
-    },
-    {
-      key: 'settings',
-      icon: Settings,
-      href: '/settings',
-      badge: null,
-      moduleCode: MODULE_CODES.SETTINGS,
-      subItems: [
-        { key: 'company', href: '/settings/company', labelKey: 'navigation.company' },
-        // users/permissions حُذفا: مجرد redirect لإدارة المؤسسة المكرَّرة في قائمتها.
-        // integrations مخفيّة حتى تُبنى تكاملات فعلية (قرار المالك).
-        { key: 'system', href: '/settings/system', labelKey: 'navigation.system' },
-        { key: 'backup', href: '/settings/backup', labelKey: 'navigation.backup' }
-      ]
-    },
-    {
-      key: 'org-admin',
-      icon: Building2,
-      href: '/org-admin',
-      badge: null,
-      moduleCode: MODULE_CODES.ORG_ADMIN,
-      requireOrgAdmin: true, // يتطلب صلاحية Org Admin
-      subItems: [
-        { key: 'dashboard', href: '/org-admin/dashboard', labelKey: 'navigation.orgAdminDashboard' },
-        { key: 'users', href: '/org-admin/users', labelKey: 'navigation.users' },
-        { key: 'invitations', href: '/org-admin/invitations', labelKey: 'navigation.invitations' },
-        { key: 'roles', href: '/org-admin/roles', labelKey: 'navigation.roles' },
-        { key: 'audit-log', href: '/org-admin/audit-log', labelKey: 'navigation.audit-log' }
-      ]
-    },
-    {
-      key: 'super-admin',
-      icon: Shield,
-      href: '/super-admin',
-      badge: null,
-      moduleCode: MODULE_CODES.SUPER_ADMIN,
-      requireSuperAdmin: true, // يتطلب صلاحية Super Admin
-      subItems: [
-        { key: 'dashboard', href: '/super-admin/dashboard', labelKey: 'navigation.orgAdminDashboard' },
-        { key: 'organizations', href: '/super-admin/organizations', labelKey: 'navigation.organizations' }
-      ]
-    },
-  ]
-
-  // 🔐 فلترة العناصر بناءً على الصلاحيات
-  const navigationItems = allNavigationItems.filter(item =>
-    shouldShowNavigationItem(item, isOrgAdmin, isSuperAdmin, hasModuleAccess)
-  )
-
   const handleItemClick = () => {
-    // Close mobile sidebar when item is clicked
-    if (globalThis.window.innerWidth < 1024) {
-      setSidebarOpen(false)
-    }
+    if (globalThis.window.innerWidth < 1024) setSidebarOpen(false)
   }
 
   return (
     <>
-      {/* Desktop Sidebar */}
       <aside
         className={cn(
-          "fixed top-16 z-40 h-[calc(100vh-4rem)] bg-card/95 backdrop-blur-sm border border-border/50 transition-all duration-300 shadow-lg",
-          sidebarCollapsed ? "w-16" : "w-64",
-          "hidden lg:block",
-          // RTL positioning
-          isRTL ? "right-0" : "left-0",
-          // RTL border
-          isRTL ? "border-l border-r-0" : "border-r border-l-0"
+          'fixed top-16 z-40 h-[calc(100vh-4rem)] bg-card/95 backdrop-blur-sm border border-border/50 transition-all duration-300 shadow-lg',
+          sidebarCollapsed ? 'w-16' : 'w-64',
+          'hidden lg:block',
+          isRTL ? 'right-0' : 'left-0',
+          isRTL ? 'border-l border-r-0' : 'border-r border-l-0',
         )}
       >
         <ScrollArea className="h-full">
           <TooltipProvider delayDuration={300}>
-            <nav className={cn("flex flex-col gap-1 p-3", getGlassClasses())}>
-              {navigationItems.map((item) => {
-                const isActive = location.pathname.startsWith(item.href)
+            <nav className={cn('flex flex-col gap-1 p-3', getGlassClasses())}>
+              {navigationItems.map(item => {
+                const isActive = isItemActive(item, location.pathname)
                 const isExpanded = expandedItems.includes(item.key)
-                const hasSubItems = item.subItems && item.subItems.length > 0
-                
                 return (
                   <div key={item.key} className="space-y-1">
-                    {sidebarCollapsed 
+                    {sidebarCollapsed
                       ? renderCollapsedItem(item, isActive, isRTL, t, handleItemClick)
-                      : renderExpandedItem(item, isActive, isExpanded, hasSubItems, isRTL, t, ChevronIcon, toggleExpanded, handleItemClick, location)
-                    }
+                      : renderExpandedItem(
+                          item,
+                          isActive,
+                          isExpanded,
+                          isRTL,
+                          t,
+                          ChevronIcon,
+                          toggleExpanded,
+                          handleItemClick,
+                          location.pathname,
+                        )}
                   </div>
                 )
               })}
@@ -581,7 +308,6 @@ export function Sidebar() {
         </ScrollArea>
       </aside>
 
-      {/* Mobile Sidebar */}
       {sidebarOpen && (
         <>
           <button
@@ -590,28 +316,33 @@ export function Sidebar() {
             className="fixed inset-0 z-40 bg-black/50 backdrop-blur-sm lg:hidden transition-opacity duration-300 border-0 p-0 cursor-pointer"
             onClick={() => setSidebarOpen(false)}
           />
-          <aside // NOSONAR S6855 - Event listeners needed for mobile sidebar interaction (stopPropagation and Escape key)
+          <aside
             className={cn(
-              "fixed top-16 h-[calc(100vh-4rem)] bg-card/95 backdrop-blur-md border border-border/50 shadow-2xl z-50",
-              "transition-transform duration-300 ease-in-out w-64",
-              // RTL positioning
-              isRTL ? "right-0" : "left-0"
+              'fixed top-16 h-[calc(100vh-4rem)] bg-card/95 backdrop-blur-md border border-border/50 shadow-2xl z-50',
+              'transition-transform duration-300 ease-in-out w-64',
+              isRTL ? 'right-0' : 'left-0',
             )}
-            onClick={(e) => e.stopPropagation()}
-            onKeyDown={(e) => {
-              if (e.key === 'Escape') {
-                setSidebarOpen(false);
-              }
+            onClick={event => event.stopPropagation()}
+            onKeyDown={event => {
+              if (event.key === 'Escape') setSidebarOpen(false)
             }}
           >
             <ScrollArea className="h-full">
-              <nav className={cn("flex flex-col gap-1 p-3", getGlassClasses())}>
-                {navigationItems.map((item) => {
-                  const isActive = location.pathname.startsWith(item.href)
+              <nav className={cn('flex flex-col gap-1 p-3', getGlassClasses())}>
+                {navigationItems.map(item => {
+                  const isActive = isItemActive(item, location.pathname)
                   const isExpanded = expandedItems.includes(item.key)
-                  const hasSubItems = item.subItems && item.subItems.length > 0
-                  
-                  return renderMobileItem(item, isActive, isExpanded, hasSubItems, isRTL, t, ChevronIcon, toggleExpanded, handleItemClick, location)
+                  return renderMobileItem(
+                    item,
+                    isActive,
+                    isExpanded,
+                    isRTL,
+                    t,
+                    ChevronIcon,
+                    toggleExpanded,
+                    handleItemClick,
+                    location.pathname,
+                  )
                 })}
               </nav>
             </ScrollArea>

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -65,7 +65,7 @@ function renderCollapsedItem(
     <Tooltip>
       <TooltipTrigger asChild>
         <NavLink
-          to={item.href}
+          to={item.landingHref ?? item.href}
           className={cn(
             'flex items-center justify-center p-3 rounded-lg text-sm font-medium transition-all duration-200',
             'hover:bg-accent/50 hover:scale-105',
@@ -144,39 +144,45 @@ function renderExpandedItem(
 ) {
   const Icon = getItemIcon(item)
   const hasChildren = Boolean(item.children?.length)
+  const landingHref = item.landingHref ?? item.href
 
-  const handleItemAction = () => {
-    if (hasChildren) toggleExpanded(item.key)
-    else handleItemClick()
-  }
+  const itemClassName = cn(
+    'w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-all duration-200 group border-0',
+    'hover:bg-accent/50 hover:shadow-sm',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+    isActive && 'bg-primary text-primary-foreground shadow-md hover:bg-primary/90',
+    isRTL ? 'text-right' : 'text-left',
+  )
+
+  const itemContent = (
+    <>
+      <Icon className="h-5 w-5 shrink-0 transition-transform group-hover:scale-110" />
+      <span className={cn('flex-1 truncate', isRTL ? 'text-right' : 'text-left')}>
+        {t(item.labelKey)}
+      </span>
+      {hasChildren && (
+        <ChevronDown
+          className={cn(
+            'h-4 w-4 shrink-0 transition-transform duration-200',
+            isExpanded && 'rotate-180',
+            isRTL && 'rotate-180',
+          )}
+        />
+      )}
+    </>
+  )
 
   return (
     <>
-      <button
-        type="button"
-        className={cn(
-          'w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-all duration-200 group border-0',
-          'hover:bg-accent/50 hover:shadow-sm',
-          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-          isActive && 'bg-primary text-primary-foreground shadow-md hover:bg-primary/90',
-          isRTL ? 'text-right' : 'text-left',
-        )}
-        onClick={handleItemAction}
-      >
-        <Icon className="h-5 w-5 shrink-0 transition-transform group-hover:scale-110" />
-        <span className={cn('flex-1 truncate', isRTL ? 'text-right' : 'text-left')}>
-          {t(item.labelKey)}
-        </span>
-        {hasChildren && (
-          <ChevronDown
-            className={cn(
-              'h-4 w-4 shrink-0 transition-transform duration-200',
-              isExpanded && 'rotate-180',
-              isRTL && 'rotate-180',
-            )}
-          />
-        )}
-      </button>
+      {hasChildren ? (
+        <button type="button" className={itemClassName} onClick={() => toggleExpanded(item.key)}>
+          {itemContent}
+        </button>
+      ) : (
+        <NavLink to={landingHref} className={itemClassName} onClick={handleItemClick}>
+          {itemContent}
+        </NavLink>
+      )}
       {renderChildren(item, isExpanded, isRTL, t, ChevronIcon, handleItemClick, pathname)}
     </>
   )
@@ -195,48 +201,58 @@ function renderMobileItem(
 ) {
   const Icon = getItemIcon(item)
   const hasChildren = Boolean(item.children?.length)
-
-  const handleItemAction = () => {
-    if (hasChildren) toggleExpanded(item.key)
-    else handleItemClick()
-  }
+  const landingHref = item.landingHref ?? item.href
 
   const handleKeyDown = (event: KeyboardEvent) => {
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault()
-      handleItemAction()
+      toggleExpanded(item.key)
     }
   }
 
+  const itemClassName = cn(
+    'flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-all duration-200 group',
+    'hover:bg-accent/50 hover:shadow-sm',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+    isActive && 'bg-primary text-primary-foreground shadow-md hover:bg-primary/90',
+    isRTL ? 'text-right' : 'text-left',
+  )
+
+  const itemContent = (
+    <>
+      <Icon className="h-5 w-5 shrink-0 transition-transform group-hover:scale-110" />
+      <span className={cn('flex-1 truncate', isRTL ? 'text-right' : 'text-left')}>
+        {t(item.labelKey)}
+      </span>
+      {hasChildren && (
+        <ChevronDown
+          className={cn(
+            'h-4 w-4 shrink-0 transition-transform duration-200',
+            isExpanded && 'rotate-180',
+            isRTL && 'rotate-180',
+          )}
+        />
+      )}
+    </>
+  )
+
   return (
     <div key={item.key} className="space-y-1">
-      <div
-        role="menuitem"
-        tabIndex={0}
-        className={cn(
-          'flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-all duration-200 cursor-pointer group',
-          'hover:bg-accent/50 hover:shadow-sm',
-          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-          isActive && 'bg-primary text-primary-foreground shadow-md hover:bg-primary/90',
-          isRTL ? 'text-right' : 'text-left',
-        )}
-        onClick={handleItemAction}
-        onKeyDown={handleKeyDown}
-      >
-        <Icon className="h-5 w-5 shrink-0 transition-transform group-hover:scale-110" />
-        <span className={cn('flex-1 truncate', isRTL ? 'text-right' : 'text-left')}>
-          {t(item.labelKey)}
-        </span>
-        {hasChildren && (
-          <ChevronDown
-            className={cn(
-              'h-4 w-4 shrink-0 transition-transform duration-200',
-              isExpanded && 'rotate-180',
-              isRTL && 'rotate-180',
-            )}
-          />
-        )}
-      </div>
+      {hasChildren ? (
+        <div
+          role="menuitem"
+          tabIndex={0}
+          className={cn(itemClassName, 'cursor-pointer')}
+          onClick={() => toggleExpanded(item.key)}
+          onKeyDown={handleKeyDown}
+        >
+          {itemContent}
+        </div>
+      ) : (
+        <NavLink to={landingHref} role="menuitem" className={itemClassName} onClick={handleItemClick}>
+          {itemContent}
+        </NavLink>
+      )}
       {renderChildren(item, isExpanded, isRTL, t, ChevronIcon, handleItemClick, pathname)}
     </div>
   )

--- a/src/config/__tests__/product-catalog.test.ts
+++ b/src/config/__tests__/product-catalog.test.ts
@@ -120,4 +120,65 @@ describe('product catalog navigation', () => {
       for (const child of item.children ?? []) expect(child).not.toHaveProperty('badge');
     }
   });
+
+  describe('landingHref', () => {
+    it('lands on the first visible child when the caller cannot enter the group root itself', () => {
+      // general_ledger.chart_of_accounts.view satisfies /general-ledger/accounts
+      // and (via be6706c) makes the Accounting group visible, but it does NOT
+      // satisfy ACCOUNTING_OVERVIEW, the actual /accounting root contract —
+      // so a collapsed-sidebar click must not send this caller to /accounting.
+      const visible = getVisibleProductNavigation(context(['general_ledger.chart_of_accounts.view']));
+      const accounting = moduleByKey(visible, 'accounting');
+
+      expect(accounting?.children?.map(c => c.href)).toEqual(['/general-ledger/accounts']);
+      expect(accounting?.landingHref).toBe('/general-ledger/accounts');
+      expect(accounting?.landingHref).not.toBe(accounting?.href);
+    });
+
+    it('lands on the group root when the caller genuinely satisfies its own contract', () => {
+      const visible = getVisibleProductNavigation(context(['accounting.journals.read']));
+      const accounting = moduleByKey(visible, 'accounting');
+
+      expect(accounting?.landingHref).toBe('/accounting');
+      expect(accounting?.landingHref).toBe(accounting?.href);
+    });
+
+    it('lands on /settings directly for a caller with only settings.users.read, even though every visible child requires settings.organization.read', () => {
+      // SETTINGS_OVERVIEW (route-permissions.ts) accepts settings.users.read on
+      // its own, so the /settings root itself is reachable — even though none
+      // of company/system/backup (all gated on settings.organization.read) are
+      // visible. Before landingHref this rendered a childless parent whose
+      // click did nothing.
+      const visible = getVisibleProductNavigation(context(['settings.users.read']));
+      const settings = moduleByKey(visible, 'settings');
+
+      expect(settings).toBeDefined();
+      expect(settings?.children).toEqual([]);
+      expect(settings?.landingHref).toBe('/settings');
+    });
+
+    it('every visible group either satisfies its own root or has a visible child to land on', () => {
+      const scenarios: ProductCatalogAccessContext[] = [
+        context([]),
+        context(['general_ledger.chart_of_accounts.view']),
+        context(['settings.users.read']),
+        context(['settings.roles.read']),
+        context(['reports.inventory.read']),
+        context(['manufacturing.work_centers.read', 'manufacturing.stage_costs.read', 'manufacturing.orders.read']),
+        context([], { isOrgAdmin: true }),
+        context([], { isSuperAdmin: true }),
+      ];
+
+      for (const scenario of scenarios) {
+        for (const item of getVisibleProductNavigation(scenario)) {
+          const landsOnRoot = item.landingHref === item.href;
+          const hasVisibleChild = (item.children?.length ?? 0) > 0;
+          expect(
+            landsOnRoot || hasVisibleChild,
+            `${item.key} landingHref=${item.landingHref} has no visible children to fall back to`,
+          ).toBe(true);
+        }
+      }
+    });
+  });
 });

--- a/src/config/__tests__/product-catalog.test.ts
+++ b/src/config/__tests__/product-catalog.test.ts
@@ -88,7 +88,10 @@ describe('product catalog navigation', () => {
     const visible = getVisibleProductNavigation(context(['reports.inventory.read']));
 
     expect(moduleByKey(visible, 'reports')).toBeDefined();
-    expect(childKeys(visible, 'reports')).toEqual(['inventory']);
+    // /reports/advanced accepts any of financial/inventory/manufacturing/sales
+    // (REPORTS_ADVANCED in route-permissions.ts), so reports.inventory.read
+    // alone satisfies both the /inventory and /advanced route contracts.
+    expect(childKeys(visible, 'reports')).toEqual(['inventory', 'advanced']);
   });
 
   it('keeps admin surfaces behind their explicit admin flags', () => {

--- a/src/config/__tests__/product-catalog.test.ts
+++ b/src/config/__tests__/product-catalog.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   PRODUCT_CATALOG,
   getVisibleProductNavigation,
+  moduleItem,
   type ProductCatalogAccessContext,
 } from '../product-catalog';
 
@@ -155,6 +156,30 @@ describe('product catalog navigation', () => {
       expect(settings).toBeDefined();
       expect(settings?.children).toEqual([]);
       expect(settings?.landingHref).toBe('/settings');
+    });
+
+    it('does not surface a parent whose only requirement comes from a hidden child (moduleItem childRequirements regression guard)', () => {
+      // 'synthetic' has no registered route contract (resolveRoutePermission
+      // returns undefined for it), so moduleItem's rootRequirements is empty —
+      // any visibility has to come from a renderable child's requirements.
+      const hiddenChild = {
+        key: 'hidden-child',
+        labelKey: 'navigation.overview',
+        href: '/synthetic/hidden',
+        moduleCode: 'synthetic',
+        requirements: [{ key: 'synthetic.hidden.read' }],
+        status: 'hidden' as const,
+      };
+      const synthetic = moduleItem('synthetic', 'synthetic-parent', '/synthetic', 'Settings', [hiddenChild]);
+
+      // A hidden child's requirement must not leak into the parent's own
+      // requirements — that's exactly what would let a permission attached
+      // to a not-yet-shipped feature silently surface an otherwise-empty
+      // parent for a caller who can see nothing underneath it.
+      expect(synthetic.requirements).toEqual([]);
+
+      const visible = getVisibleProductNavigation(context(['synthetic.hidden.read']), [synthetic]);
+      expect(visible).toEqual([]);
     });
 
     it('every visible group either satisfies its own root or has a visible child to land on', () => {

--- a/src/config/__tests__/product-catalog.test.ts
+++ b/src/config/__tests__/product-catalog.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PRODUCT_CATALOG,
+  getVisibleProductNavigation,
+  type ProductCatalogAccessContext,
+} from '../product-catalog';
+
+function context(
+  permissionKeys: readonly string[] = [],
+  overrides: Partial<Pick<ProductCatalogAccessContext, 'isOrgAdmin' | 'isSuperAdmin'>> = {},
+): ProductCatalogAccessContext {
+  const keys = new Set(permissionKeys);
+  return {
+    isOrgAdmin: false,
+    isSuperAdmin: false,
+    hasPermissionKey: key => keys.has(key),
+    ...overrides,
+  };
+}
+
+function moduleByKey(navigation: ReturnType<typeof getVisibleProductNavigation>, key: string) {
+  return navigation.find(item => item.key === key);
+}
+
+function childKeys(navigation: ReturnType<typeof getVisibleProductNavigation>, moduleKey: string): string[] {
+  return moduleByKey(navigation, moduleKey)?.children?.map(item => item.key) ?? [];
+}
+
+describe('product catalog navigation', () => {
+  it('keeps planned, hidden, and compatibility-only entries out of navigation', () => {
+    const allKeys = [
+      'inventory.items.read',
+      'inventory.stock_moves.read',
+      'inventory.warehouses.read',
+      'inventory.adjustments.read',
+      'manufacturing.orders.read',
+      'manufacturing.boms.read',
+      'manufacturing.stages.read',
+      'manufacturing.work_centers.read',
+      'manufacturing.stage_costs.read',
+      'reports.financial.read',
+      'reports.inventory.read',
+      'reports.manufacturing.read',
+      'reports.sales.read',
+      'reports.ai_insights.use',
+    ];
+    const visible = getVisibleProductNavigation(context(allKeys));
+
+    expect(childKeys(visible, 'inventory')).not.toContain('categories');
+    expect(childKeys(visible, 'inventory')).not.toContain('bins');
+    expect(childKeys(visible, 'manufacturing')).not.toContain('routing');
+    expect(childKeys(visible, 'manufacturing')).not.toContain('quality');
+    expect(childKeys(visible, 'reports')).not.toContain('gemini-compat');
+  });
+
+  it('uses exact child requirements instead of module-prefix access', () => {
+    const visible = getVisibleProductNavigation(context(['inventory.adjustments.read']));
+
+    expect(moduleByKey(visible, 'inventory')).toBeDefined();
+    expect(childKeys(visible, 'inventory')).toEqual(['overview', 'adjustments']);
+  });
+
+  it('preserves allOf semantics for manufacturing efficiency', () => {
+    const withoutOrders = getVisibleProductNavigation(
+      context(['manufacturing.work_centers.read', 'manufacturing.stage_costs.read']),
+    );
+    expect(childKeys(withoutOrders, 'manufacturing')).not.toContain('efficiency');
+
+    const complete = getVisibleProductNavigation(
+      context([
+        'manufacturing.work_centers.read',
+        'manufacturing.stage_costs.read',
+        'manufacturing.orders.read',
+      ]),
+    );
+    expect(childKeys(complete, 'manufacturing')).toContain('efficiency');
+  });
+
+  it('keeps Accounting as one visible group for General Ledger-only access', () => {
+    const visible = getVisibleProductNavigation(context(['general_ledger.chart_of_accounts.view']));
+
+    expect(visible.filter(item => item.key === 'accounting')).toHaveLength(1);
+    expect(childKeys(visible, 'accounting')).toEqual(['chart-of-accounts']);
+    expect(visible.some(item => item.key === 'general-ledger')).toBe(false);
+  });
+
+  it('shows Reports from its root contract even though there is no /reports/overview route', () => {
+    const visible = getVisibleProductNavigation(context(['reports.inventory.read']));
+
+    expect(moduleByKey(visible, 'reports')).toBeDefined();
+    expect(childKeys(visible, 'reports')).toEqual(['inventory']);
+  });
+
+  it('keeps admin surfaces behind their explicit admin flags', () => {
+    const ordinary = getVisibleProductNavigation(context());
+    expect(moduleByKey(ordinary, 'org-admin')).toBeUndefined();
+    expect(moduleByKey(ordinary, 'super-admin')).toBeUndefined();
+
+    const orgAdmin = getVisibleProductNavigation(context([], { isOrgAdmin: true }));
+    expect(moduleByKey(orgAdmin, 'org-admin')).toBeDefined();
+    expect(moduleByKey(orgAdmin, 'super-admin')).toBeUndefined();
+
+    const superAdmin = getVisibleProductNavigation(context([], { isSuperAdmin: true }));
+    expect(moduleByKey(superAdmin, 'org-admin')).toBeDefined();
+    expect(moduleByKey(superAdmin, 'super-admin')).toBeDefined();
+  });
+
+  it('keeps Dashboard visible without inventing a permission key', () => {
+    const visible = getVisibleProductNavigation(context());
+    expect(moduleByKey(visible, 'dashboard')).toBeDefined();
+    expect(childKeys(visible, 'dashboard')).toEqual(['overview', 'analytics', 'performance']);
+  });
+
+  it('contains no decorative badge field in the catalog contract', () => {
+    for (const item of PRODUCT_CATALOG) {
+      expect(item).not.toHaveProperty('badge');
+      for (const child of item.children ?? []) expect(child).not.toHaveProperty('badge');
+    }
+  });
+});

--- a/src/config/product-catalog.ts
+++ b/src/config/product-catalog.ts
@@ -83,7 +83,8 @@ function child(
   };
 }
 
-function moduleItem(
+/** Exported for the moduleItem-aggregation regression test in product-catalog.test.ts. */
+export function moduleItem(
   moduleCode: string,
   key: string,
   href: string,

--- a/src/config/product-catalog.ts
+++ b/src/config/product-catalog.ts
@@ -29,8 +29,7 @@ export interface ProductCatalogItem {
   readonly moduleCode: string;
   /**
    * Exact route-entry requirements derived from route-permissions.ts.
-   * Multiple requirements are OR-ed only for intentional cross-module groups
-   * such as the unified Accounting + General Ledger navigation group.
+   * Multiple requirements are OR-ed only for intentional navigation groups.
    */
   readonly requirements?: readonly RouteRequirement[];
   readonly status: ProductReadiness;
@@ -81,16 +80,21 @@ function moduleItem(
   children: readonly ProductCatalogItem[],
   status: ProductReadiness = 'ga',
 ): ProductCatalogItem {
+  const rootRequirements = routeRequirement(moduleCode, href, href) ?? [];
+  const childRequirements = children.flatMap(item => item.requirements ?? []);
+
   return {
     key,
     labelKey: `navigation.${key}`,
     href,
     icon,
     moduleCode,
-    // Every guarded product module defines its root `/` contract. Deriving
-    // parent navigation from the root avoids inventing `/overview` where one
-    // does not exist (Reports is the important current example).
-    requirements: routeRequirement(moduleCode, href, href),
+    // A navigation group is relevant when the caller may enter its root OR at
+    // least one visible child. This is intentionally broader than the root
+    // overview contract, but every requirement still comes from the exact
+    // fail-closed route contract. Collapsed Sidebar navigation opens the first
+    // permitted child so it never relies on a root permission the caller lacks.
+    requirements: [...rootRequirements, ...childRequirements],
     status,
     children,
   };
@@ -234,8 +238,9 @@ const superAdminChildren: readonly ProductCatalogItem[] = [
   { key: 'organizations', labelKey: 'navigation.organizations', href: '/super-admin/organizations', moduleCode: MODULE_CODES.SUPER_ADMIN, status: 'ga', requireSuperAdmin: true },
 ];
 
-const accountingOverview = resolveRoutePermission(MODULE_CODES.ACCOUNTING, '/');
-const generalLedgerOverview = resolveRoutePermission(MODULE_CODES.GENERAL_LEDGER, '/');
+const accountingRootRequirements = resolveRoutePermission(MODULE_CODES.ACCOUNTING, '/') ? [resolveRoutePermission(MODULE_CODES.ACCOUNTING, '/') as RouteRequirement] : [];
+const generalLedgerRootRequirements = resolveRoutePermission(MODULE_CODES.GENERAL_LEDGER, '/') ? [resolveRoutePermission(MODULE_CODES.GENERAL_LEDGER, '/') as RouteRequirement] : [];
+const accountingChildRequirements = accountingChildren.flatMap(item => item.requirements ?? []);
 
 export const PRODUCT_CATALOG: readonly ProductCatalogItem[] = [
   {
@@ -257,7 +262,7 @@ export const PRODUCT_CATALOG: readonly ProductCatalogItem[] = [
     href: '/accounting',
     icon: 'BookOpen',
     moduleCode: MODULE_CODES.ACCOUNTING,
-    requirements: [accountingOverview, generalLedgerOverview].filter((r): r is RouteRequirement => r !== undefined),
+    requirements: [...accountingRootRequirements, ...generalLedgerRootRequirements, ...accountingChildRequirements],
     status: 'beta',
     children: accountingChildren,
   },

--- a/src/config/product-catalog.ts
+++ b/src/config/product-catalog.ts
@@ -1,0 +1,315 @@
+import { MODULE_CODES } from './module-permissions';
+import {
+  resolveRoutePermission,
+  satisfiesRouteRequirement,
+  type RouteRequirement,
+} from './route-permissions';
+
+export type ProductReadiness = 'ga' | 'beta' | 'planned' | 'hidden';
+
+export type ProductIconKey =
+  | 'LayoutDashboard'
+  | 'Factory'
+  | 'Package'
+  | 'ShoppingCart'
+  | 'DollarSign'
+  | 'BookOpen'
+  | 'Users'
+  | 'BarChart3'
+  | 'Settings'
+  | 'Building2'
+  | 'Shield';
+
+export interface ProductCatalogItem {
+  readonly key: string;
+  readonly labelKey: string;
+  readonly href: string;
+  readonly icon?: ProductIconKey;
+  /** Primary product module. This is IA metadata, not a grant. */
+  readonly moduleCode: string;
+  /**
+   * Exact route-entry requirements derived from route-permissions.ts.
+   * Multiple requirements are OR-ed only for intentional cross-module groups
+   * such as the unified Accounting + General Ledger navigation group.
+   */
+  readonly requirements?: readonly RouteRequirement[];
+  readonly status: ProductReadiness;
+  readonly requireOrgAdmin?: boolean;
+  readonly requireSuperAdmin?: boolean;
+  readonly compatibilityOnly?: boolean;
+  readonly blockedByIssue?: number;
+  readonly children?: readonly ProductCatalogItem[];
+}
+
+export interface ProductCatalogAccessContext {
+  readonly isOrgAdmin: boolean;
+  readonly isSuperAdmin: boolean;
+  readonly hasPermissionKey: (permissionKey: string) => boolean;
+}
+
+function routeRequirement(moduleCode: string, moduleRoot: string, href: string): readonly RouteRequirement[] | undefined {
+  const subPath = href === moduleRoot ? '/' : href.slice(moduleRoot.length) || '/';
+  const requirement = resolveRoutePermission(moduleCode, subPath);
+  return requirement ? [requirement] : undefined;
+}
+
+function child(
+  moduleCode: string,
+  moduleRoot: string,
+  key: string,
+  href: string,
+  labelKey: string,
+  status: ProductReadiness = 'ga',
+  extra: Pick<ProductCatalogItem, 'blockedByIssue' | 'compatibilityOnly'> = {},
+): ProductCatalogItem {
+  return {
+    key,
+    labelKey,
+    href,
+    moduleCode,
+    requirements: routeRequirement(moduleCode, moduleRoot, href),
+    status,
+    ...extra,
+  };
+}
+
+function moduleItem(
+  moduleCode: string,
+  key: string,
+  href: string,
+  icon: ProductIconKey,
+  children: readonly ProductCatalogItem[],
+  status: ProductReadiness = 'ga',
+): ProductCatalogItem {
+  return {
+    key,
+    labelKey: `navigation.${key}`,
+    href,
+    icon,
+    moduleCode,
+    requirements: routeRequirement(moduleCode, href, `${href}/overview`),
+    status,
+    children,
+  };
+}
+
+const dashboardChildren = [
+  child(MODULE_CODES.DASHBOARD, '/dashboard', 'overview', '/dashboard/overview', 'navigation.overview'),
+  child(MODULE_CODES.DASHBOARD, '/dashboard', 'analytics', '/dashboard/analytics', 'navigation.analytics'),
+  child(MODULE_CODES.DASHBOARD, '/dashboard', 'performance', '/dashboard/performance', 'navigation.performance'),
+] as const;
+
+const manufacturingChildren = [
+  child(MODULE_CODES.MANUFACTURING, '/manufacturing', 'overview', '/manufacturing/overview', 'navigation.overview'),
+  child(MODULE_CODES.MANUFACTURING, '/manufacturing', 'orders', '/manufacturing/orders', 'navigation.orders'),
+  child(MODULE_CODES.MANUFACTURING, '/manufacturing', 'mes', '/manufacturing/mes', 'navigation.mes', 'beta'),
+  // No manufacturing.routing.* catalog contract exists yet. Keep the product
+  // concept in the catalog, but fail closed in navigation until #152 closes.
+  child(
+    MODULE_CODES.MANUFACTURING,
+    '/manufacturing',
+    'routing',
+    '/manufacturing/routing',
+    'navigation.routing',
+    'hidden',
+    { blockedByIssue: 152 },
+  ),
+  child(MODULE_CODES.MANUFACTURING, '/manufacturing', 'capacity', '/manufacturing/capacity', 'navigation.capacity', 'beta'),
+  child(MODULE_CODES.MANUFACTURING, '/manufacturing', 'efficiency', '/manufacturing/efficiency', 'navigation.efficiency', 'beta'),
+  child(MODULE_CODES.MANUFACTURING, '/manufacturing', 'process-costing', '/manufacturing/process-costing', 'navigation.process-costing', 'beta'),
+  child(MODULE_CODES.MANUFACTURING, '/manufacturing', 'equivalent-units', '/manufacturing/equivalent-units', 'navigation.equivalent-units', 'beta'),
+  child(MODULE_CODES.MANUFACTURING, '/manufacturing', 'cost-of-production', '/manufacturing/cost-of-production', 'navigation.cost-of-production', 'beta'),
+  child(MODULE_CODES.MANUFACTURING, '/manufacturing', 'variance-alerts', '/manufacturing/variance-alerts', 'navigation.variance-alerts', 'beta'),
+  child(MODULE_CODES.MANUFACTURING, '/manufacturing', 'stages', '/manufacturing/stages', 'navigation.stages'),
+  child(MODULE_CODES.MANUFACTURING, '/manufacturing', 'wip-log', '/manufacturing/wip-log', 'navigation.wipLog', 'beta'),
+  child(MODULE_CODES.MANUFACTURING, '/manufacturing', 'standard-costs', '/manufacturing/standard-costs', 'navigation.standardCosts', 'beta'),
+  child(MODULE_CODES.MANUFACTURING, '/manufacturing', 'workcenters', '/manufacturing/workcenters', 'navigation.workcenters'),
+  child(MODULE_CODES.MANUFACTURING, '/manufacturing', 'bom', '/manufacturing/bom', 'navigation.bom'),
+  // Current mounted component is an inert Coming Soon screen.
+  child(MODULE_CODES.MANUFACTURING, '/manufacturing', 'quality', '/manufacturing/quality', 'navigation.quality', 'planned'),
+] as const;
+
+const inventoryChildren = [
+  child(MODULE_CODES.INVENTORY, '/inventory', 'overview', '/inventory/overview', 'navigation.overview'),
+  child(MODULE_CODES.INVENTORY, '/inventory', 'items', '/inventory/items', 'navigation.items'),
+  // Deliberately has no route requirement: no inventory.categories.* resource
+  // exists. The old Sidebar exposed a link that could only fail closed.
+  child(MODULE_CODES.INVENTORY, '/inventory', 'categories', '/inventory/categories', 'navigation.categories', 'hidden'),
+  child(MODULE_CODES.INVENTORY, '/inventory', 'movements', '/inventory/movements', 'navigation.movements'),
+  child(MODULE_CODES.INVENTORY, '/inventory', 'adjustments', '/inventory/adjustments', 'navigation.adjustments'),
+  child(MODULE_CODES.INVENTORY, '/inventory', 'valuation', '/inventory/valuation', 'navigation.valuation'),
+  child(MODULE_CODES.INVENTORY, '/inventory', 'warehouses', '/inventory/warehouses', 'navigation.warehouses'),
+  child(MODULE_CODES.INVENTORY, '/inventory', 'locations', '/inventory/locations', 'navigation.locations'),
+  // The route is permission-gated but currently mounts a static placeholder.
+  child(MODULE_CODES.INVENTORY, '/inventory', 'bins', '/inventory/bins', 'navigation.bins', 'planned'),
+  child(MODULE_CODES.INVENTORY, '/inventory', 'transfers', '/inventory/transfers', 'navigation.transfers'),
+] as const;
+
+const purchasingChildren = [
+  child(MODULE_CODES.PURCHASING, '/purchasing', 'overview', '/purchasing/overview', 'navigation.overview'),
+  child(MODULE_CODES.PURCHASING, '/purchasing', 'suppliers', '/purchasing/suppliers', 'navigation.suppliers'),
+  child(MODULE_CODES.PURCHASING, '/purchasing', 'orders', '/purchasing/orders', 'navigation.orders'),
+  child(MODULE_CODES.PURCHASING, '/purchasing', 'receipts', '/purchasing/receipts', 'navigation.receipts'),
+  child(MODULE_CODES.PURCHASING, '/purchasing', 'invoices', '/purchasing/invoices', 'navigation.invoices'),
+  child(MODULE_CODES.PURCHASING, '/purchasing', 'payments', '/purchasing/payments', 'navigation.payments'),
+] as const;
+
+const salesChildren = [
+  child(MODULE_CODES.SALES, '/sales', 'overview', '/sales/overview', 'navigation.overview', 'beta'),
+  child(MODULE_CODES.SALES, '/sales', 'customers', '/sales/customers', 'navigation.customers', 'beta'),
+  child(MODULE_CODES.SALES, '/sales', 'orders', '/sales/orders', 'navigation.orders', 'beta'),
+  child(MODULE_CODES.SALES, '/sales', 'invoices', '/sales/invoices', 'navigation.invoices', 'beta'),
+  child(MODULE_CODES.SALES, '/sales', 'delivery', '/sales/delivery', 'navigation.delivery', 'beta'),
+  child(MODULE_CODES.SALES, '/sales', 'collections', '/sales/collections', 'navigation.collections', 'beta'),
+] as const;
+
+const accountingChildren = [
+  child(MODULE_CODES.ACCOUNTING, '/accounting', 'overview', '/accounting/overview', 'navigation.overview'),
+  child(
+    MODULE_CODES.GENERAL_LEDGER,
+    '/general-ledger',
+    'chart-of-accounts',
+    '/general-ledger/accounts',
+    'navigation.chart-of-accounts',
+  ),
+  child(MODULE_CODES.ACCOUNTING, '/accounting', 'journal-entries', '/accounting/journal-entries', 'navigation.journal-entries'),
+  child(MODULE_CODES.ACCOUNTING, '/accounting', 'trial-balance', '/accounting/trial-balance', 'navigation.trial-balance', 'beta'),
+  child(MODULE_CODES.ACCOUNTING, '/accounting', 'account-statement', '/accounting/account-statement', 'navigation.account-statement', 'beta'),
+  child(MODULE_CODES.ACCOUNTING, '/accounting', 'posting', '/accounting/posting', 'navigation.posting'),
+  child(MODULE_CODES.ACCOUNTING, '/accounting', 'reconciliation', '/accounting/reconciliation', 'navigation.reconciliation', 'beta'),
+] as const;
+
+const hrChildren = [
+  child(MODULE_CODES.HR, '/hr', 'overview', '/hr/overview', 'navigation.hr-dashboard'),
+  child(MODULE_CODES.HR, '/hr', 'employees', '/hr/employees', 'navigation.employees'),
+  child(MODULE_CODES.HR, '/hr', 'attendance', '/hr/attendance', 'navigation.attendance'),
+  child(MODULE_CODES.HR, '/hr', 'payroll', '/hr/payroll', 'navigation.payroll'),
+  child(MODULE_CODES.HR, '/hr', 'leaves', '/hr/leaves', 'navigation.leaves'),
+  child(MODULE_CODES.HR, '/hr', 'settlements', '/hr/settlements', 'navigation.settlements', 'beta'),
+  child(MODULE_CODES.HR, '/hr', 'reports', '/hr/reports', 'navigation.reports', 'beta'),
+  child(MODULE_CODES.HR, '/hr', 'settings', '/hr/settings', 'navigation.settings', 'hidden'),
+] as const;
+
+const reportsChildren = [
+  child(MODULE_CODES.REPORTS, '/reports', 'financial', '/reports/financial', 'navigation.financial', 'beta'),
+  child(MODULE_CODES.REPORTS, '/reports', 'inventory', '/reports/inventory', 'navigation.inventory'),
+  child(MODULE_CODES.REPORTS, '/reports', 'manufacturing', '/reports/manufacturing', 'navigation.manufacturing', 'beta'),
+  child(MODULE_CODES.REPORTS, '/reports', 'process-costing-dashboard', '/reports/process-costing-dashboard', 'navigation.process-costing-dashboard', 'beta'),
+  child(MODULE_CODES.REPORTS, '/reports', 'sales', '/reports/sales', 'navigation.sales', 'beta'),
+  child(MODULE_CODES.REPORTS, '/reports', 'purchasing', '/reports/purchasing', 'navigation.purchasing', 'beta'),
+  child(MODULE_CODES.REPORTS, '/reports', 'advanced', '/reports/advanced', 'navigation.advanced', 'beta'),
+  child(MODULE_CODES.REPORTS, '/reports', 'analytics', '/reports/analytics', 'navigation.analytics', 'beta'),
+  child(MODULE_CODES.REPORTS, '/reports', 'reports-insights', '/reports/insights', 'navigation.reports-insights', 'beta'),
+  child(
+    MODULE_CODES.REPORTS,
+    '/reports',
+    'gemini-compat',
+    '/reports/gemini',
+    'navigation.reports-insights',
+    'hidden',
+    { compatibilityOnly: true },
+  ),
+] as const;
+
+const settingsChildren = [
+  child(MODULE_CODES.SETTINGS, '/settings', 'company', '/settings/company', 'navigation.company'),
+  child(MODULE_CODES.SETTINGS, '/settings', 'system', '/settings/system', 'navigation.system', 'beta'),
+  child(MODULE_CODES.SETTINGS, '/settings', 'backup', '/settings/backup', 'navigation.backup', 'beta'),
+  child(MODULE_CODES.SETTINGS, '/settings', 'integrations', '/settings/integrations', 'navigation.integrations', 'hidden'),
+] as const;
+
+const orgAdminChildren: readonly ProductCatalogItem[] = [
+  { key: 'dashboard', labelKey: 'navigation.orgAdminDashboard', href: '/org-admin/dashboard', moduleCode: MODULE_CODES.ORG_ADMIN, status: 'ga', requireOrgAdmin: true },
+  { key: 'users', labelKey: 'navigation.users', href: '/org-admin/users', moduleCode: MODULE_CODES.ORG_ADMIN, status: 'ga', requireOrgAdmin: true },
+  { key: 'invitations', labelKey: 'navigation.invitations', href: '/org-admin/invitations', moduleCode: MODULE_CODES.ORG_ADMIN, status: 'ga', requireOrgAdmin: true },
+  { key: 'roles', labelKey: 'navigation.roles', href: '/org-admin/roles', moduleCode: MODULE_CODES.ORG_ADMIN, status: 'ga', requireOrgAdmin: true },
+  { key: 'audit-log', labelKey: 'navigation.audit-log', href: '/org-admin/audit-log', moduleCode: MODULE_CODES.ORG_ADMIN, status: 'ga', requireOrgAdmin: true },
+];
+
+const superAdminChildren: readonly ProductCatalogItem[] = [
+  { key: 'dashboard', labelKey: 'navigation.orgAdminDashboard', href: '/super-admin/dashboard', moduleCode: MODULE_CODES.SUPER_ADMIN, status: 'ga', requireSuperAdmin: true },
+  { key: 'organizations', labelKey: 'navigation.organizations', href: '/super-admin/organizations', moduleCode: MODULE_CODES.SUPER_ADMIN, status: 'ga', requireSuperAdmin: true },
+];
+
+const accountingOverview = resolveRoutePermission(MODULE_CODES.ACCOUNTING, '/overview');
+const generalLedgerOverview = resolveRoutePermission(MODULE_CODES.GENERAL_LEDGER, '/');
+
+export const PRODUCT_CATALOG: readonly ProductCatalogItem[] = [
+  {
+    key: 'dashboard',
+    labelKey: 'navigation.dashboard',
+    href: '/dashboard',
+    icon: 'LayoutDashboard',
+    moduleCode: MODULE_CODES.DASHBOARD,
+    status: 'ga',
+    children: dashboardChildren,
+  },
+  moduleItem(MODULE_CODES.MANUFACTURING, 'manufacturing', '/manufacturing', 'Factory', manufacturingChildren, 'beta'),
+  moduleItem(MODULE_CODES.INVENTORY, 'inventory', '/inventory', 'Package', inventoryChildren),
+  moduleItem(MODULE_CODES.PURCHASING, 'purchasing', '/purchasing', 'ShoppingCart', purchasingChildren),
+  moduleItem(MODULE_CODES.SALES, 'sales', '/sales', 'DollarSign', salesChildren, 'beta'),
+  {
+    key: 'accounting',
+    labelKey: 'navigation.accounting',
+    href: '/accounting',
+    icon: 'BookOpen',
+    moduleCode: MODULE_CODES.ACCOUNTING,
+    requirements: [accountingOverview, generalLedgerOverview].filter((r): r is RouteRequirement => r !== undefined),
+    status: 'beta',
+    children: accountingChildren,
+  },
+  moduleItem(MODULE_CODES.HR, 'hr', '/hr', 'Users', hrChildren),
+  moduleItem(MODULE_CODES.REPORTS, 'reports', '/reports', 'BarChart3', reportsChildren, 'beta'),
+  moduleItem(MODULE_CODES.SETTINGS, 'settings', '/settings', 'Settings', settingsChildren),
+  {
+    key: 'org-admin',
+    labelKey: 'navigation.org-admin',
+    href: '/org-admin',
+    icon: 'Building2',
+    moduleCode: MODULE_CODES.ORG_ADMIN,
+    status: 'ga',
+    requireOrgAdmin: true,
+    children: orgAdminChildren,
+  },
+  {
+    key: 'super-admin',
+    labelKey: 'navigation.super-admin',
+    href: '/super-admin',
+    icon: 'Shield',
+    moduleCode: MODULE_CODES.SUPER_ADMIN,
+    status: 'ga',
+    requireSuperAdmin: true,
+    children: superAdminChildren,
+  },
+] as const;
+
+function isRenderableStatus(status: ProductReadiness): boolean {
+  return status === 'ga' || status === 'beta';
+}
+
+export function canSeeCatalogItem(item: ProductCatalogItem, context: ProductCatalogAccessContext): boolean {
+  if (!isRenderableStatus(item.status) || item.compatibilityOnly) return false;
+  if (item.requireSuperAdmin) return context.isSuperAdmin;
+  if (item.requireOrgAdmin) return context.isOrgAdmin || context.isSuperAdmin;
+  if (item.moduleCode === MODULE_CODES.DASHBOARD) return true;
+  if (!item.requirements || item.requirements.length === 0) return false;
+  return item.requirements.some(requirement =>
+    satisfiesRouteRequirement(requirement, context.hasPermissionKey),
+  );
+}
+
+/**
+ * Returns a permission-filtered navigation tree without mutating the catalog.
+ * Child routes use the same exact route requirements as ModuleGuard; the
+ * catalog controls product readiness/IA only.
+ */
+export function getVisibleProductNavigation(
+  context: ProductCatalogAccessContext,
+  catalog: readonly ProductCatalogItem[] = PRODUCT_CATALOG,
+): ProductCatalogItem[] {
+  return catalog.flatMap(item => {
+    if (!canSeeCatalogItem(item, context)) return [];
+    const children = item.children?.filter(childItem => canSeeCatalogItem(childItem, context));
+    return [{ ...item, children }];
+  });
+}

--- a/src/config/product-catalog.ts
+++ b/src/config/product-catalog.ts
@@ -38,12 +38,23 @@ export interface ProductCatalogItem {
   readonly compatibilityOnly?: boolean;
   readonly blockedByIssue?: number;
   readonly children?: readonly ProductCatalogItem[];
+  /**
+   * Where a click on the collapsed icon / a childless expanded group should
+   * navigate. Computed by getVisibleProductNavigation for the caller's actual
+   * permissions — never authored statically, since it depends on whether the
+   * caller satisfies the item's own root contract or only a child's.
+   */
+  readonly landingHref?: string;
 }
 
 export interface ProductCatalogAccessContext {
   readonly isOrgAdmin: boolean;
   readonly isSuperAdmin: boolean;
   readonly hasPermissionKey: (permissionKey: string) => boolean;
+}
+
+function isRenderableStatus(status: ProductReadiness): boolean {
+  return status === 'ga' || status === 'beta';
 }
 
 function routeRequirement(moduleCode: string, moduleRoot: string, href: string): readonly RouteRequirement[] | undefined {
@@ -81,7 +92,12 @@ function moduleItem(
   status: ProductReadiness = 'ga',
 ): ProductCatalogItem {
   const rootRequirements = routeRequirement(moduleCode, href, href) ?? [];
-  const childRequirements = children.flatMap(item => item.requirements ?? []);
+  // Only a child that can actually render should be able to pull the group
+  // into view — a hidden/planned-only child's requirement must not make the
+  // parent appear with nothing reachable underneath it.
+  const childRequirements = children
+    .filter(item => isRenderableStatus(item.status) && !item.compatibilityOnly)
+    .flatMap(item => item.requirements ?? []);
 
   return {
     key,
@@ -240,7 +256,9 @@ const superAdminChildren: readonly ProductCatalogItem[] = [
 
 const accountingRootRequirements = resolveRoutePermission(MODULE_CODES.ACCOUNTING, '/') ? [resolveRoutePermission(MODULE_CODES.ACCOUNTING, '/') as RouteRequirement] : [];
 const generalLedgerRootRequirements = resolveRoutePermission(MODULE_CODES.GENERAL_LEDGER, '/') ? [resolveRoutePermission(MODULE_CODES.GENERAL_LEDGER, '/') as RouteRequirement] : [];
-const accountingChildRequirements = accountingChildren.flatMap(item => item.requirements ?? []);
+const accountingChildRequirements = accountingChildren
+  .filter(item => isRenderableStatus(item.status) && !item.compatibilityOnly)
+  .flatMap(item => item.requirements ?? []);
 
 export const PRODUCT_CATALOG: readonly ProductCatalogItem[] = [
   {
@@ -291,10 +309,6 @@ export const PRODUCT_CATALOG: readonly ProductCatalogItem[] = [
   },
 ] as const;
 
-function isRenderableStatus(status: ProductReadiness): boolean {
-  return status === 'ga' || status === 'beta';
-}
-
 export function canSeeCatalogItem(item: ProductCatalogItem, context: ProductCatalogAccessContext): boolean {
   if (!isRenderableStatus(item.status) || item.compatibilityOnly) return false;
   if (item.requireSuperAdmin) return context.isSuperAdmin;
@@ -304,6 +318,22 @@ export function canSeeCatalogItem(item: ProductCatalogItem, context: ProductCata
   return item.requirements.some(requirement =>
     satisfiesRouteRequirement(requirement, context.hasPermissionKey),
   );
+}
+
+/**
+ * Whether the caller may enter `item.href` itself — i.e. exactly what
+ * ModuleGuard evaluates for the bare module root (subPath '/'). A group can
+ * be visible in canSeeCatalogItem() via a permitted child without this being
+ * true (e.g. general_ledger.chart_of_accounts.view alone does not satisfy
+ * the Accounting root contract), which is why landingHref below can't just
+ * be item.href.
+ */
+function satisfiesOwnRoot(item: ProductCatalogItem, context: ProductCatalogAccessContext): boolean {
+  if (item.requireSuperAdmin) return context.isSuperAdmin;
+  if (item.requireOrgAdmin) return context.isOrgAdmin || context.isSuperAdmin;
+  if (item.moduleCode === MODULE_CODES.DASHBOARD) return true;
+  const rootRequirement = resolveRoutePermission(item.moduleCode, '/');
+  return rootRequirement != null && satisfiesRouteRequirement(rootRequirement, context.hasPermissionKey);
 }
 
 /**
@@ -318,6 +348,12 @@ export function getVisibleProductNavigation(
   return catalog.flatMap(item => {
     if (!canSeeCatalogItem(item, context)) return [];
     const children = item.children?.filter(childItem => canSeeCatalogItem(childItem, context));
-    return [{ ...item, children }];
+    // The caller may see this group without satisfying its own root contract
+    // (only a child's) — land on the first permitted child instead of a root
+    // ModuleGuard would reject. isRenderableStatus + the childRequirements
+    // filter above guarantee a permitted child exists whenever the root
+    // itself doesn't, so this never falls through to a stale item.href.
+    const landingHref = satisfiesOwnRoot(item, context) ? item.href : (children?.[0]?.href ?? item.href);
+    return [{ ...item, children, landingHref }];
   });
 }

--- a/src/config/product-catalog.ts
+++ b/src/config/product-catalog.ts
@@ -60,7 +60,7 @@ function child(
   href: string,
   labelKey: string,
   status: ProductReadiness = 'ga',
-  extra: Pick<ProductCatalogItem, 'blockedByIssue' | 'compatibilityOnly'> = {},
+  extra: Partial<Pick<ProductCatalogItem, 'blockedByIssue' | 'compatibilityOnly'>> = {},
 ): ProductCatalogItem {
   return {
     key,
@@ -87,7 +87,10 @@ function moduleItem(
     href,
     icon,
     moduleCode,
-    requirements: routeRequirement(moduleCode, href, `${href}/overview`),
+    // Every guarded product module defines its root `/` contract. Deriving
+    // parent navigation from the root avoids inventing `/overview` where one
+    // does not exist (Reports is the important current example).
+    requirements: routeRequirement(moduleCode, href, href),
     status,
     children,
   };
@@ -231,7 +234,7 @@ const superAdminChildren: readonly ProductCatalogItem[] = [
   { key: 'organizations', labelKey: 'navigation.organizations', href: '/super-admin/organizations', moduleCode: MODULE_CODES.SUPER_ADMIN, status: 'ga', requireSuperAdmin: true },
 ];
 
-const accountingOverview = resolveRoutePermission(MODULE_CODES.ACCOUNTING, '/overview');
+const accountingOverview = resolveRoutePermission(MODULE_CODES.ACCOUNTING, '/');
 const generalLedgerOverview = resolveRoutePermission(MODULE_CODES.GENERAL_LEDGER, '/');
 
 export const PRODUCT_CATALOG: readonly ProductCatalogItem[] = [


### PR DESCRIPTION
## Summary

ALIGN-P1: the sidebar no longer hardcodes navigation structure or gates on a coarse "has any permission in this module" check. It now renders from a single Product Catalog config, and every visible item — root or child — is gated by the **exact same route-permission contract** ModuleGuard already enforces at `route-permissions.ts`.

- `src/config/product-catalog.ts`: new source of truth for the product navigation tree (key, label, href, icon, readiness status, route requirements). Requirements are derived from `resolveRoutePermission()` per item, so the catalog can't drift from the guard.
- `src/components/layout/sidebar.tsx`: refactored (655 lines removed) to consume `getVisibleProductNavigation()` instead of a hardcoded item list + `MODULE_CODES` duplication + `hasModuleAccess()` module-prefix check.
- Removed the static `2/3`-style readiness badges; visibility is now driven by each item's real `status` (`ga` / `beta` / `planned` / `hidden`) and permission contract, not a hand-maintained count.
- `inventory.categories` and `manufacturing.routing`/`quality` are explicitly `hidden`/`planned` — they no longer render as if GA (categories has no backing resource; routing is blocked on #152; quality's mounted component is an inert placeholder).
- Accounting stays one visible group spanning Accounting + General Ledger routes (no separate `general-ledger` sidebar entry), matching how the module is actually organized.
- Fixed a collapsed-sidebar edge case: a user permissioned only for a child route (e.g. General Ledger) could have the parent group icon route them to a root they aren't permitted for. Parent groups now stay reachable only via a permitted child.
- Updated the pre-existing `sidebar-i18n.test.tsx`, which mocked the old `hasModuleAccess` shape and regex-extracted nav keys from `sidebar.tsx` source — both stale after this refactor (extraction returned zero keys, and two tests crashed calling the mocked `hasPermissionKey` as `undefined`). It now walks the live `PRODUCT_CATALOG` tree and mocks `hasPermissionKey` with real permission keys.
- Fixed a stale expectation in `product-catalog.test.ts`: `/reports/advanced` is satisfied by `reports.inventory.read` alone per the pre-existing `REPORTS_ADVANCED` contract (any of financial/inventory/manufacturing/sales) — the test asserted it stayed hidden, which didn't match `route-permissions.ts`.
- Added a ratchet test (`sidebar-product-catalog-ratchet.test.ts`) so the sidebar can't silently regress back to a hand-maintained item list.

**Product Catalog is IA/readiness metadata only — it grants no access.** PostgreSQL/RPC/RLS remains the sole security boundary; the catalog's `requirements` are pulled from the existing `route-permissions.ts` contract, never invented independently.

No SQL, no migrations, no `src` outside navigation/config, no Production writes.

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm run lint` — 0 errors (842 pre-existing warnings, unrelated to this diff)
- [x] `npm test` (full suite) — 302 test files / 4571 tests passed
- [x] `node scripts/i18n/count-hardcoded.mjs --ci` — 0 hardcoded strings
- [x] `npm run build` — succeeds, demo-password gate passes
- [ ] Manual smoke in a browser across role combinations (org admin / super admin / ordinary user with partial permissions), especially the collapsed-sidebar parent-reachability edge case


---
_Generated by [Claude Code](https://claude.ai/code/session_01RzRkXTEF1tFqdTjaf5GVHV)_