### PR TITLE
fix(f1): enforce material consumption authorization boundary

### DIFF
--- a/.github/workflows/material-consumption-auth-190-acceptance.yml
+++ b/.github/workflows/material-consumption-auth-190-acceptance.yml
@@ -1,0 +1,113 @@
+name: Material consumption auth 190
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'sql/migrations/190_material_consumption_authorization_boundary.sql'
+      - 'scripts/ci/fresh-db/acceptance_f1_material_consumption_auth_red.sql'
+      - 'scripts/ci/fresh-db/setup_190_material_consumption_auth.sql'
+      - 'scripts/ci/fresh-db/acceptance_190_material_consumption_auth.sql'
+      - '.github/workflows/material-consumption-auth-190-acceptance.yml'
+      - 'docs/db/MATERIAL_CONSUMPTION_AUTH_190_RUNBOOK.md'
+      - 'sql/baseline/**'
+  workflow_dispatch:
+
+jobs:
+  acceptance:
+    name: Prove F1 RED then Migration 190 GREEN
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      PGHOST: localhost
+      PGUSER: postgres
+      PGPASSWORD: postgres
+      PGDATABASE: wardah_190
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Resolve cutoff-189 baseline
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          PAIR=$(bash scripts/ci/fresh-db/resolve_baseline_pair.sh sql/baseline 190)
+          pair_field() { printf '%s\n' "$PAIR" | sed -n "s/^$1=//p"; }
+          echo "BASELINE=$(pair_field BASELINE_PATH)" >> "$GITHUB_ENV"
+          echo "REFERENCE=$(pair_field REFERENCE_PATH)" >> "$GITHUB_ENV"
+          CUTOFF=$(pair_field BASELINE_CUTOFF)
+          test "$CUTOFF" = "189"
+
+      - name: Build cutoff-189 database
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          createdb "$PGDATABASE"
+          psql -v ON_ERROR_STOP=1 -f scripts/ci/fresh-db/supabase_shim.sql -q
+          psql -v ON_ERROR_STOP=1 -f "$BASELINE" -q
+          psql -v ON_ERROR_STOP=1 -f "$REFERENCE" -q
+
+      - name: RED proof on pre-190 contract
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          psql -v ON_ERROR_STOP=1 \
+            -f scripts/ci/fresh-db/acceptance_f1_material_consumption_auth_red.sql \
+            2>&1 | tee /tmp/f1-190-red.out
+          grep -q 'F1_RED_PROOF_PASS' /tmp/f1-190-red.out
+          grep -q 'F1_RED_ACCEPTANCE_PASS' /tmp/f1-190-red.out
+
+      - name: Apply Migration 190
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          psql -v ON_ERROR_STOP=1 \
+            -f sql/migrations/190_material_consumption_authorization_boundary.sql \
+            2>&1 | tee /tmp/f1-190-migration.out
+          grep -q 'MATERIAL_CONSUMPTION_190_POSTFLIGHT_PASS' /tmp/f1-190-migration.out
+
+      - name: Build behavioral fixtures
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          psql -v ON_ERROR_STOP=1 \
+            -f scripts/ci/fresh-db/setup_190_material_consumption_auth.sql \
+            2>&1 | tee /tmp/f1-190-setup.out
+          grep -q 'MATERIAL_CONSUMPTION_190_SETUP_PASS' /tmp/f1-190-setup.out
+
+      - name: GREEN behavioral acceptance
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          psql -v ON_ERROR_STOP=1 \
+            -f scripts/ci/fresh-db/acceptance_190_material_consumption_auth.sql \
+            2>&1 | tee /tmp/f1-190-green.out
+          grep -q 'MATERIAL_CONSUMPTION_190_GREEN_ACCEPTANCE_PASS' /tmp/f1-190-green.out
+
+      - name: Upload F1 190 evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: material-consumption-auth-190-${{ github.run_id }}
+          path: |
+            /tmp/f1-190-red.out
+            /tmp/f1-190-migration.out
+            /tmp/f1-190-setup.out
+            /tmp/f1-190-green.out
+          retention-days: 30

--- a/docs/db/MATERIAL_CONSUMPTION_AUTH_190_RUNBOOK.md
+++ b/docs/db/MATERIAL_CONSUMPTION_AUTH_190_RUNBOOK.md
@@ -1,0 +1,135 @@
+# Migration 190 — Material Consumption Authorization Boundary
+
+**Finding:** Astra Audit F1 / S0  
+**Tracks:** #154 + material-consumption portion of #170  
+**Predecessor evidence:** PR #232 (`acceptance_f1_material_consumption_auth_red.sql`)  
+**Base for implementation:** `main@48c91a420a977215b0f377463882aa19390f3572`  
+**Production state:** NOT APPLIED by this PR
+
+## Purpose
+
+Close the proven authorization gap around manufacturing material consumption without
+changing inventory valuation, reservation arithmetic, WIP costing, or retry semantics.
+Those other contracts remain separate findings/workstreams.
+
+## Exact permission contract
+
+New ordinary permission:
+
+`manufacturing.material_consumption.consume`
+
+Catalog metadata:
+
+- module: `manufacturing`
+- resource: `material_consumption`
+- action: `consume`
+
+This key is deliberately **ordinary**, not sensitive. Therefore the central RBAC contract
+continues to give an active Org Admin the ordinary-key override. Ordinary users require
+an explicit active, unexpired role grant in the same organization.
+
+No existing role is auto-granted the new permission. Guessing from neighboring keys such
+as `inventory.stock_moves.create` would silently widen authority and is rejected by this
+design.
+
+## Mutation boundary after 190
+
+### RPC paths
+
+The following client-facing paths remain executable by `authenticated`, but all legal
+consumption reaches an exact-permission guard before business mutation:
+
+- `rpc_consume_reserved_materials_v2(uuid,uuid,jsonb)` — guarded directly
+- `rpc_consume_reserved_materials(uuid,jsonb)` — delegates to v2
+- `consume_materials_for_mo(uuid,uuid,jsonb[])` — validates MO/org then delegates to v2
+- `backflush_materials(uuid,numeric)` — guarded directly
+
+The guard is placed after the existing organization-membership check and before payload
+processing or inserts.
+
+### Direct table path
+
+`src/services/manufacturing/mesService.ts::consumeMaterial()` still performs a direct
+INSERT into `material_consumption`. Migration 190 deliberately preserves only that
+compatibility write and protects it with RLS using the same exact permission.
+
+Direct UPDATE and DELETE have no repository consumer. Migration 190 removes both their
+RLS policies and their authenticated table privileges. This also prevents direct
+mutation of POSTED history without inventing a reversal contract in this authorization
+PR.
+
+SELECT behavior is unchanged.
+
+## RED → GREEN evidence
+
+Workflow:
+
+`.github/workflows/material-consumption-auth-190-acceptance.yml`
+
+Sequence:
+
+1. rebuild cutoff-189 PostgreSQL 17 database from the published baseline;
+2. run the already-merged F1 RED proof and require the membership-only gap to reproduce;
+3. apply Migration 190;
+4. build isolated RBAC/manufacturing fixtures;
+5. run behavioral GREEN acceptance.
+
+GREEN actors/contracts:
+
+- active same-org member without permission → denied on all four entry points;
+- active same-org user with exact grant → passes authorization;
+- revoked role permission → denied;
+- expired assignment → denied;
+- inactive role → denied;
+- inactive membership → denied;
+- cross-org caller → denied;
+- active Org Admin → allowed under central ordinary-key semantics;
+- direct INSERT without permission → denied by RLS;
+- direct INSERT with permission → preserved compatibility path;
+- direct UPDATE/DELETE → denied even for a permitted caller.
+
+For v2/compatibility positive authorization, the fixture intentionally supplies an empty
+consumption list. Success is proven by reaching the next legal validation error
+`CONSUMPTIONS_REQUIRED`, rather than by building an unrelated inventory/WIP scenario.
+`backflush_materials` uses an empty-BOM work order and returns zero rows after passing the
+authorization gate. Inventory/cost arithmetic remains covered by its existing contracts.
+
+## Production rollout gate
+
+A separate explicit Production authorization is mandatory.
+
+Immediately before any apply, repeat read-only checks for:
+
+1. current migration cutoff is still 189;
+2. current definitions/ACLs/policies match Migration 190 preflight assumptions;
+3. active ordinary users/roles that legitimately perform material consumption are
+   identified and have an explicit rollout plan for the new key;
+4. active Org Admin behavior still matches the central RBAC contract.
+
+Read-only verification on 2026-09-06 found one active organization membership and it was
+an Org Admin membership. That observation is **not** a future apply assumption; it must
+be re-read immediately before Production rollout.
+
+After an authorized Production apply, required readback:
+
+- ledger cutoff advanced to 190;
+- permission key exists exactly once with expected metadata;
+- both guarded function bodies contain the exact key;
+- authenticated keeps SELECT + INSERT on `material_consumption` but not UPDATE/DELETE;
+- anon has no material-consumption mutation privilege;
+- INSERT RLS is authenticated-only and exact-permission based;
+- UPDATE/DELETE policies are absent;
+- no Production data repair is performed.
+
+## Explicit non-goals
+
+Migration 190 does not:
+
+- add retry/idempotency identity (F3);
+- change inventory valuation algorithms;
+- fix first-bin concurrency (F2);
+- define manufacturing completion truth (F4);
+- change tenant-selection identity (F5/FU-6);
+- create reversal semantics for material consumption;
+- auto-grant the permission to existing ordinary roles;
+- touch historical `material_consumption` rows.

--- a/docs/db/MATERIAL_CONSUMPTION_AUTH_190_RUNBOOK.md
+++ b/docs/db/MATERIAL_CONSUMPTION_AUTH_190_RUNBOOK.md
@@ -50,6 +50,25 @@ authorization bypass: the wrapper is `SECURITY INVOKER`, performs no DML, and de
 mutation to the guarded canonical path. The security contract is **no unauthorized side
 effect / no alternate mutation path**, not identical error precedence for malformed input.
 
+### Canonical UUID singleton-selection repair
+
+Behavioral GREEN also exposed a pre-existing PostgreSQL defect inside the canonical
+`rpc_consume_reserved_materials_v2` body itself. Three optional inference branches used
+`min(uuid)`, but PostgreSQL has no built-in `min(uuid)` aggregate:
+
+- `min(stage_id)` when stage is omitted;
+- `min(warehouse_id)` when warehouse is omitted;
+- `min(id)` for work-order inference when work order is omitted.
+
+Because Migration 190 already replaces this canonical function to add the authorization
+guard, leaving those expressions unchanged would knowingly preserve a broken supported
+path. Migration 190 therefore repairs all three together using ordered UUID arrays:
+`(array_agg(<uuid> ORDER BY <uuid>))[1]`, while retaining the existing `count(*)` gate.
+The selected UUID is only consumed when the count is exactly one, so cardinality semantics
+remain unchanged; the repair only replaces an invalid aggregate implementation.
+
+Migration postflight explicitly rejects regression to the three `min(uuid)` patterns.
+
 ### Legacy backflush quarantine
 
 The F1 GREEN work uncovered a pre-existing defect in the legacy backflush surface:
@@ -114,7 +133,8 @@ GREEN actors/contracts:
 - direct INSERT with permission → preserved compatibility path;
 - direct UPDATE/DELETE → denied even for a permitted caller;
 - `trigger_auto_backflush` is absent after 190;
-- both compatibility wrappers remain delegate-only and contain no INSERT/UPDATE/DELETE/MERGE/TRUNCATE before the guarded canonical mutator.
+- both compatibility wrappers remain delegate-only and contain no INSERT/UPDATE/DELETE/MERGE/TRUNCATE before the guarded canonical mutator;
+- canonical v2 contains no `min(uuid)` singleton-selection regression for stage, warehouse, or work order.
 
 For v2/legacy positive authorization, the fixture intentionally supplies an empty
 consumption list. Success is proven by reaching the next legal validation error
@@ -135,7 +155,8 @@ Immediately before any apply, repeat read-only checks for:
 3. active ordinary users/roles that legitimately perform material consumption are
    identified and have an explicit rollout plan for the new key;
 4. active Org Admin behavior still matches the central RBAC contract;
-5. current `trigger_auto_backflush` / `backflush_materials` state is read back and compared with the quarantine assumptions.
+5. current `trigger_auto_backflush` / `backflush_materials` state is read back and compared with the quarantine assumptions;
+6. current v2 body is read back for the three UUID singleton-selection patterns before apply.
 
 A Production readback attempt on 2026-09-06 could not confirm the backflush defect live
 because the connected `Wardah-Prod` project was reported INACTIVE and the read-only SQL
