### PR TITLE
docs(inventory): map legacy stock consumers

### DIFF
--- a/docs/architecture/INVENTORY_CONSUMER_INVENTORY_20260901.md
+++ b/docs/architecture/INVENTORY_CONSUMER_INVENTORY_20260901.md
@@ -93,6 +93,27 @@ barrel التطبيق، ولا يوجد feature أو route يستدعي عملي
 migration إضافية واختبارات قبول، ثم تطبيق Production منفصل وفق ترتيب النشر
 الموثق.
 
+### 4.3 ملفات SQL محلية غير مطبَّقة تحت `src/features/reports/sql/`
+
+بحث مستودعي إضافي كشف ملفين لم يظهرا في 4.1 أو 4.2 لأنهما ليسا كود عميل ولا
+دوال Production تم فحصها عبر `pg_proc`؛ هما مصدر SQL خام في المستودع لا يقع تحت
+`sql/migrations/` ولا يحمل اسمًا قانونيًا، ولا يستهلكه أي كود TypeScript أو
+workflow أو سكربت CI — بحث مستودعي شامل عن اسمي الملفين لم يعثر على أي مرجع
+إليهما:
+
+| المعرّف | الملف | الوصول إلى `stock_moves` | الحالة |
+|---|---|---|---|
+| SM-06 | `src/features/reports/sql/wip-view.sql:31` | `LEFT JOIN stock_moves` داخل `CREATE OR REPLACE VIEW wip_by_stage` | غير مطبَّق؛ إنشاء View يتطلب وجود العلاقة وقت التنفيذ، فمحاولة تطبيقه على المخطط الحالي تفشل بـ`relation "stock_moves" does not exist` |
+| SM-07 | `src/features/reports/sql/variance-functions.sql:32` | `LEFT JOIN stock_moves` غير محروس داخل `CREATE OR REPLACE FUNCTION calculate_material_variances` | نسخة مصدر محلية تسبق الحارس؛ **تُغاير** نسخة Production الحية لنفس الدالة الموثقة في 4.2 (SELECT ديناميكي محروس بـ`to_regclass`) — إعادة تطبيق هذا الملف حرفيًا تُعيد فتح فشل `stock_moves` الذي أغلقه الحارس الحي |
+
+الدالة الثانية في `variance-functions.sql` (`calculate_labor_variances`) لا تشير
+إلى `stock_moves` ولا تدخل هذا الجرد.
+
+هذا PR لا يعدّل أو يحذف الملفين ولا يسجلهما migration؛ هما بقايا SQL تطويرية
+مصنَّفة هنا كخامدة وغير موصولة بأي مسار تطبيق، على غرار stack الجافاسكربت
+القديم في 4.1. أي قرار لاحق (حذف، أو مواءمة مع الحارس الحي، أو تحويل إلى
+migration قانونية) هو DB/tooling follow-up مستقل، لا جزء من هذا الجرد التوثيقي.
+
 ## 5. `avg_rate` — فصل الخطأ عن العقد الصحيح
 
 ### 5.1 drift غير صالح

