### PR TITLE
feat(inventory): close direct write access to the stock ledger (Migration 185, Round 3 PR-3A)

### DIFF
--- a/.github/workflows/stock-write-surface-185-acceptance.yml
+++ b/.github/workflows/stock-write-surface-185-acceptance.yml
@@ -15,6 +15,7 @@ on:
       - 'scripts/ci/fresh-db/acceptance_185_stock_write_surface_closure_red.sql'
       - '.github/workflows/stock-write-surface-185-acceptance.yml'
       - 'sql/baseline/**'
+      - 'sql/migrations/**'
   workflow_dispatch:
 
 jobs:
@@ -60,6 +61,29 @@ jobs:
             > /tmp/chain_order.txt
           grep -q '^185_stock_write_surface_closure.sql$' /tmp/chain_order.txt
 
+          # The red proof must stay buildable even after a future Baseline
+          # regeneration folds 185 (and anything numbered after it) into the
+          # schema snapshot — at that point 185 would vanish from the chain
+          # built off the latest Baseline above, and reusing that same
+          # Baseline for the "pre-185" database would bake the fix in before
+          # the probe ever runs. Pin the red pair to the newest Baseline
+          # strictly before cutoff 185 instead, independent of whatever the
+          # latest Baseline currently is.
+          RED_PAIR=$(bash scripts/ci/fresh-db/resolve_baseline_pair.sh sql/baseline 185)
+          red_pair_field() { printf '%s\n' "$RED_PAIR" | sed -n "s/^$1=//p"; }
+          echo "RED_BASELINE=$(red_pair_field BASELINE_PATH)" >> "$GITHUB_ENV"
+          echo "RED_REFERENCE=$(red_pair_field REFERENCE_PATH)" >> "$GITHUB_ENV"
+          RED_CUTOFF=$(red_pair_field BASELINE_CUTOFF)
+          RED_CUTOFF=${RED_CUTOFF:-0}
+          python3 scripts/ci/fresh-db/build_apply_order.py sql/migrations "$RED_CUTOFF" \
+            > /tmp/red_chain_order_full.txt
+          # Cut the chain at 185 itself, not just that one line: any
+          # migration numbered after 185 must never reach the red database
+          # either, or a future addition could silently leak into what is
+          # supposed to be the pre-fix proof.
+          sed '/^185_stock_write_surface_closure.sql$/,$d' \
+            /tmp/red_chain_order_full.txt > /tmp/red_order.txt
+
       - name: Build fresh database through 185
         shell: bash
         run: |
@@ -86,10 +110,8 @@ jobs:
           set -Eeuo pipefail
           createdb wardah_red
           psql -v ON_ERROR_STOP=1 -d wardah_red -f scripts/ci/fresh-db/supabase_shim.sql -q
-          psql -v ON_ERROR_STOP=1 -d wardah_red -f "$BASELINE" -q
-          psql -v ON_ERROR_STOP=1 -d wardah_red -f "$REFERENCE" -q
-          sed '/^185_stock_write_surface_closure.sql$/d' /tmp/chain_order.txt \
-            > /tmp/red_order.txt
+          psql -v ON_ERROR_STOP=1 -d wardah_red -f "$RED_BASELINE" -q
+          psql -v ON_ERROR_STOP=1 -d wardah_red -f "$RED_REFERENCE" -q
           REPORT=/tmp/red_chain_report.txt PGDATABASE=wardah_red \
             bash scripts/ci/fresh-db/run_chain.sh sql/migrations /tmp/red_order.txt
 

--- a/.github/workflows/stock-write-surface-185-acceptance.yml
+++ b/.github/workflows/stock-write-surface-185-acceptance.yml
@@ -1,0 +1,123 @@
+name: Stock Write Surface 185 Acceptance
+
+# Round 3 (inventory integrity) PR-3A. Contract: stock_ledger_entries and
+# bins are writable only through the SECURITY DEFINER RPC surface; the
+# table-level grants that used to make that a matter of RLS-policy luck are
+# revoked. See sql/migrations/185_stock_write_surface_closure.sql for the
+# full rationale.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'sql/migrations/185_stock_write_surface_closure.sql'
+      - 'scripts/ci/fresh-db/acceptance_185_stock_write_surface_closure.sql'
+      - 'scripts/ci/fresh-db/acceptance_185_stock_write_surface_closure_red.sql'
+      - '.github/workflows/stock-write-surface-185-acceptance.yml'
+      - 'sql/baseline/**'
+  workflow_dispatch:
+
+jobs:
+  acceptance:
+    name: Ledger and bins are writable only through the RPC surface
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      PGHOST: localhost
+      PGUSER: postgres
+      PGPASSWORD: postgres
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Resolve Baseline pair and migration order
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          PAIR=$(bash scripts/ci/fresh-db/resolve_baseline_pair.sh sql/baseline)
+          pair_field() { printf '%s\n' "$PAIR" | sed -n "s/^$1=//p"; }
+          echo "BASELINE=$(pair_field BASELINE_PATH)" >> "$GITHUB_ENV"
+          echo "REFERENCE=$(pair_field REFERENCE_PATH)" >> "$GITHUB_ENV"
+          CUTOFF=$(pair_field BASELINE_CUTOFF)
+          CUTOFF=${CUTOFF:-0}
+          python3 scripts/ci/fresh-db/build_apply_order.py sql/migrations "$CUTOFF" \
+            > /tmp/chain_order.txt
+          grep -q '^185_stock_write_surface_closure.sql$' /tmp/chain_order.txt
+
+      - name: Build fresh database through 185
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          createdb wardah_fresh
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh -f scripts/ci/fresh-db/supabase_shim.sql -q
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh -f "$BASELINE" -q
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh -f "$REFERENCE" -q
+          REPORT=/tmp/chain_report.txt PGDATABASE=wardah_fresh \
+            bash scripts/ci/fresh-db/run_chain.sh sql/migrations /tmp/chain_order.txt
+
+      - name: Run Migration 185 acceptance
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          psql -v ON_ERROR_STOP=1 -d wardah_fresh \
+            -f scripts/ci/fresh-db/acceptance_185_stock_write_surface_closure.sql \
+            2>&1 | tee /tmp/stock-185.out
+          grep -q 'STOCK_185_ACCEPTANCE_PASS' /tmp/stock-185.out
+
+      - name: Red proof — reproduce the pre-185 write surface
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          createdb wardah_red
+          psql -v ON_ERROR_STOP=1 -d wardah_red -f scripts/ci/fresh-db/supabase_shim.sql -q
+          psql -v ON_ERROR_STOP=1 -d wardah_red -f "$BASELINE" -q
+          psql -v ON_ERROR_STOP=1 -d wardah_red -f "$REFERENCE" -q
+          sed '/^185_stock_write_surface_closure.sql$/d' /tmp/chain_order.txt \
+            > /tmp/red_order.txt
+          REPORT=/tmp/red_chain_report.txt PGDATABASE=wardah_red \
+            bash scripts/ci/fresh-db/run_chain.sh sql/migrations /tmp/red_order.txt
+
+          psql -v ON_ERROR_STOP=1 -d wardah_red \
+            -f scripts/ci/fresh-db/acceptance_185_stock_write_surface_closure_red.sql \
+            2>&1 | tee /tmp/stock-185-red.out
+          grep -q 'STOCK_185_RED_PROOF_PASS' /tmp/stock-185-red.out
+
+      - name: Confirm both proof directions actually ran
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          grep -q 'STOCK_185_GRANTS_OK' /tmp/stock-185.out
+          grep -q 'STOCK_185_RPC_SMOKE_OK' /tmp/stock-185.out
+          grep -q 'STOCK_185_GREEN_PROBE_OK' /tmp/stock-185.out
+          grep -q 'STOCK_185_ACCEPTANCE_PASS' /tmp/stock-185.out
+          grep -q 'STOCK_185_RED_PRECONDITION_OK' /tmp/stock-185-red.out
+          grep -q 'STOCK_185_RED_PROOF_OK' /tmp/stock-185-red.out
+          grep -q 'STOCK_185_RED_PROOF_PASS' /tmp/stock-185-red.out
+
+      - name: Upload acceptance evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: stock-write-surface-185-${{ github.run_id }}
+          path: |
+            /tmp/chain_report.txt
+            /tmp/red_chain_report.txt
+            /tmp/stock-185.out
+            /tmp/stock-185-red.out
+          retention-days: 30