@@ -147,6 +168,7 @@ After an authorized Production apply, required readback:
 - ledger cutoff advanced to 190;
 - permission key exists exactly once with expected metadata;
 - v2 and retired backflush bodies contain the exact permission key;
+- v2 no longer contains the three invalid `min(uuid)` singleton selectors;
 - retired backflush contains no direct `material_consumption` insert;
 - `trigger_auto_backflush` is absent;
 - compatibility wrappers remain delegate-only;

--- a/docs/db/MATERIAL_CONSUMPTION_AUTH_190_RUNBOOK.md
+++ b/docs/db/MATERIAL_CONSUMPTION_AUTH_190_RUNBOOK.md
@@ -2,6 +2,7 @@
 
 **Finding:** Astra Audit F1 / S0  
 **Tracks:** #154 + material-consumption portion of #170  
+**Follow-up:** #234 (canonical backflush reimplementation)  
 **Predecessor evidence:** PR #232 (`acceptance_f1_material_consumption_auth_red.sql`)  
 **Base for implementation:** `main@48c91a420a977215b0f377463882aa19390f3572`  
 **Production state:** NOT APPLIED by this PR
@@ -9,8 +10,8 @@
 ## Purpose
 
 Close the proven authorization gap around manufacturing material consumption without
-changing inventory valuation, reservation arithmetic, WIP costing, or retry semantics.
-Those other contracts remain separate findings/workstreams.
+changing canonical inventory valuation, reservation arithmetic, WIP costing, or retry
+semantics. Those other contracts remain separate findings/workstreams.
 
 ## Exact permission contract
 
@@ -34,16 +35,13 @@ design.
 
 ## Mutation boundary after 190
 
-### RPC paths
+### Canonical RPC paths
 
-The following client-facing paths remain executable by `authenticated`, but all legal
-material-consumption mutation reaches an exact-permission guard before any inventory,
-reservation, WIP-cost, or `material_consumption` write:
+The supported consumption path is permission-gated at the canonical boundary:
 
 - `rpc_consume_reserved_materials_v2(uuid,uuid,jsonb)` — guarded directly after org membership and before consumption business processing;
 - `rpc_consume_reserved_materials(uuid,jsonb)` — delegate-only wrapper to v2;
-- `consume_materials_for_mo(uuid,uuid,jsonb[])` — compatibility wrapper that reads the MO to validate the supplied organization and rejects an empty payload before delegating; it performs no mutation itself, and all mutation remains behind the v2 guard;
-- `backflush_materials(uuid,numeric)` — guarded directly before its insert loop.
+- `consume_materials_for_mo(uuid,uuid,jsonb[])` — compatibility wrapper that reads the MO to validate the supplied organization and rejects an empty payload before delegating; it performs no mutation itself, and all mutation remains behind the v2 guard.
 
 The compatibility wrapper intentionally preserves its pre-existing validation ordering.
 Therefore an unauthorized caller that supplies an empty `p_consumptions` array may receive
@@ -51,6 +49,28 @@ Therefore an unauthorized caller that supplies an empty `p_consumptions` array m
 authorization bypass: the wrapper is `SECURITY INVOKER`, performs no DML, and delegates all
 mutation to the guarded canonical path. The security contract is **no unauthorized side
 effect / no alternate mutation path**, not identical error precedence for malformed input.
+
+### Legacy backflush quarantine
+
+The F1 GREEN work uncovered a pre-existing defect in the legacy backflush surface:
+`backflush_materials` referenced the retired `manufacturing_orders.bom_id` column, and
+`auto_backflush_materials` contained the same assumption. More importantly, both legacy
+paths directly inserted `material_consumption` rows instead of using the canonical
+reservation + valued ledger/bin + stage-WIP transaction.
+
+This is not repaired by guessing a BOM selector inside the F1 security PR. Migration 190
+therefore quarantines it fail-closed:
+
+- `backflush_materials(uuid,numeric)` remains executable by `authenticated` so existing
+  callers receive an explicit contract, but it first enforces organization membership and
+  `manufacturing.material_consumption.consume`, then raises
+  `BACKFLUSH_RETIRED_PENDING_CANONICAL_REIMPLEMENTATION` with SQLSTATE `0A000`;
+- `trigger_auto_backflush` is removed from `work_orders`, preventing the broken automatic
+  path from bypassing the exact permission boundary through direct table writes;
+- functional BOM selection and canonical automatic/manual backflush are owned by #234.
+
+This preserves F1 scope: unauthorized consumption cannot occur through the legacy
+backflush surfaces, while this PR does not invent manufacturing/BOM behavior.
 
 ### Direct table path
 
@@ -81,8 +101,9 @@ Sequence:
 
 GREEN actors/contracts:
 
-- active same-org member without permission → denied on all four entry points when supplied an input shape that reaches the authorization boundary;
-- active same-org user with exact grant → passes authorization;
+- active same-org member without permission → denied on all client-reachable mutation entry points, including legacy backflush;
+- active same-org user with exact grant → passes authorization on canonical paths;
+- permitted legacy backflush caller → receives the explicit `0A000` retired contract, never a direct legacy `material_consumption` write;
 - revoked role permission → denied;
 - expired assignment → denied;
 - inactive role → denied;
@@ -92,15 +113,16 @@ GREEN actors/contracts:
 - direct INSERT without permission → denied by RLS;
 - direct INSERT with permission → preserved compatibility path;
 - direct UPDATE/DELETE → denied even for a permitted caller;
-- compatibility wrappers remain delegate-only and contain no INSERT/UPDATE/DELETE/MERGE/TRUNCATE before the guarded canonical mutator.
+- `trigger_auto_backflush` is absent after 190;
+- both compatibility wrappers remain delegate-only and contain no INSERT/UPDATE/DELETE/MERGE/TRUNCATE before the guarded canonical mutator.
 
 For v2/legacy positive authorization, the fixture intentionally supplies an empty
 consumption list. Success is proven by reaching the next legal validation error
 `CONSUMPTIONS_REQUIRED`. For `consume_materials_for_mo`, the fixture supplies one
 shape-valid row so execution passes its compatibility validation, delegates, and then
-reaches the next post-authorization stage/WIP validation. `backflush_materials` uses an
-empty-BOM work order and returns zero rows after passing the authorization gate.
-Inventory/cost arithmetic remains covered by its existing contracts.
+reaches the next post-authorization stage/WIP validation. Legacy backflush is tested as
+an explicitly permission-gated retired surface rather than as supported manufacturing
+behavior. The functional replacement is tracked in #234.
 
 ## Production rollout gate
 
@@ -112,17 +134,21 @@ Immediately before any apply, repeat read-only checks for:
 2. current definitions/ACLs/policies match Migration 190 preflight assumptions;
 3. active ordinary users/roles that legitimately perform material consumption are
    identified and have an explicit rollout plan for the new key;
-4. active Org Admin behavior still matches the central RBAC contract.
+4. active Org Admin behavior still matches the central RBAC contract;
+5. current `trigger_auto_backflush` / `backflush_materials` state is read back and compared with the quarantine assumptions.
 
-Read-only verification on 2026-09-06 found one active organization membership and it was
-an Org Admin membership. That observation is **not** a future apply assumption; it must
-be re-read immediately before Production rollout.
+A Production readback attempt on 2026-09-06 could not confirm the backflush defect live
+because the connected `Wardah-Prod` project was reported INACTIVE and the read-only SQL
+query timed out. Therefore #234 records the defect as **cutoff-189 baseline / Fresh DB
+confirmed**, not as an independently live-read Production claim.
 
 After an authorized Production apply, required readback:
 
 - ledger cutoff advanced to 190;
 - permission key exists exactly once with expected metadata;
-- both guarded function bodies contain the exact key;
+- v2 and retired backflush bodies contain the exact permission key;
+- retired backflush contains no direct `material_consumption` insert;
+- `trigger_auto_backflush` is absent;
 - compatibility wrappers remain delegate-only;
 - authenticated keeps SELECT + INSERT on `material_consumption` but not UPDATE/DELETE;
 - anon has no material-consumption mutation privilege;
@@ -134,6 +160,8 @@ After an authorized Production apply, required readback:
 
 Migration 190 does not:
 
