### PR TITLE
fix(inventory): enforce stock adjustment ledger idempotency

### DIFF
--- a/.github/workflows/stock-adjustment-idempotency-187-acceptance.yml
+++ b/.github/workflows/stock-adjustment-idempotency-187-acceptance.yml
@@ -1,0 +1,144 @@
+name: Stock adjustment idempotency 187
+
+on:
+  pull_request:
+    paths:
+      - 'sql/migrations/187_stock_adjustment_ledger_idempotency.sql'
+      - 'scripts/ci/fresh-db/setup_187_stock_adjustment_idempotency.sql'
+      - 'scripts/ci/fresh-db/acceptance_187_stock_adjustment_idempotency.sql'
+      - 'scripts/ci/fresh-db/acceptance_187_stock_adjustment_idempotency_red.sql'
+      - 'scripts/ci/fresh-db/acceptance_187_stock_adjustment_concurrency.sh'
+      - '.github/workflows/stock-adjustment-idempotency-187-acceptance.yml'
+      - 'sql/baseline/**'
+      - 'sql/migrations/**'
+  workflow_dispatch:
+
+jobs:
+  acceptance:
+    name: Prospective ledger uniqueness and deterministic race
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      PGHOST: localhost
+      PGUSER: postgres
+      PGPASSWORD: postgres
+      PGDATABASE: wardah_187
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Resolve cutoff-186 upgrade chain
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          PAIR=$(bash scripts/ci/fresh-db/resolve_baseline_pair.sh sql/baseline 187)
+          pair_field() { printf '%s\n' "$PAIR" | sed -n "s/^$1=//p"; }
+          echo "BASELINE=$(pair_field BASELINE_PATH)" >> "$GITHUB_ENV"
+          echo "REFERENCE=$(pair_field REFERENCE_PATH)" >> "$GITHUB_ENV"
+          CUTOFF=$(pair_field BASELINE_CUTOFF)
+          CUTOFF=${CUTOFF:-0}
+          python3 scripts/ci/fresh-db/build_apply_order.py sql/migrations "$CUTOFF" \
+            > /tmp/stock-187-order-full.txt
+          grep -q '^187_stock_adjustment_ledger_idempotency.sql$' \
+            /tmp/stock-187-order-full.txt
+          sed '/^187_stock_adjustment_ledger_idempotency.sql$/,$d' \
+            /tmp/stock-187-order-full.txt > /tmp/stock-187-pre-order.txt
+
+      - name: Build pre-187 database and seed historical duplicate
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          createdb "$PGDATABASE"
+          psql -v ON_ERROR_STOP=1 -f scripts/ci/fresh-db/supabase_shim.sql -q
+          psql -v ON_ERROR_STOP=1 -f "$BASELINE" -q
+          psql -v ON_ERROR_STOP=1 -f "$REFERENCE" -q
+          REPORT=/tmp/stock-187-pre-chain.txt \
+            bash scripts/ci/fresh-db/run_chain.sh \
+              sql/migrations /tmp/stock-187-pre-order.txt
+          psql -v ON_ERROR_STOP=1 \
+            -f scripts/ci/fresh-db/setup_187_stock_adjustment_idempotency.sql \
+            2>&1 | tee /tmp/stock-187-setup.out
+          grep -q 'STOCK_187_SETUP_PASS' /tmp/stock-187-setup.out
+
+      - name: Red proof
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          psql -v ON_ERROR_STOP=1 \
+            -f scripts/ci/fresh-db/acceptance_187_stock_adjustment_idempotency_red.sql \
+            2>&1 | tee /tmp/stock-187-red.out
+          grep -q 'STOCK_187_RED_PROOF_PASS' /tmp/stock-187-red.out
+
+      - name: Apply Migration 187 over historical duplicate
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          psql -v ON_ERROR_STOP=1 \
+            -f sql/migrations/187_stock_adjustment_ledger_idempotency.sql \
+            2>&1 | tee /tmp/stock-187-migration.out
+
+      - name: Green acceptance
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          psql -v ON_ERROR_STOP=1 \
+            -f scripts/ci/fresh-db/acceptance_187_stock_adjustment_idempotency.sql \
+            2>&1 | tee /tmp/stock-187-green.out
+          grep -q 'STOCK_187_GREEN_ACCEPTANCE_PASS' /tmp/stock-187-green.out
+
+      - name: Deterministic concurrency proof
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          bash scripts/ci/fresh-db/acceptance_187_stock_adjustment_concurrency.sh \
+            2>&1 | tee /tmp/stock-187-concurrency.out
+          grep -q 'STOCK_187_CONCURRENCY_PASS' /tmp/stock-187-concurrency.out
+
+      - name: Confirm every proof direction ran
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          grep -q 'STOCK_187_RED_CONTRACT_ABSENT_OK' /tmp/stock-187-red.out
+          grep -q 'STOCK_187_RED_DUPLICATE_REPRODUCED_OK' /tmp/stock-187-red.out
+          grep -q 'STOCK_187_GREEN_CONTRACT_SHAPE_OK' /tmp/stock-187-green.out
+          grep -q 'STOCK_187_GREEN_HISTORY_PRESERVED_OK' /tmp/stock-187-green.out
+          grep -q 'STOCK_187_GREEN_NULL_SOURCE_REJECTED_OK' /tmp/stock-187-green.out
+          grep -q 'STOCK_187_GREEN_SOURCE_RELATION_REJECTED_OK' /tmp/stock-187-green.out
+          grep -q 'STOCK_187_GREEN_TABLE_SOURCE_REJECTED_OK' /tmp/stock-187-green.out
+          grep -q 'STOCK_187_GREEN_VALID_RECEIPT_LINES_OK' /tmp/stock-187-green.out
+          grep -q 'STOCK_187_GREEN_RPC_REPLAY_OK' /tmp/stock-187-green.out
+          grep -q 'STOCK_187_GREEN_SOURCE_PROPAGATED_OK' /tmp/stock-187-green.out
+          grep -q 'STOCK_187_GREEN_UNIQUE_BOUNDARY_OK' /tmp/stock-187-green.out
+          grep -q 'STOCK_187_CONCURRENCY_PASS' /tmp/stock-187-concurrency.out
+
+      - name: Upload acceptance evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: stock-adjustment-idempotency-187-${{ github.run_id }}
+          path: |
+            /tmp/stock-187-pre-chain.txt
+            /tmp/stock-187-setup.out
+            /tmp/stock-187-red.out
+            /tmp/stock-187-migration.out
+            /tmp/stock-187-green.out
+            /tmp/stock-187-concurrency.out
+            /tmp/stock-187-race-*.out
+            /tmp/stock-187-race-*.err
+          retention-days: 30

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,12 @@ React 18 + TypeScript + Vite، shadcn/ui + Tailwind، Zustand + TanStack Query،
   فارغة مضللة. postflight الحي أثبت صفر مراجع `stock_moves`، وثبات بيانات
   المخزون، وSQLSTATE `0A000` للتقاعد؛ زوج Baseline cutoff 186 وُلد في run
   `33734325356` ونُشر عبر PR #214 المدموج عند `3ce8b295`.
+- `sql/migrations/187_stock_adjustment_ledger_idempotency.sql` +
+  `docs/db/STOCK_ADJUSTMENT_IDEMPOTENCY_187_RUNBOOK.md` — **اقتراح repository
+  فقط؛ غير مدموج وغير مطبق على Production**: يصحح تعريف `INV-02` من قيد عالمي
+  غير قانوني إلى حد prospective خاص بـStock Adjustment، يربط الحركة بسطر
+  `stock_adjustment_items`، ويترك تكرار `ADJ-000001` التاريخي ذي المصدر المجهول
+  دون حذف أو backfill تخميني. يحتاج قرار دمج مستقل ثم تفويض Production مستقل.
 
 ## Baseline
 

--- a/docs/ai-simulation-lab/INVENTORY_INTEGRITY_PROGRESS_20260902.md
+++ b/docs/ai-simulation-lab/INVENTORY_INTEGRITY_PROGRESS_20260902.md
@@ -4,7 +4,8 @@
 
 **مصدر الحقيقة:** سجل Production حتى Migration 186، زوج Baseline cutoff 186
 المولّد في run `33734325356` والمنشور عبر PR #214 عند `3ce8b295`، تدقيق المخزون
-read-only في 2026-08-30، ونتائج PRs #208–#213 وpostflight تطبيق 186.
+read-only في 2026-08-30، إعادة فحص INV-02 read-only في 2026-09-03، ونتائج
+PRs #208–#213 وpostflight تطبيق 186.
 
 **حد السلطة:** هذا المستند لا يفوض دمج PR، ولا تطبيق migration، ولا كتابة أو
 إصلاح بيانات على Production.
@@ -23,7 +24,7 @@ Round 3 **بدأت ولم تُغلق**. أُنجزت إغلاقات ومخرجا
 | خطأ شاشة حركات المخزون | ✅ مدموج | PR #210؛ query contract + حالة خطأ صريحة + RTL Red/Green + smoke على Staging |
 | جرد `stock_movements`/`stock_moves`/`avg_rate` | ✅ مدموج | PR #211 عند `a74c06f`؛ 11/11 checks والخيطان محلولان؛ merge commit `c4ffc44` |
 | إصلاح عقود `stock_moves` الحية | ✅ مدموج ومطبق | PR #213 / Migration 186؛ merge `956011a`؛ Production ledger `20260903083010`؛ صفر مراجع `stock_moves` وبيانات المخزون ثابتة و`0A000` مثبتة |
-| بقية عيوب S0/S1 | ⏳ مفتوحة | `INV-01`/`INV-02`/`INV-03`/`INV-04`، ثم البنود الأقل خطورة |
+| بقية عيوب S0/S1 | ⏳ مفتوحة | `INV-01`/`INV-03`/`INV-04` مفتوحة؛ Migration 187 تقترح عقدًا prospective لـ`INV-02` ولم تُدمج أو تُطبق |
 | Simulation Lab Phase 0 | ⏳ مؤجلة | لا تبدأ لمجرد خضرة UI أو CI؛ تبدأ بعد إغلاق بوابة Round 3 أدناه |
 
 لا يجوز اختزال النتيجة إلى «Round 3 مكتملة»: Migration 185 أغلقت **سطح كتابة**،
@@ -66,7 +67,7 @@ Round 3 **بدأت ولم تُغلق**. أُنجزت إغلاقات ومخرجا
 | ID | الخطورة | الاكتشاف | الحالة في 2026-09-02 |
 |---|---|---|---|
 | `INV-01` | S0 | حركة PP810837 بكمية 400 وقيمة 10,000 بلا bin | مفتوح؛ لا backfill تخميني |
-| `INV-02` | S0 | غياب idempotency فريد على `(voucher_type, voucher_id, product_id, warehouse_id)` | مفتوح؛ يحتاج migration واختبار سباق |
+| `INV-02` | S0 | غياب idempotency race-safe للتسويات؛ صياغة القيد العالمي الأصلية غير قانونية لأن مستندات أخرى تسمح بأسطر متكررة لنفس المنتج/المخزن | قيد التنفيذ في Migration 187: حد prospective خاص بـStock Adjustment + source line + سباق حتمي؛ غير مدموج وغير مطبق |
 | `INV-03` | S1 | انقطاع `qty_after_transaction` في ADJ-000001 | مفتوح؛ يرتبط بعقد التسلسل/التزامن |
 | `INV-04` | S1 | `products.stock_quantity/value` لا يتطابق دائمًا مع SLE/bins | مفتوح؛ يجب حسم كونه projection مشتقًا قبل فرضه |
 | `INV-05` | S1 | منح كتابة مباشرة على `stock_ledger_entries` و`bins` | ✅ مغلق في Migration 185 |
@@ -80,6 +81,19 @@ Round 3 **بدأت ولم تُغلق**. أُنجزت إغلاقات ومخرجا
 اللقطة التي أنتجت هذه النتائج كانت: 5 صفوف SLE مرحّلة، صفا bins، 118 منتجًا
 stockable، و4 مخازن. وهي لا تُعاد صياغتها كـ«الحالة الحالية» دون قراءة جديدة
 مؤرخة؛ قيمتها أنها دليل اكتشاف محفوظ.
+
+### 3.1 تنقيح عقد INV-02 في 2026-09-03
+
+إعادة الفحص read-only أثبتت أن صفوف SLE الخمسة كلها بلا `source_line_id`، وأن
+مجموعة تكرار تاريخية واحدة تخص `ADJ-000001`. لكنه أثبت أيضًا من عقود writers أن
+القيد العالمي المقترح أولًا سيمنع حركات قانونية: Goods Receipt وDelivery Note قد
+يحملان سطرين مستقلين لنفس المنتج/المخزن، واستهلاك التصنيع قد يكون جزئيًا.
+
+لذلك Migration 187 المقترحة لا تعيد كتابة التاريخ ولا تفرض هذا المفتاح على كل
+voucher. تفرض مستقبلًا فقط حركة Stock Adjustment واحدة لكل
+`(org_id,voucher_id,product_id,warehouse_id)` عندما يكون `source_line_id` معلومًا،
+وتلزم RPC التسوية بتمرير `stock_adjustment_items.id`. يبقى `INV-02` مفتوحًا حتى
+تُراجع وتُدمج وتُطبق migration بتفويضات منفصلة ويُحفظ postflight الحي.
 
 ---
 
@@ -119,7 +133,9 @@ stockable، و4 مخازن. وهي لا تُعاد صياغتها كـ«الحا
    Baseline cutoff 186 نُشر عبر PR #214 المدموج عند `3ce8b295`.
 4. `rpc_create_mo_with_reservation` يعمل بمواد غير فارغة عبر العقد القانوني، أو
    يُزال من سيناريو اليوم بقرار منتج موثق؛ لا fallback تاريخي.