--- a/.github/workflows/stock-write-surface-185-acceptance.yml
+++ b/.github/workflows/stock-write-surface-185-acceptance.yml
@@ -59,16 +59,19 @@ jobs:
           CUTOFF=${CUTOFF:-0}
           python3 scripts/ci/fresh-db/build_apply_order.py sql/migrations "$CUTOFF" \
             > /tmp/chain_order.txt
-          grep -q '^185_stock_write_surface_closure.sql$' /tmp/chain_order.txt
 
-          # The red proof must stay buildable even after a future Baseline
-          # regeneration folds 185 (and anything numbered after it) into the
-          # schema snapshot — at that point 185 would vanish from the chain
-          # built off the latest Baseline above, and reusing that same
-          # Baseline for the "pre-185" database would bake the fix in before
-          # the probe ever runs. Pin the red pair to the newest Baseline
-          # strictly before cutoff 185 instead, independent of whatever the
-          # latest Baseline currently is.
+          # No guard against 185 being absent from this GREEN chain: once a
+          # future Baseline regeneration folds 185 into the schema snapshot,
+          # 185 legitimately vanishes from the chain built off the latest
+          # Baseline above — the fresh database still ends up with 185's
+          # effects, just via the Baseline instead of a separate migration
+          # step, and that is a correct outcome for GREEN, not a failure.
+
+          # The red proof must stay buildable in that same future: reusing
+          # this same Baseline for the "pre-185" database would bake the fix
+          # in before the probe ever runs. Pin the red pair to the newest
+          # Baseline strictly before cutoff 185 instead, independent of
+          # whatever the latest Baseline currently is.
           RED_PAIR=$(bash scripts/ci/fresh-db/resolve_baseline_pair.sh sql/baseline 185)
           red_pair_field() { printf '%s\n' "$RED_PAIR" | sed -n "s/^$1=//p"; }
           echo "RED_BASELINE=$(red_pair_field BASELINE_PATH)" >> "$GITHUB_ENV"
@@ -77,6 +80,14 @@ jobs:
           RED_CUTOFF=${RED_CUTOFF:-0}
           python3 scripts/ci/fresh-db/build_apply_order.py sql/migrations "$RED_CUTOFF" \
             > /tmp/red_chain_order_full.txt
+          # This is where the "185 might be missing" guard actually belongs:
+          # the red chain is pinned to a pre-185 Baseline by construction, so
+          # 185 must always appear here for the cut below to mean anything.
+          # If it doesn't, the sed is a no-op and the red database silently
+          # becomes identical to green instead of reproducing the pre-fix
+          # state.
+          grep -q '^185_stock_write_surface_closure.sql$' /tmp/red_chain_order_full.txt
+
           # Cut the chain at 185 itself, not just that one line: any
           # migration numbered after 185 must never reach the red database
           # either, or a future addition could silently leak into what is

--- a/scripts/ci/fresh-db/acceptance_185_stock_write_surface_closure.sql
+++ b/scripts/ci/fresh-db/acceptance_185_stock_write_surface_closure.sql
@@ -55,6 +55,13 @@ BEGIN
     RAISE EXCEPTION 'STOCK_185_ACCEPTANCE_ANON_FUNCTION_EXECUTE_REMAINS';
   END IF;
 
