### PR TITLE
ci(baseline): distinguish workflow rerun attempts

### DIFF
--- a/.github/workflows/baseline-pr-publication-guard.yml
+++ b/.github/workflows/baseline-pr-publication-guard.yml
@@ -34,6 +34,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           SOURCE_RUN_ID: ${{ inputs.source_run_id || github.event.workflow_run.id }}
+          SOURCE_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
         shell: bash
         run: |
           set -Eeuo pipefail
@@ -49,17 +50,50 @@ jobs:
             exit 1
           fi
 
-          BRANCHES=$(gh api --paginate "repos/${REPO}/branches?per_page=100" \
-            --jq ".[].name | select(test(\"^automation/baseline-cutoff-[0-9]+-${SOURCE_RUN_ID}$\"))")
-          COUNT=$(printf '%s\n' "$BRANCHES" | sed '/^$/d' | wc -l)
-
-          if [ "$COUNT" -ne 1 ]; then
-            echo "❌ expected exactly one generated baseline branch for workflow run ${SOURCE_RUN_ID}; found ${COUNT}"
-            printf '%s\n' "$BRANCHES"
+          # workflow_dispatch has no workflow_run payload. Resolve the latest
+          # attempt from the immutable numeric run id; workflow_run supplies the
+          # attempt that actually caused this guard invocation.
+          if [ -z "$SOURCE_RUN_ATTEMPT" ]; then
+            SOURCE_RUN_ATTEMPT=$(gh api "repos/${REPO}/actions/runs/${SOURCE_RUN_ID}" --jq '.run_attempt')
+          fi
+          if ! [[ "$SOURCE_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]]; then
+            echo "❌ invalid source run attempt: [${SOURCE_RUN_ATTEMPT}] — expected a positive integer"
             exit 1
           fi
 
-          BRANCH=$(printf '%s\n' "$BRANCHES" | sed '/^$/d')
+          BRANCHES=$(gh api --paginate "repos/${REPO}/branches?per_page=100" \
+            --jq ".[].name | select(test(\"^automation/baseline-cutoff-[0-9]+-${SOURCE_RUN_ID}-attempt-${SOURCE_RUN_ATTEMPT}$\"))")
+          COUNT=$(printf '%s\n' "$BRANCHES" | sed '/^$/d' | wc -l)
+
+          if [ "$COUNT" -eq 1 ]; then
+            BRANCH=$(printf '%s\n' "$BRANCHES" | sed '/^$/d')
+            RESOLUTION="attempt-aware"
+          elif [ "$COUNT" -gt 1 ]; then
+            echo "❌ expected exactly one generated baseline branch for workflow run ${SOURCE_RUN_ID} attempt ${SOURCE_RUN_ATTEMPT}; found ${COUNT}"
+            printf '%s\n' "$BRANCHES"
+            exit 1
+          else
+            # Legacy generator branches predate the attempt suffix. A re-run can
+            # therefore leave more than one cutoff for the same run id (run
+            # 33236502184 did: 182, then 184). Production's applied-migration
+            # cutoff is monotonic, so the greatest cutoff is the latest attempt.
+            LEGACY_BRANCHES=$(gh api --paginate "repos/${REPO}/branches?per_page=100" \
+              --jq ".[].name | select(test(\"^automation/baseline-cutoff-[0-9]+-${SOURCE_RUN_ID}$\"))")
+            LEGACY_COUNT=$(printf '%s\n' "$LEGACY_BRANCHES" | sed '/^$/d' | wc -l)
+            if [ "$LEGACY_COUNT" -eq 0 ]; then
+              echo "❌ no generated baseline branch for workflow run ${SOURCE_RUN_ID} attempt ${SOURCE_RUN_ATTEMPT}"
+              exit 1
+            fi
+            BRANCH=$(printf '%s\n' "$LEGACY_BRANCHES" \
+              | sed '/^$/d' \
+              | sed -E 's#^automation/baseline-cutoff-([0-9]+)-[0-9]+$#\1\t&#' \
+              | sort -n -k1,1 \
+              | tail -n 1 \
+              | cut -f2-)
+            RESOLUTION="legacy-highest-cutoff"
+            echo "legacy branches for source run ${SOURCE_RUN_ID}: ${LEGACY_COUNT}; selected ${BRANCH}"
+          fi
+
           # --base main: the contract is "published for review against main",
           # not merely "some open PR exists from this branch".
           PR_COUNT=$(gh pr list --repo "$REPO" --state open --base main --head "$BRANCH" --json number --jq 'length')
@@ -72,5 +106,5 @@ jobs:
           fi
 
           PR_NUMBER=$(gh pr list --repo "$REPO" --state open --base main --head "$BRANCH" --json number --jq '.[0].number')
-          echo "✅ source run: ${SOURCE_RUN_ID} (event: ${GITHUB_EVENT_NAME})"
+          echo "✅ source run: ${SOURCE_RUN_ID} attempt ${SOURCE_RUN_ATTEMPT} (event: ${GITHUB_EVENT_NAME}; resolution: ${RESOLUTION})"
           echo "✅ generated baseline branch ${BRANCH} is published as PR #${PR_NUMBER}"

--- a/.github/workflows/baseline-pr-publication-guard.yml
+++ b/.github/workflows/baseline-pr-publication-guard.yml
@@ -17,6 +17,7 @@ on:
         type: string
 
 permissions:
+  actions: read
   contents: read
   pull-requests: read
 

--- a/.github/workflows/generate-baseline.yml
+++ b/.github/workflows/generate-baseline.yml
@@ -349,7 +349,10 @@ jobs:
         shell: bash
         run: |
           set -Eeuo pipefail
-          BRANCH="automation/baseline-cutoff-${CUTOFF}-${GITHUB_RUN_ID}"
+          # A workflow re-run keeps GITHUB_RUN_ID. Production may advance between
+          # attempts, so the attempt must be part of the identity; otherwise one
+          # run can leave multiple indistinguishable cutoff branches behind.
+          BRANCH="automation/baseline-cutoff-${CUTOFF}-${GITHUB_RUN_ID}-attempt-${GITHUB_RUN_ATTEMPT}"
           git switch -c "$BRANCH"
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'


### PR DESCRIPTION
## السبب

كشف الإثبات الحي بعد #204 أن Generate Schema Baseline run `33236502184` أُعيد تشغيله:

- attempt 1 أنشأ `automation/baseline-cutoff-182-33236502184`
- attempt 2 أنشأ `automation/baseline-cutoff-184-33236502184`

لأن `GITHUB_RUN_ID` ثابت بين الإعادات، افترض الحارس خطأً أن رقم التشغيل يطابق فرعًا واحدًا، فسقط التشغيل المتوقع أن يمر: [33270003847](https://github.com/6thd/wardah-process-costing/actions/runs/33270003847).

## الإصلاح

- يضيف المولّد `GITHUB_RUN_ATTEMPT` إلى أسماء الفروع الجديدة.
- يطابق الحارس رقم التشغيل + المحاولة في المسار الجديد.
- عند `workflow_dispatch` يقرأ أحدث `run_attempt` من GitHub بعد التحقق الرقمي من run id.
- للفروع التاريخية بلا suffix للمحاولة، يختار أعلى cutoff؛ سجل migrations المطبّق تراكمي وcutoff لا يتراجع.
- يظل الحكم النهائي: فرع المحاولة المختارة يجب أن يملك PR مفتوحًا واحدًا بالضبط نحو `main`.

## الإثبات قبل الدفع

- YAML parser: pass
- `bash -n` لنص الخطوة: pass
- `git diff --check`: pass
- fixture الواقعي بفرعي 182 و184: اختير 184 ومرّ مع PR #202 المفتوح.
- نفس fixture مع PR count = 0: احمرّ برسالة `has 0 open review PRs into main`.

## ترتيب القبول

1. CI على الرأس المنشور.
2. دمج هذا PR.
3. dispatch للتشغيل `33236502184` و#202 مفتوح: يجب أن يمر.
4. إغلاق #202 مؤقتًا ثم dispatch: يجب أن يفشل.
5. إعادة فتح #202 ثم متابعة مراجعته.

لا يكتب هذا PR إلى Production ولا يغيّر محتوى الـBaseline.