-5. إغلاق `INV-02` باختبار idempotency/سباق حتمي قبل فرض قيد على Production.
+5. إغلاق `INV-02`: Migration 187 المقترحة تمر Red/Green والسباق الحتمي، ثم قرار
+   دمج مستقل، ثم تطبيق Production/postflight بتفويض مستقل. لا يُفرض القيد
+   العالمي المرفوض ولا تُعالج صفوف `NULL source_line_id` تخمينيًا.
 6. إغلاق `INV-01` و`INV-03` بعقد bin/continuity قابل للفرض، مع فصل إصلاح البيانات
    التاريخية عن تغيير المخطط.
 7. حسم `INV-04` كـprojection قانوني أو مرجع غير ملزم، ثم تعديل الثابت وفق القرار.
@@ -136,7 +152,7 @@ stockable، و4 مخازن. وهي لا تُعاد صياغتها كـ«الحا
 | 1 | جرد consumers في PR #211 | evidence/docs | ✅ مدموج عند `c4ffc44` |
 | 2 | تثبيت مزامنة الوثائق في PR #212 على `main` | docs-only | ✅ مدموج عند `4e63a55`؛ لم يغيّر قاعدة البيانات |
 | 3 | PR-1R / Migration 186 لعقود المخزون القديمة | DB-first | ✅ PR #213 مدموج، Production مطبق ومثبت postflight؛ Baseline cutoff 186 منشور عبر PR #214 عند `3ce8b295` |
-| 4 | idempotency للمخزون (`INV-02`) | DB | duplicate preflight + سباق حتمي + قيد قانوني |
+| 4 | idempotency للمخزون (`INV-02`) | DB | 🟡 Migration 187 مقترحة: duplicate preflight + Red/Green + سباق حتمي + قيد Stock Adjustment prospective؛ لا Production apply بعد |
 | 5 | bin/continuity (`INV-01`/`INV-03`) | DB/data split | عقد مستقبلي منفصل عن remediation التاريخي |
 | 6 | projection والهوية (`INV-04`/`INV-06`) | DB/application حسب القرار | مصدر حقيقة واحد واختبار مستهلك |
 | 7 | UoM/org/provenance (`INV-07`/`INV-08`/`INV-10`) | follow-ups محددة | بلا backfill استنتاجي |

--- a/docs/ai-simulation-lab/README.md
+++ b/docs/ai-simulation-lab/README.md
@@ -16,7 +16,7 @@
 |---|---|---|
 | **Round 1 — Accounting Truth Alignment** | ✅ مكتملة | Migration 182 نقلت `rpc_get_trial_balance` إلى `gl_entries/gl_entry_lines`؛ Migration 183 أغلقت قراءة العرض المباشرة وألزمت RBAC؛ PR #200 جعلت الـRPC مصدر العميل الوحيد لميزان المراجعة |
 | **Round 2 — GL Posting Integrity** | ✅ مكتملة | PR #201 مدموجة؛ Migration 184 مطبقة على Production ومثبتة postflight؛ الحارس المؤجل RLS-proof عبر `SECURITY DEFINER` مع EXECUTE مغلق عن أدوار العميل |
-| **Round 3 — Inventory Integrity** | 🟡 قيد التنفيذ | Migrations 185–186 وPRs #210–#214 أُغلقت و186 مطبقة postflight وBaseline 186 منشور؛ بقية S0/S1 ما زالت مفتوحة |
+| **Round 3 — Inventory Integrity** | 🟡 قيد التنفيذ | Migrations 185–186 وPRs #210–#215 أُغلقت؛ 187 مقترحة في المستودع فقط لمعالجة INV-02 بعقد prospective ولم تُدمج أو تُطبق؛ بقية S0/S1 ما زالت مفتوحة |
 | **Phase 0 — Simulation Environment** | ⏳ مؤجلة | تبدأ بعد إغلاق جولات الحقيقة/السلامة السابقة |
 
 ### ما أُغلق فعليًا
@@ -47,6 +47,10 @@
   لـ`stock_moves` وثبات مجاميع المخزون والتقاعد الصريح بـ`0A000`. run
   `33734325356` أعاد بناء Baseline cutoff 186 بنجاح، ونشره PR #214 المدموج عند
   `3ce8b295`.
+- اقتراح Migration 187 ينقّح `INV-02`: لا يفرض المفتاح العالمي على حركات قانونية
+  متعددة الأسطر، بل يربط Stock Adjustment مستقبلًا بسطر المصدر ويثبت الحد بسباق
+  حتمي. الاقتراح غير مدموج وغير مطبق على Production، والتكرار التاريخي لا يُحذف
+  ولا يُعاد نسبه تخمينيًا.
 
 ### ما أُغلق في Baseline وحوكمته
 
@@ -63,7 +67,8 @@
 
 - **Issue #195:** مطابقة أكواد الحسابات القانونية التاريخية ذات `account_id IS NULL`
   مسار بيانات مستقل ينتظر مصدر Finance موثوقًا؛ لا تخمين ولا backfill استنتاجي.
-- **Round 3:** PRs #211–#213 مدموجة وMigration 186 مطبقة؛ التالي إغلاقات
+- **Round 3:** PRs #211–#215 مدموجة وMigration 186 مطبقة؛ Migration 187 مقترحة
+  وغير مطبقة، ثم تتبعها بقية إغلاقات
   S0/S1 المتبقية حسب
   [`INVENTORY_INTEGRITY_PROGRESS_20260902.md`](./INVENTORY_INTEGRITY_PROGRESS_20260902.md).
 - **Phase 0:** يبدأ بعد إغلاق Round 3، بينما يبقى #195 مسار معالجة مستقلًا

--- a/docs/db/STOCK_ADJUSTMENT_IDEMPOTENCY_187_RUNBOOK.md
+++ b/docs/db/STOCK_ADJUSTMENT_IDEMPOTENCY_187_RUNBOOK.md
@@ -1,0 +1,142 @@
+# Migration 187 — Prospective Stock Adjustment Ledger Idempotency
+
+## Status and authority boundary
+
+Migration 187 is a repository proposal. It is not merged and has not been
+applied to Production. This runbook does not authorize a merge, a Production
+migration, or historical data repair. Each requires its own explicit decision.
+
+The migration is additive and transactional. It creates one partial unique
+index, one source/identity guard, two source-aware helper overloads, and replaces the
+existing stock-adjustment submission RPC so it passes the legal source line.
+It does not delete, rewrite, or backfill any ledger row.
+
+## Corrected invariant
+
+The discovery record originally described INV-02 as a missing global unique
+constraint on:
+
+```text
+(voucher_type, voucher_id, product_id, warehouse_id)
+```
+
+That is not a legal invariant for every voucher type:
+
+- one Goods Receipt can have distinct source lines for the same product and
+  warehouse;
+- one Delivery Note can likewise carry distinct legal lines;
+- manufacturing consumption may be posted in valid partial operations.
+
+Stock Adjustments have a narrower contract. The live
+`rpc_submit_stock_adjustment` already rejects duplicate
+`(product_id,effective_warehouse_id)` items within one adjustment. Migration
+187 therefore enforces one prospective Stock Adjustment movement per:
+
+```text
+(org_id, voucher_id, product_id, warehouse_id)
+```
+
+The index applies only when `source_line_id IS NOT NULL` and the normalized
+voucher type is `stock adjustment`. The source-aware helper verifies that the
+source is the matching `stock_adjustment_items.id`, belongs to the voucher and
+organization, and resolves to the same product and warehouse.
+
+## Production discovery snapshot
+
+A read-only Production audit on 2026-09-03 established the pre-migration
+state. It made no writes:
+
+- the migration ledger ended at 186 (`20260903083010`);
+- `stock_ledger_entries` contained five rows;
+- all five rows had `source_line_id IS NULL`;
+- one historical duplicate group existed for `ADJ-000001` / Stock Adjustment;
+- the two entry IDs were
+  `e9812b2e-6215-47c7-adab-8aa89c38945a` and
+  `fc7257f0-a7ef-4f45-87fa-0f40f2ae7d91`;
+- no unique voucher/product/warehouse index existed.
+
+Those rows have unknown source provenance. Migration 187 deliberately leaves
+them outside the partial index and keeps UPDATE possible so the legal
+cancellation path is not disabled. It does not guess which row is canonical.
+
+## Repository changes
+
+`sql/migrations/187_stock_adjustment_ledger_idempotency.sql`:
+
+1. refuses to run if the required tables, column, or live functions are absent;
+2. refuses unexpected pre-existing v187 objects or duplicate source-aware rows;
+3. creates
+   `uq_sle_stock_adjustment_voucher_product_warehouse_v187`;
+4. adds a trigger that rejects a new Stock Adjustment movement without a valid
+   source relation and guards later identity/source changes, while allowing
+   provenance-neutral updates to historical NULL-source rows;
+5. adds source-aware incoming/outgoing overloads while preserving the complete
+   live valuation, reservation-floor, bin, and product-projection behavior;
+6. passes `stock_adjustment_items.id` from
+   `rpc_submit_stock_adjustment(uuid)`;
+7. pins `search_path` and keeps the new internal overloads executable only by
+   `service_role`; and
+8. verifies the index, trigger, overloads, ACLs, and RPC propagation before
+   commit.
+
+The historical helper signatures remain present because other legal voucher
+families depend on them. The trigger makes the old incoming helper fail closed
+if a future caller tries to write a Stock Adjustment without a source line.
+The outgoing helper already fails before inserting when the same misuse occurs.
+
+## Acceptance evidence
+
+The dedicated PostgreSQL 17 workflow reconstructs cutoff 186, seeds the known
+historical shape, and runs all directions below:
+
+| Direction | Required proof |
+|---|---|
+| Red | v187 objects are absent and two identical pre-187 Stock Adjustment helper calls create two ledger rows |
+| Upgrade | Migration 187 applies successfully while the historical NULL-source duplicate exists |
+| History | the two historical rows remain present and updateable |
+| Fail closed | a new Stock Adjustment through the old helper raises `STOCK_SOURCE_LINE_REQUIRED` |
+| Source identity | a source line from the wrong voucher is rejected by both the helper and the table boundary with `STOCK_SOURCE_LINE_MISMATCH` before stock mutation |
+| Compatibility | two Goods Receipt lines with the same voucher/product/warehouse remain legal |
+| RPC replay | submit writes one source-aware movement; exact replay creates no second row |
+| Unique boundary | a second matching source item reaches the named unique index and rolls back bin mutation |
+| Race | two callers are observed waiting on the same bin lock; exactly one commits and the final state is `11|1|1` |
+
+The race is deterministic rather than two merely backgrounded calls: a blocker
+transaction holds the bin row, the script polls `pg_stat_activity` until both
+callers are waiting on a lock, and only then releases contention.
+
+## Pre-Production review
+
+Before any separately authorized Production apply:
+
+1. merge only the exact reviewed PR head;
+2. require the full Fresh DB chain and the dedicated v187 acceptance workflow;
+3. re-run the read-only duplicate and source-line audit;
+4. confirm the migration ledger still ends at 186;
+5. confirm no non-NULL-source duplicate would violate the partial index;
+6. record row counts, stock quantity/value totals, and the known historical IDs;
+7. confirm `rpc_submit_stock_adjustment` and both historical helpers still match
+   their reviewed definitions; and
+8. use the repository-first Production workflow, not an ad-hoc dashboard edit.
+
+## Postflight after a separately authorized apply
+
+Record raw query output proving:
+
+- Migration 187 is present exactly once in the ledger;
+- the partial unique index is valid and ready;
+- the trigger is enabled for INSERT and identity/source-column UPDATE events;
+- the source-aware overloads exist with the reviewed ACLs;
+- the submission RPC contains `v_item.id` propagation;
+- the five historical rows and the two known duplicate IDs are unchanged;
+- stock row counts and quantity/value totals are unchanged by migration apply;
+- no non-NULL-source Stock Adjustment duplicate exists; and
+- no unexpected Supabase security or performance advisor regression appeared.
+
+## Recovery
+
+Do not edit Migration 187 after application and do not delete historical rows to
+make the index appear clean. If a repository defect is found before Production,
+fix the PR normally. If a defect is found after Production, use a new numbered,
+forward-only migration. Historical duplicate remediation remains a separate
+data decision requiring an authoritative source and explicit authorization.

--- a/scripts/ci/fresh-db/acceptance_186_stock_moves_contract.sql
+++ b/scripts/ci/fresh-db/acceptance_186_stock_moves_contract.sql
@@ -120,6 +120,66 @@ VALUES (
   'Stock 186 Warehouse'
 );
 