+- reimplement manual or automatic backflush (owned by #234);
+- choose or infer a BOM for a manufacturing order;
 - add retry/idempotency identity (F3);
 - change inventory valuation algorithms;
 - fix first-bin concurrency (F2);

--- a/docs/db/MATERIAL_CONSUMPTION_AUTH_190_RUNBOOK.md
+++ b/docs/db/MATERIAL_CONSUMPTION_AUTH_190_RUNBOOK.md
@@ -37,15 +37,20 @@ design.
 ### RPC paths
 
 The following client-facing paths remain executable by `authenticated`, but all legal
-consumption reaches an exact-permission guard before business mutation:
+material-consumption mutation reaches an exact-permission guard before any inventory,
+reservation, WIP-cost, or `material_consumption` write:
 
-- `rpc_consume_reserved_materials_v2(uuid,uuid,jsonb)` — guarded directly
-- `rpc_consume_reserved_materials(uuid,jsonb)` — delegates to v2
-- `consume_materials_for_mo(uuid,uuid,jsonb[])` — validates MO/org then delegates to v2
-- `backflush_materials(uuid,numeric)` — guarded directly
+- `rpc_consume_reserved_materials_v2(uuid,uuid,jsonb)` — guarded directly after org membership and before consumption business processing;
+- `rpc_consume_reserved_materials(uuid,jsonb)` — delegate-only wrapper to v2;
+- `consume_materials_for_mo(uuid,uuid,jsonb[])` — compatibility wrapper that reads the MO to validate the supplied organization and rejects an empty payload before delegating; it performs no mutation itself, and all mutation remains behind the v2 guard;
+- `backflush_materials(uuid,numeric)` — guarded directly before its insert loop.
 
-The guard is placed after the existing organization-membership check and before payload
-processing or inserts.
+The compatibility wrapper intentionally preserves its pre-existing validation ordering.
+Therefore an unauthorized caller that supplies an empty `p_consumptions` array may receive
+`CONSUMPTIONS_REQUIRED` before reaching the canonical permission denial. This is not an
+authorization bypass: the wrapper is `SECURITY INVOKER`, performs no DML, and delegates all
+mutation to the guarded canonical path. The security contract is **no unauthorized side
+effect / no alternate mutation path**, not identical error precedence for malformed input.
 
 ### Direct table path
 
@@ -76,7 +81,7 @@ Sequence:
 
 GREEN actors/contracts:
 
-- active same-org member without permission → denied on all four entry points;
+- active same-org member without permission → denied on all four entry points when supplied an input shape that reaches the authorization boundary;
 - active same-org user with exact grant → passes authorization;
 - revoked role permission → denied;
 - expired assignment → denied;
@@ -86,13 +91,16 @@ GREEN actors/contracts:
 - active Org Admin → allowed under central ordinary-key semantics;
 - direct INSERT without permission → denied by RLS;
 - direct INSERT with permission → preserved compatibility path;
-- direct UPDATE/DELETE → denied even for a permitted caller.
+- direct UPDATE/DELETE → denied even for a permitted caller;
+- compatibility wrappers remain delegate-only and contain no INSERT/UPDATE/DELETE/MERGE/TRUNCATE before the guarded canonical mutator.
 
-For v2/compatibility positive authorization, the fixture intentionally supplies an empty
+For v2/legacy positive authorization, the fixture intentionally supplies an empty
 consumption list. Success is proven by reaching the next legal validation error
-`CONSUMPTIONS_REQUIRED`, rather than by building an unrelated inventory/WIP scenario.
-`backflush_materials` uses an empty-BOM work order and returns zero rows after passing the
-authorization gate. Inventory/cost arithmetic remains covered by its existing contracts.
+`CONSUMPTIONS_REQUIRED`. For `consume_materials_for_mo`, the fixture supplies one
+shape-valid row so execution passes its compatibility validation, delegates, and then
+reaches the next post-authorization stage/WIP validation. `backflush_materials` uses an
+empty-BOM work order and returns zero rows after passing the authorization gate.
+Inventory/cost arithmetic remains covered by its existing contracts.
 
 ## Production rollout gate
 
@@ -115,6 +123,7 @@ After an authorized Production apply, required readback:
 - ledger cutoff advanced to 190;
 - permission key exists exactly once with expected metadata;
 - both guarded function bodies contain the exact key;
+- compatibility wrappers remain delegate-only;
 - authenticated keeps SELECT + INSERT on `material_consumption` but not UPDATE/DELETE;
 - anon has no material-consumption mutation privilege;
 - INSERT RLS is authenticated-only and exact-permission based;
@@ -132,4 +141,5 @@ Migration 190 does not:
 - change tenant-selection identity (F5/FU-6);
 - create reversal semantics for material consumption;
 - auto-grant the permission to existing ordinary roles;
+- normalize legacy validation-error precedence;
 - touch historical `material_consumption` rows.

--- a/scripts/ci/fresh-db/acceptance_190_material_consumption_auth.sql
+++ b/scripts/ci/fresh-db/acceptance_190_material_consumption_auth.sql
@@ -50,11 +50,17 @@ BEGIN
     END IF;
   END;
 
+  -- The compatibility wrapper intentionally validates non-empty input before
+  -- delegating. Supply one shape-valid row so this actor reaches the canonical
+  -- v2 authorization guard instead of stopping at CONSUMPTIONS_REQUIRED.
   BEGIN
     PERFORM public.consume_materials_for_mo(
       '19019019-1000-4000-8000-000000000001',
       '19019019-1000-4000-8000-000000000030',
-      ARRAY[]::jsonb[]
+      ARRAY[jsonb_build_object(
+        'item_id', '19019019-1000-4000-8000-000000000010',
+        'quantity', 1
+      )]::jsonb[]
     );
   EXCEPTION WHEN raise_exception THEN
     IF SQLERRM='MATERIAL_CONSUMPTION_PERMISSION_DENIED' THEN
@@ -106,9 +112,11 @@ $no_permission$;
 RESET ROLE;
 
 -- ---------------------------------------------------------------------------
--- Explicit active grant: authorization passes. v2/compatibility wrappers reach
--- the next input-validation gate, backflush reaches its legal empty-BOM result,
--- and compatibility direct INSERT succeeds. UPDATE/DELETE remain unsupported.
+-- Explicit active grant: authorization passes. v2/legacy reach the next
+-- payload-validation gate. The compatibility wrapper receives a non-empty
+-- payload, delegates, passes authorization and reaches the next stage/WIP gate.
+-- Backflush reaches its legal empty-BOM result, and compatibility direct INSERT
+-- succeeds. UPDATE/DELETE remain unsupported.
 -- ---------------------------------------------------------------------------
 SELECT set_config('request.jwt.claim.sub', '19019019-0000-4000-8000-000000000003', true);
 SELECT set_config('request.jwt.claims', '{"sub":"19019019-0000-4000-8000-000000000003","role":"authenticated"}', true);
@@ -159,10 +167,13 @@ BEGIN
     PERFORM public.consume_materials_for_mo(
       '19019019-1000-4000-8000-000000000001',
       '19019019-1000-4000-8000-000000000030',
-      ARRAY[]::jsonb[]
+      ARRAY[jsonb_build_object(
+        'item_id', '19019019-1000-4000-8000-000000000010',
+        'quantity', 1
+      )]::jsonb[]
     );
   EXCEPTION WHEN raise_exception THEN
-    IF SQLERRM='CONSUMPTIONS_REQUIRED' THEN
+    IF SQLERRM='STAGE_REQUIRED_FOR_MATERIAL_CONSUMPTION' THEN
       v_compat_passed_auth := true;
     ELSE
       RAISE;
@@ -390,11 +401,17 @@ $cross_org$;
 RESET ROLE;
 
 -- ---------------------------------------------------------------------------
--- ACL/policy invariants: authenticated read + guarded insert remain;
--- unsupported direct mutations and anon mutation grants are gone.
+-- ACL/policy and transitive-wrapper invariants: authenticated read + guarded
+-- insert remain; unsupported direct mutations and anon mutation grants are gone.
+-- Compatibility wrappers may preserve legacy validation ordering, but they must
+-- remain delegate-only and must not perform DML before reaching the v2 guard.
 -- ---------------------------------------------------------------------------
 DO $surface$
-DECLARE v_insert_policies integer;
+DECLARE
+  v_insert_policies integer;
+  v_compat_src text;
+  v_legacy_src text;
+  v_compat_security_definer boolean;
 BEGIN
   IF NOT has_table_privilege('authenticated','public.material_consumption','SELECT')
      OR NOT has_table_privilege('authenticated','public.material_consumption','INSERT') THEN
@@ -407,6 +424,26 @@ BEGIN
      OR has_table_privilege('anon','public.material_consumption','UPDATE')
      OR has_table_privilege('anon','public.material_consumption','DELETE') THEN
     RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_DIRECT_MUTATION_SURFACE_REOPENED';
+  END IF;
+
+  SELECT p.prosrc, p.prosecdef
+  INTO v_compat_src, v_compat_security_definer
+  FROM pg_proc p
+  WHERE p.oid='public.consume_materials_for_mo(uuid,uuid,jsonb[])'::regprocedure;
+
+  IF v_compat_security_definer
+     OR v_compat_src !~ 'rpc_consume_reserved_materials'
+     OR v_compat_src ~* '\m(INSERT|UPDATE|DELETE|MERGE|TRUNCATE)\M' THEN
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_COMPAT_WRAPPER_NOT_DELEGATE_ONLY';
+  END IF;
+
+  SELECT p.prosrc INTO v_legacy_src
+  FROM pg_proc p
+  WHERE p.oid='public.rpc_consume_reserved_materials(uuid,jsonb)'::regprocedure;
+
+  IF v_legacy_src !~ 'rpc_consume_reserved_materials_v2'
+     OR v_legacy_src ~* '\m(INSERT|UPDATE|DELETE|MERGE|TRUNCATE)\M' THEN
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_LEGACY_WRAPPER_NOT_DELEGATE_ONLY';
   END IF;
 
   SELECT count(*) INTO v_insert_policies
@@ -426,6 +463,7 @@ BEGIN
     RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_UNSUPPORTED_POLICY_REOPENED';
   END IF;
 
+  RAISE NOTICE 'MATERIAL_CONSUMPTION_190_TRANSITIVE_WRAPPERS_OK';
   RAISE NOTICE 'MATERIAL_CONSUMPTION_190_SURFACE_OK';
 END
 $surface$;

--- a/scripts/ci/fresh-db/acceptance_190_material_consumption_auth.sql
+++ b/scripts/ci/fresh-db/acceptance_190_material_consumption_auth.sql
@@ -115,8 +115,9 @@ RESET ROLE;
 -- Explicit active grant: authorization passes. v2/legacy reach the next
 -- payload-validation gate. The compatibility wrapper receives a non-empty
 -- payload, delegates, passes authorization and reaches the next stage/WIP gate.
--- Backflush reaches its legal empty-BOM result, and compatibility direct INSERT
--- succeeds. UPDATE/DELETE remain unsupported.
+-- Legacy backflush passes authorization then fails explicitly as retired until
+-- #234 provides a canonical implementation. Direct INSERT succeeds while
+-- UPDATE/DELETE remain unsupported.
 -- ---------------------------------------------------------------------------
 SELECT set_config('request.jwt.claim.sub', '19019019-0000-4000-8000-000000000003', true);
 SELECT set_config('request.jwt.claims', '{"sub":"19019019-0000-4000-8000-000000000003","role":"authenticated"}', true);
@@ -127,7 +128,7 @@ DECLARE
   v_v2_passed_auth boolean := false;
   v_legacy_passed_auth boolean := false;
   v_compat_passed_auth boolean := false;
-  v_backflush_count integer;
+  v_backflush_retired boolean := false;
   v_update_denied boolean := false;
   v_delete_denied boolean := false;
 BEGIN
@@ -180,14 +181,17 @@ BEGIN
     END IF;
   END;
 
-  SELECT count(*) INTO v_backflush_count
-  FROM public.backflush_materials(
-    '19019019-1000-4000-8000-000000000040', 1
-  );
-
-  IF v_backflush_count <> 0 THEN
-    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_EMPTY_BOM_BACKFLUSH_WRONG: %', v_backflush_count;
-  END IF;
+  BEGIN
+    PERFORM 1 FROM public.backflush_materials(
+      '19019019-1000-4000-8000-000000000040', 1
+    );
+  EXCEPTION WHEN feature_not_supported THEN
+    IF SQLERRM='BACKFLUSH_RETIRED_PENDING_CANONICAL_REIMPLEMENTATION' THEN
+      v_backflush_retired := true;
+    ELSE
+      RAISE;
+    END IF;
+  END;
 
   INSERT INTO public.material_consumption(
     id, org_id, work_order_id, mo_id, item_id,
@@ -216,15 +220,17 @@ BEGIN
     v_delete_denied := true;
   END;
 
-  IF NOT (v_v2_passed_auth AND v_legacy_passed_auth AND v_compat_passed_auth)
+  IF NOT (v_v2_passed_auth AND v_legacy_passed_auth AND v_compat_passed_auth
+          AND v_backflush_retired)
      OR NOT v_update_denied OR NOT v_delete_denied THEN
     RAISE EXCEPTION
-      'MATERIAL_CONSUMPTION_190_EXPLICIT_GRANT_PATH_WRONG: v2=% legacy=% compat=% update_denied=% delete_denied=%',
+      'MATERIAL_CONSUMPTION_190_EXPLICIT_GRANT_PATH_WRONG: v2=% legacy=% compat=% backflush_retired=% update_denied=% delete_denied=%',
       v_v2_passed_auth,v_legacy_passed_auth,v_compat_passed_auth,
-      v_update_denied,v_delete_denied;
+      v_backflush_retired,v_update_denied,v_delete_denied;
   END IF;
 
   RAISE NOTICE 'MATERIAL_CONSUMPTION_190_EXPLICIT_GRANT_OK';
+  RAISE NOTICE 'MATERIAL_CONSUMPTION_190_BACKFLUSH_QUARANTINED_OK';
   RAISE NOTICE 'MATERIAL_CONSUMPTION_190_DIRECT_UPDATE_DELETE_CLOSED_OK';
 END
 $granted$;
@@ -405,12 +411,14 @@ RESET ROLE;
 -- insert remain; unsupported direct mutations and anon mutation grants are gone.
 -- Compatibility wrappers may preserve legacy validation ordering, but they must
 -- remain delegate-only and must not perform DML before reaching the v2 guard.
+-- The broken automatic backflush trigger must remain absent until #234.
 -- ---------------------------------------------------------------------------
 DO $surface$
 DECLARE
   v_insert_policies integer;
   v_compat_src text;
   v_legacy_src text;
+  v_backflush_src text;
   v_compat_security_definer boolean;
 BEGIN
   IF NOT has_table_privilege('authenticated','public.material_consumption','SELECT')
@@ -444,6 +452,27 @@ BEGIN
   IF v_legacy_src !~ 'rpc_consume_reserved_materials_v2'
      OR v_legacy_src ~* '\m(INSERT|UPDATE|DELETE|MERGE|TRUNCATE)\M' THEN
     RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_LEGACY_WRAPPER_NOT_DELEGATE_ONLY';
+  END IF;
+
+  SELECT p.prosrc INTO v_backflush_src
+  FROM pg_proc p
+  WHERE p.oid='public.backflush_materials(uuid,numeric)'::regprocedure;
+
+  IF v_backflush_src !~ 'manufacturing.material_consumption.consume'
+     OR v_backflush_src !~ 'BACKFLUSH_RETIRED_PENDING_CANONICAL_REIMPLEMENTATION'
+     OR v_backflush_src ~* '\mINSERT\s+INTO\s+(public\.)?material_consumption\M' THEN
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_BACKFLUSH_QUARANTINE_DRIFT';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM pg_trigger t
+    JOIN pg_class c ON c.oid=t.tgrelid
+    JOIN pg_namespace n ON n.oid=c.relnamespace
+    WHERE n.nspname='public' AND c.relname='work_orders'
+      AND t.tgname='trigger_auto_backflush' AND NOT t.tgisinternal
+  ) THEN
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_AUTO_BACKFLUSH_TRIGGER_REOPENED';
   END IF;
 
   SELECT count(*) INTO v_insert_policies

--- a/scripts/ci/fresh-db/acceptance_190_material_consumption_auth.sql
+++ b/scripts/ci/fresh-db/acceptance_190_material_consumption_auth.sql
@@ -1,0 +1,435 @@
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- Ordinary active same-org member without the exact permission: denied on
+-- every supported consumption entry point and on direct INSERT.
+-- ---------------------------------------------------------------------------
+SELECT set_config('request.jwt.claim.sub', '19019019-0000-4000-8000-000000000002', true);
+SELECT set_config('request.jwt.claims', '{"sub":"19019019-0000-4000-8000-000000000002","role":"authenticated"}', true);
+SET LOCAL ROLE authenticated;
+
+DO $no_permission$
+DECLARE
+  v_denied_v2 boolean := false;
+  v_denied_legacy boolean := false;
+  v_denied_compat boolean := false;
+  v_denied_backflush boolean := false;
+  v_denied_insert boolean := false;
+BEGIN
+  IF public.has_permission(
+    (SELECT auth.uid()),
+    '19019019-1000-4000-8000-000000000001',
+    'manufacturing.material_consumption.consume'
+  ) THEN
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_NO_PERMISSION_FIXTURE_WRONG';
+  END IF;
+
+  BEGIN
+    PERFORM public.rpc_consume_reserved_materials_v2(
+      '19019019-1000-4000-8000-000000000030', NULL, '[]'::jsonb
+    );
+  EXCEPTION WHEN raise_exception THEN
+    IF SQLERRM='MATERIAL_CONSUMPTION_PERMISSION_DENIED' THEN
+      v_denied_v2 := true;
+    ELSE
+      RAISE;
+    END IF;
+  END;
+
+  BEGIN
+    PERFORM public.rpc_consume_reserved_materials(
+      '19019019-1000-4000-8000-000000000030', '[]'::jsonb
+    );
+  EXCEPTION WHEN raise_exception THEN
+    IF SQLERRM='MATERIAL_CONSUMPTION_PERMISSION_DENIED' THEN
+      v_denied_legacy := true;
+    ELSE
+      RAISE;
+    END IF;
+  END;
+
+  BEGIN
+    PERFORM public.consume_materials_for_mo(
+      '19019019-1000-4000-8000-000000000001',
+      '19019019-1000-4000-8000-000000000030',
+      ARRAY[]::jsonb[]
+    );
+  EXCEPTION WHEN raise_exception THEN
+    IF SQLERRM='MATERIAL_CONSUMPTION_PERMISSION_DENIED' THEN
+      v_denied_compat := true;
+    ELSE
+      RAISE;
+    END IF;
+  END;
+
+  BEGIN
+    PERFORM 1 FROM public.backflush_materials(
+      '19019019-1000-4000-8000-000000000040', 1
+    );
+  EXCEPTION WHEN raise_exception THEN
+    IF SQLERRM='MATERIAL_CONSUMPTION_PERMISSION_DENIED' THEN
+      v_denied_backflush := true;
+    ELSE
+      RAISE;
+    END IF;
+  END;
+
+  BEGIN
+    INSERT INTO public.material_consumption(
+      id, org_id, work_order_id, mo_id, item_id,
+      consumed_quantity, consumption_type, status
+    ) VALUES (
+      '19019019-1000-4000-8000-000000000051',
+      '19019019-1000-4000-8000-000000000001',
+      '19019019-1000-4000-8000-000000000040',
+      '19019019-1000-4000-8000-000000000030',
+      '19019019-1000-4000-8000-000000000010',
+      1, 'MANUAL', 'PENDING'
+    );
+  EXCEPTION WHEN insufficient_privilege THEN
+    v_denied_insert := true;
+  END;
+
+  IF NOT (v_denied_v2 AND v_denied_legacy AND v_denied_compat
+          AND v_denied_backflush AND v_denied_insert) THEN
+    RAISE EXCEPTION
+      'MATERIAL_CONSUMPTION_190_MEMBER_WITHOUT_PERMISSION_NOT_DENIED: v2=% legacy=% compat=% backflush=% insert=%',
+      v_denied_v2,v_denied_legacy,v_denied_compat,v_denied_backflush,v_denied_insert;
+  END IF;
+
+  RAISE NOTICE 'MATERIAL_CONSUMPTION_190_NO_PERMISSION_DENIED_OK';
+END
+$no_permission$;
+
+RESET ROLE;
+
+-- ---------------------------------------------------------------------------
+-- Explicit active grant: authorization passes. v2/compatibility wrappers reach
+-- the next input-validation gate, backflush reaches its legal empty-BOM result,
+-- and compatibility direct INSERT succeeds. UPDATE/DELETE remain unsupported.
+-- ---------------------------------------------------------------------------
+SELECT set_config('request.jwt.claim.sub', '19019019-0000-4000-8000-000000000003', true);
+SELECT set_config('request.jwt.claims', '{"sub":"19019019-0000-4000-8000-000000000003","role":"authenticated"}', true);
+SET LOCAL ROLE authenticated;
+
+DO $granted$
+DECLARE
+  v_v2_passed_auth boolean := false;
+  v_legacy_passed_auth boolean := false;
+  v_compat_passed_auth boolean := false;
+  v_backflush_count integer;
+  v_update_denied boolean := false;
+  v_delete_denied boolean := false;
+BEGIN
+  IF NOT public.has_permission(
+    (SELECT auth.uid()),
+    '19019019-1000-4000-8000-000000000001',
+    'manufacturing.material_consumption.consume'
+  ) THEN
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_EXPLICIT_GRANT_NOT_EFFECTIVE';
+  END IF;
+
+  BEGIN
+    PERFORM public.rpc_consume_reserved_materials_v2(
+      '19019019-1000-4000-8000-000000000030', NULL, '[]'::jsonb
+    );
+  EXCEPTION WHEN raise_exception THEN
+    IF SQLERRM='CONSUMPTIONS_REQUIRED' THEN
+      v_v2_passed_auth := true;
+    ELSE
+      RAISE;
+    END IF;
+  END;
+
+  BEGIN
+    PERFORM public.rpc_consume_reserved_materials(
+      '19019019-1000-4000-8000-000000000030', '[]'::jsonb
+    );
+  EXCEPTION WHEN raise_exception THEN
+    IF SQLERRM='CONSUMPTIONS_REQUIRED' THEN
+      v_legacy_passed_auth := true;
+    ELSE
+      RAISE;
+    END IF;
+  END;
+
+  BEGIN
+    PERFORM public.consume_materials_for_mo(
+      '19019019-1000-4000-8000-000000000001',
+      '19019019-1000-4000-8000-000000000030',
+      ARRAY[]::jsonb[]
+    );
+  EXCEPTION WHEN raise_exception THEN
+    IF SQLERRM='CONSUMPTIONS_REQUIRED' THEN
+      v_compat_passed_auth := true;
+    ELSE
+      RAISE;
+    END IF;
+  END;
+
+  SELECT count(*) INTO v_backflush_count
+  FROM public.backflush_materials(
+    '19019019-1000-4000-8000-000000000040', 1
+  );
+
+  IF v_backflush_count <> 0 THEN
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_EMPTY_BOM_BACKFLUSH_WRONG: %', v_backflush_count;
+  END IF;
+
+  INSERT INTO public.material_consumption(
+    id, org_id, work_order_id, mo_id, item_id,
+    consumed_quantity, consumption_type, status
+  ) VALUES (
+    '19019019-1000-4000-8000-000000000050',
+    '19019019-1000-4000-8000-000000000001',
+    '19019019-1000-4000-8000-000000000040',
+    '19019019-1000-4000-8000-000000000030',
+    '19019019-1000-4000-8000-000000000010',
+    1, 'MANUAL', 'PENDING'
+  );
+
+  BEGIN
+    UPDATE public.material_consumption
+    SET notes='must not update directly'
+    WHERE id='19019019-1000-4000-8000-000000000050';
+  EXCEPTION WHEN insufficient_privilege THEN
+    v_update_denied := true;
+  END;
+
+  BEGIN
+    DELETE FROM public.material_consumption
+    WHERE id='19019019-1000-4000-8000-000000000050';
+  EXCEPTION WHEN insufficient_privilege THEN
+    v_delete_denied := true;
+  END;
+
+  IF NOT (v_v2_passed_auth AND v_legacy_passed_auth AND v_compat_passed_auth)
+     OR NOT v_update_denied OR NOT v_delete_denied THEN
+    RAISE EXCEPTION
+      'MATERIAL_CONSUMPTION_190_EXPLICIT_GRANT_PATH_WRONG: v2=% legacy=% compat=% update_denied=% delete_denied=%',
+      v_v2_passed_auth,v_legacy_passed_auth,v_compat_passed_auth,
+      v_update_denied,v_delete_denied;
+  END IF;
+
+  RAISE NOTICE 'MATERIAL_CONSUMPTION_190_EXPLICIT_GRANT_OK';
+  RAISE NOTICE 'MATERIAL_CONSUMPTION_190_DIRECT_UPDATE_DELETE_CLOSED_OK';
+END
+$granted$;
+
+RESET ROLE;
+
+-- ---------------------------------------------------------------------------
+-- Org admin: ordinary permission keeps the central admin override.
+-- ---------------------------------------------------------------------------
+SELECT set_config('request.jwt.claim.sub', '19019019-0000-4000-8000-000000000001', true);
+SELECT set_config('request.jwt.claims', '{"sub":"19019019-0000-4000-8000-000000000001","role":"authenticated"}', true);
+SET LOCAL ROLE authenticated;
+
+DO $org_admin$
+DECLARE
+  v_passed_auth boolean := false;
+BEGIN
+  IF NOT public.has_permission(
+    (SELECT auth.uid()),
+    '19019019-1000-4000-8000-000000000001',
+    'manufacturing.material_consumption.consume'
+  ) THEN
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_ORG_ADMIN_OVERRIDE_LOST';
+  END IF;
+
+  BEGIN
+    PERFORM public.rpc_consume_reserved_materials_v2(
+      '19019019-1000-4000-8000-000000000030', NULL, '[]'::jsonb
+    );
+  EXCEPTION WHEN raise_exception THEN
+    IF SQLERRM='CONSUMPTIONS_REQUIRED' THEN
+      v_passed_auth := true;
+    ELSE
+      RAISE;
+    END IF;
+  END;
+
+  IF NOT v_passed_auth THEN
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_ORG_ADMIN_RPC_DENIED';
+  END IF;
+
+  RAISE NOTICE 'MATERIAL_CONSUMPTION_190_ORG_ADMIN_OK';
+END
+$org_admin$;
+
+RESET ROLE;
+
+-- ---------------------------------------------------------------------------
+-- Revoked, expired and inactive role: exact grant must not survive.
+-- ---------------------------------------------------------------------------
+SELECT set_config('request.jwt.claim.sub', '19019019-0000-4000-8000-000000000004', true);
+SELECT set_config('request.jwt.claims', '{"sub":"19019019-0000-4000-8000-000000000004","role":"authenticated"}', true);
+SET LOCAL ROLE authenticated;
+DO $revoked$
+DECLARE v_denied boolean := false;
+BEGIN
+  IF public.has_permission((SELECT auth.uid()),'19019019-1000-4000-8000-000000000001','manufacturing.material_consumption.consume') THEN
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_REVOKED_PERMISSION_SURVIVED';
+  END IF;
+  BEGIN
+    PERFORM public.rpc_consume_reserved_materials_v2('19019019-1000-4000-8000-000000000030',NULL,'[]'::jsonb);
+  EXCEPTION WHEN raise_exception THEN
+    v_denied := SQLERRM='MATERIAL_CONSUMPTION_PERMISSION_DENIED';
+  END;
+  IF NOT v_denied THEN RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_REVOKED_RPC_NOT_DENIED'; END IF;
+  RAISE NOTICE 'MATERIAL_CONSUMPTION_190_REVOKED_OK';
+END
+$revoked$;
+RESET ROLE;
+
+SELECT set_config('request.jwt.claim.sub', '19019019-0000-4000-8000-000000000005', true);
+SELECT set_config('request.jwt.claims', '{"sub":"19019019-0000-4000-8000-000000000005","role":"authenticated"}', true);
+SET LOCAL ROLE authenticated;
+DO $expired$
+DECLARE v_denied boolean := false;
+BEGIN
+  IF public.has_permission((SELECT auth.uid()),'19019019-1000-4000-8000-000000000001','manufacturing.material_consumption.consume') THEN
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_EXPIRED_PERMISSION_SURVIVED';
+  END IF;
+  BEGIN
+    PERFORM public.rpc_consume_reserved_materials_v2('19019019-1000-4000-8000-000000000030',NULL,'[]'::jsonb);
+  EXCEPTION WHEN raise_exception THEN
+    v_denied := SQLERRM='MATERIAL_CONSUMPTION_PERMISSION_DENIED';
+  END;
+  IF NOT v_denied THEN RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_EXPIRED_RPC_NOT_DENIED'; END IF;
+  RAISE NOTICE 'MATERIAL_CONSUMPTION_190_EXPIRED_OK';
+END
+$expired$;
+RESET ROLE;
+
+SELECT set_config('request.jwt.claim.sub', '19019019-0000-4000-8000-000000000006', true);
+SELECT set_config('request.jwt.claims', '{"sub":"19019019-0000-4000-8000-000000000006","role":"authenticated"}', true);
+SET LOCAL ROLE authenticated;
+DO $inactive_role$
+DECLARE v_denied boolean := false;
+BEGIN
+  IF public.has_permission((SELECT auth.uid()),'19019019-1000-4000-8000-000000000001','manufacturing.material_consumption.consume') THEN
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_INACTIVE_ROLE_PERMISSION_SURVIVED';
+  END IF;
+  BEGIN
+    PERFORM public.rpc_consume_reserved_materials_v2('19019019-1000-4000-8000-000000000030',NULL,'[]'::jsonb);
+  EXCEPTION WHEN raise_exception THEN
+    v_denied := SQLERRM='MATERIAL_CONSUMPTION_PERMISSION_DENIED';
+  END;
+  IF NOT v_denied THEN RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_INACTIVE_ROLE_RPC_NOT_DENIED'; END IF;
+  RAISE NOTICE 'MATERIAL_CONSUMPTION_190_INACTIVE_ROLE_OK';
+END
+$inactive_role$;
+RESET ROLE;
+
+-- ---------------------------------------------------------------------------
+-- Inactive membership and cross-org caller: fail closed before any write.
+-- Error text belongs to wardah_assert_org_member and is intentionally not
+-- coupled here; only the denied outcome is contractual.
+-- ---------------------------------------------------------------------------
+SELECT set_config('request.jwt.claim.sub', '19019019-0000-4000-8000-000000000007', true);
+SELECT set_config('request.jwt.claims', '{"sub":"19019019-0000-4000-8000-000000000007","role":"authenticated"}', true);
+SET LOCAL ROLE authenticated;
+DO $inactive_membership$
+DECLARE v_denied boolean := false;
+BEGIN
+  BEGIN
+    PERFORM public.rpc_consume_reserved_materials_v2('19019019-1000-4000-8000-000000000030',NULL,'[]'::jsonb);
+  EXCEPTION WHEN OTHERS THEN
+    v_denied := true;
+  END;
+  IF NOT v_denied THEN RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_INACTIVE_MEMBERSHIP_RPC_ALLOWED'; END IF;
+
+  BEGIN
+    INSERT INTO public.material_consumption(
+      org_id,work_order_id,mo_id,item_id,consumed_quantity,consumption_type,status
+    ) VALUES (
+      '19019019-1000-4000-8000-000000000001','19019019-1000-4000-8000-000000000040',
+      '19019019-1000-4000-8000-000000000030','19019019-1000-4000-8000-000000000010',
+      1,'MANUAL','PENDING'
+    );
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_INACTIVE_MEMBERSHIP_INSERT_ALLOWED';
+  EXCEPTION WHEN insufficient_privilege THEN
+    NULL;
+  END;
+  RAISE NOTICE 'MATERIAL_CONSUMPTION_190_INACTIVE_MEMBERSHIP_OK';
+END
+$inactive_membership$;
+RESET ROLE;
+
+SELECT set_config('request.jwt.claim.sub', '19019019-0000-4000-8000-000000000008', true);
+SELECT set_config('request.jwt.claims', '{"sub":"19019019-0000-4000-8000-000000000008","role":"authenticated"}', true);
+SET LOCAL ROLE authenticated;
+DO $cross_org$
+DECLARE v_denied boolean := false;
+BEGIN
+  BEGIN
+    PERFORM public.rpc_consume_reserved_materials_v2('19019019-1000-4000-8000-000000000030',NULL,'[]'::jsonb);
+  EXCEPTION WHEN OTHERS THEN
+    v_denied := true;
+  END;
+  IF NOT v_denied THEN RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_CROSS_ORG_RPC_ALLOWED'; END IF;
+
+  BEGIN
+    INSERT INTO public.material_consumption(
+      org_id,work_order_id,mo_id,item_id,consumed_quantity,consumption_type,status
+    ) VALUES (
+      '19019019-1000-4000-8000-000000000001','19019019-1000-4000-8000-000000000040',
+      '19019019-1000-4000-8000-000000000030','19019019-1000-4000-8000-000000000010',
+      1,'MANUAL','PENDING'
+    );
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_CROSS_ORG_INSERT_ALLOWED';
+  EXCEPTION WHEN insufficient_privilege THEN
+    NULL;
+  END;
+  RAISE NOTICE 'MATERIAL_CONSUMPTION_190_CROSS_ORG_OK';
+END
+$cross_org$;
+RESET ROLE;
+
+-- ---------------------------------------------------------------------------
+-- ACL/policy invariants: authenticated read + guarded insert remain;
+-- unsupported direct mutations and anon mutation grants are gone.
+-- ---------------------------------------------------------------------------
+DO $surface$
+DECLARE v_insert_policies integer;
+BEGIN
+  IF NOT has_table_privilege('authenticated','public.material_consumption','SELECT')
+     OR NOT has_table_privilege('authenticated','public.material_consumption','INSERT') THEN
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_COMPATIBILITY_SURFACE_LOST';
+  END IF;
+
+  IF has_table_privilege('authenticated','public.material_consumption','UPDATE')
+     OR has_table_privilege('authenticated','public.material_consumption','DELETE')
+     OR has_table_privilege('anon','public.material_consumption','INSERT')
+     OR has_table_privilege('anon','public.material_consumption','UPDATE')
+     OR has_table_privilege('anon','public.material_consumption','DELETE') THEN
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_DIRECT_MUTATION_SURFACE_REOPENED';
+  END IF;
+
+  SELECT count(*) INTO v_insert_policies
+  FROM pg_policies
+  WHERE schemaname='public' AND tablename='material_consumption'
+    AND cmd='INSERT' AND roles='{authenticated}'
+    AND coalesce(with_check,'') ILIKE '%manufacturing.material_consumption.consume%';
+  IF v_insert_policies <> 1 THEN
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_INSERT_RLS_DRIFT: %', v_insert_policies;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname='public' AND tablename='material_consumption'
+      AND cmd IN ('UPDATE','DELETE')
+  ) THEN
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_UNSUPPORTED_POLICY_REOPENED';
+  END IF;
+
+  RAISE NOTICE 'MATERIAL_CONSUMPTION_190_SURFACE_OK';
+END
+$surface$;
+
+ROLLBACK;
+
+SELECT 'MATERIAL_CONSUMPTION_190_GREEN_ACCEPTANCE_PASS' AS result;