+  -- The migration's contract is that only PUBLIC/anon lost EXECUTE;
+  -- service_role's own separate grant must be untouched.
+  IF NOT has_function_privilege('service_role', 'public.consume_materials_for_mo(uuid,uuid,jsonb[])', 'EXECUTE')
+     OR NOT has_function_privilege('service_role', 'public.update_warehouse_gl_mapping(uuid,uuid,uuid,uuid,uuid,uuid,uuid)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'STOCK_185_ACCEPTANCE_SERVICE_ROLE_FUNCTION_EXECUTE_MISSING';
+  END IF;
+
   RAISE NOTICE 'STOCK_185_GRANTS_OK';
 END
 $grants$;

--- a/scripts/ci/fresh-db/acceptance_185_stock_write_surface_closure.sql
+++ b/scripts/ci/fresh-db/acceptance_185_stock_write_surface_closure.sql
@@ -1,0 +1,196 @@
+-- Acceptance for Migration 185 / Round 3 stock write-surface closure.
+-- Runs on a database built through 185. Proves three things, not two:
+--   1. The grant/EXECUTE shape matches the migration's postflight exactly.
+--   2. The legitimate RPC write path (SECURITY DEFINER, runs as owner)
+--      still writes stock_ledger_entries and bins correctly — closing the
+--      table grant did not also close the supported surface.
+--   3. A direct client write is rejected by the grant itself (SQLSTATE
+--      42501), even when a hypothetical permissive RLS policy would
+--      otherwise allow it — proving the fix is the revoked grant, not the
+--      accidental absence of a policy.
+--
+-- Fixture ids are fixed literals (not gen_random_uuid()) so they can be
+-- referenced after SET LOCAL ROLE authenticated without a SELECT against
+-- auth.users under that role, which authenticated cannot perform.
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- ---------------------------------------------------------------------
+-- 1. Grant/EXECUTE shape (mirrors the migration's own postflight).
+-- ---------------------------------------------------------------------
+DO $grants$
+DECLARE
+  v_table text;
+  v_priv text;
+BEGIN
+  FOREACH v_table IN ARRAY ARRAY['stock_ledger_entries', 'bins']
+  LOOP
+    IF NOT has_table_privilege('authenticated', format('public.%I', v_table), 'SELECT') THEN
+      RAISE EXCEPTION 'STOCK_185_ACCEPTANCE_AUTHENTICATED_SELECT_MISSING: %', v_table;
+    END IF;
+
+    FOREACH v_priv IN ARRAY ARRAY['INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'REFERENCES', 'TRIGGER']
+    LOOP
+      IF has_table_privilege('authenticated', format('public.%I', v_table), v_priv) THEN
+        RAISE EXCEPTION 'STOCK_185_ACCEPTANCE_AUTHENTICATED_WRITE_REMAINS: % %', v_table, v_priv;
+      END IF;
+    END LOOP;
+
+    FOREACH v_priv IN ARRAY ARRAY['SELECT', 'INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'REFERENCES', 'TRIGGER', 'MAINTAIN']
+    LOOP
+      IF has_table_privilege('anon', format('public.%I', v_table), v_priv) THEN
+        RAISE EXCEPTION 'STOCK_185_ACCEPTANCE_ANON_PRIVILEGE_REMAINS: % %', v_table, v_priv;
+      END IF;
+    END LOOP;
+  END LOOP;
+
+  IF NOT (has_table_privilege('authenticated', 'public.warehouses', 'INSERT')
+          AND has_table_privilege('anon', 'public.warehouses', 'INSERT')) THEN
+    RAISE EXCEPTION 'STOCK_185_ACCEPTANCE_WAREHOUSES_SCOPE_VIOLATION';
+  END IF;
+
+  IF has_function_privilege('anon', 'public.consume_materials_for_mo(uuid,uuid,jsonb[])', 'EXECUTE')
+     OR has_function_privilege('anon', 'public.update_warehouse_gl_mapping(uuid,uuid,uuid,uuid,uuid,uuid,uuid)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'STOCK_185_ACCEPTANCE_ANON_FUNCTION_EXECUTE_REMAINS';
+  END IF;
+
+  RAISE NOTICE 'STOCK_185_GRANTS_OK';
+END
+$grants$;
+
+-- ---------------------------------------------------------------------
+-- 2. RPC smoke: the SECURITY DEFINER write path is unaffected.
+-- ---------------------------------------------------------------------
+INSERT INTO public.organizations (id, name, code)
+VALUES ('51856185-0000-0000-0000-000000000001', 'Stock 185 Smoke', 'STK185-SMOKE');
+
+INSERT INTO public.products (id, org_id, code, name, is_stockable, base_uom_id)
+SELECT '51856185-0000-0000-0000-000000000002', '51856185-0000-0000-0000-000000000001',
+       'STK185-PRD', 'Stock 185 Smoke Product', true, u.id
+FROM public.uoms u
+WHERE u.org_id IS NULL AND u.is_active AND NOT u.is_product_specific
+LIMIT 1;
+
+DO $seed_check$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.products WHERE id = '51856185-0000-0000-0000-000000000002') THEN
+    RAISE EXCEPTION 'STOCK_185_ACCEPTANCE_NO_SYSTEM_UOM_SEEDED';
+  END IF;
+END
+$seed_check$;
+
+INSERT INTO public.warehouses (id, org_id, code, name)
+VALUES ('51856185-0000-0000-0000-000000000003', '51856185-0000-0000-0000-000000000001',
+        'STK185-WH', 'Stock 185 Smoke Warehouse');
+
+INSERT INTO auth.users (id, email)
+VALUES ('51856185-0000-0000-0000-000000000004', 'stock185-smoke@example.test');
+
+INSERT INTO public.user_organizations (user_id, org_id, is_active)
+VALUES ('51856185-0000-0000-0000-000000000004', '51856185-0000-0000-0000-000000000001', true);
+
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub', '51856185-0000-0000-0000-000000000004', true);
+SELECT set_config(
+  'request.jwt.claims',
+  '{"sub":"51856185-0000-0000-0000-000000000004","role":"authenticated"}',
+  true
+);
+
+DO $smoke$
+DECLARE
+  v_product uuid := '51856185-0000-0000-0000-000000000002';
+  v_warehouse uuid := '51856185-0000-0000-0000-000000000003';
+  v_result jsonb;
+  v_sle_count integer;
+  v_bin_qty numeric;
+  v_product_qty numeric;
+BEGIN
+  v_result := public.rpc_manual_stock_movement_v2(jsonb_build_object(
+    'product_id', v_product,
+    'warehouse_id', v_warehouse,
+    'quantity', 120,
+    'movement_type', 'in',
+    'unit_cost_entered', 4
+  ));
+
+  IF COALESCE((v_result ->> 'applied')::boolean, false) IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'STOCK_185_ACCEPTANCE_RPC_WRITE_NOT_APPLIED: %', v_result;
+  END IF;
+
+  SELECT COUNT(*) INTO v_sle_count
+  FROM public.stock_ledger_entries
+  WHERE product_id = v_product AND warehouse_id = v_warehouse;
+
+  SELECT actual_qty INTO v_bin_qty
+  FROM public.bins
+  WHERE product_id = v_product AND warehouse_id = v_warehouse;
+
+  SELECT stock_quantity INTO v_product_qty
+  FROM public.products
+  WHERE id = v_product;
+
+  IF v_sle_count <> 1 OR v_bin_qty IS DISTINCT FROM 120::numeric OR v_product_qty IS DISTINCT FROM 120::numeric THEN
+    RAISE EXCEPTION
+      'STOCK_185_ACCEPTANCE_RPC_WRITE_MISMATCH: sle_count=% bin_qty=% product_qty=%',
+      v_sle_count, v_bin_qty, v_product_qty;
+  END IF;
+
+  RAISE NOTICE 'STOCK_185_RPC_SMOKE_OK: legitimate write path unaffected by the revoked table grants';
+END
+$smoke$;
+
+RESET ROLE;
+
+-- ---------------------------------------------------------------------
+-- 3. Green probe: a direct write is rejected by the grant itself, even
+--    under a hypothetical permissive policy for every command.
+-- ---------------------------------------------------------------------
+SAVEPOINT wardah_185_green_probe;
+
+CREATE POLICY wardah_185_tmp_all ON public.stock_ledger_entries
+  FOR ALL TO authenticated USING (true) WITH CHECK (true);
+
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub', '51856185-0000-0000-0000-000000000004', true);
+SELECT set_config(
+  'request.jwt.claims',
+  '{"sub":"51856185-0000-0000-0000-000000000004","role":"authenticated"}',
+  true
+);
+
+DO $probe$
+DECLARE
+  v_product uuid := '51856185-0000-0000-0000-000000000002';
+  v_warehouse uuid := '51856185-0000-0000-0000-000000000003';
+  v_org uuid := '51856185-0000-0000-0000-000000000001';
+  v_caught boolean := false;
+BEGIN
+  BEGIN
+    INSERT INTO public.stock_ledger_entries (
+      voucher_type, voucher_id, voucher_number, product_id, warehouse_id,
+      posting_date, posting_time, actual_qty, qty_after_transaction,
+      valuation_rate, stock_value, stock_value_difference, org_id
+    ) VALUES (
+      'Stock Adjustment', gen_random_uuid(), 'STK185-PROBE', v_product, v_warehouse,
+      CURRENT_DATE, CURRENT_TIME, 1, 1, 1, 1, 1, v_org
+    );
+  EXCEPTION WHEN insufficient_privilege THEN
+    v_caught := true;
+  END;
+
+  IF NOT v_caught THEN
+    RAISE EXCEPTION 'STOCK_185_GREEN_PROBE_DIRECT_INSERT_SUCCEEDED_UNEXPECTEDLY';
+  END IF;
+
+  RAISE NOTICE
+    'STOCK_185_GREEN_PROBE_OK: direct insert rejected (insufficient_privilege) despite a permissive FOR ALL policy';
+END
+$probe$;
+
+RESET ROLE;
+ROLLBACK TO SAVEPOINT wardah_185_green_probe;
+
+\echo 'STOCK_185_ACCEPTANCE_PASS'
+ROLLBACK;

--- a/scripts/ci/fresh-db/acceptance_185_stock_write_surface_closure.sql
+++ b/scripts/ci/fresh-db/acceptance_185_stock_write_surface_closure.sql
@@ -45,10 +45,13 @@ BEGIN
     END LOOP;
   END LOOP;
 
-  IF NOT (has_table_privilege('authenticated', 'public.warehouses', 'INSERT')
-          AND has_table_privilege('anon', 'public.warehouses', 'INSERT')) THEN
-    RAISE EXCEPTION 'STOCK_185_ACCEPTANCE_WAREHOUSES_SCOPE_VIOLATION';
-  END IF;
+  -- warehouses is intentionally NOT checked here. This script is a
+  -- permanent gate re-triggered by any sql/migrations/** change, but
+  -- warehouses' write surface is documented deferred future work (see the
+  -- migration header) — pinning its pre-185 grants here would make closing
+  -- that surface later fail this gate forever for doing the intended
+  -- follow-up. That 185 itself did not touch warehouses is proven once, at
+  -- migration time, in 185's own postflight — not re-asserted permanently.
 
   IF has_function_privilege('anon', 'public.consume_materials_for_mo(uuid,uuid,jsonb[])', 'EXECUTE')
      OR has_function_privilege('anon', 'public.update_warehouse_gl_mapping(uuid,uuid,uuid,uuid,uuid,uuid,uuid)', 'EXECUTE') THEN
@@ -56,7 +59,13 @@ BEGIN
   END IF;
 
   -- The migration's contract is that only PUBLIC/anon lost EXECUTE;
-  -- service_role's own separate grant must be untouched.
+  -- authenticated's and service_role's own separate grants must be
+  -- untouched.
+  IF NOT has_function_privilege('authenticated', 'public.consume_materials_for_mo(uuid,uuid,jsonb[])', 'EXECUTE')
+     OR NOT has_function_privilege('authenticated', 'public.update_warehouse_gl_mapping(uuid,uuid,uuid,uuid,uuid,uuid,uuid)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'STOCK_185_ACCEPTANCE_AUTHENTICATED_FUNCTION_EXECUTE_MISSING';
+  END IF;
+
   IF NOT has_function_privilege('service_role', 'public.consume_materials_for_mo(uuid,uuid,jsonb[])', 'EXECUTE')
      OR NOT has_function_privilege('service_role', 'public.update_warehouse_gl_mapping(uuid,uuid,uuid,uuid,uuid,uuid,uuid)', 'EXECUTE') THEN
     RAISE EXCEPTION 'STOCK_185_ACCEPTANCE_SERVICE_ROLE_FUNCTION_EXECUTE_MISSING';

--- a/scripts/ci/fresh-db/acceptance_185_stock_write_surface_closure_red.sql
+++ b/scripts/ci/fresh-db/acceptance_185_stock_write_surface_closure_red.sql
@@ -1,0 +1,78 @@
+-- Red proof for Migration 185: run through 184 with 185 omitted.
+--
+-- Confirms the risk 185 closes was real, not assumed: before 185,
+-- authenticated already holds full table-level write privileges on
+-- stock_ledger_entries, and a permissive policy — the same one the green
+-- probe adds and rolls back — lets a direct client INSERT succeed. RLS
+-- alone (no policy for INSERT today) is what stops this pre-185, not a
+-- revoked grant; the moment a policy exists for that command, the retained
+-- grant and the policy combine and the ledger is directly writable.
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+DO $preconditions$
+BEGIN
+  IF NOT (has_table_privilege('authenticated', 'public.stock_ledger_entries', 'INSERT')
+          AND has_table_privilege('authenticated', 'public.stock_ledger_entries', 'UPDATE')
+          AND has_table_privilege('authenticated', 'public.stock_ledger_entries', 'DELETE')
+          AND has_table_privilege('authenticated', 'public.bins', 'INSERT')
+          AND has_table_privilege('anon', 'public.stock_ledger_entries', 'SELECT')) THEN
+    RAISE EXCEPTION 'STOCK_185_RED_PRECONDITION_FAILED: expected pre-185 grants to still be present';
+  END IF;
+  RAISE NOTICE 'STOCK_185_RED_PRECONDITION_OK: pre-185 grants present on authenticated and anon';
+END
+$preconditions$;
+
+INSERT INTO public.organizations (id, name, code)
+VALUES ('51856185-0000-0000-0000-0000000000a1', 'Stock 185 Red', 'STK185-RED');
+
+INSERT INTO public.warehouses (id, org_id, code, name)
+VALUES ('51856185-0000-0000-0000-0000000000a2', '51856185-0000-0000-0000-0000000000a1',
+        'STK185-RED-WH', 'Stock 185 Red Warehouse');
+
+INSERT INTO public.products (id, org_id, code, name, is_stockable, base_uom_id)
+SELECT '51856185-0000-0000-0000-0000000000a3', '51856185-0000-0000-0000-0000000000a1',
+       'STK185-RED-PRD', 'Stock 185 Red Product', true, u.id
+FROM public.uoms u
+WHERE u.org_id IS NULL AND u.is_active AND NOT u.is_product_specific
+LIMIT 1;
+
+SAVEPOINT wardah_185_red_probe;
+
+CREATE POLICY wardah_185_tmp_all ON public.stock_ledger_entries
+  FOR ALL TO authenticated USING (true) WITH CHECK (true);
+
+SET LOCAL ROLE authenticated;
+
+DO $probe$
+DECLARE
+  v_product uuid := '51856185-0000-0000-0000-0000000000a3';
+  v_warehouse uuid := '51856185-0000-0000-0000-0000000000a2';
+  v_org uuid := '51856185-0000-0000-0000-0000000000a1';
+BEGIN
+  INSERT INTO public.stock_ledger_entries (
+    voucher_type, voucher_id, voucher_number, product_id, warehouse_id,
+    posting_date, posting_time, actual_qty, qty_after_transaction,
+    valuation_rate, stock_value, stock_value_difference, org_id
+  ) VALUES (
+    'Stock Adjustment', gen_random_uuid(), 'STK185-RED-PROBE', v_product, v_warehouse,
+    CURRENT_DATE, CURRENT_TIME, 1, 1, 1, 1, 1, v_org
+  );
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.stock_ledger_entries WHERE voucher_number = 'STK185-RED-PROBE'
+  ) THEN
+    RAISE EXCEPTION 'STOCK_185_RED_PROBE_INSERT_DID_NOT_PERSIST';
+  END IF;
+
+  RAISE NOTICE
+    'STOCK_185_RED_PROOF_OK: direct insert succeeded pre-185 once a permissive policy existed, using the still-present table grant';
+END
+$probe$;
+
+RESET ROLE;
+ROLLBACK TO SAVEPOINT wardah_185_red_probe;
+
+\echo 'STOCK_185_RED_PROOF_PASS'
+ROLLBACK;

--- a/sql/migrations/185_stock_write_surface_closure.sql
+++ b/sql/migrations/185_stock_write_surface_closure.sql
@@ -45,10 +45,11 @@
 -- regardless of caller. update_warehouse_gl_mapping is also SECURITY
 -- INVOKER with no guard of its own; its UPDATE on warehouses and INSERT
 -- into warehouse_gl_mapping both currently no-op/fail under RLS for lack of
--- a write policy on either table, for any role. Removing the unused anon
--- EXECUTE grant now is defense in depth against either of those RLS gaps
--- being closed later while the stale anon grant is forgotten — it is not a
--- claim that either function is safe to call.
+-- a write policy on either table, for roles subject to RLS (service_role
+-- bypasses RLS entirely and is not covered by this claim). Removing the
+-- unused anon EXECUTE grant now is defense in depth against either of
+-- those RLS gaps being closed later while the stale anon grant is
+-- forgotten — it is not a claim that either function is safe to call.
 --
 -- Scope: table grants + two anon-executable function grants only. No RLS
 -- policy is added or changed, no RPC signature changes, no data is scanned
@@ -137,8 +138,9 @@ BEGIN
   END LOOP;
 
   -- warehouses is deliberately untouched by this migration. Prove the
-  -- pre-185 grant shape is exactly unchanged, so a future edit here cannot
-  -- silently widen this migration's scope.
+  -- specific pre-185 grants this migration must not touch are still in
+  -- place (this checks those four privileges, not full ACL equivalence),
+  -- so a future edit here cannot silently widen this migration's scope.
   IF NOT (has_table_privilege('authenticated', 'public.warehouses', 'INSERT')
           AND has_table_privilege('authenticated', 'public.warehouses', 'UPDATE')
           AND has_table_privilege('authenticated', 'public.warehouses', 'DELETE')
@@ -154,6 +156,15 @@ BEGIN
   IF NOT has_function_privilege('authenticated', 'public.consume_materials_for_mo(uuid,uuid,jsonb[])', 'EXECUTE')
      OR NOT has_function_privilege('authenticated', 'public.update_warehouse_gl_mapping(uuid,uuid,uuid,uuid,uuid,uuid,uuid)', 'EXECUTE') THEN
     RAISE EXCEPTION 'STOCK_185_AUTHENTICATED_FUNCTION_EXECUTE_MUST_REMAIN';
+  END IF;
+
+  -- The header names service_role as untouched by this migration; only the
+  -- REVOKE ... FROM PUBLIC, anon statements above were run, so service_role
+  -- must still hold EXECUTE through its own separate grant. Prove that
+  -- claim instead of leaving it asserted only in prose.
+  IF NOT has_function_privilege('service_role', 'public.consume_materials_for_mo(uuid,uuid,jsonb[])', 'EXECUTE')
+     OR NOT has_function_privilege('service_role', 'public.update_warehouse_gl_mapping(uuid,uuid,uuid,uuid,uuid,uuid,uuid)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'STOCK_185_SERVICE_ROLE_FUNCTION_EXECUTE_MUST_REMAIN';
   END IF;
 END
 $postflight$;

--- a/sql/migrations/185_stock_write_surface_closure.sql
+++ b/sql/migrations/185_stock_write_surface_closure.sql
@@ -1,0 +1,161 @@
+-- 185_stock_write_surface_closure
+--
+-- Round 3 (inventory integrity) finding INV-05: stock_ledger_entries is the
+-- legal inventory ledger and bins is its derived per-(product, warehouse)
+-- balance (see CLAUDE.md, "Inventory architecture"). Every legitimate write
+-- to either table already goes through a SECURITY DEFINER RPC
+-- (rpc_post_goods_receipt, rpc_create/submit/cancel_stock_adjustment,
+-- rpc_manual_stock_movement_v2, rpc_consume_reserved_materials_v2, or the
+-- internal wardah_apply_stock_incoming/outgoing helpers they call) — these
+-- run as the function owner and do not depend on the caller's table-level
+-- grants at all.
+--
+-- Despite that, a read-only audit on 2026-08-30 found authenticated and
+-- anon still held table-level INSERT/UPDATE/DELETE/TRUNCATE/REFERENCES/
+-- TRIGGER on both tables. Today RLS happens to block a direct write anyway,
+-- because neither table has a permissive policy for those commands — but
+-- that is an emergent, fragile property, not a designed one: the day a
+-- policy is added for any of those commands (for a read-model view, a
+-- reporting join, anything), the untouched grant combines with it
+-- immediately and a direct client write bypasses the ledger. This is the
+-- same latent gap Migration 176 closed on the RBAC tables: RLS and
+-- privileges are independent layers, and a missing policy is not a
+-- substitute for revoking the grant.
+--
+-- This migration closes only that gap. It does not touch:
+--   * warehouses. A live UI consumer path performs direct INSERT/UPDATE/
+--     DELETE against it; closing that grant needs its own consumer
+--     inventory and contract decision, not this migration.
+--   * service_role, and authenticated's SELECT on both tables — the
+--     admin/report surfaces still read stock_ledger_entries and bins
+--     directly under RLS; only the write privileges are removed.
+--   * the MAINTAIN privilege PostgreSQL 17 also grants by default on both
+--     tables to both roles (VACUUM/ANALYZE/CLUSTER/REINDEX, not a data
+--     write). REVOKE ALL removes it from anon as a side effect; it is left
+--     on authenticated pending a separate, explicit decision — this
+--     migration's authorized scope names INSERT/UPDATE/DELETE/TRUNCATE/
+--     REFERENCES/TRIGGER only.
+--
+-- consume_materials_for_mo and update_warehouse_gl_mapping are revoked from
+-- anon because neither has a legitimate anon caller, not because either is
+-- otherwise dangerous today: consume_materials_for_mo is SECURITY INVOKER
+-- with no org-membership guard of its own (RLS on material_reservations is
+-- what actually scopes its UPDATE) and its INSERT INTO stock_moves targets
+-- a table that does not exist in this schema, so it fails closed today
+-- regardless of caller. update_warehouse_gl_mapping is also SECURITY
+-- INVOKER with no guard of its own; its UPDATE on warehouses and INSERT
+-- into warehouse_gl_mapping both currently no-op/fail under RLS for lack of
+-- a write policy on either table, for any role. Removing the unused anon
+-- EXECUTE grant now is defense in depth against either of those RLS gaps
+-- being closed later while the stale anon grant is forgotten — it is not a
+-- claim that either function is safe to call.
+--
+-- Scope: table grants + two anon-executable function grants only. No RLS
+-- policy is added or changed, no RPC signature changes, no data is scanned
+-- or rewritten.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '30s';
+SET LOCAL statement_timeout = '5min';
+
+DO $preflight$
+BEGIN
+  IF to_regclass('public.stock_ledger_entries') IS NULL
+     OR to_regclass('public.bins') IS NULL THEN
+    RAISE EXCEPTION 'STOCK_185_REQUIRED_TABLE_MISSING';
+  END IF;
+
+  IF to_regprocedure('public.rpc_post_goods_receipt(jsonb)') IS NULL
+     OR to_regprocedure('public.rpc_create_stock_adjustment(jsonb)') IS NULL
+     OR to_regprocedure('public.rpc_submit_stock_adjustment(uuid)') IS NULL
+     OR to_regprocedure('public.rpc_cancel_stock_adjustment(uuid,text)') IS NULL
+     OR to_regprocedure('public.rpc_manual_stock_movement_v2(jsonb)') IS NULL
+     OR to_regprocedure('public.rpc_consume_reserved_materials_v2(uuid,uuid,jsonb)') IS NULL
+     OR to_regprocedure('public.wardah_apply_stock_incoming(uuid,uuid,uuid,numeric,numeric,text,uuid,text,date)') IS NULL
+     OR to_regprocedure('public.wardah_apply_stock_outgoing(uuid,uuid,uuid,numeric,text,uuid,text,date)') IS NULL
+     OR to_regprocedure('public.consume_materials_for_mo(uuid,uuid,jsonb[])') IS NULL
+     OR to_regprocedure('public.update_warehouse_gl_mapping(uuid,uuid,uuid,uuid,uuid,uuid,uuid)') IS NULL THEN
+    RAISE EXCEPTION 'STOCK_185_REQUIRED_FUNCTION_MISSING';
+  END IF;
+END
+$preflight$;
+
+-- The supported client surface for the inventory ledger is RPC-only for
+-- mutations. Keep authenticated's read access; remove every table-level
+-- mutation privilege that could bypass that surface.
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER
+  ON TABLE public.stock_ledger_entries, public.bins
+  FROM authenticated;
+
+-- anon has no legitimate reason to hold any privilege on the legal ledger
+-- or its derived balances.
+REVOKE ALL ON TABLE public.stock_ledger_entries, public.bins FROM anon;
+
+-- authenticated keeps EXECUTE on both (see header note on why neither is a
+-- live risk today); only anon's reach is removed. Both functions were
+-- created without an explicit REVOKE, so PostgreSQL's default EXECUTE
+-- grant to PUBLIC is still in their ACL alongside the explicit per-role
+-- grants (confirmed live: proacl held both "=X/postgres" and
+-- "anon=X/postgres" entries). Revoking only the anon-targeted grant would
+-- have left anon executing through its PUBLIC membership regardless;
+-- authenticated and service_role are unaffected because they hold their
+-- own separate grants already.
+REVOKE EXECUTE ON FUNCTION public.consume_materials_for_mo(uuid, uuid, jsonb[])
+  FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.update_warehouse_gl_mapping(uuid, uuid, uuid, uuid, uuid, uuid, uuid)
+  FROM PUBLIC, anon;
+
+DO $postflight$
+DECLARE
+  v_table text;
+  v_priv text;
+BEGIN
+  FOREACH v_table IN ARRAY ARRAY['stock_ledger_entries', 'bins']
+  LOOP
+    IF NOT has_table_privilege('authenticated', format('public.%I', v_table), 'SELECT') THEN
+      RAISE EXCEPTION 'STOCK_185_AUTHENTICATED_SELECT_MUST_REMAIN: %', v_table;
+    END IF;
+
+    FOREACH v_priv IN ARRAY ARRAY['INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'REFERENCES', 'TRIGGER']
+    LOOP
+      IF has_table_privilege('authenticated', format('public.%I', v_table), v_priv) THEN
+        RAISE EXCEPTION 'STOCK_185_AUTHENTICATED_WRITE_PRIVILEGE_REMAINS: % %', v_table, v_priv;
+      END IF;
+    END LOOP;
+
+    FOREACH v_priv IN ARRAY ARRAY['SELECT', 'INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'REFERENCES', 'TRIGGER', 'MAINTAIN']
+    LOOP
+      IF has_table_privilege('anon', format('public.%I', v_table), v_priv) THEN
+        RAISE EXCEPTION 'STOCK_185_ANON_PRIVILEGE_REMAINS: % %', v_table, v_priv;
+      END IF;
+
+      IF NOT has_table_privilege('service_role', format('public.%I', v_table), v_priv) THEN
+        RAISE EXCEPTION 'STOCK_185_SERVICE_ROLE_PRIVILEGE_LOST: % %', v_table, v_priv;
+      END IF;
+    END LOOP;
+  END LOOP;
+
+  -- warehouses is deliberately untouched by this migration. Prove the
+  -- pre-185 grant shape is exactly unchanged, so a future edit here cannot
+  -- silently widen this migration's scope.
+  IF NOT (has_table_privilege('authenticated', 'public.warehouses', 'INSERT')
+          AND has_table_privilege('authenticated', 'public.warehouses', 'UPDATE')
+          AND has_table_privilege('authenticated', 'public.warehouses', 'DELETE')
+          AND has_table_privilege('anon', 'public.warehouses', 'INSERT')) THEN
+    RAISE EXCEPTION 'STOCK_185_WAREHOUSES_SCOPE_VIOLATION';
+  END IF;
+
+  IF has_function_privilege('anon', 'public.consume_materials_for_mo(uuid,uuid,jsonb[])', 'EXECUTE')
+     OR has_function_privilege('anon', 'public.update_warehouse_gl_mapping(uuid,uuid,uuid,uuid,uuid,uuid,uuid)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'STOCK_185_ANON_FUNCTION_EXECUTE_REMAINS';
+  END IF;
+
+  IF NOT has_function_privilege('authenticated', 'public.consume_materials_for_mo(uuid,uuid,jsonb[])', 'EXECUTE')
+     OR NOT has_function_privilege('authenticated', 'public.update_warehouse_gl_mapping(uuid,uuid,uuid,uuid,uuid,uuid,uuid)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'STOCK_185_AUTHENTICATED_FUNCTION_EXECUTE_MUST_REMAIN';
+  END IF;
+END
+$postflight$;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Round 3 (inventory integrity) finding INV-05. `stock_ledger_entries` is the legal inventory ledger and `bins` is its derived per-(product, warehouse) balance (see CLAUDE.md, "Inventory architecture"). Every legitimate write to either table already goes through a `SECURITY DEFINER` RPC (`rpc_post_goods_receipt`, `rpc_create/submit/cancel_stock_adjustment`, `rpc_manual_stock_movement_v2`, `rpc_consume_reserved_materials_v2`, or the internal `wardah_apply_stock_incoming/outgoing` helpers) — these run as the function owner and do not depend on the caller's table-level grants at all.

Despite that, a read-only audit on 2026-08-30 found `authenticated` and `anon` still held table-level `INSERT/UPDATE/DELETE/TRUNCATE/REFERENCES/TRIGGER` on both tables. RLS happens to block a direct write today only because neither table has a permissive policy for those commands — an emergent, fragile property, not a designed one. This is the same latent gap Migration 176 closed on the RBAC tables: RLS and privileges are independent layers, and a missing policy is not a substitute for revoking the grant.

Migration 185 revokes those write privileges from `authenticated` (keeping `SELECT`) and all privileges from `anon`, and revokes `EXECUTE` on `consume_materials_for_mo` and `update_warehouse_gl_mapping` from `anon` (and from `PUBLIC`, since both functions were created without an explicit `REVOKE` and still carried PostgreSQL's default `PUBLIC` grant). `warehouses` is deliberately excluded — a live UI path writes to it directly; closing that is separate, deferred work.

## Full verification (in the migration's own commit)

Acceptance runs on a database built through 185 and proves three things: the grant/EXECUTE shape, that `rpc_manual_stock_movement_v2` still writes `stock_ledger_entries`/`bins`/`products` correctly (the supported surface is unaffected), and that a direct client `INSERT` is rejected with `insufficient_privilege` even under a temporary permissive `FOR ALL` policy added and rolled back inside the test — proving the fix is the revoked grant, not the accidental absence of a policy. The red-proof script runs the same probe on a database built through 184 with 185 omitted and shows the insert succeeding, confirming the risk was real.

## This PR's history: two rounds of independent governance review, both closed

This branch was reviewed twice by the release owner against the actual pushed diff (not just the plan) before authorization to open this PR. Both rounds found real defects in the CI acceptance workflow itself (not in the migration's SQL), all fixed and independently re-verified.

**Round 1** (`4044e68` → `9e1a613`):
1. The red proof reused the same Baseline/reference pair as the green build. Once a future Baseline regeneration folds 185 into the schema snapshot, that pair would no longer let the red database reproduce the pre-185 state — the fix would already be baked into the Baseline itself. Fixed by resolving a second, independently pinned pair via `resolve_baseline_pair.sh sql/baseline 185` (the script's `before_cutoff` parameter exists for exactly this), giving `RED_BASELINE`/`RED_REFERENCE`/`RED_CUTOFF` strictly before cutoff 185 regardless of whatever Baseline is "latest".
2. The red chain was trimmed by deleting only 185's single line from the green chain, which would let migrations numbered after 185 leak into the "red" (pre-fix) database once any existed. Fixed with a range delete (`sed '/^185_..._closure.sql$/,$d'`) cutting 185 and everything after it.
3. The gate's `paths` trigger only watched 185's own file, so a later migration re-granting what 185 revoked would not re-run this gate. Widened to include `sql/migrations/**`, matching the Ledger Truth gate pattern (`trial-balance-ledger-truth.yml`).
4. `service_role`'s `EXECUTE` on both functions was claimed in the migration's prose but never asserted. Added to both the migration's postflight and the green acceptance script.
5. Two doc corrections: "fails under RLS for any role" → "for roles subject to RLS" (`service_role` bypasses RLS and was never in scope for that claim); the `warehouses` postflight comment now says it proves four specific pre-185 grants remain, not that the full ACL shape is unchanged.

**Round 2** (`9e1a613` → `6552af8`):
1. The point-1 fix above left a stale guard: `grep -q '^185_...sql$' /tmp/chain_order.txt` still checked the *green* chain, which legitimately stops containing 185 once a future Baseline folds it in — a false CI failure, reproduced locally against a synthetic cutoff-190 Baseline. Moved the guard to `/tmp/red_chain_order_full.txt` (built from the pinned `RED_CUTOFF`), where the invariant actually belongs: the red chain is supposed to contain 185 by construction, and if it ever doesn't, the range-delete becomes a silent no-op.
2. Widening the trigger to `sql/migrations/**` made the green acceptance script's `warehouses` grant-shape check self-defeating: it pinned `warehouses`' pre-185 grants forever, so the documented deferred follow-up (closing `warehouses`' write surface) would fail this gate. Removed that check from the permanent script; it stays exactly once, in 185's own postflight. Also added `authenticated`'s `EXECUTE` check to the green script alongside `service_role`'s, per review recommendation — same category of permanent state, unlike `warehouses`.

Both rounds' fixes were re-verified end to end against a real local PostgreSQL (16 — no Docker/PG17 available in the working sandbox either; the two already-known PG16/17 gaps, `transaction_timeout` and the `MAINTAIN` privilege, were patched only in local scratch copies, never in any committed file), including reproducing each described bug live before confirming the fix: a synthetic future Baseline to prove both the green-chain-empties-at-fold and the red-pair-stays-pinned behaviors, and a live `REVOKE` on `warehouses` to prove the green acceptance script no longer breaks on the deferred follow-up.

## Explicitly out of scope

- `warehouses`' write surface (documented deferred work, tracked only as a comment, not an issue yet).
- `authenticated`'s `MAINTAIN` privilege on both tables (PostgreSQL 17 default grant; `anon`'s is revoked as a side effect of `REVOKE ALL`, `authenticated`'s is left pending a separate explicit decision).
- Any RLS policy change, RPC signature change, or data rewrite.
- No merge, no Production access, no application of Migration 185 to Production. This PR requests review and CI (PostgreSQL 17) only.

## CI

This is the first time this branch's real CI (PostgreSQL 17 service, `pglast` migration governance, etc.) runs on GitHub Actions — all prior verification was local (PostgreSQL 16 for the acceptance logic, `pglast` installed locally for migration syntax across all 213 files). Awaiting those results before any further action.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HHkc92HLZJVrC7Gha3FYzf)_