### PR TITLE
ci: fail when generated baseline has no review PR

### DIFF
--- a/.github/workflows/baseline-pr-publication-guard.yml
+++ b/.github/workflows/baseline-pr-publication-guard.yml
@@ -1,9 +1,20 @@
 name: Baseline PR Publication Guard
 
+# This guard validates a completed baseline-generation lifecycle.
+# No pull_request trigger is intentional: PR events do not carry the source
+# Generate Schema Baseline run identity, so they cannot produce a meaningful
+# verdict for this contract.
+
 on:
   workflow_run:
     workflows: ["Generate Schema Baseline"]
     types: [completed]
+  workflow_dispatch:
+    inputs:
+      source_run_id:
+        description: "Generate Schema Baseline workflow run id to validate"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -12,17 +23,22 @@ permissions:
 jobs:
   require-review-pr:
     name: Require generated baseline review PR
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: >-
+      ${{ (github.event_name == 'workflow_run'
+           && github.event.workflow_run.conclusion == 'success')
+          || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
       - name: Resolve generated branch and require PR
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id || github.event.workflow_run.id }}
         shell: bash
         run: |
           set -Eeuo pipefail
+
+          echo "source run: ${SOURCE_RUN_ID} (event: ${GITHUB_EVENT_NAME})"
 
           BRANCHES=$(gh api --paginate "repos/${REPO}/branches?per_page=100" \
             --jq ".[].name | select(test(\"^automation/baseline-cutoff-[0-9]+-${SOURCE_RUN_ID}$\"))")
@@ -39,9 +55,11 @@ jobs:
 
           if [ "$PR_COUNT" -ne 1 ]; then
             echo "❌ generated baseline branch ${BRANCH} has ${PR_COUNT} open review PRs"
+            echo "   source run: ${SOURCE_RUN_ID} (event: ${GITHUB_EVENT_NAME})"
             echo "   A green baseline generation is not sufficient until the generated branch is published for review."
             exit 1
           fi
 
           PR_NUMBER=$(gh pr list --repo "$REPO" --state open --head "$BRANCH" --json number --jq '.[0].number')
+          echo "✅ source run: ${SOURCE_RUN_ID} (event: ${GITHUB_EVENT_NAME})"
           echo "✅ generated baseline branch ${BRANCH} is published as PR #${PR_NUMBER}"