--- a/scripts/ci/fresh-db/setup_190_material_consumption_auth.sql
+++ b/scripts/ci/fresh-db/setup_190_material_consumption_auth.sql
@@ -1,0 +1,120 @@
+\set ON_ERROR_STOP on
+
+INSERT INTO public.organizations (id, name, code) VALUES
+  ('19019019-1000-4000-8000-000000000001', 'F1 Auth Org A', 'F1-A'),
+  ('19019019-2000-4000-8000-000000000001', 'F1 Auth Org B', 'F1-B');
+
+INSERT INTO auth.users (id, email) VALUES
+  ('19019019-0000-4000-8000-000000000001', 'f1-admin@example.test'),
+  ('19019019-0000-4000-8000-000000000002', 'f1-no-perm@example.test'),
+  ('19019019-0000-4000-8000-000000000003', 'f1-granted@example.test'),
+  ('19019019-0000-4000-8000-000000000004', 'f1-revoked@example.test'),
+  ('19019019-0000-4000-8000-000000000005', 'f1-expired@example.test'),
+  ('19019019-0000-4000-8000-000000000006', 'f1-inactive-role@example.test'),
+  ('19019019-0000-4000-8000-000000000007', 'f1-inactive-member@example.test'),
+  ('19019019-0000-4000-8000-000000000008', 'f1-cross-org@example.test');
+
+INSERT INTO public.user_organizations
+  (user_id, org_id, role, is_active, is_org_admin)
+VALUES
+  ('19019019-0000-4000-8000-000000000001', '19019019-1000-4000-8000-000000000001', 'admin', true, true),
+  ('19019019-0000-4000-8000-000000000002', '19019019-1000-4000-8000-000000000001', 'user', true, false),
+  ('19019019-0000-4000-8000-000000000003', '19019019-1000-4000-8000-000000000001', 'user', true, false),
+  ('19019019-0000-4000-8000-000000000004', '19019019-1000-4000-8000-000000000001', 'user', true, false),
+  ('19019019-0000-4000-8000-000000000005', '19019019-1000-4000-8000-000000000001', 'user', true, false),
+  ('19019019-0000-4000-8000-000000000006', '19019019-1000-4000-8000-000000000001', 'user', true, false),
+  ('19019019-0000-4000-8000-000000000007', '19019019-1000-4000-8000-000000000001', 'user', false, false),
+  ('19019019-0000-4000-8000-000000000008', '19019019-2000-4000-8000-000000000001', 'user', true, false);
+
+INSERT INTO public.roles (id, org_id, name, name_ar, is_active) VALUES
+  ('19019019-3000-4000-8000-000000000001', '19019019-1000-4000-8000-000000000001', 'F1 Granted', 'F1 ممنوح', true),
+  ('19019019-3000-4000-8000-000000000002', '19019019-1000-4000-8000-000000000001', 'F1 Revoked', 'F1 مسحوب', true),
+  ('19019019-3000-4000-8000-000000000003', '19019019-1000-4000-8000-000000000001', 'F1 Expired', 'F1 منتهي', true),
+  ('19019019-3000-4000-8000-000000000004', '19019019-1000-4000-8000-000000000001', 'F1 Inactive Role', 'F1 دور غير نشط', false),
+  ('19019019-3000-4000-8000-000000000005', '19019019-1000-4000-8000-000000000001', 'F1 Inactive Member', 'F1 عضوية غير نشطة', true);
+
+INSERT INTO public.role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM public.roles r
+CROSS JOIN public.permissions p
+WHERE r.id IN (
+    '19019019-3000-4000-8000-000000000001'::uuid,
+    '19019019-3000-4000-8000-000000000003'::uuid,
+    '19019019-3000-4000-8000-000000000004'::uuid,
+    '19019019-3000-4000-8000-000000000005'::uuid
+  )
+  AND p.permission_key='manufacturing.material_consumption.consume';
+
+-- F1 Revoked intentionally receives no role_permissions row.
+INSERT INTO public.user_roles (user_id, role_id, org_id, expires_at) VALUES
+  ('19019019-0000-4000-8000-000000000003', '19019019-3000-4000-8000-000000000001', '19019019-1000-4000-8000-000000000001', NULL),
+  ('19019019-0000-4000-8000-000000000004', '19019019-3000-4000-8000-000000000002', '19019019-1000-4000-8000-000000000001', NULL),
+  ('19019019-0000-4000-8000-000000000005', '19019019-3000-4000-8000-000000000003', '19019019-1000-4000-8000-000000000001', now() - interval '1 day'),
+  ('19019019-0000-4000-8000-000000000006', '19019019-3000-4000-8000-000000000004', '19019019-1000-4000-8000-000000000001', NULL),
+  ('19019019-0000-4000-8000-000000000007', '19019019-3000-4000-8000-000000000005', '19019019-1000-4000-8000-000000000001', NULL);
+
+INSERT INTO public.items (id, org_id, code, name)
+VALUES (
+  '19019019-1000-4000-8000-000000000010',
+  '19019019-1000-4000-8000-000000000001',
+  'F1-MAT',
+  'F1 Material'
+);
+
+INSERT INTO public.work_centers (id, org_id, code, name)
+VALUES (
+  '19019019-1000-4000-8000-000000000020',
+  '19019019-1000-4000-8000-000000000001',
+  'F1-WC',
+  'F1 Work Center'
+);
+
+INSERT INTO public.manufacturing_orders (
+  id, org_id, order_number, quantity, status
+) VALUES (
+  '19019019-1000-4000-8000-000000000030',
+  '19019019-1000-4000-8000-000000000001',
+  'F1-MO-001',
+  1,
+  'draft'
+);
+
+INSERT INTO public.work_orders (
+  id, org_id, mo_id, work_center_id, work_order_number,
+  operation_sequence, operation_name, planned_quantity, status
+) VALUES (
+  '19019019-1000-4000-8000-000000000040',
+  '19019019-1000-4000-8000-000000000001',
+  '19019019-1000-4000-8000-000000000030',
+  '19019019-1000-4000-8000-000000000020',
+  'F1-WO-001',
+  1,
+  'F1 Operation',
+  1,
+  'READY'
+);
+
+DO $setup_check$
+BEGIN
+  IF (SELECT count(*) FROM public.permissions
+      WHERE permission_key='manufacturing.material_consumption.consume') <> 1 THEN
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_SETUP_PERMISSION_MISSING';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.has_permission(
+      '19019019-0000-4000-8000-000000000003'::uuid,
+      '19019019-1000-4000-8000-000000000001'::uuid,
+      'manufacturing.material_consumption.consume'
+    ) AS allowed
+    WHERE allowed
+  ) THEN
+    -- has_permission is caller-identity guarded, so this direct postgres call
+    -- is expected to be false. The authenticated acceptance below proves the
+    -- actual actor path; only fixture existence is asserted here.
+    NULL;
+  END IF;
+
+  RAISE NOTICE 'MATERIAL_CONSUMPTION_190_SETUP_PASS';
+END
+$setup_check$;