+INSERT INTO auth.users (id, email)
+VALUES ('51856186-1000-0000-0000-000000000009', 'stock186-green@example.test');
+
+INSERT INTO public.user_organizations (user_id, org_id, is_active)
+VALUES (
+  '51856186-1000-0000-0000-000000000009',
+  '51856186-1000-0000-0000-000000000001',
+  true
+);
+
+-- Migration 187 requires every prospective Stock Adjustment ledger row to
+-- carry legal source provenance. Keep this Migration 186 fixture representative
+-- of the current contract while preserving its original balance assertions.
+INSERT INTO public.stock_adjustments (
+  id, organization_id, org_id, adjustment_number, adjustment_date,
+  posting_date, adjustment_type, reason, warehouse_id, status, created_by
+)
+VALUES
+  (
+    '51856186-1000-0000-0000-000000000006',
+    '51856186-1000-0000-0000-000000000001',
+    '51856186-1000-0000-0000-000000000001',
+    'STK186-OPEN', CURRENT_DATE, CURRENT_DATE, 'OTHER',
+    'Migration 186 open-ledger fixture',
+    '51856186-1000-0000-0000-000000000004', 'SUBMITTED',
+    '51856186-1000-0000-0000-000000000009'
+  ),
+  (
+    '51856186-1000-0000-0000-000000000012',
+    '51856186-1000-0000-0000-000000000001',
+    '51856186-1000-0000-0000-000000000001',
+    'STK186-CANCELLED', CURRENT_DATE, CURRENT_DATE, 'OTHER',
+    'Migration 186 cancelled-ledger fixture',
+    '51856186-1000-0000-0000-000000000004', 'CANCELLED',
+    '51856186-1000-0000-0000-000000000009'
+  );
+
+INSERT INTO public.stock_adjustment_items (
+  id, adjustment_id, organization_id, product_id, warehouse_id,
+  current_qty, new_qty, difference_qty, current_rate, new_rate,
+  value_difference
+)
+VALUES
+  (
+    '51856186-1000-0000-0000-000000000013',
+    '51856186-1000-0000-0000-000000000006',
+    '51856186-1000-0000-0000-000000000001',
+    '51856186-1000-0000-0000-000000000002',
+    '51856186-1000-0000-0000-000000000004',
+    0, 10, 10, 2, 2, 20
+  ),
+  (
+    '51856186-1000-0000-0000-000000000014',
+    '51856186-1000-0000-0000-000000000012',
+    '51856186-1000-0000-0000-000000000001',
+    '51856186-1000-0000-0000-000000000002',
+    '51856186-1000-0000-0000-000000000004',
+    10, 7, -3, 2, 2, -6
+  );
+
 INSERT INTO public.bins (
   id, org_id, product_id, warehouse_id, actual_qty, reserved_qty,
   valuation_rate, stock_value, stock_queue
@@ -136,7 +196,7 @@ INSERT INTO public.stock_ledger_entries (
   voucher_type, voucher_id, voucher_number, product_id, warehouse_id,
   posting_date, actual_qty, qty_after_transaction, incoming_rate,
   valuation_rate, stock_value, stock_value_difference, stock_queue,
-  is_cancelled, docstatus, org_id
+  is_cancelled, docstatus, org_id, source_line_id
 )
 VALUES (
   'Stock Adjustment',
@@ -147,7 +207,8 @@ VALUES (
   CURRENT_DATE, 10, 10, 2, 2, 20, 20,
   '[{"qty":10,"rate":2}]'::jsonb,
   false, 1,
-  '51856186-1000-0000-0000-000000000001'
+  '51856186-1000-0000-0000-000000000001',
+  '51856186-1000-0000-0000-000000000013'
 );
 
 -- A cancelled original remains part of the legal event stream alongside its
@@ -157,7 +218,7 @@ INSERT INTO public.stock_ledger_entries (
   voucher_type, voucher_id, voucher_number, product_id, warehouse_id,
   posting_date, actual_qty, qty_after_transaction, incoming_rate, outgoing_rate,
   valuation_rate, stock_value, stock_value_difference, stock_queue,
-  is_cancelled, docstatus, org_id
+  is_cancelled, docstatus, org_id, source_line_id
 )
 VALUES
   (
@@ -169,7 +230,8 @@ VALUES
     CURRENT_DATE, -3, 7, NULL, 2, 2, 14, -6,
     '[{"qty":7,"rate":2}]'::jsonb,
     true, 1,
-    '51856186-1000-0000-0000-000000000001'
+    '51856186-1000-0000-0000-000000000001',
+    '51856186-1000-0000-0000-000000000014'
   ),
   (
     'Stock Adjustment Reversal',
@@ -180,7 +242,8 @@ VALUES
     CURRENT_DATE, 3, 10, 2, NULL, 2, 20, 6,
     '[{"qty":10,"rate":2}]'::jsonb,
     false, 1,
-    '51856186-1000-0000-0000-000000000001'
+    '51856186-1000-0000-0000-000000000001',
+    NULL
   );
 
 DO $balance_mismatch$
@@ -240,16 +303,6 @@ VALUES (
   '51856186-1000-0000-0000-000000000002',
   2,
   'reserved'
-);
-
-INSERT INTO auth.users (id, email)
-VALUES ('51856186-1000-0000-0000-000000000009', 'stock186-green@example.test');
-
-INSERT INTO public.user_organizations (user_id, org_id, is_active)
-VALUES (
-  '51856186-1000-0000-0000-000000000009',
-  '51856186-1000-0000-0000-000000000001',
-  true
 );
 
 SET LOCAL ROLE authenticated;

--- a/scripts/ci/fresh-db/acceptance_187_stock_adjustment_concurrency.sh
+++ b/scripts/ci/fresh-db/acceptance_187_stock_adjustment_concurrency.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+: "${PGDATABASE:?PGDATABASE must be set}"
+
+PSQL=(psql -X -v ON_ERROR_STOP=1 -qAt)
+tmp_prefix=/tmp/stock-187-race
+org_id='51856187-2000-0000-0000-000000000001'
+product_id='51856187-2000-0000-0000-000000000002'
+warehouse_id='51856187-2000-0000-0000-000000000003'
+bin_id='51856187-2000-0000-0000-000000000004'
+adjustment_id='51856187-2000-0000-0000-000000000005'
+source_a='51856187-2000-0000-0000-000000000006'
+source_b='51856187-2000-0000-0000-000000000007'
+actor_id='51856187-2000-0000-0000-000000000008'
+
+rm -f "${tmp_prefix}"-*.ready "${tmp_prefix}"-*.out "${tmp_prefix}"-*.err
+
+"${PSQL[@]}" <<SQL
+INSERT INTO public.organizations (id, name, code)
+VALUES ('$org_id', 'Stock 187 Race', 'STK187-RACE');
+
+INSERT INTO public.products (id, org_id, code, name, is_stockable, base_uom_id)
+SELECT '$product_id', '$org_id', 'STK187-RACE-P', 'Stock 187 Race Product', true, u.id
+FROM public.uoms u
+WHERE u.org_id IS NULL AND u.is_active AND NOT u.is_product_specific
+LIMIT 1;
+
+INSERT INTO public.warehouses (id, org_id, code, name)
+VALUES ('$warehouse_id', '$org_id', 'STK187-RACE-WH', 'Stock 187 Race Warehouse');
+
+INSERT INTO public.bins (
+  id, org_id, product_id, warehouse_id, actual_qty, reserved_qty,
+  valuation_rate, stock_value, stock_queue
+) VALUES (
+  '$bin_id', '$org_id', '$product_id', '$warehouse_id', 10, 0,
+  1, 10, '[{"qty":10,"rate":1}]'::jsonb
+);
+
+INSERT INTO auth.users (id, email)
+VALUES ('$actor_id', 'stock-187-race@wardah-e2e.invalid');
+
+INSERT INTO public.stock_adjustments (
+  id, organization_id, org_id, adjustment_number, adjustment_date,
+  posting_date, adjustment_type, reason, warehouse_id, status, created_by
+) VALUES (
+  '$adjustment_id', '$org_id', '$org_id', 'STK187-RACE-ADJ', CURRENT_DATE,
+  CURRENT_DATE, 'OTHER', 'Migration 187 race', '$warehouse_id', 'DRAFT', '$actor_id'
+);
+
+INSERT INTO public.stock_adjustment_items (
+  id, adjustment_id, organization_id, product_id, warehouse_id,
+  current_qty, new_qty, difference_qty, current_rate, new_rate, value_difference
+) VALUES
+  ('$source_a', '$adjustment_id', '$org_id', '$product_id', '$warehouse_id',
+   10, 11, 1, 1, 1, 1),
+  ('$source_b', '$adjustment_id', '$org_id', '$product_id', '$warehouse_id',
+   10, 11, 1, 1, 1, 1);
+SQL
+
+blocker_ready="${tmp_prefix}-blocker.ready"
+"${PSQL[@]}" >"${tmp_prefix}-blocker.out" 2>"${tmp_prefix}-blocker.err" <<SQL &
+BEGIN;
+SELECT id FROM public.bins WHERE id = '$bin_id' FOR UPDATE;
+\! touch $blocker_ready
+SELECT pg_sleep(3);
+COMMIT;
+SQL
+blocker_pid=$!
+
+for _ in $(seq 1 100); do
+  [[ -f "$blocker_ready" ]] && break
+  sleep 0.05
+done
+if [[ ! -f "$blocker_ready" ]]; then
+  wait "$blocker_pid" || true
+  echo 'STOCK_187_CONCURRENCY_FAIL: blocker did not become ready' >&2
+  exit 1
+fi
+
+run_adjustment() {
+  local suffix=$1
+  local source_id=$2
+  local output=$3
+  local error=$4
+
+  PGAPPNAME="stock-187-$suffix" "${PSQL[@]}" >"$output" 2>"$error" <<SQL
+BEGIN;
+SELECT public.wardah_apply_stock_incoming(
+  '$org_id',
+  '$product_id',
+  '$warehouse_id',
+  1,
+  1,
+  'Stock Adjustment',
+  '$adjustment_id',
+  'STK187-RACE-ADJ',
+  CURRENT_DATE,
+  '$source_id'
+);
+COMMIT;
+SQL
+}
+
+run_adjustment A "$source_a" "${tmp_prefix}-a.out" "${tmp_prefix}-a.err" &
+pid_a=$!
+run_adjustment B "$source_b" "${tmp_prefix}-b.out" "${tmp_prefix}-b.err" &
+pid_b=$!
+
+waiting=0
+for _ in $(seq 1 100); do
+  waiting=$("${PSQL[@]}" <<SQL
+SELECT count(*)
+FROM pg_stat_activity
+WHERE application_name IN ('stock-187-A', 'stock-187-B')
+  AND state = 'active'
+  AND wait_event_type = 'Lock';
+SQL
+)
+  [[ "$waiting" == '2' ]] && break
+  sleep 0.05
+done
+if [[ "$waiting" != '2' ]]; then
+  echo "STOCK_187_CONCURRENCY_FAIL: expected two callers waiting on the bin lock; got $waiting" >&2
+  wait "$pid_a" || true
+  wait "$pid_b" || true
+  wait "$blocker_pid" || true
+  exit 1
+fi
+
+status_a=0
+status_b=0
+wait "$pid_a" || status_a=$?
+wait "$pid_b" || status_b=$?
+wait "$blocker_pid"
+
+if [[ "$status_a" -eq 0 && "$status_b" -eq 0 ]] \
+   || [[ "$status_a" -ne 0 && "$status_b" -ne 0 ]]; then
+  echo "STOCK_187_CONCURRENCY_FAIL: expected exactly one success; statuses=$status_a,$status_b" >&2
+  exit 1
+fi
+
+if ! grep -q 'uq_sle_stock_adjustment_voucher_product_warehouse_v187' \
+  "${tmp_prefix}-a.err" "${tmp_prefix}-b.err"; then
+  echo 'STOCK_187_CONCURRENCY_FAIL: loser did not hit the unique stock-adjustment boundary' >&2
+  exit 1
+fi
+
+final_state=$("${PSQL[@]}" <<SQL
+SELECT
+  b.actual_qty::text || '|' ||
+  count(sle.id)::text || '|' ||
+  count(DISTINCT sle.source_line_id)::text
+FROM public.bins b
+LEFT JOIN public.stock_ledger_entries sle
+  ON sle.org_id = b.org_id
+ AND sle.product_id = b.product_id
+ AND sle.warehouse_id = b.warehouse_id
+ AND sle.voucher_type = 'Stock Adjustment'
+ AND sle.voucher_id = '$adjustment_id'
+WHERE b.id = '$bin_id'
+GROUP BY b.actual_qty;
+SQL
+)
+
+if [[ "$final_state" != '11.000000|1|1' && "$final_state" != '11|1|1' ]]; then
+  echo "STOCK_187_CONCURRENCY_FAIL: expected bin|rows|sources=11|1|1; got $final_state" >&2
+  exit 1
+fi
+
+printf 'STOCK_187_CONCURRENCY_PASS bin|rows|sources=%s statuses=%s,%s\n' \
+  "$final_state" "$status_a" "$status_b"

--- a/scripts/ci/fresh-db/acceptance_187_stock_adjustment_idempotency.sql
+++ b/scripts/ci/fresh-db/acceptance_187_stock_adjustment_idempotency.sql
@@ -1,0 +1,474 @@
+-- Green acceptance for Migration 187. Runs on an upgraded cutoff-186 database
+-- that carries a historical duplicate with source_line_id NULL.
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+DO $contract_shape$
+DECLARE
+  v_index_definition text;
+  v_trigger_definition text;
+  v_historical_count integer;
+BEGIN
+  SELECT pg_get_indexdef(
+    'public.uq_sle_stock_adjustment_voucher_product_warehouse_v187'::regclass
+  ) INTO v_index_definition;
+
+  IF v_index_definition IS NULL
+     OR v_index_definition NOT LIKE 'CREATE UNIQUE INDEX%'
+     OR v_index_definition NOT LIKE '%source_line_id IS NOT NULL%'
+     OR v_index_definition NOT LIKE '%stock adjustment%' THEN
+    RAISE EXCEPTION 'STOCK_187_GREEN_INDEX_DRIFT: %', v_index_definition;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgrelid = 'public.stock_ledger_entries'::regclass
+      AND tgname = 'trg_sle_stock_adjustment_source_line_v187'
+      AND tgenabled = 'O'
+      AND NOT tgisinternal
+  ) THEN
+    RAISE EXCEPTION 'STOCK_187_GREEN_TRIGGER_MISSING';
+  END IF;
+
+  SELECT pg_get_triggerdef(oid)
+  INTO v_trigger_definition
+  FROM pg_trigger
+  WHERE tgrelid = 'public.stock_ledger_entries'::regclass
+    AND tgname = 'trg_sle_stock_adjustment_source_line_v187'
+    AND NOT tgisinternal;
+
+  IF v_trigger_definition NOT LIKE '%BEFORE INSERT OR UPDATE OF%'
+     OR v_trigger_definition NOT LIKE '%source_line_id%' THEN
+    RAISE EXCEPTION 'STOCK_187_GREEN_TRIGGER_DRIFT: %', v_trigger_definition;
+  END IF;
+
+  IF to_regprocedure(
+       'public.wardah_apply_stock_incoming(uuid,uuid,uuid,numeric,numeric,text,uuid,text,date,uuid)'
+     ) IS NULL
+     OR to_regprocedure(
+       'public.wardah_apply_stock_outgoing(uuid,uuid,uuid,numeric,text,uuid,text,date,uuid)'
+     ) IS NULL THEN
+    RAISE EXCEPTION 'STOCK_187_GREEN_HELPER_OVERLOAD_MISSING';
+  END IF;
+
+  SELECT count(*)
+  INTO v_historical_count
+  FROM public.stock_ledger_entries
+  WHERE voucher_id = '51856187-1000-0000-0000-000000000006'
+    AND source_line_id IS NULL;
+
+  IF v_historical_count <> 2 THEN
+    RAISE EXCEPTION
+      'STOCK_187_GREEN_HISTORICAL_ROWS_CHANGED: count=%',
+      v_historical_count;
+  END IF;
+
+  RAISE NOTICE 'STOCK_187_GREEN_CONTRACT_SHAPE_OK';
+  RAISE NOTICE 'STOCK_187_GREEN_HISTORY_PRESERVED_OK';
+END
+$contract_shape$;
+
+-- The guard is INSERT-only: historical rows remain updateable by the legal
+-- cancellation workflow even though their source provenance is unknown.
+UPDATE public.stock_ledger_entries
+SET modified_at = now()
+WHERE id = '51856187-1000-0000-0000-000000000007';
+
+DO $new_null_rejected$
+DECLARE
+  v_caught boolean := false;
+BEGIN
+  BEGIN
+    PERFORM public.wardah_apply_stock_incoming(
+      '51856187-1000-0000-0000-000000000001',
+      '51856187-1000-0000-0000-000000000002',
+      '51856187-1000-0000-0000-000000000003',
+      1,
+      1,
+      'Stock Adjustment',
+      '51856187-1000-0000-0000-000000000010',
+      'STK187-NULL-REJECT',
+      CURRENT_DATE
+    );
+  EXCEPTION WHEN raise_exception THEN
+    IF SQLERRM = 'STOCK_SOURCE_LINE_REQUIRED' THEN
+      v_caught := true;
+    ELSE
+      RAISE;
+    END IF;
+  END;
+
+  IF NOT v_caught THEN
+    RAISE EXCEPTION 'STOCK_187_GREEN_NULL_SOURCE_ACCEPTED';
+  END IF;
+
+  RAISE NOTICE 'STOCK_187_GREEN_NULL_SOURCE_REJECTED_OK';
+END
+$new_null_rejected$;
+
+-- Two distinct Goods Receipt lines may legally share voucher/product/warehouse.
+-- This proves Migration 187 did not install the invalid global four-column key.
+SELECT public.wardah_apply_stock_incoming(
+  '51856187-1000-0000-0000-000000000001',
+  '51856187-1000-0000-0000-000000000002',
+  '51856187-1000-0000-0000-000000000003',
+  1,
+  1,
+  'Goods Receipt',
+  '51856187-1000-0000-0000-000000000011',
+  'STK187-GR-TWO-LINES',
+  CURRENT_DATE
+);
+
+SELECT public.wardah_apply_stock_incoming(
+  '51856187-1000-0000-0000-000000000001',
+  '51856187-1000-0000-0000-000000000002',
+  '51856187-1000-0000-0000-000000000003',
+  1,
+  1,
+  'Goods Receipt',
+  '51856187-1000-0000-0000-000000000011',
+  'STK187-GR-TWO-LINES',
+  CURRENT_DATE
+);
+
+DO $goods_receipt_compatibility$
+BEGIN
+  IF (
+    SELECT count(*)
+    FROM public.stock_ledger_entries
+    WHERE voucher_type = 'Goods Receipt'
+      AND voucher_id = '51856187-1000-0000-0000-000000000011'
+      AND product_id = '51856187-1000-0000-0000-000000000002'
+      AND warehouse_id = '51856187-1000-0000-0000-000000000003'
+  ) <> 2 THEN
+    RAISE EXCEPTION 'STOCK_187_GREEN_VALID_RECEIPT_LINES_REJECTED';
+  END IF;
+
+  RAISE NOTICE 'STOCK_187_GREEN_VALID_RECEIPT_LINES_OK';
+END
+$goods_receipt_compatibility$;
+
+INSERT INTO public.products (
+  id, org_id, code, name, is_stockable, base_uom_id
+)
+SELECT
+  '51856187-1000-0000-0000-000000000012',
+  '51856187-1000-0000-0000-000000000001',
+  'STK187-ADJ',
+  'Stock 187 Adjustment Product',
+  true,
+  u.id
+FROM public.uoms u
+WHERE u.org_id IS NULL
+  AND u.is_active
+  AND NOT u.is_product_specific
+LIMIT 1;
+
+INSERT INTO public.stock_adjustments (
+  id,
+  organization_id,
+  org_id,
+  adjustment_number,
+  adjustment_date,
+  posting_date,
+  adjustment_type,
+  reason,
+  warehouse_id,
+  status,
+  created_by
+)
+VALUES (
+  '51856187-1000-0000-0000-000000000013',
+  '51856187-1000-0000-0000-000000000001',
+  '51856187-1000-0000-0000-000000000001',
+  'STK187-ADJ-001',
+  CURRENT_DATE,
+  CURRENT_DATE,
+  'OTHER',
+  'Migration 187 acceptance',
+  '51856187-1000-0000-0000-000000000003',
+  'DRAFT',
+  '51856187-1000-0000-0000-000000000005'
+);
+
+INSERT INTO public.stock_adjustment_items (
+  id,
+  adjustment_id,
+  organization_id,
+  product_id,
+  warehouse_id,
+  current_qty,
+  new_qty,
+  difference_qty,
+  current_rate,
+  new_rate,
+  value_difference
+)
+VALUES (
+  '51856187-1000-0000-0000-000000000014',
+  '51856187-1000-0000-0000-000000000013',
+  '51856187-1000-0000-0000-000000000001',
+  '51856187-1000-0000-0000-000000000012',
+  '51856187-1000-0000-0000-000000000003',
+  0,
+  1,
+  1,
+  0,
+  0,
+  0
+);
+
+DO $source_relation_guard$
+DECLARE
+  v_caught boolean := false;
+BEGIN
+  BEGIN
+    PERFORM public.wardah_apply_stock_incoming(
+      '51856187-1000-0000-0000-000000000001',
+      '51856187-1000-0000-0000-000000000012',
+      '51856187-1000-0000-0000-000000000003',
+      1,
+      0,
+      'Stock Adjustment',
+      '51856187-1000-0000-0000-000000000016',
+      'STK187-WRONG-SOURCE',
+      CURRENT_DATE,
+      '51856187-1000-0000-0000-000000000014'
+    );
+  EXCEPTION WHEN raise_exception THEN
+    IF SQLERRM = 'STOCK_SOURCE_LINE_MISMATCH' THEN
+      v_caught := true;
+    ELSE
+      RAISE;
+    END IF;
+  END;
+
+  IF NOT v_caught THEN
+    RAISE EXCEPTION 'STOCK_187_GREEN_SOURCE_RELATION_ACCEPTED';
+  END IF;
+
+  RAISE NOTICE 'STOCK_187_GREEN_SOURCE_RELATION_REJECTED_OK';
+END
+$source_relation_guard$;
+
+DO $table_source_relation_guard$
+DECLARE
+  v_caught boolean := false;
+BEGIN
+  BEGIN
+    INSERT INTO public.stock_ledger_entries (
+      voucher_type,
+      voucher_id,
+      voucher_number,
+      product_id,
+      warehouse_id,
+      posting_date,
+      actual_qty,
+      qty_after_transaction,
+      incoming_rate,
+      valuation_rate,
+      stock_value,
+      stock_value_difference,
+      stock_queue,
+      docstatus,
+      org_id,
+      source_line_id
+    ) VALUES (
+      'Stock Adjustment',
+      '51856187-1000-0000-0000-000000000016',
+      'STK187-WRONG-SOURCE-DIRECT',
+      '51856187-1000-0000-0000-000000000012',
+      '51856187-1000-0000-0000-000000000003',
+      CURRENT_DATE,
+      1,
+      1,
+      0,
+      0,
+      0,
+      0,
+      '[]'::jsonb,
+      1,
+      '51856187-1000-0000-0000-000000000001',
+      '51856187-1000-0000-0000-000000000014'
+    );
+  EXCEPTION WHEN raise_exception THEN
+    IF SQLERRM = 'STOCK_SOURCE_LINE_MISMATCH' THEN
+      v_caught := true;
+    ELSE
+      RAISE;
+    END IF;
+  END;
+
+  IF NOT v_caught THEN
+    RAISE EXCEPTION 'STOCK_187_GREEN_TABLE_SOURCE_RELATION_ACCEPTED';
+  END IF;
+
+  RAISE NOTICE 'STOCK_187_GREEN_TABLE_SOURCE_REJECTED_OK';
+END
+$table_source_relation_guard$;
+
+SET LOCAL ROLE authenticated;
+SELECT set_config(
+  'request.jwt.claim.sub',
+  '51856187-1000-0000-0000-000000000005',
+  true
+);
+SELECT set_config(
+  'request.jwt.claims',
+  '{"sub":"51856187-1000-0000-0000-000000000005","role":"authenticated"}',
+  true
+);
+
+DO $submit_and_replay$
+DECLARE
+  v_first jsonb;
+  v_second jsonb;
+BEGIN
+  v_first := public.rpc_submit_stock_adjustment(
+    '51856187-1000-0000-0000-000000000013'
+  );
+  v_second := public.rpc_submit_stock_adjustment(
+    '51856187-1000-0000-0000-000000000013'
+  );
+
+  IF NOT COALESCE((v_first ->> 'success')::boolean, false)
+     OR COALESCE((v_first ->> 'duplicate')::boolean, false)
+     OR NOT COALESCE((v_second ->> 'duplicate')::boolean, false) THEN
+    RAISE EXCEPTION
+      'STOCK_187_GREEN_SUBMIT_REPLAY_WRONG: first=% second=%',
+      v_first,
+      v_second;
+  END IF;
+END
+$submit_and_replay$;
+
+RESET ROLE;
+
+DO $source_propagated$
+DECLARE
+  v_rows integer;
+  v_source uuid;
+  v_status text;
+BEGIN
+  SELECT count(*), (array_agg(source_line_id ORDER BY id))[1]
+  INTO v_rows, v_source
+  FROM public.stock_ledger_entries
+  WHERE voucher_type = 'Stock Adjustment'
+    AND voucher_id = '51856187-1000-0000-0000-000000000013';
+
+  SELECT status
+  INTO v_status
+  FROM public.stock_adjustments
+  WHERE id = '51856187-1000-0000-0000-000000000013';
+
+  IF v_rows <> 1
+     OR v_source IS DISTINCT FROM
+       '51856187-1000-0000-0000-000000000014'::uuid
+     OR v_status IS DISTINCT FROM 'SUBMITTED' THEN
+    RAISE EXCEPTION
+      'STOCK_187_GREEN_SOURCE_NOT_PROPAGATED: rows=% source=% status=%',
+      v_rows,
+      v_source,
+      v_status;
+  END IF;
+
+  RAISE NOTICE 'STOCK_187_GREEN_RPC_REPLAY_OK';
+  RAISE NOTICE 'STOCK_187_GREEN_SOURCE_PROPAGATED_OK';
+END
+$source_propagated$;
+
+-- A second source item for the same adjustment/product/warehouse is invalid.
+-- The helper verifies the source relation, then the unique index remains the
+-- final race-safe boundary even if a future caller misses the RPC pre-check.
+INSERT INTO public.stock_adjustment_items (
+  id,
+  adjustment_id,
+  organization_id,
+  product_id,
+  warehouse_id,
+  current_qty,
+  new_qty,
+  difference_qty,
+  current_rate,
+  new_rate,
+  value_difference
+)
+VALUES (
+  '51856187-1000-0000-0000-000000000015',
+  '51856187-1000-0000-0000-000000000013',
+  '51856187-1000-0000-0000-000000000001',
+  '51856187-1000-0000-0000-000000000012',
+  '51856187-1000-0000-0000-000000000003',
+  1,
+  2,
+  1,
+  0,
+  0,
+  0
+);
+
+DO $unique_boundary$
+DECLARE
+  v_caught boolean := false;
+  v_bin_before numeric;
+  v_bin_after numeric;
+BEGIN
+  SELECT actual_qty
+  INTO v_bin_before
+  FROM public.bins
+  WHERE product_id = '51856187-1000-0000-0000-000000000012'
+    AND warehouse_id = '51856187-1000-0000-0000-000000000003';
+
+  BEGIN
+    PERFORM public.wardah_apply_stock_incoming(
+      '51856187-1000-0000-0000-000000000001',
+      '51856187-1000-0000-0000-000000000012',
+      '51856187-1000-0000-0000-000000000003',
+      1,
+      0,
+      'Stock Adjustment',
+      '51856187-1000-0000-0000-000000000013',
+      'STK187-ADJ-001',
+      CURRENT_DATE,
+      '51856187-1000-0000-0000-000000000015'
+    );
+  EXCEPTION WHEN unique_violation THEN
+    IF SQLERRM LIKE
+       '%uq_sle_stock_adjustment_voucher_product_warehouse_v187%' THEN
+      v_caught := true;
+    ELSE
+      RAISE;
+    END IF;
+  END;
+
+  SELECT actual_qty
+  INTO v_bin_after
+  FROM public.bins
+  WHERE product_id = '51856187-1000-0000-0000-000000000012'
+    AND warehouse_id = '51856187-1000-0000-0000-000000000003';
+
+  IF NOT v_caught
+     OR v_bin_after IS DISTINCT FROM v_bin_before
+     OR (
+       SELECT count(*)
+       FROM public.stock_ledger_entries
+       WHERE voucher_type = 'Stock Adjustment'
+         AND voucher_id = '51856187-1000-0000-0000-000000000013'
+     ) <> 1 THEN
+    RAISE EXCEPTION
+      'STOCK_187_GREEN_UNIQUE_BOUNDARY_FAILED: caught=% before=% after=%',
+      v_caught,
+      v_bin_before,
+      v_bin_after;
+  END IF;
+
+  RAISE NOTICE 'STOCK_187_GREEN_UNIQUE_BOUNDARY_OK';
+END
+$unique_boundary$;
+
+ROLLBACK;
+
+SELECT 'STOCK_187_GREEN_ACCEPTANCE_PASS' AS result;

--- a/scripts/ci/fresh-db/acceptance_187_stock_adjustment_idempotency_red.sql
+++ b/scripts/ci/fresh-db/acceptance_187_stock_adjustment_idempotency_red.sql
@@ -1,0 +1,89 @@
+-- Red proof for Migration 187. This runs after cutoff 186 and before 187.
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+DO $red_shape$
+BEGIN
+  IF to_regclass(
+       'public.uq_sle_stock_adjustment_voucher_product_warehouse_v187'
+     ) IS NOT NULL
+     OR to_regprocedure(
+       'public.wardah_apply_stock_incoming(uuid,uuid,uuid,numeric,numeric,text,uuid,text,date,uuid)'
+     ) IS NOT NULL
+     OR to_regprocedure(
+       'public.wardah_apply_stock_outgoing(uuid,uuid,uuid,numeric,text,uuid,text,date,uuid)'
+     ) IS NOT NULL
+     OR to_regprocedure(
+       'public.wardah_187_require_stock_source_line()'
+     ) IS NOT NULL
+     OR EXISTS (
+       SELECT 1
+       FROM pg_trigger
+       WHERE tgrelid = 'public.stock_ledger_entries'::regclass
+         AND tgname = 'trg_sle_stock_adjustment_source_line_v187'
+         AND NOT tgisinternal
+     ) THEN
+    RAISE EXCEPTION 'STOCK_187_RED_CONTRACT_ALREADY_PRESENT';
+  END IF;
+
+  RAISE NOTICE 'STOCK_187_RED_CONTRACT_ABSENT_OK';
+END
+$red_shape$;
+
+SELECT public.wardah_apply_stock_incoming(
+  '51856187-1000-0000-0000-000000000001',
+  '51856187-1000-0000-0000-000000000002',
+  '51856187-1000-0000-0000-000000000003',
+  1,
+  1,
+  'Stock Adjustment',
+  '51856187-1000-0000-0000-000000000009',
+  'STK187-RED-DUP',
+  CURRENT_DATE
+);
+
+SELECT public.wardah_apply_stock_incoming(
+  '51856187-1000-0000-0000-000000000001',
+  '51856187-1000-0000-0000-000000000002',
+  '51856187-1000-0000-0000-000000000003',
+  1,
+  1,
+  'Stock Adjustment',
+  '51856187-1000-0000-0000-000000000009',
+  'STK187-RED-DUP',
+  CURRENT_DATE
+);
+
+DO $red_duplicate$
+DECLARE
+  v_rows integer;
+  v_bin_qty numeric;
+BEGIN
+  SELECT count(*)
+  INTO v_rows
+  FROM public.stock_ledger_entries
+  WHERE voucher_type = 'Stock Adjustment'
+    AND voucher_id = '51856187-1000-0000-0000-000000000009'
+    AND product_id = '51856187-1000-0000-0000-000000000002'
+    AND warehouse_id = '51856187-1000-0000-0000-000000000003';
+
+  SELECT actual_qty
+  INTO v_bin_qty
+  FROM public.bins
+  WHERE id = '51856187-1000-0000-0000-000000000004';
+
+  IF v_rows <> 2 OR v_bin_qty IS DISTINCT FROM 12::numeric THEN
+    RAISE EXCEPTION
+      'STOCK_187_RED_DUPLICATE_NOT_REPRODUCED: rows=% bin=%',
+      v_rows,
+      v_bin_qty;
+  END IF;
+
+  RAISE NOTICE 'STOCK_187_RED_DUPLICATE_REPRODUCED_OK';
+END
+$red_duplicate$;
+
+ROLLBACK;
+
+SELECT 'STOCK_187_RED_PROOF_PASS' AS result;

--- a/scripts/ci/fresh-db/setup_187_stock_adjustment_idempotency.sql
+++ b/scripts/ci/fresh-db/setup_187_stock_adjustment_idempotency.sql
@@ -1,0 +1,146 @@
+\set ON_ERROR_STOP on
+
+INSERT INTO public.organizations (id, name, code)
+VALUES (
+  '51856187-1000-0000-0000-000000000001',
+  'Stock 187 Upgrade',
+  'STK187-UPGRADE'
+);
+
+INSERT INTO public.products (
+  id, org_id, code, name, is_stockable, base_uom_id
+)
+SELECT
+  '51856187-1000-0000-0000-000000000002',
+  '51856187-1000-0000-0000-000000000001',
+  'STK187-HISTORY',
+  'Stock 187 Historical Product',
+  true,
+  u.id
+FROM public.uoms u
+WHERE u.org_id IS NULL
+  AND u.is_active
+  AND NOT u.is_product_specific
+LIMIT 1;
+
+DO $seed_check$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.products
+    WHERE id = '51856187-1000-0000-0000-000000000002'
+  ) THEN
+    RAISE EXCEPTION 'STOCK_187_SETUP_NO_SYSTEM_UOM';
+  END IF;
+END
+$seed_check$;
+
+INSERT INTO public.warehouses (id, org_id, code, name)
+VALUES (
+  '51856187-1000-0000-0000-000000000003',
+  '51856187-1000-0000-0000-000000000001',
+  'STK187-WH',
+  'Stock 187 Warehouse'
+);
+
+INSERT INTO public.bins (
+  id, org_id, product_id, warehouse_id, actual_qty, reserved_qty,
+  valuation_rate, stock_value, stock_queue
+)
+VALUES (
+  '51856187-1000-0000-0000-000000000004',
+  '51856187-1000-0000-0000-000000000001',
+  '51856187-1000-0000-0000-000000000002',
+  '51856187-1000-0000-0000-000000000003',
+  10,
+  0,
+  1,
+  10,
+  '[{"qty":10,"rate":1}]'::jsonb
+);
+
+INSERT INTO auth.users (id, email)
+VALUES (
+  '51856187-1000-0000-0000-000000000005',
+  'stock187-upgrade@example.test'
+);
+
+INSERT INTO public.user_organizations (
+  user_id, org_id, is_active, is_org_admin
+)
+VALUES (
+  '51856187-1000-0000-0000-000000000005',
+  '51856187-1000-0000-0000-000000000001',
+  true,
+  true
+);
+
+-- A faithful shape for the known Production condition: duplicate historical
+-- Stock Adjustment rows whose source-line provenance is unavailable. Migration
+-- 187 must neither rewrite nor reject these rows during application.
+INSERT INTO public.stock_ledger_entries (
+  id,
+  voucher_type,
+  voucher_id,
+  voucher_number,
+  product_id,
+  warehouse_id,
+  posting_date,
+  posting_time,
+  actual_qty,
+  qty_after_transaction,
+  incoming_rate,
+  valuation_rate,
+  stock_value,
+  stock_value_difference,
+  stock_queue,
+  is_cancelled,
+  docstatus,
+  org_id,
+  created_at
+)
+VALUES
+  (
+    '51856187-1000-0000-0000-000000000007',
+    'Stock Adjustment',
+    '51856187-1000-0000-0000-000000000006',
+    'STK187-HIST-DUP',
+    '51856187-1000-0000-0000-000000000002',
+    '51856187-1000-0000-0000-000000000003',
+    DATE '2025-11-10',
+    TIME '12:03:50',
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    '[{"qty":1,"rate":1}]'::jsonb,
+    false,
+    1,
+    '51856187-1000-0000-0000-000000000001',
+    TIMESTAMPTZ '2025-11-11 09:03:49+00'
+  ),
+  (
+    '51856187-1000-0000-0000-000000000008',
+    'Stock Adjustment',
+    '51856187-1000-0000-0000-000000000006',
+    'STK187-HIST-DUP',
+    '51856187-1000-0000-0000-000000000002',
+    '51856187-1000-0000-0000-000000000003',
+    DATE '2025-11-10',
+    TIME '12:12:51',
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    '[{"qty":1,"rate":1}]'::jsonb,
+    false,
+    1,
+    '51856187-1000-0000-0000-000000000001',
+    TIMESTAMPTZ '2025-11-11 09:12:50+00'
+  );
+
+SELECT 'STOCK_187_SETUP_PASS' AS result;