--- a/docs/architecture/INVENTORY_CONSUMER_INVENTORY_20260901.md
+++ b/docs/architecture/INVENTORY_CONSUMER_INVENTORY_20260901.md
@@ -1,0 +1,149 @@
+# جرد مستهلكي المخزون القديم — Round 3 Consumers
+
+**التاريخ:** 2026-09-01
+**قاعدة الجرد:** `main@3ff77ba4c0a21aa119e85eaf9c5a6a0c2c0c3fed`
+**النطاق:** `stock_movements` و`stock_moves` و`avg_rate`
+**نوع التغيير:** تحليل أثر واختبار snapshot فقط؛ لا تعديل سلوك، لا migration، ولا كتابة على Production.
+
+## 1. النتيجة التنفيذية
+
+لا تمثل الأسماء الثلاثة عقدًا واحدًا:
+
+| الاسم | الحالة القانونية الحالية | الحكم |
+|---|---|---|
+| `stock_movements` | الجدول غير موجود في Production ولا في `database.generated.ts` | مرجع schema قديم في adapter غير موصول بالواجهة الحالية |
+| `stock_moves` | الجدول غير موجود في Production ولا في `database.generated.ts` | مراجع مختلطة: كود قديم خامل، fallback تطويري، ودوال Production حية بعضها محمي وبعضها معطّل عند الاستدعاء |
+| `bins.avg_rate` | العمود غير موجود؛ العمود القانوني هو `bins.valuation_rate` | drift حقيقي داخل `SupabaseInventoryRepository`، لكنه في مسار غير موصول بالواجهة الحالية |
+| `simulate_cogs.avg_rate` | حقل إرجاع موجود في عقد الـRPC والأنواع المولدة | اسم صالح مستقل، وليس عمود `bins`؛ لا يُستبدل آليًا |
+
+شاشة حركات المخزون الحالية ليست مستهلكًا لأي من الجدولين القديمين. بعد PR #210
+تقرأ `stock_ledger_entries`، وهو سجل الحركة القانوني الموثق في `CLAUDE.md`.
+
+## 2. إثبات المخطط الحي — قراءة فقط
+
+نُفذ فحص catalog read-only على Production (`uutfztmqvajmsxnrqeiv`) في
+2026-09-01، دون أي كتابة:
+
+| الكائن | `to_regclass` / catalog | الأنواع المولدة |
+|---|---|---|
+| `public.stock_movements` | `NULL` | غير موجود |
+| `public.stock_moves` | `NULL` | غير موجود |
+| `public.stock_ledger_entries` | موجود | موجود |
+| `public.bins` | موجود | موجود |
+
+أعمدة `bins` الحية والمولدة تشمل `valuation_rate` ولا تشمل `avg_rate`. ويطابق ذلك
+`src/types/database.generated.ts` وBaseline الحالي
+`sql/baseline/000_schema_baseline_20260830_083021.sql`.
+
+## 3. `stock_movements` — مستهلكان داخل adapter خامل
+
+`src/infrastructure/repositories/SupabaseInventoryRepository.ts` يحتوي مسارين
+مباشرين:
+
+| المعرّف | المسار | النوع | النتيجة لو استُدعي |
+|---|---|---|---|
+| SMV-01 | `recordStockMovement()` | كتابة مباشرة | يفشل لأن relation غير موجودة |
+| SMV-02 | `getStockMovements()` | قراءة مباشرة | يفشل لأن relation غير موجودة |
+
+سلسلة الوصول هي `IInventoryRepository` ← `InventoryAppService` ←
+`src/application/hooks/useInventory.ts`. لا يوجد import إنتاجي لهذه hooks خارج
+barrel التطبيق، ولا يوجد feature أو route يستدعي عمليتي الحركة. لذلك العطب حقيقي
+بنيويًا لكنه غير واقع في شاشة المستخدم الحالية.
+
+الاختبارات الحالية في
+`src/infrastructure/repositories/__tests__/SupabaseInventoryRepository.test.ts`
+تستبدل Supabase كله بـmock، وتعيد صفوف `stock_movements` بالشكل الذي يتوقعه الكود،
+ولا تؤكد اسم الجدول في الاستدعاء. خضرتها لا تثبت توافق المخطط.
+
+المراجع داخل migrations المبكرة (`03` و`04`) تاريخية؛ فحص أجسام الدوال الحية لم
+يجد دالة Production ما زالت تشير إلى `stock_movements`. وتصنيف RBAC الموجود يضع
+الاسم أصلًا تحت Issue #148 بوصفه `stale_not_in_production`.
+
+## 4. `stock_moves` — خريطة المستهلكين
+
+### 4.1 كود العميل
+
+| المعرّف | المستهلك | الوصول | قابلية الوصول الحالية | الحكم |
+|---|---|---|---|---|
+| SM-01 | `enhanced-sales-service.ts` / `recordSalesInventoryMovement()` | INSERT | داخل fallback تطويري فقط؛ Production يفشل مغلقًا قبل fallback إذا غاب `rpc_post_delivery_note` | غير مستخدم في Production، لكنه يخصم `products.stock_quantity` أولًا ثم يتسامح مع غياب سجل الحركة في التطوير |
+| SM-02 | `js/modules/{inventory,purchasing,sales,processCosting}.js` | قراءات وكتابات مباشرة | `js/main.js` يستوردها، لكن `index.html` يشغّل `/src/main.tsx` ولا يحمّل `js/main.js` | stack قديم غير موصول بتطبيق Vite الحالي |
+| SM-03 | `inventory-validator.ts` → `validate_stock_balance` | RPC قراءة | singleton مُصدّر بلا مستدعٍ إنتاجي في `src` | الـRPC نفسها حية لكنها معطلة بسبب الجدول الغائب؛ الخطأ يتحول إلى warning إن استُخدم validator |
+| SM-04 | `createOrder.ts` → `rpc_create_mo_with_reservation` | RPC كتابة | شاشة التصنيع الحالية تنشئ MO بلا `materials`، فلا تدخل هذا الفرع | تمرير مواد غير فارغة يجعل الدالة الحية تقرأ الجدول الغائب وتفشل |
+| SM-05 | `updateStatus.ts` → `rpc_complete_manufacturing_order` | RPC كتابة | مسار إنتاجي | جسم الدالة يتحقق من `to_regclass` قبل INSERT، فيتجاوز المرآة القديمة بأمان |
+
+المفاتيح `inventory.stock_moves.*` في route/RBAC catalog أسماء صلاحيات، لا وصولًا
+إلى جدول `stock_moves`. وهي تحمي حاليًا شاشات الحركة والتحويل القانونية؛ لا تُحذف
+لمجرد غياب الجدول الذي يشبه اسمها.
+
+### 4.2 دوال Production الحية
+
+فحص `pg_proc` read-only أعاد سبع دوال تحمل مرجعًا مباشرًا أو غير مباشر:
+
+| الدالة | الوصول إلى `stock_moves` | الحارس | الحكم الحالي |
+|---|---|---|---|
+| `calculate_material_variances` | SELECT ديناميكي | `to_regclass` | آمنة وظيفيًا: تعيد صفوفًا فارغة عند غياب الجدول |
+| `rpc_complete_manufacturing_order` | INSERT | `to_regclass` | آمنة من 42P01: تتجاوز كتابة المرآة القديمة |
+| `rpc_create_mo_with_reservation` | SELECT مباشر عند مواد غير فارغة | لا يوجد | معطلة لذلك الفرع؛ لا تُختبر بكتابة Production في هذا الجرد |
+| `consume_materials_for_mo` | INSERT مباشر | لا يوجد | معطلة عند الاستدعاء؛ ما زالت ممنوحة لـ`authenticated` و`service_role` بعد 185 |
+| `validate_stock_balance` | SELECT مباشر | لا يوجد | معطلة عند الاستدعاء؛ ممنوحة حاليًا لـ`PUBLIC`/`anon`/`authenticated` |
+| `comprehensive_data_integrity_check` | يستدعي `validate_stock_balance` | لا يوجد حول الاستدعاء | يرث فشل الدالة السابقة؛ ممنوحة حاليًا لـ`PUBLIC`/`anon`/`authenticated` |
+| `simulate_cogs` | لا يقرأ `stock_moves` | غير منطبق | ظهر في البحث بسبب حقل الإرجاع `avg_rate` فقط |
+
+هذا PR لا يعيد كتابة هذه الدوال ولا يسحب منحًا. إغلاقها يحتاج DB PR مستقلًا مع
+migration إضافية واختبارات قبول، ثم تطبيق Production منفصل وفق ترتيب النشر
+الموثق.
+
+## 5. `avg_rate` — فصل الخطأ عن العقد الصحيح
+
+### 5.1 drift غير صالح
+
+`SupabaseInventoryRepository` يستخدم `bins.avg_rate` في أربعة مواضع:
+
+1. `updateBin()` يرسل UPDATE لعمود غير موجود.
+2. `createBin()` يرسل INSERT لعمود غير موجود.
+3. `getStockBalance()` يطلب العمود داخل select string.
+4. `mapBin()` يقرأه من الصف الوهمي.
+
+العمود القانوني هو `valuation_rate`. والاختبار الحالي يمرر `avg_rate` داخل mock،
+فيعيد إنتاج توقع الكود لا شكل قاعدة البيانات.
+
+هذا المسار غير موصول بواجهة حالية، لكن إصلاح الاسم وحده لا يكفي لاعتماد adapter:
+نفسه يحتوي كتابة مباشرة للمخزون و`stock_movements` الغائبة و`stock_reservations`
+المصنفة تاريخية. قرار follow-up يجب أن يكون إما تقاعد adapter كاملًا، أو إعادة
+كتابته على العقود القانونية وRPCs الذرية؛ لا ترقيع `avg_rate` منفردًا.
+
+### 5.2 عقد صالح يجب الحفاظ عليه
+
+`simulate_cogs(uuid,numeric)` يعيد حقلًا محسوبًا اسمه `avg_rate`، والاسم موجود في
+`database.generated.ts`. لا يوجد عمود بهذا الاسم في `bins`، ولا تعارض بين
+الحالتين. المستهلك المعرّف هو
+`SupabaseInventoryValuationRepository.simulateCOGS()` عبر RPC، لكن service/DI
+الحاليين لا يملكان feature إنتاجيًا مستدعيًا. صفحة `ValuationTesting.tsx` مستبعدة
+صراحةً من TypeScript وغير موصولة بأي route وتستورد module محذوفًا.
+
+منح `simulate_cogs` الحالية تقع ضمن فجوة قراءة المخزون المتتبعة أصلًا في Issue
+#173؛ هذا الجرد لا يكرر إصلاح RBAC داخل PR توثيقي.
+
+أما `avgRate` في مقياس ساعات مراكز العمل واختبار حساب متوسط ledger فهو متغير
+محلي غير متعلق بمخطط `bins`، ولذلك خارج نطاق الإصلاح.
+
+## 6. القرار الناتج وترتيب المتابعة
+
+1. **هذا PR:** يحفظ الجرد واختبار snapshot فقط، بلا تغيير سلوك.
+2. **مزامنة AI Simulation Lab:** بعد دمج هذا الجرد، تُحدّث حالة Round 3 والكتالوجات
+   اعتمادًا عليه بدل إعادة الاكتشاف.
+3. **PR-1R / DB follow-up:** يحسم الدوال الحية التي تشير إلى `stock_moves` الغائب
+   (إعادة توجيه إلى `stock_ledger_entries`/`bins` أو تقاعد وسحب المنح) في migration
+   مستقلة مع Red/Green وFresh DB.
+4. **Application follow-up مستقل:** تقاعد `SupabaseInventoryRepository` القديم أو
+   مواءمته كاملةً؛ لا يخلط مع DB/security ولا مع UI cleanup.
+5. **Issue #173:** يبقى مسار تشديد صلاحيات read RPCs، ومنها `simulate_cogs` و
+   `validate_stock_balance` إن بقيت الأخيرة أصلًا.
+
+## 7. حدود الإثبات
+
+- جرد المستودع كامل، وفحص Production كان catalog read-only فقط.
+- لم تُستدعَ أي دالة كتابة، ولم تُنشأ fixture أو حركة مخزون.
+- لا يثبت غياب import داخل المستودع عدم وجود مستهلك خارجي غير محفوظ هنا.
+- لا يُعد هذا المستند قرارًا بإحياء `stock_moves` أو `stock_movements`؛ المصدر
+  القانوني الحالي يبقى `stock_ledger_entries` مع `bins`.