--- a/scripts/ci/fresh-db/setup_190_material_consumption_auth.sql
+++ b/scripts/ci/fresh-db/setup_190_material_consumption_auth.sql
@@ -14,6 +14,10 @@ INSERT INTO auth.users (id, email) VALUES
   ('19019019-0000-4000-8000-000000000007', 'f1-inactive-member@example.test'),
   ('19019019-0000-4000-8000-000000000008', 'f1-cross-org@example.test');
 
+-- Every user who receives a user_roles row starts with an active membership.
+-- Migration 175 enforces that invariant at INSERT time. The inactive-member
+-- actor is deactivated only after its role assignment exists, matching the
+-- supported reversible membership-toggle contract documented by Migration 175.
 INSERT INTO public.user_organizations
   (user_id, org_id, role, is_active, is_org_admin)
 VALUES
@@ -23,7 +27,7 @@ VALUES
   ('19019019-0000-4000-8000-000000000004', '19019019-1000-4000-8000-000000000001', 'user', true, false),
   ('19019019-0000-4000-8000-000000000005', '19019019-1000-4000-8000-000000000001', 'user', true, false),
   ('19019019-0000-4000-8000-000000000006', '19019019-1000-4000-8000-000000000001', 'user', true, false),
-  ('19019019-0000-4000-8000-000000000007', '19019019-1000-4000-8000-000000000001', 'user', false, false),
+  ('19019019-0000-4000-8000-000000000007', '19019019-1000-4000-8000-000000000001', 'user', true, false),
   ('19019019-0000-4000-8000-000000000008', '19019019-2000-4000-8000-000000000001', 'user', true, false);
 
 INSERT INTO public.roles (id, org_id, name, name_ar, is_active) VALUES