--- a/sql/migrations/187_stock_adjustment_ledger_idempotency.sql
+++ b/sql/migrations/187_stock_adjustment_ledger_idempotency.sql
@@ -896,11 +896,6 @@ BEGIN
   END IF;
 
   IF has_function_privilege(
-       'PUBLIC',
-       'public.wardah_apply_stock_incoming(uuid,uuid,uuid,numeric,numeric,text,uuid,text,date,uuid)',
-       'EXECUTE'
-     )
-     OR has_function_privilege(
        'anon',
        'public.wardah_apply_stock_incoming(uuid,uuid,uuid,numeric,numeric,text,uuid,text,date,uuid)',
        'EXECUTE'
@@ -913,11 +908,6 @@ BEGIN
      OR NOT has_function_privilege(
        'service_role',
        'public.wardah_apply_stock_incoming(uuid,uuid,uuid,numeric,numeric,text,uuid,text,date,uuid)',
-       'EXECUTE'
-     )
-     OR has_function_privilege(
-       'PUBLIC',
-       'public.wardah_apply_stock_outgoing(uuid,uuid,uuid,numeric,text,uuid,text,date,uuid)',
        'EXECUTE'
      )
      OR has_function_privilege(
@@ -947,11 +937,6 @@ BEGIN
   END IF;
 
   IF has_function_privilege(
-       'PUBLIC',
-       'public.rpc_submit_stock_adjustment(uuid)',
-       'EXECUTE'
-     )
-     OR has_function_privilege(
        'anon',
        'public.rpc_submit_stock_adjustment(uuid)',
        'EXECUTE'

--- a/sql/migrations/187_stock_adjustment_ledger_idempotency.sql
+++ b/sql/migrations/187_stock_adjustment_ledger_idempotency.sql
@@ -362,6 +362,21 @@ BEGIN
 END;
 $function$;
 
+-- Keep the service-only ACL adjacent to the DEFINER body so repository guards
+-- can prove the helper is not client-callable before inspecting later objects.
+REVOKE ALL ON FUNCTION public.wardah_apply_stock_incoming(
+  uuid, uuid, uuid, numeric, numeric, text, uuid, text, date, uuid
+) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.wardah_apply_stock_incoming(
+  uuid, uuid, uuid, numeric, numeric, text, uuid, text, date, uuid
+) FROM anon;
+REVOKE ALL ON FUNCTION public.wardah_apply_stock_incoming(
+  uuid, uuid, uuid, numeric, numeric, text, uuid, text, date, uuid
+) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.wardah_apply_stock_incoming(
+  uuid, uuid, uuid, numeric, numeric, text, uuid, text, date, uuid
+) TO service_role;
+
 -- Source-aware outgoing overload. Its valuation, reservation-floor, bin, and
 -- product-projection behavior is the exact Migration 186 contract; only source
 -- validation/storage is added.
@@ -616,19 +631,6 @@ BEGIN
   );
 END;
 $function$;
-
-REVOKE ALL ON FUNCTION public.wardah_apply_stock_incoming(
-  uuid, uuid, uuid, numeric, numeric, text, uuid, text, date, uuid
-) FROM PUBLIC;
-REVOKE ALL ON FUNCTION public.wardah_apply_stock_incoming(
-  uuid, uuid, uuid, numeric, numeric, text, uuid, text, date, uuid
-) FROM anon;
-REVOKE ALL ON FUNCTION public.wardah_apply_stock_incoming(
-  uuid, uuid, uuid, numeric, numeric, text, uuid, text, date, uuid
-) FROM authenticated;
-GRANT EXECUTE ON FUNCTION public.wardah_apply_stock_incoming(
-  uuid, uuid, uuid, numeric, numeric, text, uuid, text, date, uuid
-) TO service_role;
 
 REVOKE ALL ON FUNCTION public.wardah_apply_stock_outgoing(
   uuid, uuid, uuid, numeric, text, uuid, text, date, uuid

--- a/sql/migrations/187_stock_adjustment_ledger_idempotency.sql
+++ b/sql/migrations/187_stock_adjustment_ledger_idempotency.sql
@@ -1,0 +1,969 @@
+-- Migration 187: prospective stock-adjustment ledger idempotency.
+--
+-- The originally proposed global key
+--   (voucher_type, voucher_id, product_id, warehouse_id)
+-- is not a legal invariant for every stock movement. Goods receipts and
+-- delivery notes may contain separate source lines for the same product and
+-- warehouse, and material consumption may be posted partially more than once
+-- against one manufacturing order. Stock adjustments are different: the live
+-- RPC already rejects duplicate product/warehouse lines in one adjustment.
+--
+-- Production also contains historical stock-adjustment rows without
+-- source_line_id, including the known ADJ-000001 duplicate. This migration does
+-- not delete, rewrite, or guess provenance for those rows. It enforces the
+-- invariant prospectively on INSERT while leaving historical rows updateable
+-- (notably by the legal cancellation workflow).
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '60s';
+
+DO $preflight$
+BEGIN
+  IF to_regclass('public.stock_ledger_entries') IS NULL
+     OR to_regclass('public.stock_adjustments') IS NULL
+     OR to_regclass('public.stock_adjustment_items') IS NULL THEN
+    RAISE EXCEPTION 'STOCK_187_REQUIRED_RELATION_MISSING';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'stock_ledger_entries'
+      AND column_name = 'source_line_id'
+      AND data_type = 'uuid'
+  ) THEN
+    RAISE EXCEPTION 'STOCK_187_SOURCE_LINE_COLUMN_MISSING';
+  END IF;
+
+  IF to_regprocedure(
+       'public.wardah_apply_stock_incoming(uuid,uuid,uuid,numeric,numeric,text,uuid,text,date)'
+     ) IS NULL
+     OR to_regprocedure(
+       'public.wardah_apply_stock_outgoing(uuid,uuid,uuid,numeric,text,uuid,text,date)'
+     ) IS NULL
+     OR to_regprocedure('public.rpc_submit_stock_adjustment(uuid)') IS NULL THEN
+    RAISE EXCEPTION 'STOCK_187_REQUIRED_FUNCTION_MISSING';
+  END IF;
+
+  IF to_regclass(
+       'public.uq_sle_stock_adjustment_voucher_product_warehouse_v187'
+     ) IS NOT NULL
+     OR to_regprocedure(
+       'public.wardah_187_require_stock_source_line()'
+     ) IS NOT NULL
+     OR to_regprocedure(
+       'public.wardah_apply_stock_incoming(uuid,uuid,uuid,numeric,numeric,text,uuid,text,date,uuid)'
+     ) IS NOT NULL
+     OR to_regprocedure(
+       'public.wardah_apply_stock_outgoing(uuid,uuid,uuid,numeric,text,uuid,text,date,uuid)'
+     ) IS NOT NULL THEN
+    RAISE EXCEPTION 'STOCK_187_OBJECT_ALREADY_EXISTS';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgrelid = 'public.stock_ledger_entries'::regclass
+      AND tgname = 'trg_sle_stock_adjustment_source_line_v187'
+      AND NOT tgisinternal
+  ) THEN
+    RAISE EXCEPTION 'STOCK_187_TRIGGER_ALREADY_EXISTS';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.stock_ledger_entries
+    WHERE lower(btrim(voucher_type::text)) = 'stock adjustment'
+      AND source_line_id IS NOT NULL
+    GROUP BY org_id, voucher_id, product_id, warehouse_id
+    HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'STOCK_187_PROSPECTIVE_DUPLICATE_PRESENT';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.stock_ledger_entries sle
+    WHERE lower(btrim(sle.voucher_type::text)) = 'stock adjustment'
+      AND sle.source_line_id IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1
+        FROM public.stock_adjustment_items sai
+        JOIN public.stock_adjustments sa ON sa.id = sai.adjustment_id
+        WHERE sai.id = sle.source_line_id
+          AND sai.adjustment_id = sle.voucher_id
+          AND sai.organization_id = sle.org_id
+          AND sai.product_id = sle.product_id
+          AND COALESCE(sai.warehouse_id, sa.warehouse_id) = sle.warehouse_id
+          AND COALESCE(sa.org_id, sa.organization_id) = sle.org_id
+      )
+  ) THEN
+    RAISE EXCEPTION 'STOCK_187_SOURCE_RELATION_DRIFT';
+  END IF;
+END
+$preflight$;
+
+CREATE UNIQUE INDEX uq_sle_stock_adjustment_voucher_product_warehouse_v187
+  ON public.stock_ledger_entries (
+    org_id,
+    voucher_id,
+    product_id,
+    warehouse_id
+  )
+  WHERE source_line_id IS NOT NULL
+    AND lower(btrim(voucher_type::text)) = 'stock adjustment';
+
+CREATE OR REPLACE FUNCTION public.wardah_187_require_stock_source_line()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+  IF lower(btrim(NEW.voucher_type::text)) = 'stock adjustment' THEN
+    IF NEW.source_line_id IS NULL THEN
+      IF TG_OP = 'INSERT' THEN
+        RAISE EXCEPTION 'STOCK_SOURCE_LINE_REQUIRED';
+      END IF;
+
+      IF OLD.source_line_id IS NOT NULL
+         OR NEW.voucher_type IS DISTINCT FROM OLD.voucher_type
+         OR NEW.voucher_id IS DISTINCT FROM OLD.voucher_id
+         OR NEW.product_id IS DISTINCT FROM OLD.product_id
+         OR NEW.warehouse_id IS DISTINCT FROM OLD.warehouse_id
+         OR NEW.org_id IS DISTINCT FROM OLD.org_id THEN
+        RAISE EXCEPTION 'STOCK_SOURCE_LINE_REQUIRED';
+      END IF;
+
+      -- Historical NULL-source rows remain updateable for cancellation and
+      -- provenance-neutral maintenance.
+      RETURN NEW;
+    END IF;
+
+    IF NOT EXISTS (
+      SELECT 1
+      FROM public.stock_adjustment_items sai
+      JOIN public.stock_adjustments sa ON sa.id = sai.adjustment_id
+      WHERE sai.id = NEW.source_line_id
+        AND sai.adjustment_id = NEW.voucher_id
+        AND sai.organization_id = NEW.org_id
+        AND sai.product_id = NEW.product_id
+        AND COALESCE(sai.warehouse_id, sa.warehouse_id) = NEW.warehouse_id
+        AND COALESCE(sa.org_id, sa.organization_id) = NEW.org_id
+    ) THEN
+      RAISE EXCEPTION 'STOCK_SOURCE_LINE_MISMATCH';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.wardah_187_require_stock_source_line() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.wardah_187_require_stock_source_line() FROM anon;
+REVOKE ALL ON FUNCTION public.wardah_187_require_stock_source_line() FROM authenticated;
+REVOKE ALL ON FUNCTION public.wardah_187_require_stock_source_line() FROM service_role;
+
+CREATE TRIGGER trg_sle_stock_adjustment_source_line_v187
+BEFORE INSERT OR UPDATE OF
+  voucher_type,
+  voucher_id,
+  product_id,
+  warehouse_id,
+  org_id,
+  source_line_id
+ON public.stock_ledger_entries
+FOR EACH ROW
+EXECUTE FUNCTION public.wardah_187_require_stock_source_line();
+
+-- Source-aware incoming overload. The historical nine-argument helper remains
+-- intact for receipt/delivery compatibility, but the trigger above makes it
+-- fail closed if any caller tries to use it for a new Stock Adjustment row.
+CREATE OR REPLACE FUNCTION public.wardah_apply_stock_incoming(
+  p_org uuid,
+  p_product uuid,
+  p_warehouse uuid,
+  p_qty numeric,
+  p_rate numeric,
+  p_voucher_type text,
+  p_voucher_id uuid,
+  p_voucher_number text,
+  p_posting_date date,
+  p_source_line_id uuid
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_method text;
+  v_prev_qty numeric := 0;
+  v_prev_value numeric := 0;
+  v_prev_queue jsonb := '[]'::jsonb;
+  v_new_qty numeric;
+  v_new_value numeric;
+  v_new_rate numeric;
+  v_new_queue jsonb;
+  v_len integer;
+  v_prod_qty numeric;
+  v_prod_rate numeric;
+BEGIN
+  IF p_warehouse IS NULL OR p_qty IS NULL OR p_qty <= 0 THEN
+    RETURN jsonb_build_object('applied', false, 'reason', 'NO_WAREHOUSE_OR_QTY');
+  END IF;
+
+  IF lower(btrim(COALESCE(p_voucher_type, ''))) = 'stock adjustment' THEN
+    IF p_source_line_id IS NULL THEN
+      RAISE EXCEPTION 'STOCK_SOURCE_LINE_REQUIRED';
+    END IF;
+
+    IF NOT EXISTS (
+      SELECT 1
+      FROM public.stock_adjustment_items sai
+      JOIN public.stock_adjustments sa ON sa.id = sai.adjustment_id
+      WHERE sai.id = p_source_line_id
+        AND sai.adjustment_id = p_voucher_id
+        AND sai.organization_id = p_org
+        AND sai.product_id = p_product
+        AND COALESCE(sai.warehouse_id, sa.warehouse_id) = p_warehouse
+        AND COALESCE(sa.org_id, sa.organization_id) = p_org
+    ) THEN
+      RAISE EXCEPTION 'STOCK_SOURCE_LINE_MISMATCH';
+    END IF;
+  END IF;
+
+  SELECT COALESCE(valuation_method, 'Weighted Average')
+  INTO v_method
+  FROM public.products
+  WHERE id = p_product AND org_id = p_org;
+  v_method := COALESCE(v_method, 'Weighted Average');
+
+  SELECT actual_qty, stock_value, stock_queue
+  INTO v_prev_qty, v_prev_value, v_prev_queue
+  FROM public.bins
+  WHERE product_id = p_product AND warehouse_id = p_warehouse
+  FOR UPDATE;
+
+  v_prev_qty := COALESCE(v_prev_qty, 0);
+  v_prev_value := COALESCE(v_prev_value, 0);
+  v_prev_queue := COALESCE(v_prev_queue, '[]'::jsonb);
+
+  v_new_qty := v_prev_qty + p_qty;
+  v_new_value := v_prev_value + (p_qty * p_rate);
+  v_new_queue := v_prev_queue
+    || jsonb_build_array(jsonb_build_object('qty', p_qty, 'rate', p_rate));
+
+  IF v_method = 'FIFO' THEN
+    v_new_rate := COALESCE((v_new_queue -> 0 ->> 'rate')::numeric, p_rate);
+  ELSIF v_method = 'LIFO' THEN
+    v_len := jsonb_array_length(v_new_queue);
+    v_new_rate := COALESCE((v_new_queue -> (v_len - 1) ->> 'rate')::numeric, p_rate);
+  ELSE
+    v_new_rate := CASE WHEN v_new_qty > 0 THEN v_new_value / v_new_qty ELSE 0 END;
+    v_new_queue := jsonb_build_array(
+      jsonb_build_object('qty', v_new_qty, 'rate', v_new_rate)
+    );
+  END IF;
+
+  INSERT INTO public.stock_ledger_entries (
+    voucher_type,
+    voucher_id,
+    voucher_number,
+    product_id,
+    warehouse_id,
+    posting_date,
+    actual_qty,
+    qty_after_transaction,
+    incoming_rate,
+    valuation_rate,
+    stock_value,
+    stock_value_difference,
+    stock_queue,
+    docstatus,
+    org_id,
+    created_by,
+    source_line_id
+  ) VALUES (
+    p_voucher_type,
+    p_voucher_id,
+    p_voucher_number,
+    p_product,
+    p_warehouse,
+    COALESCE(p_posting_date, CURRENT_DATE),
+    p_qty,
+    v_new_qty,
+    p_rate,
+    v_new_rate,
+    v_new_value,
+    p_qty * p_rate,
+    v_new_queue,
+    1,
+    p_org,
+    auth.uid(),
+    p_source_line_id
+  );
+
+  INSERT INTO public.bins (
+    org_id,
+    product_id,
+    warehouse_id,
+    actual_qty,
+    valuation_rate,
+    stock_value,
+    stock_queue,
+    updated_at
+  ) VALUES (
+    p_org,
+    p_product,
+    p_warehouse,
+    v_new_qty,
+    v_new_rate,
+    v_new_value,
+    v_new_queue,
+    now()
+  )
+  ON CONFLICT (product_id, warehouse_id) DO UPDATE SET
+    actual_qty = EXCLUDED.actual_qty,
+    valuation_rate = EXCLUDED.valuation_rate,
+    stock_value = EXCLUDED.stock_value,
+    stock_queue = EXCLUDED.stock_queue,
+    updated_at = now();
+
+  SELECT COALESCE(SUM(actual_qty), 0),
+         CASE
+           WHEN COALESCE(SUM(actual_qty), 0) > 0
+             THEN SUM(stock_value) / SUM(actual_qty)
+           ELSE NULL
+         END
+  INTO v_prod_qty, v_prod_rate
+  FROM public.bins
+  WHERE product_id = p_product AND org_id = p_org;
+
+  UPDATE public.products
+  SET stock_quantity = v_prod_qty,
+      cost_price = COALESCE(v_prod_rate, cost_price),
+      updated_at = now()
+  WHERE id = p_product AND org_id = p_org;
+
+  RETURN jsonb_build_object(
+    'applied', true,
+    'new_qty', v_new_qty,
+    'new_rate', round(v_new_rate, 6),
+    'new_value', round(v_new_value, 6),
+    'method', v_method,
+    'source_line_id', p_source_line_id,
+    'product_synced', jsonb_build_object(
+      'stock_quantity', v_prod_qty,
+      'cost_price', round(COALESCE(v_prod_rate, 0), 6)
+    )
+  );
+END;
+$function$;
+
+-- Source-aware outgoing overload. Its valuation, reservation-floor, bin, and
+-- product-projection behavior is the exact Migration 186 contract; only source
+-- validation/storage is added.
+CREATE OR REPLACE FUNCTION public.wardah_apply_stock_outgoing(
+  p_org uuid,
+  p_product uuid,
+  p_warehouse uuid,
+  p_qty numeric,
+  p_voucher_type text,
+  p_voucher_id uuid,
+  p_voucher_number text,
+  p_posting_date date,
+  p_source_line_id uuid
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_method text;
+  v_prev_qty numeric;
+  v_prev_value numeric;
+  v_prev_queue jsonb;
+  v_new_qty numeric;
+  v_new_value numeric;
+  v_new_rate numeric;
+  v_new_queue jsonb;
+  v_remaining numeric;
+  v_take numeric;
+  v_batch_qty numeric;
+  v_batch_rate numeric;
+  v_cogs numeric := 0;
+  v_idx integer;
+  v_len integer;
+  v_prod_qty numeric;
+  v_prod_value numeric;
+  v_prod_rate numeric;
+  v_total_on_hand numeric;
+  v_other_mo_reserved numeric;
+BEGIN
+  PERFORM public.wardah_assert_org_member(p_org);
+
+  IF p_product IS NULL OR p_warehouse IS NULL OR p_qty IS NULL OR p_qty <= 0 THEN
+    RAISE EXCEPTION 'INVALID_STOCK_OUT_PARAMETERS';
+  END IF;
+
+  IF lower(btrim(COALESCE(p_voucher_type, ''))) = 'stock adjustment' THEN
+    IF p_source_line_id IS NULL THEN
+      RAISE EXCEPTION 'STOCK_SOURCE_LINE_REQUIRED';
+    END IF;
+
+    IF NOT EXISTS (
+      SELECT 1
+      FROM public.stock_adjustment_items sai
+      JOIN public.stock_adjustments sa ON sa.id = sai.adjustment_id
+      WHERE sai.id = p_source_line_id
+        AND sai.adjustment_id = p_voucher_id
+        AND sai.organization_id = p_org
+        AND sai.product_id = p_product
+        AND COALESCE(sai.warehouse_id, sa.warehouse_id) = p_warehouse
+        AND COALESCE(sa.org_id, sa.organization_id) = p_org
+    ) THEN
+      RAISE EXCEPTION 'STOCK_SOURCE_LINE_MISMATCH';
+    END IF;
+  END IF;
+
+  SELECT COALESCE(valuation_method::text, 'Weighted Average')
+  INTO v_method
+  FROM public.products
+  WHERE id = p_product AND org_id = p_org;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'PRODUCT_NOT_FOUND_OR_WRONG_ORG';
+  END IF;
+
+  PERFORM 1
+  FROM public.bins
+  WHERE org_id = p_org AND product_id = p_product
+  ORDER BY warehouse_id, id
+  FOR UPDATE;
+
+  SELECT COALESCE(SUM(actual_qty), 0)
+  INTO v_total_on_hand
+  FROM public.bins
+  WHERE org_id = p_org AND product_id = p_product;
+
+  SELECT COALESCE(SUM(GREATEST(
+    quantity_reserved
+      - COALESCE(quantity_consumed, 0)
+      - COALESCE(quantity_released, 0),
+    0
+  )), 0)
+  INTO v_other_mo_reserved
+  FROM public.material_reservations
+  WHERE org_id = p_org
+    AND product_id = p_product
+    AND status = 'reserved'
+    AND NOT (
+      lower(COALESCE(p_voucher_type, '')) = 'material consumption'
+      AND p_voucher_id IS NOT NULL
+      AND mo_id = p_voucher_id
+    );
+
+  IF v_total_on_hand - p_qty < v_other_mo_reserved THEN
+    RAISE EXCEPTION
+      'INSUFFICIENT_UNRESERVED_STOCK: on_hand=%, protected_mo=%, requested=%',
+      v_total_on_hand,
+      v_other_mo_reserved,
+      p_qty;
+  END IF;
+
+  SELECT COALESCE(actual_qty, 0),
+         COALESCE(stock_value, 0),
+         COALESCE(stock_queue, '[]'::jsonb)
+  INTO v_prev_qty, v_prev_value, v_prev_queue
+  FROM public.bins
+  WHERE org_id = p_org
+    AND product_id = p_product
+    AND warehouse_id = p_warehouse
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'BIN_NOT_FOUND';
+  END IF;
+  IF v_prev_qty < p_qty THEN
+    RAISE EXCEPTION 'INSUFFICIENT_STOCK: available=%, required=%', v_prev_qty, p_qty;
+  END IF;
+
+  v_new_qty := v_prev_qty - p_qty;
+  v_new_queue := v_prev_queue;
+
+  IF v_method IN ('FIFO', 'LIFO') AND jsonb_array_length(v_new_queue) > 0 THEN
+    v_remaining := p_qty;
+    WHILE v_remaining > 0 LOOP
+      v_len := jsonb_array_length(v_new_queue);
+      IF v_len = 0 THEN
+        RAISE EXCEPTION 'STOCK_QUEUE_INSUFFICIENT';
+      END IF;
+      v_idx := CASE WHEN v_method = 'FIFO' THEN 0 ELSE v_len - 1 END;
+      v_batch_qty := COALESCE((v_new_queue -> v_idx ->> 'qty')::numeric, 0);
+      v_batch_rate := COALESCE((v_new_queue -> v_idx ->> 'rate')::numeric, 0);
+      IF v_batch_qty <= 0 THEN
+        v_new_queue := v_new_queue - v_idx;
+        CONTINUE;
+      END IF;
+      v_take := LEAST(v_remaining, v_batch_qty);
+      v_cogs := v_cogs + (v_take * v_batch_rate);
+      v_remaining := v_remaining - v_take;
+      IF v_take = v_batch_qty THEN
+        v_new_queue := v_new_queue - v_idx;
+      ELSE
+        v_new_queue := jsonb_set(
+          v_new_queue,
+          ARRAY[v_idx::text, 'qty'],
+          to_jsonb(v_batch_qty - v_take),
+          false
+        );
+      END IF;
+    END LOOP;
+    v_new_value := GREATEST(v_prev_value - v_cogs, 0);
+    IF v_new_qty = 0 THEN
+      v_new_rate := 0;
+      v_new_queue := '[]'::jsonb;
+    ELSE
+      v_len := jsonb_array_length(v_new_queue);
+      v_idx := CASE WHEN v_method = 'FIFO' THEN 0 ELSE v_len - 1 END;
+      v_new_rate := COALESCE((v_new_queue -> v_idx ->> 'rate')::numeric, 0);
+    END IF;
+  ELSE
+    v_batch_rate := CASE WHEN v_prev_qty > 0 THEN v_prev_value / v_prev_qty ELSE 0 END;
+    v_cogs := p_qty * v_batch_rate;
+    v_new_value := GREATEST(v_prev_value - v_cogs, 0);
+    v_new_rate := CASE WHEN v_new_qty > 0 THEN v_new_value / v_new_qty ELSE 0 END;
+    v_new_queue := CASE
+      WHEN v_new_qty > 0
+        THEN jsonb_build_array(jsonb_build_object('qty', v_new_qty, 'rate', v_new_rate))
+      ELSE '[]'::jsonb
+    END;
+  END IF;
+
+  INSERT INTO public.stock_ledger_entries (
+    voucher_type,
+    voucher_id,
+    voucher_number,
+    product_id,
+    warehouse_id,
+    posting_date,
+    actual_qty,
+    qty_after_transaction,
+    outgoing_rate,
+    valuation_rate,
+    stock_value,
+    stock_value_difference,
+    stock_queue,
+    is_cancelled,
+    docstatus,
+    org_id,
+    created_by,
+    source_line_id
+  ) VALUES (
+    p_voucher_type,
+    p_voucher_id,
+    p_voucher_number,
+    p_product,
+    p_warehouse,
+    COALESCE(p_posting_date, CURRENT_DATE),
+    -p_qty,
+    v_new_qty,
+    CASE WHEN p_qty > 0 THEN v_cogs / p_qty ELSE 0 END,
+    v_new_rate,
+    v_new_value,
+    -v_cogs,
+    v_new_queue,
+    false,
+    1,
+    p_org,
+    auth.uid(),
+    p_source_line_id
+  );
+
+  UPDATE public.bins
+  SET actual_qty = v_new_qty,
+      valuation_rate = v_new_rate,
+      stock_value = v_new_value,
+      stock_queue = v_new_queue,
+      updated_at = now()
+  WHERE org_id = p_org
+    AND product_id = p_product
+    AND warehouse_id = p_warehouse;
+
+  SELECT COALESCE(SUM(actual_qty), 0),
+         COALESCE(SUM(stock_value), 0)
+  INTO v_prod_qty, v_prod_value
+  FROM public.bins
+  WHERE org_id = p_org AND product_id = p_product;
+  v_prod_rate := CASE WHEN v_prod_qty > 0 THEN v_prod_value / v_prod_qty ELSE 0 END;
+
+  UPDATE public.products
+  SET stock_quantity = v_prod_qty,
+      stock_value = v_prod_value,
+      cost_price = CASE WHEN v_prod_qty > 0 THEN v_prod_rate ELSE cost_price END,
+      updated_at = now()
+  WHERE id = p_product AND org_id = p_org;
+
+  RETURN jsonb_build_object(
+    'applied', true,
+    'new_qty', v_new_qty,
+    'new_rate', round(v_new_rate, 6),
+    'new_value', round(v_new_value, 6),
+    'cogs', round(v_cogs, 6),
+    'method', v_method,
+    'source_line_id', p_source_line_id
+  );
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.wardah_apply_stock_incoming(
+  uuid, uuid, uuid, numeric, numeric, text, uuid, text, date, uuid
+) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.wardah_apply_stock_incoming(
+  uuid, uuid, uuid, numeric, numeric, text, uuid, text, date, uuid
+) FROM anon;
+REVOKE ALL ON FUNCTION public.wardah_apply_stock_incoming(
+  uuid, uuid, uuid, numeric, numeric, text, uuid, text, date, uuid
+) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.wardah_apply_stock_incoming(
+  uuid, uuid, uuid, numeric, numeric, text, uuid, text, date, uuid
+) TO service_role;
+
+REVOKE ALL ON FUNCTION public.wardah_apply_stock_outgoing(
+  uuid, uuid, uuid, numeric, text, uuid, text, date, uuid
+) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.wardah_apply_stock_outgoing(
+  uuid, uuid, uuid, numeric, text, uuid, text, date, uuid
+) FROM anon;
+REVOKE ALL ON FUNCTION public.wardah_apply_stock_outgoing(
+  uuid, uuid, uuid, numeric, text, uuid, text, date, uuid
+) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.wardah_apply_stock_outgoing(
+  uuid, uuid, uuid, numeric, text, uuid, text, date, uuid
+) TO service_role;
+
+-- Carry forward the complete live stock-adjustment submission contract from
+-- Migration 125, changing only the two helper calls to pass v_item.id.
+CREATE OR REPLACE FUNCTION public.rpc_submit_stock_adjustment(
+  p_adjustment_id uuid
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_adj public.stock_adjustments%rowtype;
+  v_item record;
+  v_warehouse uuid;
+  v_result jsonb;
+  v_gl jsonb;
+  v_debit uuid;
+  v_credit uuid;
+  v_amount numeric;
+  v_signed_value numeric;
+  v_actual_qty numeric;
+  v_item_count integer;
+  v_distinct_count integer;
+BEGIN
+  SELECT * INTO v_adj
+  FROM public.stock_adjustments
+  WHERE id = p_adjustment_id
+  FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'ADJUSTMENT_NOT_FOUND'; END IF;
+
+  v_adj.org_id := COALESCE(v_adj.org_id, v_adj.organization_id);
+  PERFORM public.wardah_assert_org_admin(v_adj.org_id);
+
+  IF v_adj.status = 'SUBMITTED' THEN
+    RETURN jsonb_build_object(
+      'success', true,
+      'duplicate', true,
+      'adjustment_id', v_adj.id,
+      'gl_entry_id', v_adj.canonical_gl_entry_id
+    );
+  END IF;
+  IF v_adj.status <> 'DRAFT' THEN RAISE EXCEPTION 'ADJUSTMENT_NOT_DRAFT'; END IF;
+  IF COALESCE(v_adj.requires_approval, false) AND v_adj.approved_by IS NULL THEN
+    RAISE EXCEPTION 'ADJUSTMENT_APPROVAL_REQUIRED';
+  END IF;
+
+  SELECT count(*),
+         count(DISTINCT ROW(product_id, COALESCE(warehouse_id, v_adj.warehouse_id)))
+  INTO v_item_count, v_distinct_count
+  FROM public.stock_adjustment_items
+  WHERE adjustment_id = v_adj.id;
+
+  IF v_item_count = 0 THEN RAISE EXCEPTION 'ADJUSTMENT_REQUIRES_ITEMS'; END IF;
+  IF v_item_count <> v_distinct_count THEN
+    RAISE EXCEPTION 'DUPLICATE_PRODUCT_WAREHOUSE_LINES';
+  END IF;
+
+  FOR v_item IN
+    SELECT *
+    FROM public.stock_adjustment_items
+    WHERE adjustment_id = v_adj.id
+    ORDER BY id
+  LOOP
+    v_warehouse := COALESCE(v_item.warehouse_id, v_adj.warehouse_id);
+    IF v_warehouse IS NULL THEN RAISE EXCEPTION 'WAREHOUSE_REQUIRED'; END IF;
+
+    IF v_item.difference_qty > 0 THEN
+      v_result := public.wardah_apply_stock_incoming(
+        v_adj.org_id,
+        v_item.product_id,
+        v_warehouse,
+        v_item.difference_qty,
+        COALESCE(v_item.new_rate, v_item.current_rate, 0),
+        'Stock Adjustment',
+        v_adj.id,
+        v_adj.adjustment_number,
+        v_adj.posting_date,
+        v_item.id
+      );
+      IF NOT COALESCE((v_result ->> 'applied')::boolean, false) THEN
+        RAISE EXCEPTION 'STOCK_IN_NOT_APPLIED: %', v_result;
+      END IF;
+    ELSIF v_item.difference_qty < 0 THEN
+      PERFORM public.wardah_apply_stock_outgoing(
+        v_adj.org_id,
+        v_item.product_id,
+        v_warehouse,
+        abs(v_item.difference_qty),
+        'Stock Adjustment',
+        v_adj.id,
+        v_adj.adjustment_number,
+        v_adj.posting_date,
+        v_item.id
+      );
+    END IF;
+  END LOOP;
+
+  SELECT COALESCE(SUM(actual_qty), 0),
+         COALESCE(SUM(stock_value_difference), 0)
+  INTO v_actual_qty, v_signed_value
+  FROM public.stock_ledger_entries
+  WHERE org_id = v_adj.org_id
+    AND voucher_type = 'Stock Adjustment'
+    AND voucher_id = v_adj.id
+    AND COALESCE(is_cancelled, false) = false;
+
+  v_amount := abs(v_signed_value);
+  IF v_amount > 0 THEN
+    IF v_adj.inventory_account_id IS NULL THEN
+      RAISE EXCEPTION 'INVENTORY_ACCOUNT_REQUIRED';
+    END IF;
+    IF v_signed_value > 0 THEN
+      IF v_adj.increase_account_id IS NULL THEN
+        RAISE EXCEPTION 'INCREASE_ACCOUNT_REQUIRED';
+      END IF;
+      v_debit := v_adj.inventory_account_id;
+      v_credit := v_adj.increase_account_id;
+    ELSE
+      IF v_adj.decrease_account_id IS NULL THEN
+        RAISE EXCEPTION 'DECREASE_ACCOUNT_REQUIRED';
+      END IF;
+      v_debit := v_adj.decrease_account_id;
+      v_credit := v_adj.inventory_account_id;
+    END IF;
+
+    v_gl := public.rpc_create_journal_entry(jsonb_build_object(
+      'org_id', v_adj.org_id,
+      'entry_date', v_adj.posting_date,
+      'reference_type', 'Stock Adjustment',
+      'reference_number', v_adj.adjustment_number,
+      'description', v_adj.reason,
+      'idempotency_key', 'stock-adjustment:' || v_adj.id::text,
+      'auto_post', true,
+      'lines', jsonb_build_array(
+        jsonb_build_object(
+          'line_number', 1,
+          'account_id', v_debit,
+          'debit', v_amount,
+          'credit', 0,
+          'description', v_adj.reason
+        ),
+        jsonb_build_object(
+          'line_number', 2,
+          'account_id', v_credit,
+          'debit', 0,
+          'credit', v_amount,
+          'description', v_adj.reason
+        )
+      )
+    ));
+  END IF;
+
+  UPDATE public.stock_adjustments
+  SET status = 'SUBMITTED',
+      total_qty_difference = v_actual_qty,
+      total_value_difference = v_signed_value,
+      submitted_by = auth.uid(),
+      submitted_at = now(),
+      canonical_gl_entry_id = NULLIF(v_gl ->> 'entry_id', '')::uuid,
+      updated_by = auth.uid(),
+      updated_at = now()
+  WHERE id = v_adj.id;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'adjustment_id', v_adj.id,
+    'actual_qty_difference', v_actual_qty,
+    'actual_value_difference', v_signed_value,
+    'gl_entry_id', NULLIF(v_gl ->> 'entry_id', '')::uuid
+  );
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.rpc_submit_stock_adjustment(uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.rpc_submit_stock_adjustment(uuid) FROM anon;
+GRANT EXECUTE ON FUNCTION public.rpc_submit_stock_adjustment(uuid) TO authenticated;
+
+COMMENT ON INDEX public.uq_sle_stock_adjustment_voucher_product_warehouse_v187 IS
+  'Migration 187: one prospective Stock Adjustment movement per org/voucher/product/warehouse; historical rows with unknown source_line_id remain outside the predicate.';
+
+COMMENT ON FUNCTION public.wardah_187_require_stock_source_line() IS
+  'Migration 187 source guard: new Stock Adjustment SLE rows and later identity changes require a legal source_line_id; provenance-neutral historical updates remain possible.';
+
+COMMENT ON FUNCTION public.wardah_apply_stock_incoming(
+  uuid, uuid, uuid, numeric, numeric, text, uuid, text, date, uuid
+) IS
+  'Migration 187 source-aware incoming stock helper. Stock Adjustment sources must match stock_adjustment_items.';
+
+COMMENT ON FUNCTION public.wardah_apply_stock_outgoing(
+  uuid, uuid, uuid, numeric, text, uuid, text, date, uuid
+) IS
+  'Migration 187 source-aware outgoing stock helper preserving the complete Migration 186 valuation and reservation-floor contract.';
+
+DO $postflight$
+DECLARE
+  v_submit_definition text;
+  v_index_definition text;
+  v_trigger_definition text;
+BEGIN
+  SELECT pg_get_indexdef('public.uq_sle_stock_adjustment_voucher_product_warehouse_v187'::regclass)
+  INTO v_index_definition;
+
+  IF v_index_definition IS NULL
+     OR v_index_definition NOT LIKE 'CREATE UNIQUE INDEX%'
+     OR v_index_definition NOT LIKE '%source_line_id IS NOT NULL%'
+     OR v_index_definition NOT LIKE '%stock adjustment%' THEN
+    RAISE EXCEPTION 'STOCK_187_INDEX_DEFINITION_DRIFT: %', v_index_definition;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_index
+    WHERE indexrelid =
+      'public.uq_sle_stock_adjustment_voucher_product_warehouse_v187'::regclass
+      AND indisunique
+      AND indisvalid
+      AND indisready
+  ) THEN
+    RAISE EXCEPTION 'STOCK_187_INDEX_NOT_READY';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgrelid = 'public.stock_ledger_entries'::regclass
+      AND tgname = 'trg_sle_stock_adjustment_source_line_v187'
+      AND tgenabled = 'O'
+      AND NOT tgisinternal
+  ) THEN
+    RAISE EXCEPTION 'STOCK_187_TRIGGER_NOT_ENABLED';
+  END IF;
+
+  SELECT pg_get_triggerdef(oid)
+  INTO v_trigger_definition
+  FROM pg_trigger
+  WHERE tgrelid = 'public.stock_ledger_entries'::regclass
+    AND tgname = 'trg_sle_stock_adjustment_source_line_v187'
+    AND NOT tgisinternal;
+
+  IF v_trigger_definition NOT LIKE '%BEFORE INSERT OR UPDATE OF%'
+     OR v_trigger_definition NOT LIKE '%source_line_id%' THEN
+    RAISE EXCEPTION 'STOCK_187_TRIGGER_DEFINITION_DRIFT: %', v_trigger_definition;
+  END IF;
+
+  IF to_regprocedure(
+       'public.wardah_apply_stock_incoming(uuid,uuid,uuid,numeric,numeric,text,uuid,text,date,uuid)'
+     ) IS NULL
+     OR to_regprocedure(
+       'public.wardah_apply_stock_outgoing(uuid,uuid,uuid,numeric,text,uuid,text,date,uuid)'
+     ) IS NULL THEN
+    RAISE EXCEPTION 'STOCK_187_SOURCE_AWARE_HELPER_MISSING';
+  END IF;
+
+  IF has_function_privilege(
+       'PUBLIC',
+       'public.wardah_apply_stock_incoming(uuid,uuid,uuid,numeric,numeric,text,uuid,text,date,uuid)',
+       'EXECUTE'
+     )
+     OR has_function_privilege(
+       'anon',
+       'public.wardah_apply_stock_incoming(uuid,uuid,uuid,numeric,numeric,text,uuid,text,date,uuid)',
+       'EXECUTE'
+     )
+     OR has_function_privilege(
+       'authenticated',
+       'public.wardah_apply_stock_incoming(uuid,uuid,uuid,numeric,numeric,text,uuid,text,date,uuid)',
+       'EXECUTE'
+     )
+     OR NOT has_function_privilege(
+       'service_role',
+       'public.wardah_apply_stock_incoming(uuid,uuid,uuid,numeric,numeric,text,uuid,text,date,uuid)',
+       'EXECUTE'
+     )
+     OR has_function_privilege(
+       'PUBLIC',
+       'public.wardah_apply_stock_outgoing(uuid,uuid,uuid,numeric,text,uuid,text,date,uuid)',
+       'EXECUTE'
+     )
+     OR has_function_privilege(
+       'anon',
+       'public.wardah_apply_stock_outgoing(uuid,uuid,uuid,numeric,text,uuid,text,date,uuid)',
+       'EXECUTE'
+     )
+     OR has_function_privilege(
+       'authenticated',
+       'public.wardah_apply_stock_outgoing(uuid,uuid,uuid,numeric,text,uuid,text,date,uuid)',
+       'EXECUTE'
+     )
+     OR NOT has_function_privilege(
+       'service_role',
+       'public.wardah_apply_stock_outgoing(uuid,uuid,uuid,numeric,text,uuid,text,date,uuid)',
+       'EXECUTE'
+     ) THEN
+    RAISE EXCEPTION 'STOCK_187_HELPER_ACL_DRIFT';
+  END IF;
+
+  SELECT pg_get_functiondef('public.rpc_submit_stock_adjustment(uuid)'::regprocedure)
+  INTO v_submit_definition;
+  IF v_submit_definition NOT LIKE '%v_item.id%'
+     OR v_submit_definition NOT LIKE '%wardah_apply_stock_incoming%'
+     OR v_submit_definition NOT LIKE '%wardah_apply_stock_outgoing%' THEN
+    RAISE EXCEPTION 'STOCK_187_SUBMIT_SOURCE_PROPAGATION_MISSING';
+  END IF;
+
+  IF has_function_privilege(
+       'PUBLIC',
+       'public.rpc_submit_stock_adjustment(uuid)',
+       'EXECUTE'
+     )
+     OR has_function_privilege(
+       'anon',
+       'public.rpc_submit_stock_adjustment(uuid)',
+       'EXECUTE'
+     )
+     OR NOT has_function_privilege(
+       'authenticated',
+       'public.rpc_submit_stock_adjustment(uuid)',
+       'EXECUTE'
+     ) THEN
+    RAISE EXCEPTION 'STOCK_187_SUBMIT_ACL_DRIFT';
+  END IF;
+END
+$postflight$;
+
+COMMIT;

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -11713,33 +11713,64 @@ export type Database = {
         Args: { p_lines: Json; p_org: string }
         Returns: undefined
       }
-      wardah_apply_stock_incoming: {
-        Args: {
-          p_org: string
-          p_posting_date: string
-          p_product: string
-          p_qty: number
-          p_rate: number
-          p_voucher_id: string
-          p_voucher_number: string
-          p_voucher_type: string
-          p_warehouse: string
-        }
-        Returns: Json
-      }
-      wardah_apply_stock_outgoing: {
-        Args: {
-          p_org: string
-          p_posting_date: string
-          p_product: string
-          p_qty: number
-          p_voucher_id: string
-          p_voucher_number: string
-          p_voucher_type: string
-          p_warehouse: string
-        }
-        Returns: Json
-      }
+      wardah_apply_stock_incoming:
+        | {
+            Args: {
+              p_org: string
+              p_posting_date: string
+              p_product: string
+              p_qty: number
+              p_rate: number
+              p_source_line_id: string
+              p_voucher_id: string
+              p_voucher_number: string
+              p_voucher_type: string
+              p_warehouse: string
+            }
+            Returns: Json
+          }
+        | {
+            Args: {
+              p_org: string
+              p_posting_date: string
+              p_product: string
+              p_qty: number
+              p_rate: number
+              p_voucher_id: string
+              p_voucher_number: string
+              p_voucher_type: string
+              p_warehouse: string
+            }
+            Returns: Json
+          }
+      wardah_apply_stock_outgoing:
+        | {
+            Args: {
+              p_org: string
+              p_posting_date: string
+              p_product: string
+              p_qty: number
+              p_voucher_id: string
+              p_voucher_number: string
+              p_voucher_type: string
+              p_warehouse: string
+            }
+            Returns: Json
+          }
+        | {
+            Args: {
+              p_org: string
+              p_posting_date: string
+              p_product: string
+              p_qty: number
+              p_source_line_id: string
+              p_voucher_id: string
+              p_voucher_number: string
+              p_voucher_type: string
+              p_warehouse: string
+            }
+            Returns: Json
+          }
       wardah_assert_org_admin: { Args: { p_org: string }; Returns: undefined }
       wardah_assert_org_member: { Args: { p_org: string }; Returns: undefined }
       wardah_create_posted_voucher_gl: {


### PR DESCRIPTION
## Scope

Closes the repository implementation portion of **INV-02** with a prospective, race-safe Stock Adjustment ledger boundary.

This PR deliberately does **not** apply Migration 187 to Production, repair historical rows, merge itself, or change application UI.

## Corrected invariant

The originally documented global key `(voucher_type, voucher_id, product_id, warehouse_id)` is not legal for every inventory voucher: Goods Receipts, Delivery Notes, and partial manufacturing consumption can contain multiple valid movements for the same product and warehouse.

Migration 187 therefore enforces one prospective **Stock Adjustment** movement per:

```
(org_id, voucher_id, product_id, warehouse_id)
```

only when `source_line_id IS NOT NULL`. The source is validated against the matching `stock_adjustment_items` row at both helper and table boundaries.

Historical NULL-source rows—including the known `ADJ-000001` duplicate—are neither deleted nor backfilled and remain updateable by the legal cancellation path.

## Changes

- add `187_stock_adjustment_ledger_idempotency.sql`;
- add a partial unique index and source/identity trigger;
- add source-aware incoming/outgoing helper overloads;
- pass `stock_adjustment_items.id` from `rpc_submit_stock_adjustment`;
- preserve the full Migration 186 outgoing valuation and manufacturing-reservation floor;
- add cutoff-186 Red proof, Green acceptance, and deterministic two-caller race;
- add the v187 PostgreSQL 17 workflow and runbook;
- update Round 3 documentation without claiming INV-02 or Production complete;
- retain the workflow-generated `database.generated.ts` overloads for the new source-aware helpers.

## Verification completed before push

- SQL syntax: all 215 migration files accepted by `pglast`;
- migration governance: repository contract and all unit suites passed;
- TypeScript: clean;
- ESLint: 0 errors (831 pre-existing warnings);
- Vitest: **307/307 files, 4597/4597 tests passed**;
- production build: passed;
- demo-password build gate: passed.

The first PostgreSQL 17 run exposed and fixed one postflight-only defect: `has_function_privilege('PUBLIC', ...)` tried to resolve PUBLIC as a role. Commit `16de4ea9` removes those redundant calls; checking `anon`/`authenticated` already detects inherited PUBLIC EXECUTE. No runtime contract or data path changed.

The next run exposed two integration-only compatibility issues, both fixed in `b9574010`: the service-only incoming helper ACL is now adjacent to its `SECURITY DEFINER` body so the repository guard can prove it is not client-callable, and the Migration 186 acceptance fixture now creates legal Stock Adjustment source rows instead of inserting provenance-free prospective ledger rows. Migration 187's fail-closed trigger and index were not weakened.

The dedicated PostgreSQL 17 workflow must execute successfully on the corrected head. It reconstructs cutoff 186, proves the pre-187 duplicate Red state, upgrades over a historical NULL-source duplicate, runs Green compatibility/fail-closed assertions, and forces both race callers to queue on the same bin lock before asserting exactly one commit.

## Production boundary

The Production audit used to design this change was read-only. Production remains at Migration 186. Applying 187 later requires a separate explicit authorization after merge review, followed by captured preflight/postflight evidence.

## Head provenance

- base: `main@a7032c280553acb887c01bcbe40b9c48b57350d9`
- reviewed tree: `191d55a49141f93c264ded0aedbbeb0ee3300ff4`
- remote head: `b9574010c30776c9b3ac2212eda081761d2e1759`
- original isolated-worktree commit retained locally: `2516a2d3689ea5667d013297b465c9ce84a6c7b7`

No merge or auto-merge is requested.