--- a/src/infrastructure/repositories/__tests__/inventory-consumer-snapshot.test.ts
+++ b/src/infrastructure/repositories/__tests__/inventory-consumer-snapshot.test.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+// This deliberately pins the discovery snapshot. A follow-up that retires or
+// rewrites a consumer must supersede the audit and update this contract.
+const read = (path: string) => readFileSync(path, 'utf8')
+
+const count = (source: string, token: string) => source.split(token).length - 1
+
+describe('Round 3 inventory consumer snapshot', () => {
+  const generatedTypes = read('src/types/database.generated.ts')
+  const currentBaseline = read('sql/baseline/000_schema_baseline_20260830_083021.sql')
+
+  it('pins the canonical relations and bins valuation column', () => {
+    expect(generatedTypes).not.toMatch(/^      stock_movements: \{/m)
+    expect(generatedTypes).not.toMatch(/^      stock_moves: \{/m)
+    expect(currentBaseline).not.toMatch(/^CREATE TABLE public\.stock_movements\b/m)
+    expect(currentBaseline).not.toMatch(/^CREATE TABLE public\.stock_moves\b/m)
+
+    const binsStart = generatedTypes.indexOf('      bins: {')
+    const binsEnd = generatedTypes.indexOf('      bom_alternatives: {', binsStart)
+    expect(binsStart).toBeGreaterThanOrEqual(0)
+    expect(binsEnd).toBeGreaterThan(binsStart)
+
+    const binsContract = generatedTypes.slice(binsStart, binsEnd)
+    expect(binsContract).toContain('valuation_rate')
+    expect(binsContract).not.toContain('avg_rate')
+  })
+
+  it('pins the two stale stock_movements calls and four bins.avg_rate references', () => {
+    const repository = read('src/infrastructure/repositories/SupabaseInventoryRepository.ts')
+
+    expect(count(repository, ".from('stock_movements')")).toBe(2)
+    expect(count(repository, 'avg_rate')).toBe(4)
+  })
+
+  it('keeps the stock_moves browser write classified as a development fallback', () => {
+    const salesService = read('src/services/enhanced-sales-service.ts')
+
+    expect(count(salesService, ".from('stock_moves')")).toBe(1)
+    expect(salesService).toContain('if (import.meta.env.PROD)')
+    expect(salesService.indexOf('if (import.meta.env.PROD)')).toBeLessThan(
+      salesService.indexOf('const deliveryNumber = await generateDeliveryNumber()')
+    )
+  })
+
+  it('keeps the legacy JavaScript stack outside the active Vite entrypoint', () => {
+    const indexHtml = read('index.html')
+    const legacyMain = read('js/main.js')
+    const legacyModules = [
+      'js/modules/inventory.js',
+      'js/modules/purchasing.js',
+      'js/modules/sales.js',
+      'js/modules/processCosting.js',
+    ].map(read).join('\n')
+
+    expect(indexHtml).toContain('/src/main.tsx')
+    expect(indexHtml).not.toContain('/js/main.js')
+    expect(legacyMain).toContain("from './modules/inventory.js'")
+    expect(count(legacyModules, '.from(T.stock_moves)')).toBe(9)
+  })
+
+  it('distinguishes the valid simulate_cogs result field from bins.avg_rate', () => {
+    const valuationRepository = read(
+      'src/infrastructure/repositories/SupabaseInventoryValuationRepository.ts'
+    )
+
+    expect(generatedTypes).toMatch(
+      /simulate_cogs:[\s\S]*?Returns: \{[\s\S]*?avg_rate: number/
+    )
+    expect(valuationRepository).toContain(".rpc('simulate_cogs'")
+  })
+})

--- a/src/infrastructure/repositories/__tests__/inventory-consumer-snapshot.test.ts
+++ b/src/infrastructure/repositories/__tests__/inventory-consumer-snapshot.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs'
+import { readdirSync, readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 
 // This deliberately pins the discovery snapshot. A follow-up that retires or
@@ -7,9 +7,23 @@ const read = (path: string) => readFileSync(path, 'utf8')
 
 const count = (source: string, token: string) => source.split(token).length - 1
 
+// Mirrors scripts/ci/fresh-db/resolve_baseline_pair.sh's no-cutoff-arg
+// selection (`find ... -name '000_schema_baseline_*.sql' | sort | tail -1`):
+// once another Baseline pair is generated, this test must inspect the
+// current one, not the dated file recorded when it was written.
+const resolveLatestBaseline = () => {
+  const dir = 'sql/baseline'
+  const latest = readdirSync(dir)
+    .filter((name) => /^000_schema_baseline_.*\.sql$/.test(name))
+    .sort()
+    .at(-1)
+  if (!latest) throw new Error(`no 000_schema_baseline_*.sql found in ${dir}`)
+  return `${dir}/${latest}`
+}
+
 describe('Round 3 inventory consumer snapshot', () => {
   const generatedTypes = read('src/types/database.generated.ts')
-  const currentBaseline = read('sql/baseline/000_schema_baseline_20260830_083021.sql')
+  const currentBaseline = read(resolveLatestBaseline())
 
   it('pins the canonical relations and bins valuation column', () => {
     expect(generatedTypes).not.toMatch(/^      stock_movements: \{/m)


### PR DESCRIPTION
## Summary

- inventory all repository and live-function consumers of `stock_movements`, `stock_moves`, and `avg_rate`
- distinguish stale `bins.avg_rate` references from the valid `simulate_cogs.avg_rate` result field
- add a focused source-contract snapshot so later retirement or rewrites must update the recorded inventory explicitly

## Key findings

- `stock_movements` and `stock_moves` are absent from the current baseline, generated types, and Production catalog
- `bins` exposes `valuation_rate`, not `avg_rate`
- the stale browser repository and legacy JavaScript stack are currently dormant
- several live Production functions still reference `stock_moves`; guarded functions fail safely, while unguarded branches require a separate DB migration/follow-up
- RBAC names such as `inventory.stock_moves.*` are permission identifiers and are not table consumers

## Verification

- `node_modules/.bin/vitest run --coverage.enabled=false` — 307 files / 4597 tests passed
- focused snapshot — 5/5 passed
- `tsc --noEmit -p tsconfig.json` — passed
- `eslint --no-ignore src/infrastructure/repositories/__tests__/inventory-consumer-snapshot.test.ts` — passed
- `npm run build` — passed, including `check:no-demo-passwords`
- `git diff --check` — clean

## Scope and safety

- base: `main@3ff77ba4c0a21aa119e85eaf9c5a6a0c2c0c3fed` (merged PR #210)
- documentation and test guard only; no runtime behavior change
- no migration
- Production access during discovery was catalog/read-only only
- no Production write and no Staging fixture insertion
- AI Simulation Lab sync remains a separate follow-up after this PR
- no merge or auto-merge requested