@@ -52,6 +56,11 @@ INSERT INTO public.user_roles (user_id, role_id, org_id, expires_at) VALUES
   ('19019019-0000-4000-8000-000000000005', '19019019-3000-4000-8000-000000000003', '19019019-1000-4000-8000-000000000001', now() - interval '1 day'),
   ('19019019-0000-4000-8000-000000000006', '19019019-3000-4000-8000-000000000004', '19019019-1000-4000-8000-000000000001', NULL),
   ('19019019-0000-4000-8000-000000000007', '19019019-3000-4000-8000-000000000005', '19019019-1000-4000-8000-000000000001', NULL);
+
+UPDATE public.user_organizations
+SET is_active=false, updated_at=now()
+WHERE user_id='19019019-0000-4000-8000-000000000007'::uuid
+  AND org_id='19019019-1000-4000-8000-000000000001'::uuid;
 
 INSERT INTO public.items (id, org_id, code, name)
 VALUES (
@@ -102,17 +111,14 @@ BEGIN
   END IF;
 
   IF NOT EXISTS (
-    SELECT 1 FROM public.has_permission(
-      '19019019-0000-4000-8000-000000000003'::uuid,
-      '19019019-1000-4000-8000-000000000001'::uuid,
-      'manufacturing.material_consumption.consume'
-    ) AS allowed
-    WHERE allowed
+    SELECT 1
+    FROM public.user_roles ur
+    JOIN public.user_organizations uo
+      ON uo.user_id=ur.user_id AND uo.org_id=ur.org_id
+    WHERE ur.user_id='19019019-0000-4000-8000-000000000007'::uuid
+      AND uo.is_active IS FALSE
   ) THEN
-    -- has_permission is caller-identity guarded, so this direct postgres call
-    -- is expected to be false. The authenticated acceptance below proves the
-    -- actual actor path; only fixture existence is asserted here.
-    NULL;
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_SETUP_INACTIVE_MEMBER_FIXTURE_WRONG';
   END IF;
 
   RAISE NOTICE 'MATERIAL_CONSUMPTION_190_SETUP_PASS';

--- a/scripts/ci/fresh-db/setup_190_material_consumption_auth.sql
+++ b/scripts/ci/fresh-db/setup_190_material_consumption_auth.sql
@@ -88,6 +88,16 @@ INSERT INTO public.manufacturing_orders (
   'draft'
 );
 
+-- work_orders has a load-maintenance trigger that calls wardah_assert_org_member.
+-- Run this fixture insert with the explicit test Org Admin identity instead of
+-- disabling or bypassing the trigger.
+SELECT set_config('request.jwt.claim.sub', '19019019-0000-4000-8000-000000000001', false);
+SELECT set_config(
+  'request.jwt.claims',
+  '{"sub":"19019019-0000-4000-8000-000000000001","role":"authenticated"}',
+  false
+);
+
 INSERT INTO public.work_orders (
   id, org_id, mo_id, work_center_id, work_order_number,
   operation_sequence, operation_name, planned_quantity, status
@@ -102,6 +112,9 @@ INSERT INTO public.work_orders (
   1,
   'READY'
 );
+
+SELECT set_config('request.jwt.claim.sub', '', false);
+SELECT set_config('request.jwt.claims', '{}', false);
 
 DO $setup_check$
 BEGIN

--- a/sql/migrations/190_material_consumption_authorization_boundary.sql
+++ b/sql/migrations/190_material_consumption_authorization_boundary.sql
@@ -123,7 +123,8 @@ BEGIN
     v_stage:=NULLIF(p_consumptions->0->>'stage_id','')::uuid;
   END IF;
   IF v_stage IS NULL THEN
-    SELECT count(*),min(stage_id) INTO v_count,v_stage
+    SELECT count(*),(array_agg(stage_id ORDER BY stage_id))[1]
+      INTO v_count,v_stage
     FROM public.stage_wip_log
     WHERE org_id=v_org AND mo_id=p_mo_id AND COALESCE(is_closed,false)=false
       AND CURRENT_DATE BETWEEN period_start AND period_end;
@@ -171,7 +172,8 @@ BEGIN
 
     v_warehouse:=NULLIF(v_row->>'warehouse_id','')::uuid;
     IF v_warehouse IS NULL THEN
-      SELECT count(*),min(warehouse_id) INTO v_count,v_warehouse
+      SELECT count(*),(array_agg(warehouse_id ORDER BY warehouse_id))[1]
+        INTO v_count,v_warehouse
       FROM public.bins
       WHERE org_id=v_org AND product_id=v_product AND actual_qty>=v_qty_base;
       IF v_count<>1 THEN RAISE EXCEPTION 'WAREHOUSE_REQUIRED_FOR_CONSUMPTION'; END IF;
@@ -179,7 +181,8 @@ BEGIN
 
     v_work_order:=NULLIF(v_row->>'work_order_id','')::uuid;
     IF v_work_order IS NULL THEN
-      SELECT count(*),min(id) INTO v_count,v_work_order
+      SELECT count(*),(array_agg(id ORDER BY id))[1]
+        INTO v_count,v_work_order
       FROM public.work_orders
       WHERE org_id=v_org AND mo_id=p_mo_id AND status NOT IN ('COMPLETED','CANCELLED');
       IF v_count<>1 THEN RAISE EXCEPTION 'WORK_ORDER_REQUIRED_FOR_CONSUMPTION'; END IF;
@@ -340,6 +343,15 @@ BEGIN
   IF position('manufacturing.material_consumption.consume' in v_def)=0
      OR position('has_permission' in v_def)=0 THEN
     RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_V2_GUARD_MISSING';
+  END IF;
+
+  -- PostgreSQL has no built-in min(uuid) aggregate. The pre-190 body used it
+  -- for stage, warehouse and work-order singleton selection, making otherwise
+  -- valid canonical requests fail before their intended cardinality gates.
+  IF v_def ~* 'min\s*\(\s*stage_id\s*\)'
+     OR v_def ~* 'min\s*\(\s*warehouse_id\s*\)'
+     OR v_def ~* 'select\s+count\s*\(\s*\*\s*\)\s*,\s*min\s*\(\s*id\s*\)' THEN
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_UUID_MIN_AGGREGATE_REMAINS';
   END IF;
 
   SELECT pg_get_functiondef(

--- a/sql/migrations/190_material_consumption_authorization_boundary.sql
+++ b/sql/migrations/190_material_consumption_authorization_boundary.sql
@@ -1,13 +1,16 @@
 -- 190_material_consumption_authorization_boundary
 --
 -- Astra audit F1 / S0. Closes the material-consumption authorization gap
--- proven by PR #232 without changing inventory/costing semantics.
+-- proven by PR #232 without changing canonical inventory/costing semantics.
 --
 -- Contract:
 --   * one ordinary exact permission: manufacturing.material_consumption.consume
 --   * org-admin semantics remain those of the central has_permission() contract
---   * all authenticated consumption RPC entry points are protected transitively
---     by guarding rpc_consume_reserved_materials_v2 and backflush_materials
+--   * canonical consumption RPCs are protected by an exact permission guard
+--   * the legacy backflush RPC is permission-gated then explicitly retired until
+--     issue #234 reimplements it on the canonical BOM + inventory contract
+--   * the broken auto-backflush trigger is removed so it cannot bypass the same
+--     authorization boundary via direct material_consumption writes
 --   * direct INSERT remains as a compatibility path for mesService.consumeMaterial,
 --     but RLS now requires the same exact permission
 --   * direct UPDATE/DELETE are unsupported and their grants/policies are removed
@@ -237,6 +240,11 @@ BEGIN
 END;
 $function$;
 
+-- Legacy backflush is not a legal canonical consumption implementation: the
+-- current body references the retired manufacturing_orders.bom_id column and
+-- writes material_consumption directly without the reservation/ledger/WIP
+-- atomic contract. Keep the published entry point only as a guarded, explicit
+-- retirement until #234 reimplements backflush on the canonical path.
 CREATE OR REPLACE FUNCTION public.backflush_materials(
   p_work_order_id uuid,
   p_quantity_produced numeric
@@ -244,56 +252,41 @@ CREATE OR REPLACE FUNCTION public.backflush_materials(
 RETURNS SETOF material_consumption
 LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path TO 'public'
+SET search_path TO 'public', 'pg_temp'
 AS $function$
 DECLARE
-    v_work_order RECORD;
-    v_mo RECORD;
-    v_bom_line RECORD;
+  v_org uuid;
 BEGIN
-    SELECT wo.*, mo.bom_id, mo.org_id as mo_org_id
-    INTO v_work_order
-    FROM work_orders wo
-    JOIN manufacturing_orders mo ON wo.mo_id = mo.id
-    WHERE wo.id = p_work_order_id;
+  SELECT mo.org_id INTO v_org
+  FROM public.work_orders wo
+  JOIN public.manufacturing_orders mo ON mo.id=wo.mo_id
+  WHERE wo.id=p_work_order_id;
 
-    IF NOT FOUND THEN
-        RAISE EXCEPTION 'Work order not found: %', p_work_order_id;
-    END IF;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'WORK_ORDER_NOT_FOUND';
+  END IF;
 
-    PERFORM public.wardah_assert_org_member(v_work_order.mo_org_id);
-    IF NOT public.has_permission(
-      auth.uid(), v_work_order.mo_org_id,
-      'manufacturing.material_consumption.consume'
-    ) THEN
-      RAISE EXCEPTION 'MATERIAL_CONSUMPTION_PERMISSION_DENIED';
-    END IF;
+  PERFORM public.wardah_assert_org_member(v_org);
+  IF NOT public.has_permission(
+    auth.uid(), v_org, 'manufacturing.material_consumption.consume'
+  ) THEN
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_PERMISSION_DENIED';
+  END IF;
 
-    FOR v_bom_line IN
-        SELECT bl.*, i.name as item_name
-        FROM bom_lines bl
-        JOIN items i ON bl.item_id = i.id
-        WHERE bl.bom_id = v_work_order.bom_id
-        AND bl.item_type IN ('RAW_MATERIAL', 'COMPONENT')
-    LOOP
-        RETURN QUERY
-        INSERT INTO material_consumption (
-            org_id, work_order_id, mo_id, item_id,
-            planned_quantity, consumed_quantity, consumption_type,
-            unit_cost, total_cost, status, consumption_date, created_by
-        ) VALUES (
-            v_work_order.mo_org_id, p_work_order_id, v_work_order.mo_id, v_bom_line.item_id,
-            v_bom_line.quantity * (v_work_order.planned_quantity),
-            v_bom_line.quantity * p_quantity_produced,
-            'BACKFLUSH',
-            v_bom_line.unit_cost,
-            v_bom_line.unit_cost * v_bom_line.quantity * p_quantity_produced,
-            'PENDING', NOW(), auth.uid()
-        )
-        RETURNING *;
-    END LOOP;
+  RAISE EXCEPTION 'BACKFLUSH_RETIRED_PENDING_CANONICAL_REIMPLEMENTATION'
+    USING ERRCODE='0A000',
+          HINT='Tracked in GitHub issue #234; use rpc_consume_reserved_materials_v2 for canonical material consumption.';
 END;
 $function$;
+
+COMMENT ON FUNCTION public.backflush_materials(uuid,numeric) IS
+  'Permission-gated retired legacy backflush. The former implementation referenced manufacturing_orders.bom_id and bypassed canonical reservation/ledger/WIP consumption. Tracked by #234.';
+
+-- The automatic trigger had the same retired bom_id dependency and performed a
+-- direct material_consumption INSERT outside the exact-permission boundary.
+-- Disable the trigger fail-closed until #234 defines canonical automatic
+-- execution and system-actor authorization semantics.
+DROP TRIGGER IF EXISTS trigger_auto_backflush ON public.work_orders;
 
 -- Compatibility direct INSERT remains, but only for callers holding the exact
 -- material-consumption permission. SELECT remains unchanged.
@@ -353,8 +346,23 @@ BEGIN
     'public.backflush_materials(uuid,numeric)'::regprocedure
   ) INTO v_def;
   IF position('manufacturing.material_consumption.consume' in v_def)=0
-     OR position('has_permission' in v_def)=0 THEN
-    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_BACKFLUSH_GUARD_MISSING';
+     OR position('has_permission' in v_def)=0
+     OR position('BACKFLUSH_RETIRED_PENDING_CANONICAL_REIMPLEMENTATION' in v_def)=0
+     OR v_def ~* '\mINSERT\s+INTO\s+(public\.)?material_consumption\M' THEN
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_BACKFLUSH_QUARANTINE_MISSING';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM pg_trigger t
+    JOIN pg_class c ON c.oid=t.tgrelid
+    JOIN pg_namespace n ON n.oid=c.relnamespace
+    WHERE n.nspname='public'
+      AND c.relname='work_orders'
+      AND t.tgname='trigger_auto_backflush'
+      AND NOT t.tgisinternal
+  ) THEN
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_AUTO_BACKFLUSH_TRIGGER_REMAINS';
   END IF;
 
   IF NOT has_function_privilege(

--- a/sql/migrations/190_material_consumption_authorization_boundary.sql
+++ b/sql/migrations/190_material_consumption_authorization_boundary.sql
@@ -1,0 +1,419 @@
+-- 190_material_consumption_authorization_boundary
+--
+-- Astra audit F1 / S0. Closes the material-consumption authorization gap
+-- proven by PR #232 without changing inventory/costing semantics.
+--
+-- Contract:
+--   * one ordinary exact permission: manufacturing.material_consumption.consume
+--   * org-admin semantics remain those of the central has_permission() contract
+--   * all authenticated consumption RPC entry points are protected transitively
+--     by guarding rpc_consume_reserved_materials_v2 and backflush_materials
+--   * direct INSERT remains as a compatibility path for mesService.consumeMaterial,
+--     but RLS now requires the same exact permission
+--   * direct UPDATE/DELETE are unsupported and their grants/policies are removed
+--   * SELECT behavior is deliberately unchanged
+--
+-- No data rewrite. No role is auto-granted the new permission.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '30s';
+SET LOCAL statement_timeout = '5min';
+
+DO $preflight$
+DECLARE
+  v_manufacturing_module_count integer;
+BEGIN
+  IF to_regclass('public.permissions') IS NULL
+     OR to_regclass('public.modules') IS NULL
+     OR to_regclass('public.material_consumption') IS NULL
+     OR to_regclass('public.manufacturing_orders') IS NULL
+     OR to_regclass('public.work_orders') IS NULL THEN
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_REQUIRED_TABLE_MISSING';
+  END IF;
+
+  IF to_regprocedure('public.has_permission(uuid,uuid,character varying)') IS NULL
+     OR to_regprocedure('public.wardah_assert_org_member(uuid)') IS NULL
+     OR to_regprocedure('public.rpc_consume_reserved_materials_v2(uuid,uuid,jsonb)') IS NULL
+     OR to_regprocedure('public.rpc_consume_reserved_materials(uuid,jsonb)') IS NULL
+     OR to_regprocedure('public.consume_materials_for_mo(uuid,uuid,jsonb[])') IS NULL
+     OR to_regprocedure('public.backflush_materials(uuid,numeric)') IS NULL THEN
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_REQUIRED_FUNCTION_MISSING';
+  END IF;
+
+  SELECT count(*) INTO v_manufacturing_module_count
+  FROM public.modules
+  WHERE name = 'manufacturing';
+
+  IF v_manufacturing_module_count <> 1 THEN
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_MANUFACTURING_MODULE_DRIFT: %',
+      v_manufacturing_module_count;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.permissions p
+    JOIN public.modules m ON m.id = p.module_id
+    WHERE p.permission_key = 'manufacturing.material_consumption.consume'
+      AND (
+        m.name IS DISTINCT FROM 'manufacturing'
+        OR p.resource IS DISTINCT FROM 'material_consumption'
+        OR p.action IS DISTINCT FROM 'consume'
+      )
+  ) THEN
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_PERMISSION_KEY_COLLISION';
+  END IF;
+END
+$preflight$;
+
+INSERT INTO public.permissions (
+  id, module_id, resource, resource_ar, action, action_ar,
+  permission_key, description, description_ar
+)
+SELECT
+  '19019019-0000-4000-8000-000000000001'::uuid,
+  m.id,
+  'material_consumption',
+  'استهلاك المواد',
+  'consume',
+  'استهلاك',
+  'manufacturing.material_consumption.consume',
+  'Consume manufacturing materials and create material-consumption records',
+  'استهلاك مواد التصنيع وإنشاء سجلات استهلاك المواد'
+FROM public.modules m
+WHERE m.name = 'manufacturing'
+ON CONFLICT (permission_key) DO NOTHING;
+
+CREATE OR REPLACE FUNCTION public.rpc_consume_reserved_materials_v2(
+  p_mo_id uuid,
+  p_stage_id uuid,
+  p_consumptions jsonb
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_org uuid; v_mo_number text; v_stage uuid:=p_stage_id; v_wip_id uuid;
+  v_row jsonb; v_res public.material_reservations%rowtype; v_product uuid;
+  v_uom uuid; v_qty_entered numeric; v_qty_base numeric; v_factor numeric;
+  v_warehouse uuid; v_count integer; v_remaining numeric; v_work_order uuid;
+  v_stock jsonb; v_cogs numeric; v_total_cogs numeric:=0; v_unit_cost numeric;
+BEGIN
+  SELECT org_id,order_number INTO v_org,v_mo_number
+  FROM public.manufacturing_orders WHERE id=p_mo_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'MANUFACTURING_ORDER_NOT_FOUND'; END IF;
+
+  PERFORM public.wardah_assert_org_member(v_org);
+  IF NOT public.has_permission(
+    auth.uid(), v_org, 'manufacturing.material_consumption.consume'
+  ) THEN
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_PERMISSION_DENIED';
+  END IF;
+
+  IF jsonb_typeof(p_consumptions)<>'array' OR jsonb_array_length(p_consumptions)=0 THEN
+    RAISE EXCEPTION 'CONSUMPTIONS_REQUIRED';
+  END IF;
+
+  IF v_stage IS NULL THEN
+    v_stage:=NULLIF(p_consumptions->0->>'stage_id','')::uuid;
+  END IF;
+  IF v_stage IS NULL THEN
+    SELECT count(*),min(stage_id) INTO v_count,v_stage
+    FROM public.stage_wip_log
+    WHERE org_id=v_org AND mo_id=p_mo_id AND COALESCE(is_closed,false)=false
+      AND CURRENT_DATE BETWEEN period_start AND period_end;
+    IF v_count<>1 THEN RAISE EXCEPTION 'STAGE_REQUIRED_FOR_MATERIAL_CONSUMPTION'; END IF;
+  END IF;
+
+  SELECT id INTO v_wip_id FROM public.stage_wip_log
+  WHERE org_id=v_org AND mo_id=p_mo_id AND stage_id=v_stage
+    AND COALESCE(is_closed,false)=false
+    AND CURRENT_DATE BETWEEN period_start AND period_end
+  ORDER BY period_end DESC LIMIT 1 FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'OPEN_STAGE_WIP_LOG_NOT_FOUND'; END IF;
+
+  FOR v_row IN SELECT value FROM jsonb_array_elements(p_consumptions) LOOP
+    IF NULLIF(v_row->>'reservation_id','') IS NOT NULL THEN
+      SELECT * INTO v_res FROM public.material_reservations
+      WHERE id=(v_row->>'reservation_id')::uuid AND org_id=v_org
+        AND mo_id=p_mo_id AND status='reserved' FOR UPDATE;
+    ELSE
+      SELECT * INTO v_res FROM public.material_reservations
+      WHERE org_id=v_org AND mo_id=p_mo_id
+        AND item_id=(v_row->>'item_id')::uuid AND status='reserved'
+      ORDER BY created_at,id LIMIT 1 FOR UPDATE;
+    END IF;
+    IF NOT FOUND THEN RAISE EXCEPTION 'ACTIVE_RESERVATION_NOT_FOUND'; END IF;
+
+    v_product:=COALESCE(
+      v_res.product_id,
+      public.wardah_resolve_product_id(v_org,v_res.item_id,now())
+    );
+    SELECT COALESCE(NULLIF(v_row->>'uom_id','')::uuid,v_res.uom_id,p.base_uom_id)
+      INTO v_uom FROM public.products p WHERE p.id=v_product AND p.org_id=v_org;
+    v_qty_entered:=NULLIF(v_row->>'quantity','')::numeric;
+    IF v_qty_entered IS NULL OR v_qty_entered<=0 THEN
+      RAISE EXCEPTION 'INVALID_CONSUMPTION_QUANTITY';
+    END IF;
+    v_factor:=public.wardah_uom_factor(v_org,v_product,v_uom,now());
+    v_qty_base:=round(v_qty_entered*v_factor,6);
+
+    v_remaining:=v_res.quantity_reserved-COALESCE(v_res.quantity_consumed,0)-COALESCE(v_res.quantity_released,0);
+    IF v_qty_base>v_remaining THEN
+      RAISE EXCEPTION 'CONSUMPTION_EXCEEDS_RESERVATION: remaining=%, requested_base=%',
+        v_remaining,v_qty_base;
+    END IF;
+
+    v_warehouse:=NULLIF(v_row->>'warehouse_id','')::uuid;
+    IF v_warehouse IS NULL THEN
+      SELECT count(*),min(warehouse_id) INTO v_count,v_warehouse
+      FROM public.bins
+      WHERE org_id=v_org AND product_id=v_product AND actual_qty>=v_qty_base;
+      IF v_count<>1 THEN RAISE EXCEPTION 'WAREHOUSE_REQUIRED_FOR_CONSUMPTION'; END IF;
+    END IF;
+
+    v_work_order:=NULLIF(v_row->>'work_order_id','')::uuid;
+    IF v_work_order IS NULL THEN
+      SELECT count(*),min(id) INTO v_count,v_work_order
+      FROM public.work_orders
+      WHERE org_id=v_org AND mo_id=p_mo_id AND status NOT IN ('COMPLETED','CANCELLED');
+      IF v_count<>1 THEN RAISE EXCEPTION 'WORK_ORDER_REQUIRED_FOR_CONSUMPTION'; END IF;
+    ELSIF NOT EXISTS (
+      SELECT 1 FROM public.work_orders
+      WHERE id=v_work_order AND org_id=v_org AND mo_id=p_mo_id
+    ) THEN
+      RAISE EXCEPTION 'WORK_ORDER_NOT_FOUND_OR_WRONG_MO';
+    END IF;
+
+    v_stock:=public.wardah_apply_stock_outgoing(
+      v_org,v_product,v_warehouse,v_qty_base,
+      'Material Consumption',p_mo_id,v_mo_number,CURRENT_DATE
+    );
+    IF NOT COALESCE((v_stock->>'applied')::boolean,false) THEN
+      RAISE EXCEPTION 'STOCK_OUT_NOT_APPLIED';
+    END IF;
+    v_cogs:=COALESCE((v_stock->>'cogs')::numeric,0);
+    v_unit_cost:=CASE WHEN v_qty_base>0 THEN v_cogs/v_qty_base ELSE 0 END;
+
+    INSERT INTO public.material_consumption(
+      org_id,work_order_id,mo_id,item_id,product_id,reservation_id,stage_id,
+      planned_quantity,consumed_quantity,consumption_type,warehouse_id,
+      unit_cost,total_cost,status,consumption_date,notes,created_by,
+      uom_id,qty_entered,conversion_factor_snapshot,stock_valuation_result
+    ) VALUES (
+      v_org,v_work_order,p_mo_id,v_res.item_id,v_product,v_res.id,v_stage,
+      v_res.quantity_reserved,v_qty_base,COALESCE(NULLIF(v_row->>'consumption_type',''),'MANUAL'),v_warehouse,
+      v_unit_cost,v_cogs,'POSTED',now(),NULLIF(v_row->>'notes',''),auth.uid(),
+      v_uom,v_qty_entered,v_factor,v_stock
+    );
+
+    UPDATE public.stage_wip_log
+    SET cost_material=COALESCE(cost_material,0)+v_cogs,updated_at=now(),updated_by=auth.uid()
+    WHERE id=v_wip_id;
+
+    UPDATE public.material_reservations
+    SET product_id=v_product,uom_id=v_uom,
+        qty_entered=COALESCE(qty_entered,quantity_reserved),
+        conversion_factor_snapshot=COALESCE(conversion_factor_snapshot,1),
+        quantity_consumed=COALESCE(quantity_consumed,0)+v_qty_base,
+        status=CASE
+          WHEN COALESCE(quantity_consumed,0)+v_qty_base+COALESCE(quantity_released,0)>=quantity_reserved
+          THEN 'consumed' ELSE 'reserved' END,
+        consumed_at=now(),updated_at=now()
+    WHERE id=v_res.id;
+
+    v_total_cogs:=v_total_cogs+v_cogs;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'success',true,'mo_id',p_mo_id,'stage_id',v_stage,
+    'stage_wip_log_id',v_wip_id,
+    'consumption_count',jsonb_array_length(p_consumptions),
+    'material_cost_posted',round(v_total_cogs,6),
+    'inventory_atomic',true,'wip_cost_atomic',true,'uom_atomic',true
+  );
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.backflush_materials(
+  p_work_order_id uuid,
+  p_quantity_produced numeric
+)
+RETURNS SETOF material_consumption
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+    v_work_order RECORD;
+    v_mo RECORD;
+    v_bom_line RECORD;
+BEGIN
+    SELECT wo.*, mo.bom_id, mo.org_id as mo_org_id
+    INTO v_work_order
+    FROM work_orders wo
+    JOIN manufacturing_orders mo ON wo.mo_id = mo.id
+    WHERE wo.id = p_work_order_id;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'Work order not found: %', p_work_order_id;
+    END IF;
+
+    PERFORM public.wardah_assert_org_member(v_work_order.mo_org_id);
+    IF NOT public.has_permission(
+      auth.uid(), v_work_order.mo_org_id,
+      'manufacturing.material_consumption.consume'
+    ) THEN
+      RAISE EXCEPTION 'MATERIAL_CONSUMPTION_PERMISSION_DENIED';
+    END IF;
+
+    FOR v_bom_line IN
+        SELECT bl.*, i.name as item_name
+        FROM bom_lines bl
+        JOIN items i ON bl.item_id = i.id
+        WHERE bl.bom_id = v_work_order.bom_id
+        AND bl.item_type IN ('RAW_MATERIAL', 'COMPONENT')
+    LOOP
+        RETURN QUERY
+        INSERT INTO material_consumption (
+            org_id, work_order_id, mo_id, item_id,
+            planned_quantity, consumed_quantity, consumption_type,
+            unit_cost, total_cost, status, consumption_date, created_by
+        ) VALUES (
+            v_work_order.mo_org_id, p_work_order_id, v_work_order.mo_id, v_bom_line.item_id,
+            v_bom_line.quantity * (v_work_order.planned_quantity),
+            v_bom_line.quantity * p_quantity_produced,
+            'BACKFLUSH',
+            v_bom_line.unit_cost,
+            v_bom_line.unit_cost * v_bom_line.quantity * p_quantity_produced,
+            'PENDING', NOW(), auth.uid()
+        )
+        RETURNING *;
+    END LOOP;
+END;
+$function$;
+
+-- Compatibility direct INSERT remains, but only for callers holding the exact
+-- material-consumption permission. SELECT remains unchanged.
+DROP POLICY IF EXISTS material_consumption_insert_policy
+  ON public.material_consumption;
+CREATE POLICY material_consumption_insert_policy
+  ON public.material_consumption
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    public.has_permission(
+      (SELECT auth.uid()),
+      org_id,
+      'manufacturing.material_consumption.consume'::character varying
+    )
+  );
+
+-- No repository consumer updates or deletes material_consumption directly.
+-- Remove the latent mutation path entirely instead of permission-gating it.
+DROP POLICY IF EXISTS material_consumption_update_policy
+  ON public.material_consumption;
+DROP POLICY IF EXISTS material_consumption_delete_policy
+  ON public.material_consumption;
+
+REVOKE UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER
+  ON TABLE public.material_consumption
+  FROM authenticated;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER
+  ON TABLE public.material_consumption
+  FROM anon;
+
+DO $postflight$
+DECLARE
+  v_def text;
+  v_policy_count integer;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.permissions p
+    JOIN public.modules m ON m.id=p.module_id
+    WHERE p.permission_key='manufacturing.material_consumption.consume'
+      AND m.name='manufacturing'
+      AND p.resource='material_consumption'
+      AND p.action='consume'
+  ) THEN
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_PERMISSION_MISSING';
+  END IF;
+
+  SELECT pg_get_functiondef(
+    'public.rpc_consume_reserved_materials_v2(uuid,uuid,jsonb)'::regprocedure
+  ) INTO v_def;
+  IF position('manufacturing.material_consumption.consume' in v_def)=0
+     OR position('has_permission' in v_def)=0 THEN
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_V2_GUARD_MISSING';
+  END IF;
+
+  SELECT pg_get_functiondef(
+    'public.backflush_materials(uuid,numeric)'::regprocedure
+  ) INTO v_def;
+  IF position('manufacturing.material_consumption.consume' in v_def)=0
+     OR position('has_permission' in v_def)=0 THEN
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_BACKFLUSH_GUARD_MISSING';
+  END IF;
+
+  IF NOT has_function_privilege(
+      'authenticated','public.rpc_consume_reserved_materials_v2(uuid,uuid,jsonb)','EXECUTE')
+     OR NOT has_function_privilege(
+      'authenticated','public.rpc_consume_reserved_materials(uuid,jsonb)','EXECUTE')
+     OR NOT has_function_privilege(
+      'authenticated','public.consume_materials_for_mo(uuid,uuid,jsonb[])','EXECUTE')
+     OR NOT has_function_privilege(
+      'authenticated','public.backflush_materials(uuid,numeric)','EXECUTE') THEN
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_AUTHENTICATED_RPC_ACL_DRIFT';
+  END IF;
+
+  IF NOT has_table_privilege('authenticated','public.material_consumption','SELECT')
+     OR NOT has_table_privilege('authenticated','public.material_consumption','INSERT') THEN
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_AUTHENTICATED_READ_INSERT_MUST_REMAIN';
+  END IF;
+
+  IF has_table_privilege('authenticated','public.material_consumption','UPDATE')
+     OR has_table_privilege('authenticated','public.material_consumption','DELETE')
+     OR has_table_privilege('authenticated','public.material_consumption','TRUNCATE')
+     OR has_table_privilege('authenticated','public.material_consumption','REFERENCES')
+     OR has_table_privilege('authenticated','public.material_consumption','TRIGGER') THEN
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_AUTHENTICATED_UNSUPPORTED_MUTATION_REMAINS';
+  END IF;
+
+  IF has_table_privilege('anon','public.material_consumption','INSERT')
+     OR has_table_privilege('anon','public.material_consumption','UPDATE')
+     OR has_table_privilege('anon','public.material_consumption','DELETE')
+     OR has_table_privilege('anon','public.material_consumption','TRUNCATE')
+     OR has_table_privilege('anon','public.material_consumption','REFERENCES')
+     OR has_table_privilege('anon','public.material_consumption','TRIGGER') THEN
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_ANON_MUTATION_REMAINS';
+  END IF;
+
+  SELECT count(*) INTO v_policy_count
+  FROM pg_policies
+  WHERE schemaname='public'
+    AND tablename='material_consumption'
+    AND cmd='INSERT'
+    AND roles='{authenticated}'
+    AND coalesce(with_check,'') ILIKE '%has_permission%'
+    AND coalesce(with_check,'') ILIKE '%manufacturing.material_consumption.consume%';
+
+  IF v_policy_count <> 1 THEN
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_INSERT_POLICY_WRONG: %', v_policy_count;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname='public'
+      AND tablename='material_consumption'
+      AND cmd IN ('UPDATE','DELETE')
+  ) THEN
+    RAISE EXCEPTION 'MATERIAL_CONSUMPTION_190_UNSUPPORTED_WRITE_POLICY_REMAINS';
+  END IF;
+
+  RAISE NOTICE 'MATERIAL_CONSUMPTION_190_POSTFLIGHT_PASS';
+END
+$postflight$;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Implements Astra finding **F1 / S0** after the merged RED proof in PR #232.

