### PR TITLE
fix(inventory): distinguish stock-ledger read failure from zero movements

### DIFF
--- a/src/features/inventory/__tests__/stock-movements-load-error.test.tsx
+++ b/src/features/inventory/__tests__/stock-movements-load-error.test.tsx
@@ -1,0 +1,122 @@
+// src/features/inventory/__tests__/stock-movements-load-error.test.tsx
+//
+// PR-R3-UI1 / INV-11: the stock movements screen queried
+// products(name, code, unit_of_measure) — a column that does not exist on
+// products (the real columns are `unit` and `base_uom_id`) — so the read
+// always failed with HTTP 400. The catch block only toasted and fell
+// through to `movements = []`, so a failed read rendered identically to a
+// legitimately empty ledger ("لا توجد حركات مخزون بعد", count "(0)") even
+// though Production held real posted entries. Red proof: with the failure
+// still simulated (as the pre-fix query would have produced), the screen
+// must show an explicit error, never the "zero movements" empty state or a
+// misleading "(0)" count. Green proof: a successful read still renders the
+// movements list untouched.
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { toast } from 'sonner';
+
+const hasPermissionKeyMock = vi.fn((_key: string) => true);
+
+vi.mock('@/hooks/usePermissions', () => ({
+  usePermissions: () => ({
+    hasPermissionKey: (key: string) => hasPermissionKeyMock(key),
+  }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'ar' } }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
+}));
+
+const stockMovementsGetAll = vi.fn();
+
+vi.mock('@/services/supabase-service', () => ({
+  itemsService: { getAll: vi.fn().mockResolvedValue([]) },
+  categoriesService: { getAll: vi.fn().mockResolvedValue([]) },
+  stockMovementsService: { getAll: (...args: unknown[]) => stockMovementsGetAll(...args) },
+}));
+
+vi.mock('@/lib/supabase', () => ({
+  getSupabase: () => ({
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          order: () => Promise.resolve({ data: [], error: null }),
+        }),
+      }),
+    }),
+  }),
+}));
+
+vi.mock('@/hooks/use-uom-engine-enabled', () => ({
+  useUomEngineEnabled: () => ({ isEnabled: false }),
+}));
+
+vi.mock('@/hooks/use-product-uom-status', () => ({
+  useProductUomStatus: () => ({ isEnabled: false, isSuccess: true, needsSetup: () => false }),
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ currentOrgId: 'org-1', user: { id: 'user-1' }, isAuthenticated: true }),
+}));
+
+import { InventoryModule } from '../index';
+
+function renderMovements() {
+  return render(
+    <MemoryRouter initialEntries={['/inventory/movements']}>
+      <Routes>
+        <Route path="/inventory/*" element={<InventoryModule />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  hasPermissionKeyMock.mockReturnValue(true);
+});
+
+describe('StockMovements — read failure vs. genuinely empty ledger (INV-11)', () => {
+  it('RED: a failed read shows an explicit error, never the empty-ledger state or a "(0)" count', async () => {
+    stockMovementsGetAll.mockRejectedValue(
+      Object.assign(new Error('column products.unit_of_measure does not exist'), { code: '42703' })
+    );
+
+    renderMovements();
+
+    await waitFor(() => expect(stockMovementsGetAll).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+
+    expect(screen.getByText('تعذّر تحميل حركات المخزون')).toBeInTheDocument();
+    expect(screen.queryByText('لا توجد حركات مخزون بعد')).not.toBeInTheDocument();
+    expect(screen.queryByText(/حركات المخزون \(0\)/)).not.toBeInTheDocument();
+  });
+
+  it('GREEN: a successful read renders the real movements, not an error', async () => {
+    stockMovementsGetAll.mockResolvedValue([
+      {
+        id: 'sle-1',
+        voucher_type: 'Stock Adjustment',
+        voucher_number: 'ADJ-1',
+        actual_qty: 5,
+        qty_after_transaction: 5,
+        valuation_rate: 10,
+        stock_value: 50,
+        posting_date: '2026-08-30',
+        item: { name: 'Widget', code: 'WID-1' },
+      },
+    ]);
+
+    renderMovements();
+
+    await waitFor(() => expect(screen.getByText('Widget')).toBeInTheDocument());
+    expect(screen.queryByText('تعذّر تحميل حركات المخزون')).not.toBeInTheDocument();
+    expect(screen.getByText('حركات المخزون (1)')).toBeInTheDocument();
+  });
+});

--- a/src/features/inventory/index.tsx
+++ b/src/features/inventory/index.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Badge } from '@/components/ui/badge'
 import { Card } from '@/components/ui/card'
-import { X, Trash2, PackageOpen } from 'lucide-react'
+import { X, Trash2, PackageOpen, AlertCircle } from 'lucide-react'
 import { PageHeader } from '@/components/ui/page-header'
 import { EmptyState } from '@/components/ui/empty-state'
 import { itemsService, categoriesService, stockMovementsService } from '@/services/supabase-service'
@@ -1861,20 +1861,27 @@ function StockMovements() {
   const canRead = hasPermissionKey('inventory.stock_moves.read')
   const [movements, setMovements] = useState<any[]>([])
   const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
 
   useEffect(() => {
     if (!canRead) {
       setMovements([])
+      setLoadError(null)
       setLoading(false)
       return
     }
     const loadMovements = async () => {
+      setLoadError(null)
       try {
         const data = await stockMovementsService.getAll()
         setMovements(data || [])
       } catch (error) {
         console.error('Error loading stock movements:', error)
         toast.error('خطأ في تحميل حركات المخزون')
+        // A failed read is not the same fact as "zero movements exist" —
+        // surface it explicitly instead of falling through to the empty
+        // state, which would tell the user the ledger has nothing in it.
+        setLoadError('تعذّر تحميل حركات المخزون. تحقق من الاتصال وحاول مرة أخرى.')
       } finally {
         setLoading(false)
       }
@@ -1897,10 +1904,18 @@ function StockMovements() {
 
       <div className="bg-card rounded-lg border">
         <div className="p-4 border-b">
-          <h3 className="font-semibold">حركات المخزون ({movements.length})</h3>
+          <h3 className="font-semibold">
+            حركات المخزون {loadError ? '' : `(${movements.length})`}
+          </h3>
         </div>
         <div className="divide-y">
-          {movements.length === 0 ? (
+          {loadError ? (
+            <EmptyState
+              icon={<AlertCircle className="text-destructive/60" />}
+              title="تعذّر تحميل حركات المخزون"
+              description={loadError}
+            />
+          ) : movements.length === 0 ? (
             <EmptyState
               title="لا توجد حركات مخزون بعد"
               description="تظهر الحركات هنا تلقائياً مع أول استلام أو صرف أو تسوية"

--- a/src/services/supabase-service.test.ts
+++ b/src/services/supabase-service.test.ts
@@ -466,5 +466,40 @@ describe('supabase-service customersService', () => {
   })
 })
 
+describe('supabase-service stockMovementsService query contract (INV-11)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('uses only real product columns for all-ledger and product-filtered reads', async () => {
+    const { getSupabase } = await import('../lib/supabase')
+    const { stockMovementsService } = await import('./supabase-service')
+
+    const movements = [{ id: 'sle-1', item: { name: 'Widget', code: 'WID-1' } }]
+    const postingTimeOrder = vi.fn().mockResolvedValue({ data: movements, error: null })
+    const postingDateOrder = vi.fn(() => ({ order: postingTimeOrder }))
+    const productFilter = vi.fn(() => ({ order: postingDateOrder }))
+    const select = vi.fn(() => ({ eq: productFilter, order: postingDateOrder }))
+    const from = vi.fn(() => ({ select }))
+
+    ;(getSupabase as unknown as GetSupabaseMock).mockReturnValue({ from })
+
+    await expect(stockMovementsService.getAll()).resolves.toEqual(movements)
+    await expect(stockMovementsService.getByItemId('product-1')).resolves.toEqual(movements)
+
+    expect(from).toHaveBeenCalledTimes(2)
+    expect(from).toHaveBeenNthCalledWith(1, 'stock_ledger_entries')
+    expect(from).toHaveBeenNthCalledWith(2, 'stock_ledger_entries')
+    expect(select).toHaveBeenCalledTimes(2)
+    expect(select).toHaveBeenNthCalledWith(1, '*, item:products(name, code)')
+    expect(select).toHaveBeenNthCalledWith(2, '*, item:products(name, code)')
+    expect(productFilter).toHaveBeenCalledOnce()
+    expect(productFilter).toHaveBeenCalledWith('product_id', 'product-1')
+    expect(postingDateOrder).toHaveBeenCalledTimes(2)
+    expect(postingDateOrder).toHaveBeenCalledWith('posting_date', { ascending: false })
+    expect(postingTimeOrder).toHaveBeenCalledTimes(2)
+    expect(postingTimeOrder).toHaveBeenCalledWith('posting_time', { ascending: false })
+  })
+})
 
 

--- a/src/services/supabase-service.ts
+++ b/src/services/supabase-service.ts
@@ -407,7 +407,7 @@ export const stockMovementsService = {
     const supabase = await getClient()
     const { data, error } = await supabase
       .from('stock_ledger_entries')
-      .select('*, item:products(name, code, unit_of_measure)')
+      .select('*, item:products(name, code)')
       .order('posting_date', { ascending: false })
       .order('posting_time', { ascending: false })
 
@@ -419,7 +419,7 @@ export const stockMovementsService = {
     const supabase = await getClient()
     const { data, error } = await supabase
       .from('stock_ledger_entries')
-      .select('*, item:products(name, code, unit_of_measure)')
+      .select('*, item:products(name, code)')
       .eq('product_id', productId)
       .order('posting_date', { ascending: false })
       .order('posting_time', { ascending: false })


### PR DESCRIPTION
## Summary

Closes the Round 3 UI finding **INV-11**.

The stock movements screen selected `products.unit_of_measure`, which does not exist. PostgREST returned HTTP 400, but the component converted that failed read into the same `(0)` / empty-ledger UI used for a legitimate zero-row result.

This PR:

- changes both stock-ledger product joins to `item:products(name, code)`;
- introduces an explicit load-error state;
- prevents a failed request from showing `(0)` or “لا توجد حركات مخزون بعد”;
- preserves the genuine empty-ledger state and successful row rendering.

## Verification

- Official head: `93004eb65879b1a3a652edf1ae2baea21376a8ed`
- Full suite: **306 test files / 4591 tests passed**
- Production build: **passed**
- Demo-password build gate: **passed**
- Dedicated RTL Red/Green coverage:
  - rejected read renders an explicit error and never the false zero state;
  - successful read renders the returned movement and correct count.
- Authenticated browser smoke on the Vercel Preview backed by isolated **Wardah-Staging**:
  - `GET /rest/v1/stock_ledger_entries` → **HTTP 200**
  - decoded select: `*,item:products(name,code)`
  - no `unit_of_measure`
  - Staging ledger independently confirmed to contain **0 rows**, so the displayed `(0)` is a legitimate empty state.

## Scope

- No migration.
- No Production write or deployment.
- No test data inserted into Staging.
- The separate `/rest/v1/users` 404 profile-path finding is intentionally excluded from this PR.
- Do not merge without explicit owner authorization.