--- a/.github/workflows/baseline-pr-publication-guard.yml
+++ b/.github/workflows/baseline-pr-publication-guard.yml
@@ -1,0 +1,47 @@
+name: Baseline PR Publication Guard
+
+on:
+  workflow_run:
+    workflows: ["Generate Schema Baseline"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  require-review-pr:
+    name: Require generated baseline review PR
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve generated branch and require PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          BRANCHES=$(gh api --paginate "repos/${REPO}/branches?per_page=100" \
+            --jq ".[].name | select(test(\"^automation/baseline-cutoff-[0-9]+-${SOURCE_RUN_ID}$\"))")
+          COUNT=$(printf '%s\n' "$BRANCHES" | sed '/^$/d' | wc -l)
+
+          if [ "$COUNT" -ne 1 ]; then
+            echo "❌ expected exactly one generated baseline branch for workflow run ${SOURCE_RUN_ID}; found ${COUNT}"
+            printf '%s\n' "$BRANCHES"
+            exit 1
+          fi
+
+          BRANCH=$(printf '%s\n' "$BRANCHES" | sed '/^$/d')
+          PR_COUNT=$(gh pr list --repo "$REPO" --state open --head "$BRANCH" --json number --jq 'length')
+
+          if [ "$PR_COUNT" -ne 1 ]; then
+            echo "❌ generated baseline branch ${BRANCH} has ${PR_COUNT} open review PRs"
+            echo "   A green baseline generation is not sufficient until the generated branch is published for review."
+            exit 1
+          fi
+
+          PR_NUMBER=$(gh pr list --repo "$REPO" --state open --head "$BRANCH" --json number --jq '.[0].number')
+          echo "✅ generated baseline branch ${BRANCH} is published as PR #${PR_NUMBER}"

--- a/.github/workflows/baseline-pr-publication-guard.yml
+++ b/.github/workflows/baseline-pr-publication-guard.yml
@@ -40,6 +40,15 @@ jobs:
 
           echo "source run: ${SOURCE_RUN_ID} (event: ${GITHUB_EVENT_NAME})"
 
+          # SOURCE_RUN_ID is interpolated into the jq filter below. Rejecting
+          # anything but digits keeps that filter well formed and, just as
+          # importantly, separates "you typed the run id wrong" from the real
+          # verdicts: a missing branch and a missing review PR.
+          if ! [[ "$SOURCE_RUN_ID" =~ ^[0-9]+$ ]]; then
+            echo "❌ invalid source run id: [${SOURCE_RUN_ID}] — expected digits only"
+            exit 1
+          fi
+
           BRANCHES=$(gh api --paginate "repos/${REPO}/branches?per_page=100" \
             --jq ".[].name | select(test(\"^automation/baseline-cutoff-[0-9]+-${SOURCE_RUN_ID}$\"))")
           COUNT=$(printf '%s\n' "$BRANCHES" | sed '/^$/d' | wc -l)
@@ -51,15 +60,17 @@ jobs:
           fi
 
           BRANCH=$(printf '%s\n' "$BRANCHES" | sed '/^$/d')
-          PR_COUNT=$(gh pr list --repo "$REPO" --state open --head "$BRANCH" --json number --jq 'length')
+          # --base main: the contract is "published for review against main",
+          # not merely "some open PR exists from this branch".
+          PR_COUNT=$(gh pr list --repo "$REPO" --state open --base main --head "$BRANCH" --json number --jq 'length')
 
           if [ "$PR_COUNT" -ne 1 ]; then
-            echo "❌ generated baseline branch ${BRANCH} has ${PR_COUNT} open review PRs"
+            echo "❌ generated baseline branch ${BRANCH} has ${PR_COUNT} open review PRs into main"
             echo "   source run: ${SOURCE_RUN_ID} (event: ${GITHUB_EVENT_NAME})"
             echo "   A green baseline generation is not sufficient until the generated branch is published for review."
             exit 1
           fi
 
-          PR_NUMBER=$(gh pr list --repo "$REPO" --state open --head "$BRANCH" --json number --jq '.[0].number')
+          PR_NUMBER=$(gh pr list --repo "$REPO" --state open --base main --head "$BRANCH" --json number --jq '.[0].number')
           echo "✅ source run: ${SOURCE_RUN_ID} (event: ${GITHUB_EVENT_NAME})"
           echo "✅ generated baseline branch ${BRANCH} is published as PR #${PR_NUMBER}"


### PR DESCRIPTION
## Problem

`Generate Schema Baseline` can finish green after pushing the generated branch even when `gh pr create` fails. That is exactly what happened on run `33236502184`: the pair `20260829_135152` was generated, validated, rebuilt on a clean PostgreSQL 17 and pushed to `automation/baseline-cutoff-184-33236502184`, but PR creation was refused (`GitHub Actions is not permitted to create or approve pull requests`) and the step downgraded that refusal to a warning. The job stayed green while the repository governance contract — a baseline reaches `main` only through a review PR — was unmet, and PR #202 had to be opened by hand.

## Guard

A `workflow_run` guard on successful baseline-generator runs. For the source run it:

- resolves exactly one `automation/baseline-cutoff-CUTOFF-RUNID` branch;
- requires exactly one open PR from that branch **into `main`**;
- fails otherwise.

It also rejects a `source_run_id` that is not digits. That value is interpolated into a jq filter, so the check keeps the filter well formed — and it gives the guard a third distinct verdict, so a mistyped run id no longer surfaces as `found 0 branches`, which would be indistinguishable from a real failure.

Every path — success and both failures — prints the source run id and the triggering event, so the log alone identifies which run was validated and whether the verdict came from a real generator completion or a manual proof.

## Provability

A `workflow_dispatch` trigger takes `source_run_id`, so both directions can be proved against a real generator run without producing an extra baseline pair or a competing PR. The job condition covers both events; without that, a dispatch run would report success having executed nothing.

There is deliberately **no `pull_request` trigger**, and the file says so inline. PR events carry no source generator run identity, so they cannot produce a meaningful verdict: such a trigger would either fail on every workflow PR or pass vacuously. A green check that proves nothing is the failure mode this PR exists to remove.

## Merge and proof order

This guard cannot be exercised before it is merged: `workflow_dispatch` is only offered for workflows present on the default branch. It is therefore merged **unproven and inert** — it gates nothing, posts no PR check, and touches no database — and proved immediately afterwards:

1. merge this PR (status: merged but unproven);
2. dispatch with `source_run_id=33236502184` while #202 is open → expect **pass**, one branch and one open review PR;
3. close #202 temporarily — closing does not delete the head branch — and dispatch again → expect **failure on `has 0 open review PRs into main`**, the arm that describes the original defect, rather than the branch-count arm;
4. reopen #202 and continue its normal review.

## Scope

Separate from baseline artifact PR #202 by design: CI governance is not mixed with generated schema content. This guard makes the failure visible; it does not yet make the generator itself fail at `gh pr create`. That remains a tracked follow-up in `docs/ai-simulation-lab/ACCOUNTING_INTEGRITY_PROGRESS_20260829.md`, along with enabling *Allow GitHub Actions to create and approve pull requests* if automatic PR creation is wanted.