### Contract

- adds ordinary exact permission `manufacturing.material_consumption.consume`
- guards `rpc_consume_reserved_materials_v2`; legacy wrappers inherit that canonical guard
- preserves direct `material_consumption` INSERT only for the current `mesService.consumeMaterial()` compatibility path, protected by exact-permission RLS
- removes direct UPDATE/DELETE policies and authenticated privileges
- quarantines the pre-existing broken legacy backflush surface instead of inventing BOM behavior inside this security PR:
  - `backflush_materials` enforces membership + exact permission, then fails explicitly with SQLSTATE `0A000`
  - `trigger_auto_backflush` is removed because it used the same retired `mo.bom_id` assumption and directly inserted `material_consumption` outside the canonical boundary
  - canonical backflush reimplementation is tracked separately in #234
- SELECT behavior is unchanged
- no existing role is auto-granted the new permission

### Evidence

Fresh DB workflow performs:

1. cutoff-189 rebuild
2. merged F1 RED proof before the migration
3. Migration 190
4. isolated RBAC/manufacturing fixtures
5. behavioral GREEN checks for no-permission, exact grant, revoked, expired, inactive role, inactive membership, cross-org, Org Admin, direct INSERT RLS, UPDATE/DELETE closure, compatibility-wrapper delegation, and legacy backflush quarantine

