### PR TITLE
fix(rbac): stop background permission revalidation from unmounting the page (#237)

### DIFF
--- a/src/components/auth/__tests__/ModuleGuard.background-revalidation.test.tsx
+++ b/src/components/auth/__tests__/ModuleGuard.background-revalidation.test.tsx
@@ -1,0 +1,210 @@
+// src/components/auth/__tests__/ModuleGuard.background-revalidation.test.tsx
+//
+// Issue #237: a tab refocus (visibilitychange) made usePermissions()
+// revalidate its snapshot by flipping `loading` back to true. Every consumer
+// built on that hook — ModuleGuard included — renders a loading screen IN
+// PLACE OF `children` while `loading` is true, so the already-mounted page
+// got unmounted and remounted a moment later, destroying any component-local
+// state it held (in-progress form input, wizard step, ...).
+//
+// These exercise the real ModuleGuard + real usePermissions against a
+// mocked Supabase RPC, the same way ModuleGuard.identity-switch.test.tsx
+// does — a mocked usePermissions could only assert what ModuleGuard does
+// with a given loading/permission combination, not that the hook actually
+// produces (or stops producing) `loading: true` for a background
+// revalidation.
+
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const rpcMock = vi.fn();
+
+vi.mock('@/lib/supabase', () => ({
+  getSupabase: () => ({ rpc: rpcMock }),
+}));
+
+let authState = {
+  user: { id: 'user-1' } as { id: string } | null,
+  currentOrgId: 'org-a' as string | null,
+  isAuthenticated: true,
+};
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => authState,
+}));
+
+vi.mock('@/lib/safe-storage', () => ({
+  safeLocalStorage: { getItem: () => null, setItem: () => undefined },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import { ModuleGuard } from '../ModuleGuard';
+import { clearPermissionCache } from '@/hooks/usePermissions';
+
+function snapshot(overrides: Record<string, unknown> = {}) {
+  return {
+    data: {
+      user_id: 'user-1',
+      org_id: 'org-a',
+      is_super_admin: false,
+      is_org_admin: false,
+      // Same (moduleCode, path, key) combination already proven to satisfy
+      // the route-permission contract in ModuleGuard.identity-switch.test.tsx.
+      permission_keys: ['sales.sales_orders.read'],
+      sensitive_permission_keys: [],
+      generated_at: new Date().toISOString(),
+      ...overrides,
+    },
+    error: null,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(res => { resolve = res; });
+  return { promise, resolve };
+}
+
+// Counts real mounts of this exact component, not re-renders — proves an
+// unmount/remount occurred rather than just a prop/state change.
+let mountCount = 0;
+
+function DraftForm() {
+  mountCount += 1;
+  return <input aria-label="draft-note" defaultValue="" />;
+}
+
+function Tree() {
+  return (
+    <MemoryRouter initialEntries={['/sales']}>
+      <Routes>
+        <Route
+          path="/sales"
+          element={
+            <ModuleGuard moduleCode="sales">
+              <DraftForm />
+            </ModuleGuard>
+          }
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('ModuleGuard — background permission revalidation on tab refocus (#237)', () => {
+  beforeEach(() => {
+    rpcMock.mockReset();
+    clearPermissionCache();
+    mountCount = 0;
+    authState = { user: { id: 'user-1' }, currentOrgId: 'org-a', isAuthenticated: true };
+  });
+
+  it('shows LoadingState and blocks content on the very first load (fail-closed, unchanged)', async () => {
+    const pending = deferred<{ data: unknown; error: null }>();
+    rpcMock.mockImplementation(() => pending.promise);
+
+    render(<Tree />);
+
+    expect(screen.getByText('auth.checkingPermissions')).toBeInTheDocument();
+    expect(screen.queryByLabelText('draft-note')).not.toBeInTheDocument();
+
+    act(() => { pending.resolve(snapshot()); });
+    await waitFor(() => expect(screen.getByLabelText('draft-note')).toBeInTheDocument());
+    expect(mountCount).toBe(1);
+  });
+
+  it('does not unmount the page or lose in-progress input on a same-permission background revalidation', async () => {
+    rpcMock.mockResolvedValueOnce(snapshot());
+    render(<Tree />);
+    await waitFor(() => expect(screen.getByLabelText('draft-note')).toBeInTheDocument());
+    expect(mountCount).toBe(1);
+
+    const input = screen.getByLabelText('draft-note') as HTMLInputElement;
+    await userEvent.type(input, 'unsaved draft text');
+    expect(input.value).toBe('unsaved draft text');
+
+    // Tab refocus: usePermissions revalidates against the backend. The
+    // revalidation promise is deliberately resolved in `finally` below: if
+    // the in-flight assertions throw (the RED case, pre-fix), the promise
+    // must still settle so it doesn't linger in the hook's shared
+    // cross-instance in-flight map and hang every later test that asks for
+    // this same (user, org) key.
+    const revalidation = deferred<{ data: unknown; error: null }>();
+    rpcMock.mockImplementation(() => revalidation.promise);
+    act(() => { document.dispatchEvent(new Event('visibilitychange')); });
+
+    try {
+      // The revalidation must not swap the page out for a loading screen
+      // while it is in flight — that swap is exactly what destroyed
+      // `input`'s value before this fix.
+      expect(screen.queryByText('auth.checkingPermissions')).not.toBeInTheDocument();
+      expect(screen.getByLabelText('draft-note')).toBeInTheDocument();
+    } finally {
+      act(() => { revalidation.resolve(snapshot()); });
+    }
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    expect(mountCount).toBe(1);
+    expect((screen.getByLabelText('draft-note') as HTMLInputElement).value).toBe('unsaved draft text');
+  });
+
+  it('still enforces a permission revoked during background revalidation', async () => {
+    rpcMock.mockResolvedValueOnce(snapshot());
+    render(<Tree />);
+    await waitFor(() => expect(screen.getByLabelText('draft-note')).toBeInTheDocument());
+
+    const revalidation = deferred<{ data: unknown; error: null }>();
+    rpcMock.mockImplementation(() => revalidation.promise);
+    act(() => { document.dispatchEvent(new Event('visibilitychange')); });
+
+    // The backend reports the grant was revoked in another tab.
+    act(() => { revalidation.resolve(snapshot({ permission_keys: [] })); });
+
+    await waitFor(() => expect(screen.getByText('auth.accessDenied')).toBeInTheDocument());
+    expect(screen.queryByLabelText('draft-note')).not.toBeInTheDocument();
+  });
+
+  it('coalesces one background revalidation across two mounted ModuleGuard consumers (dedup preserved)', async () => {
+    rpcMock.mockResolvedValue(snapshot());
+
+    function TwoConsumers() {
+      return (
+        <MemoryRouter initialEntries={['/sales']}>
+          <Routes>
+            <Route
+              path="/sales"
+              element={
+                <>
+                  <ModuleGuard moduleCode="sales"><div>sidebar-widget</div></ModuleGuard>
+                  <ModuleGuard moduleCode="sales"><DraftForm /></ModuleGuard>
+                </>
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      );
+    }
+
+    render(<TwoConsumers />);
+    await waitFor(() => expect(screen.getByLabelText('draft-note')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('sidebar-widget')).toBeInTheDocument());
+
+    rpcMock.mockClear();
+    const shared = deferred<{ data: unknown; error: null }>();
+    rpcMock.mockImplementation(() => shared.promise);
+
+    act(() => { document.dispatchEvent(new Event('visibilitychange')); });
+
+    expect(rpcMock).toHaveBeenCalledTimes(1);
+
+    act(() => { shared.resolve(snapshot()); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+    expect(mountCount).toBe(1);
+  });
+});

--- a/src/hooks/__tests__/usePermissions.snapshot.test.tsx
+++ b/src/hooks/__tests__/usePermissions.snapshot.test.tsx
@@ -196,6 +196,40 @@ describe('usePermissions — backend snapshot is the only source of truth', () =
     await waitFor(() => expect(result.current.hasPermissionKey(ORDINARY)).toBe(true));
     expect(result.current.loading).toBe(false);
   });
+
+  it('treats a failed background revalidation as no-trusted-snapshot again, so the next retry blocks like an initial load', async () => {
+    // PR #238 review: a background revalidation that fails calls reset(),
+    // which wipes the trusted snapshot this identity had — fail-closed,
+    // unchanged. But hasLoadedSnapshotRef must be wiped along with it. If it
+    // weren't, the NEXT attempt would still read as "already have a trusted
+    // snapshot, this is just a background refresh" and skip setting
+    // `loading`, even though there is nothing trusted left to fall back on
+    // while that next attempt is in flight.
+    rpcMock.mockResolvedValueOnce(snapshot({ permission_keys: [ORDINARY] }));
+    const { result } = renderHook(() => usePermissions());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.hasPermissionKey(ORDINARY)).toBe(true);
+
+    // Tab refocus triggers a revalidation that fails (network blip, expired
+    // session, ...).
+    rpcMock.mockResolvedValueOnce({ data: null, error: { message: 'network blip' } });
+    act(() => { document.dispatchEvent(new Event('visibilitychange')); });
+    await waitFor(() => expect(result.current.error).toBeTruthy());
+    // Fail-closed: the stale grant does not survive an unreadable snapshot.
+    expect(result.current.hasPermissionKey(ORDINARY)).toBe(false);
+
+    // The next attempt (another tab refocus) must block again — there is no
+    // trusted snapshot to lean on, so this is an initial/recovery load, not
+    // a silent background one.
+    const retry = deferred<{ data: unknown; error: null }>();
+    rpcMock.mockImplementation(() => retry.promise);
+    act(() => { document.dispatchEvent(new Event('visibilitychange')); });
+    expect(result.current.loading).toBe(true);
+
+    act(() => { retry.resolve(snapshot({ permission_keys: [ORDINARY] })); });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.hasPermissionKey(ORDINARY)).toBe(true);
+  });
 });
 
 describe('usePermissions — org-switch races and cross-consumer de-duplication', () => {

--- a/src/hooks/__tests__/usePermissions.snapshot.test.tsx
+++ b/src/hooks/__tests__/usePermissions.snapshot.test.tsx
@@ -171,6 +171,31 @@ describe('usePermissions — backend snapshot is the only source of truth', () =
 
     expect(result.current.hasPermissionKey(SENSITIVE)).toBe(false);
   });
+
+  it('does not flip loading back to true for a background revalidation after tab refocus (#237)', async () => {
+    // A trusted snapshot already exists for this identity once the initial
+    // load settles. The visibilitychange listener below re-reads the backend
+    // (correct — a grant/revocation elsewhere must not go unnoticed), but
+    // that re-read must not make `loading` look like a fresh, blocking load:
+    // every ModuleGuard/PermissionGuard/withPermission consumer treats
+    // `loading` as "swap the page out for a spinner", which would unmount an
+    // already-rendered page and destroy any in-progress local state it held.
+    rpcMock.mockResolvedValueOnce(snapshot());
+    const { result } = renderHook(() => usePermissions());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const revalidation = deferred<{ data: unknown; error: null }>();
+    rpcMock.mockImplementation(() => revalidation.promise);
+    act(() => { document.dispatchEvent(new Event('visibilitychange')); });
+
+    // The revalidation request is in flight right now — this is the exact
+    // window in which the pre-fix hook set loading back to true.
+    expect(result.current.loading).toBe(false);
+
+    act(() => { revalidation.resolve(snapshot({ permission_keys: [ORDINARY] })); });
+    await waitFor(() => expect(result.current.hasPermissionKey(ORDINARY)).toBe(true));
+    expect(result.current.loading).toBe(false);
+  });
 });
 
 describe('usePermissions — org-switch races and cross-consumer de-duplication', () => {

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -126,6 +126,18 @@ export function usePermissions(): UserPermissions & {
   // no longer cares about, and must not overwrite the newer state.
   const latestRequestKeyRef = useRef<string | null>(null);
 
+  // Whether a trusted snapshot has already been obtained for the CURRENT
+  // identity. `loading` means "no trusted snapshot exists yet" — true only
+  // until the first successful (or cache-hit) read for this (user, org)
+  // pair. A later re-read of an identity that already has one — the
+  // visibilitychange listener below, or an explicit refreshPermissions() —
+  // is a background revalidation, not an initial load, and must not flip
+  // `loading` back to true: every ModuleGuard/PermissionGuard/withPermission
+  // consumer swaps `children` out for a loading screen while `loading` is
+  // true, which would unmount an already-rendered page — and any
+  // component-local state it held — for the duration of the re-check.
+  const hasLoadedSnapshotRef = useRef(false);
+
   // Detecting an org/user switch here, during render, is deliberate rather
   // than doing it in its own useEffect. An effect runs after the mount/reload
   // effect below in the same commit, so it would wipe out a result that
@@ -158,6 +170,9 @@ export function usePermissions(): UserPermissions & {
   if (lastRenderedKeyRef.current !== renderRequestKey) {
     lastRenderedKeyRef.current = renderRequestKey;
     latestRequestKeyRef.current = renderRequestKey;
+    // A genuinely new identity has no trusted snapshot yet — back to an
+    // initial, fail-closed load for it.
+    hasLoadedSnapshotRef.current = false;
     reset();
     setError(null);
     setLoading(renderRequestKey !== null);
@@ -205,10 +220,17 @@ export function usePermissions(): UserPermissions & {
       setIsOrgAdmin(permissionCache.isOrgAdmin);
       setIsSuperAdmin(permissionCache.isSuperAdmin);
       setLoading(false);
+      hasLoadedSnapshotRef.current = true;
       return;
     }
 
-    setLoading(true);
+    // Only the first read for this identity blocks. A trusted snapshot
+    // already exists past this point on a background revalidation, so
+    // `loading` stays false while the RPC round-trip is in flight — see the
+    // ref's declaration above for why.
+    if (!hasLoadedSnapshotRef.current) {
+      setLoading(true);
+    }
     setError(null);
 
     const { snapshot, error: snapshotError } = await fetchPermissionSnapshot(requestKey, orgIdToCheck);
@@ -260,6 +282,7 @@ export function usePermissions(): UserPermissions & {
     setSensitivePermissionKeys(sensitive);
     setIsOrgAdmin(!!snapshot.is_org_admin);
     setIsSuperAdmin(!!snapshot.is_super_admin);
+    hasLoadedSnapshotRef.current = true;
 
     permissionCache = {
       orgId: orgIdToCheck,
@@ -279,6 +302,7 @@ export function usePermissions(): UserPermissions & {
       loadPermissions();
     } else {
       latestRequestKeyRef.current = null;
+      hasLoadedSnapshotRef.current = false;
       reset();
       setLoading(false);
     }

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -247,6 +247,11 @@ export function usePermissions(): UserPermissions & {
       // Fail closed: an unreadable snapshot must not leave stale grants in place.
       reset();
       setLoading(false);
+      // reset() just cleared whatever trusted snapshot this identity had —
+      // there is no longer one to fall back on, so the NEXT attempt is an
+      // initial/recovery load again, not a background revalidation, and
+      // must block like one.
+      hasLoadedSnapshotRef.current = false;
       return;
     }
 
@@ -264,6 +269,9 @@ export function usePermissions(): UserPermissions & {
       setError('فشل تحميل الصلاحيات');
       reset();
       setLoading(false);
+      // Same reasoning as the read-failure branch above: no trusted
+      // snapshot survives this reset, so the next attempt must block again.
+      hasLoadedSnapshotRef.current = false;
       return;
     }
 


### PR DESCRIPTION
Fixes #237.

## Summary

- Tab refocus makes `usePermissions()` revalidate its permission snapshot via a `visibilitychange` listener — correct and unchanged. The bug: that revalidation unconditionally set `loading = true` before the RPC round-trip, and every guard built on the hook (`ModuleGuard`, `PermissionGuard`, `withPermission`) renders a loading screen **in place of** `children` while `loading` is true. That swap unmounted the already-rendered page and remounted it once the snapshot resolved, destroying any in-progress component-local state it held (form input, wizard step, ...).
- Fix establishes the invariant: `loading` = "no trusted permission snapshot exists yet for the current identity." A `hasLoadedSnapshotRef` tracks whether the first read for the current identity has already succeeded (or hit a warm cache); `loadPermissions()` only sets `loading = true` when it hasn't. The ref resets on an actual identity change (new org/user — still fail-closed, unchanged behavior), on sign-out, **and on a failed revalidation** (see review correction below).
- A background revalidation (tab refocus, or an explicit `refreshPermissions()`) against an identity that already has a trusted snapshot now runs without ever touching `loading`, so the guard keeps rendering the current page while the RPC is in flight, and only re-renders once the answer arrives — access denied if the permission was revoked, unchanged otherwise.
- Scope: one hook (`src/hooks/usePermissions.ts`). No changes to any guard component, the RPC contract, the cross-instance in-flight request dedup (`inFlightSnapshotRequests`), or the permission cache.

## Review correction (commit `cdf8ade`)

Caught in review: `loadPermissions()`'s two failure branches (unreadable snapshot, identity mismatch) call `reset()` to fail closed, clearing the trusted permission state — but left `hasLoadedSnapshotRef` at `true`. That broke the hook's own invariant: after `reset()` there is no trusted snapshot left, yet the ref said there was, so the *next* attempt would still skip `setLoading(true)` and silently behave like a background refresh with nothing trusted to fall back on while it was in flight.

Fix: both failure branches now also set `hasLoadedSnapshotRef.current = false`, so a retry after a failed revalidation is correctly treated as an initial/recovery load again — it blocks with `loading = true` until a new snapshot is obtained. Added a hook-level regression test (`treats a failed background revalidation as no-trusted-snapshot again, so the next retry blocks like an initial load`) and confirmed it fails against the pre-correction code before restoring the fix.

## Known remaining gap (tracked separately, not blocking)

A failed revalidation — including a purely transient network/session error, not an actual revocation — still fails closed by clearing permissions, which unmounts the guarded page to Access Denied just like a real revocation would. That can lose unsaved input on a transient blip, distinct from the case this PR fixes (a *successful* revalidation no longer unmounts anything). Filed as #239 for a separate design pass (e.g. a non-destructive blocking overlay for transient failures instead of unmounting, while still blocking sensitive actions) — explicitly out of scope here so as not to touch the fail-closed security behavior in this PR.

## Red → Green evidence

Three commits, in order:

1. **`test(rbac): add RED regression coverage...`** (`0e60147`) — adds the regression tests against the *pre-fix* hook.
   - `does not flip loading back to true for a background revalidation after tab refocus (#237)` (hook-level) — **RED**
   - `does not unmount the page or lose in-progress input on a same-permission background revalidation` (component-level, new `ModuleGuard.background-revalidation.test.tsx`) — **RED**
   - `coalesces one background revalidation across two mounted ModuleGuard consumers (dedup preserved)` — **RED** on the mount-count assertion (the RPC-count/dedup assertion in the same test already passed pre-fix)
   - Safety-net tests already **green** at this commit: `shows LoadingState and blocks content on the very first load (fail-closed, unchanged)`, `still enforces a permission revoked during background revalidation`.

2. **`fix(rbac): stop background permission revalidation from unmounting the page...`** (`16ce027`) — the minimal hook change. All of the above **GREEN** afterward, along with the full existing suite (4602/4602).

3. **`fix(rbac): reset hasLoadedSnapshotRef when a revalidation fails...`** (`cdf8ade`) — the review correction above, plus its regression test, confirmed RED against the pre-correction code and GREEN after (4603/4603 full suite).

```
# after commit 1, before commit 2 (pre-fix):
 Tests  3 failed | 17 passed (20)   [usePermissions.snapshot.test.tsx + ModuleGuard.background-revalidation.test.tsx]

# after commit 2 (post-fix, pre-correction):
 Tests  122 passed (122)  [full auth/permissions-guard targeted set]
 Tests  4602 passed (4602) [full project suite, 308 files]

# new invariant test against pre-correction code (isolated run):
 Tests  1 failed | 16 skipped (17)  — "expected false to be true" on result.current.loading

# after commit 3 (post-correction):
 Tests  4603 passed (4603) [full project suite, 308 files]
```

## What each new/changed test covers

- **Unmount / state loss (the reported bug):** a `<DraftForm>` with an `<input>` inside `ModuleGuard` keeps its typed, unsaved value and does not remount across a same-permission background revalidation triggered by `visibilitychange`.
- **Security counterpart:** a permission revoked while a background revalidation is in flight is still enforced — the guard swaps to `AccessDeniedPage` once the new snapshot arrives.
- **Initial load stays fail-closed:** the very first load for an identity still blocks on `LoadingState` until the RPC resolves — unchanged.
- **Dedup preserved:** one `visibilitychange` event across two mounted `ModuleGuard` consumers still produces exactly one `rpc_permission_snapshot` call (`inFlightSnapshotRequests`), and neither consumer's subtree unmounts.
- **Hook-level:** `usePermissions().loading` stays `false` throughout a background revalidation once a trusted snapshot already exists for the current identity.
- **Failed-revalidation recovery (review correction):** a background revalidation that fails is fail-closed as before (stale grant cleared), and the *next* attempt for that identity blocks with `loading = true` again, rather than silently behaving like a background refresh with nothing trusted behind it.

## Test plan

- [x] `usePermissions.snapshot.test.tsx` (21 tests, includes both new RED→GREEN hook tests)
- [x] `ModuleGuard.background-revalidation.test.tsx` (new, 4 tests)
- [x] `ModuleGuard.identity-switch.test.tsx`, `ModuleGuard.module-access.test.tsx` (unchanged, still green — org-switch fail-closed and per-route permission contract unaffected)
- [x] Broader permission-gating suite (purchasing, manufacturing, inventory, sales, sidebar, route-permissions) — 90/90 passed
- [x] Full project test suite — 4603/4603 passed
- [x] `tsc --noEmit` — clean
- [x] `eslint` on changed files — clean

## Constraints honored

- No broad RBAC refactor, no auth/session redesign, no database/RPC/RLS/migration changes, no unrelated cleanup.
- Not merged; no Production write performed.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAR77Gn6eXH1HFqXqEHrEN