### Files

- `sql/migrations/190_material_consumption_authorization_boundary.sql`
- `scripts/ci/fresh-db/setup_190_material_consumption_auth.sql`
- `scripts/ci/fresh-db/acceptance_190_material_consumption_auth.sql`
- `.github/workflows/material-consumption-auth-190-acceptance.yml`
- `docs/db/MATERIAL_CONSUMPTION_AUTH_190_RUNBOOK.md`

### Discovery during GREEN

The dedicated acceptance exposed a pre-existing cutoff-189 defect: both `backflush_materials` and `auto_backflush_materials` reference `manufacturing_orders.bom_id`, which is absent from the legal schema. More importantly, both paths directly write `material_consumption` rather than using canonical reservation + valued ledger/bin + stage-WIP atomic consumption. This is tracked in #234 and intentionally not reimplemented here.

A live Production readback attempt on 2026-09-06 could not confirm that defect independently because the connected `Wardah-Prod` project was reported INACTIVE and the read-only SQL timed out. The defect claim is therefore baseline/Fresh-DB confirmed, not a live Production assertion.

### Safety

- no Production apply
- no historical data rewrite
- no inventory valuation/costing algorithm change
- no guessed BOM-selection semantics
- no F2/F3/F4/F5 implementation
- Production rollout requires separate explicit authorization and a fresh role/membership + backflush-state readback

Tracks #154 and the material-consumption portion of #170. Follow-up #234 owns canonical backflush.

Draft until the dedicated 190 workflow and general gates are green and the diff is reviewed. No merge authorization is implied.