### PR TITLE
Harden SECURITY DEFINER acceptance contract for PR #241

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main, develop ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main, develop, f2/m191-stock-concurrency-implementation ]
 
 jobs:
   test:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -316,6 +316,30 @@ jobs:
           PGUSER: postgres
           PGPASSWORD: postgres
 
+      - name: DEFINER guard contract in the catalog (and proof it can fail)
+        # check_definer_guards.py proves STRUCTURE inside one migration's bytes.
+        # This proves the FINAL STATE the chain produced and the PostgreSQL
+        # semantics the scanner's rules rest on - which functions really are
+        # SECURITY DEFINER, who can really execute them, and whether the
+        # recognized guards still resolve to the reviewed single-signature
+        # helpers. The selftest feeds four broken catalogs through the same file
+        # first and reverts every mutation, so a gate that cannot fail cannot
+        # pass unnoticed.
+        run: |
+          set -Eeuo pipefail
+          if ! psql -d wardah_fresh -tAc \
+            "SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+             WHERE n.nspname = 'public'
+               AND p.proname = 'wardah_lock_products_for_stock_write'" | grep -q 1; then
+            echo "⏭ migration 191 not present in fresh DB (baseline may be ahead) — skipping"
+            exit 0
+          fi
+          PGDATABASE=wardah_fresh bash scripts/ci/fresh-db/selftest_definer_guard_contract.sh
+        env:
+          PGHOST: localhost
+          PGUSER: postgres
+          PGPASSWORD: postgres
+
       - name: Upload reference data report
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/f2-stock-write-concurrency-191-acceptance.yml
+++ b/.github/workflows/f2-stock-write-concurrency-191-acceptance.yml
@@ -30,6 +30,8 @@ on:
       - 'scripts/ci/fresh-db/acceptance_f2_stock_bin_race_red.sh'
       - 'scripts/ci/check_definer_guards.py'
       - 'scripts/ci/test_check_definer_guards.py'
+      - 'scripts/ci/fresh-db/acceptance_definer_guard_contract.sql'
+      - 'scripts/ci/fresh-db/selftest_definer_guard_contract.sh'
       - 'docs/db/m191-slices/**'
       - 'docs/db/m191-evidence/harness/**'
       - '.github/workflows/f2-stock-write-concurrency-191-acceptance.yml'
@@ -106,6 +108,22 @@ jobs:
           python3 scripts/ci/test_check_definer_guards.py 2>&1 | tee /tmp/191-definer-selftest.out
           python3 scripts/ci/check_definer_guards.py
 
+      - name: DEFINER guard contract in the catalog (and proof it can fail)
+        # The static scanner reads one migration's bytes; it cannot see what the
+        # whole chain finally produced. This step asks the database instead:
+        # which functions ARE definer, who can actually execute them, whether the
+        # recognized guards are still the reviewed single-signature functions,
+        # and whether PL/pgSQL still catches P0001 by its class code P0000 - the
+        # semantics the scanner's swallow analysis rests on. The selftest drives
+        # four deliberately broken catalogs through the same file first, so a
+        # gate that cannot fail cannot pass unnoticed. It reverts every mutation.
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          bash scripts/ci/fresh-db/selftest_definer_guard_contract.sh \
+            2>&1 | tee /tmp/191-definer-contract.out
+          grep -q 'DEFINER_GUARD_CONTRACT_SELFTEST_PASS' /tmp/191-definer-contract.out
+
       - name: Catalog contract for the thirteen objects
         shell: bash
         run: |
@@ -170,6 +188,7 @@ jobs:
           path: |
             /tmp/chain_report.txt
             /tmp/191-definer-selftest.out
+            /tmp/191-definer-contract.out
             /tmp/191-contract.out
             /tmp/191-selftest.out
             /tmp/191-static.out

--- a/.github/workflows/f2-stock-write-concurrency-191-acceptance.yml
+++ b/.github/workflows/f2-stock-write-concurrency-191-acceptance.yml
@@ -22,7 +22,7 @@ name: F2 Stock Write Concurrency 191 Acceptance
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, f2/m191-stock-concurrency-implementation]
     paths:
       - 'sql/migrations/191_f2_stock_write_concurrency_closure.sql'
       - 'scripts/ci/fresh-db/acceptance_191_f2_stock_write_concurrency.sql'

--- a/docs/db/m191-evidence/M191_DEFINER_SCANNER_ACCEPTANCE_HARDENING.md
+++ b/docs/db/m191-evidence/M191_DEFINER_SCANNER_ACCEPTANCE_HARDENING.md
@@ -59,10 +59,16 @@ falsifiable by `scripts/ci/fresh-db/selftest_definer_guard_contract.sh`.
 
 ## 3. The REDs, reproduced through the real `check_file()` first
 
-Every row below returned `[]` — accepted, no error — at the reviewed head
-`afc0272a09070e4a9c60c68c0eac4b8447e7ce14`, from a temporary `999_*.sql`
-(strict) or `150_*.sql` (historical) fixture driven through `check_file()`
-itself, not through a helper.
+Every row below was driven through `check_file()` itself — not through a helper
+— from a temporary `999_*.sql` (strict) or `150_*.sql` (historical) fixture, at
+the reviewed head `afc0272a09070e4a9c60c68c0eac4b8447e7ce14`.
+
+Rows are labelled by what that run actually returned. A row with `accepted` in
+the **Before** column returned `[]` there: that is the false green, frozen. A row
+marked **control** was already rejected at the reviewed head and is kept as a
+regression case — it is *not* a closed finding, and is not counted as one. Six
+fixtures across sections D and G are controls; they are called out in place
+rather than left to inflate the total.
 
 ### D — exception categories catching authorization failures
 
@@ -76,9 +82,17 @@ placement cannot be the reason it passed.
 | `WHEN SQLSTATE 'P0000'` | accepted | rejected |
 | `WHEN SQLSTATE /* reason */ 'P0001'` | accepted | rejected |
 | `WHEN unique_violation OR plpgsql_error` | accepted | rejected |
-| `WHEN unique_violation OR SQLSTATE 'P0001'` | accepted | rejected |
-| `WHEN OTHERS` / `raise_exception` / `SQLSTATE 'P0001'` | rejected | rejected |
+| `WHEN unique_violation OR SQLSTATE 'P0001'` | rejected — **control** | rejected |
+| `WHEN OTHERS` / `raise_exception` / `SQLSTATE 'P0001'` | rejected — **control** | rejected |
 | `WHEN unique_violation` / `foreign_key_violation` / `data_exception` | accepted | **accepted** (no false red) |
+
+The two **control** rows cover four fixtures that were already rejected at the
+reviewed head, and are kept as regression cases rather than counted as closed
+findings: `OTHERS` and `raise_exception` were matched by name by the old
+condition regex, and `SQLSTATE 'P0001'` — alone or inside an OR list — was found
+by the old raw-text search, which scanned the whole handler range. The four
+reject rows above them are the closure: the category door, which nothing
+reached. The final row is an accept control.
 
 PostgreSQL matches a handler either on the exact SQLSTATE or on its **category**
 — a code whose last three characters are `000`. A bare `RAISE EXCEPTION` is
@@ -131,10 +145,17 @@ age.
 | `REVOKE ... ON FUNCTION public.f_somewhere_else(uuid) FROM PUBLIC` | accepted | rejected |
 | `REVOKE ... ON FUNCTION public.f_c(text)` for a definition of `f_c(uuid)` | accepted | rejected |
 | REVOKE from PUBLIC, then `GRANT ... TO PUBLIC` | accepted | rejected |
-| REVOKE placed **before** the definition | accepted | rejected |
-| `REVOKE ... ON ALL FUNCTIONS IN SCHEMA public` | accepted | rejected (not attribution) |
+| REVOKE placed **before** the definition | rejected — **control** | rejected |
+| `REVOKE ... ON ALL FUNCTIONS IN SCHEMA public` | rejected — **control** | rejected (not attribution) |
 | close PUBLIC, grant `authenticated` (strict) | accepted | rejected |
 | close PUBLIC, grant `authenticated` (≤190) | accepted | **accepted** — see below |
+
+The two **control** rows were already rejected at the reviewed head — the old
+window started at the definition, so an earlier REVOKE was never in it, and the
+old pattern required `ON FUNCTION`, so `ON ALL FUNCTIONS IN SCHEMA` never
+matched. They are kept because the rewrite could easily have started crediting
+either, and neither should be credited. The four closed findings are the three
+reject rows above them plus the strict `authenticated` row below.
 
 The exemption is now an ACL replay against the definition's own identity:
 PostgreSQL grants EXECUTE to PUBLIC on every new function, so the surface starts
@@ -195,9 +216,21 @@ same-named function is likewise no longer conflated with `public`'s.
 
 Three separate closures, because an overload is a different function in
 PostgreSQL: `KNOWN_EXEMPT` stops applying at the cutoff, a recognized guard call
-must match the helper's canonical arity, and a migration that redefines a
-recognized helper is a hard stop rather than a judgement call — the guard the
-scanner reads and the guard the database will run would be two different bodies.
+must match the helper's canonical arity, and **from the cutoff on** a migration
+that redefines a recognized helper is a hard stop rather than a judgement call —
+the guard the scanner reads and the guard the database will run would be two
+different bodies.
+
+That third rule is scoped to ≥191 because it has to be, not out of caution:
+`123_fix_user_profile_trigger_and_active_guards.sql` and
+`178_journal_rbac_and_canonical_manual_lifecycle.sql` both replace a recognized
+helper and both sit inside the scanned set, so a rule applied at every age would
+turn two immutable historical migrations red. The consequence is worth stating
+plainly: from 191 on there is no escape hatch for a legitimate helper
+replacement, and migration 178 is proof that those happen. A migration that
+genuinely must replace one of the four helpers has to change this scanner in the
+same PR, with the review that implies — which is the intent, but it is a cost,
+not a free rule.
 
 ## 4. What did NOT change verdict
 
@@ -299,3 +332,20 @@ the catalog exactly as it found it.
 - The strict reachability rules can reject a future function whose returns and
   raises are all provably guarded. The remedy is to move the authorization
   boundary earlier, never to weaken the gate.
+- **The catalog contract's assertions 4 and 5 are fixture-scoped, and do not
+  enumerate.** §4 pins the security mode of thirteen named signatures and §5 the
+  privilege ledger of five, against roughly 155 `SECURITY DEFINER` functions in
+  `public`. A function outside those lists — unguarded, `SECURITY DEFINER`, and
+  granted to `authenticated` — leaves the contract green; that was verified by
+  creating exactly such a function and watching `DEFINER_GUARD_CONTRACT_PASS`
+  still print. The static scanner is what covers that case, and only for
+  migrations newer than the baseline cutoff, so a definer surface opened by an
+  older migration and never altered since is asserted by neither layer. §§1-3
+  (exception semantics, guard identity, mixed-case twins) *are* catalog-wide.
+  Widening §§4-5 into an enumeration with a pinned allowlist is a real
+  improvement and a separate change: it would have to classify all 155, which is
+  an audit, not a polish.
+- The selftest proves four of the five assertions falsifiable. §1 has no mutant
+  because its subject is PostgreSQL's own matching rule, which cannot be mutated
+  from SQL; its negative control (`unique_violation` must not catch) is the
+  discrimination evidence that stands in for one.

--- a/docs/db/m191-evidence/M191_DEFINER_SCANNER_ACCEPTANCE_HARDENING.md
+++ b/docs/db/m191-evidence/M191_DEFINER_SCANNER_ACCEPTANCE_HARDENING.md
@@ -1,0 +1,301 @@
+# SECURITY DEFINER scanner — acceptance-layer hardening
+
+**Scope:** `scripts/ci/check_definer_guards.py` and its acceptance layer.
+**Migration 191 production SQL is byte-unchanged.** `sql/migrations/191_f2_stock_write_concurrency_closure.sql`
+stays at `md5 ff7b8c01a59e290825056b11ed9febbd`; nothing in this pass edits it.
+**Zero `KNOWN_EXEMPT` entries were added** — the set is asserted intact by
+`test_no_new_known_exempt_entries`, and is now *narrowed* rather than widened.
+
+---
+
+## 1. Why this is one pass and not six regex patches
+
+Five of the six accepted findings have the same root: the scanner attributed
+`SECURITY DEFINER` **by position** — find the phrase, walk backwards to the
+nearest `CREATE ... FUNCTION`, take the next 4000 characters as the body, and
+accept any `REVOKE ... FROM PUBLIC` that happened to sit before the next
+`CREATE`. Every one of those steps is an assumption about layout, not about
+identity, and each finding is a different way to violate the layout while
+staying valid SQL.
+
+Patching them individually would have added six more layout assumptions. The
+pass instead parses each file's statements **once**, into identities:
+
+```
+CREATE/ALTER FUNCTION  ->  Identity(schema, name, arg-type list)  + own extent
+GRANT/REVOKE           ->  Identity targets + grantees + order
+```
+
+and every later rule reads that model. A definition owns only its own statement,
+so it cannot borrow the next function's body; a REVOKE is credited only to the
+function it names; an `ALTER ... SECURITY DEFINER` is a statement in its own
+right rather than something blamed on its neighbour; and a quoted identity is
+read from the unmasked source, case intact.
+
+The sixth finding — exception categories — is not attribution but PostgreSQL
+semantics, and is handled by resolving handler conditions properly rather than
+by adding alternatives to a regex.
+
+## 2. Which layer owns what
+
+The instruction was explicit: catalog-backed validation where PostgreSQL
+semantics are required, static scanning only for structural guarantees, and no
+attempt at a PL/pgSQL compiler. The split:
+
+| Question | Layer | Why |
+|---|---|---|
+| Is the guard an executable call, at outer level, reachable, un-swallowed? | static | structure inside one file's bytes |
+| Does this REVOKE name this function and this overload? | static | structure inside one file's bytes |
+| Is this `ALTER ... SECURITY DEFINER` guarded by anything? | static | nothing to read — rejected structurally |
+| Is a quoted identity a different function from an exempt name? | static | identity is textual |
+| Does `WHEN plpgsql_error` catch a `RAISE EXCEPTION`? | **catalog** | PostgreSQL's matching rule, asserted live |
+| Which functions really ARE `SECURITY DEFINER` after the whole chain? | **catalog** | a later migration's ALTER is invisible per-file |
+| Who really holds EXECUTE at the end? | **catalog** | the ACL is the authority, not the DDL text |
+| Does a guard NAME still resolve to the reviewed helper? | **catalog** | overload resolution is the database's job |
+
+Static: `scripts/ci/check_definer_guards.py`, `scripts/ci/test_check_definer_guards.py`.
+Catalog: `scripts/ci/fresh-db/acceptance_definer_guard_contract.sql`, proved
+falsifiable by `scripts/ci/fresh-db/selftest_definer_guard_contract.sh`.
+
+## 3. The REDs, reproduced through the real `check_file()` first
+
+Every row below returned `[]` — accepted, no error — at the reviewed head
+`afc0272a09070e4a9c60c68c0eac4b8447e7ce14`, from a temporary `999_*.sql`
+(strict) or `150_*.sql` (historical) fixture driven through `check_file()`
+itself, not through a helper.
+
+### D — exception categories catching authorization failures
+
+Fixture shape: the assertion at the function's own outer statement level, the
+handler on the function's own `BEGIN`, a privileged write in the handler. So
+placement cannot be the reason it passed.
+
+| Handler | Before | After |
+|---|---|---|
+| `WHEN plpgsql_error` (class P0000) | accepted | rejected |
+| `WHEN SQLSTATE 'P0000'` | accepted | rejected |
+| `WHEN SQLSTATE /* reason */ 'P0001'` | accepted | rejected |
+| `WHEN unique_violation OR plpgsql_error` | accepted | rejected |
+| `WHEN unique_violation OR SQLSTATE 'P0001'` | accepted | rejected |
+| `WHEN OTHERS` / `raise_exception` / `SQLSTATE 'P0001'` | rejected | rejected |
+| `WHEN unique_violation` / `foreign_key_violation` / `data_exception` | accepted | **accepted** (no false red) |
+
+PostgreSQL matches a handler either on the exact SQLSTATE or on its **category**
+— a code whose last three characters are `000`. A bare `RAISE EXCEPTION` is
+P0001, whose category is P0000, so `plpgsql_error` catches it. Verified live,
+not inferred, and pinned by §1 of the catalog contract.
+
+Handler conditions are now resolved on **masked structure** with only the
+SQLSTATE *value* recovered from the raw source. That is what makes the
+comment-separated form resolve without a separator regex having to anticipate
+comments: by the time the condition is read, the comment is whitespace.
+
+Unknown condition names are treated as non-catching, and that is sound rather
+than optimistic: PostgreSQL rejects an unrecognized condition name at compile
+time, so an attacker cannot invent one. Only `OTHERS`, `raise_exception` and
+`plpgsql_error` can reach P0001.
+
+### E — unreachable guards due to control flow
+
+`RETURN` was modelled; an aborting `RAISE` at the outer statement level was not.
+
+```sql
+RAISE EXCEPTION 'NOT_IMPLEMENTED';
+PERFORM public.wardah_assert_org_member(p_org);   -- accepted; never executes
+```
+
+A raise **inside a conditional** is not an exit and must not cost a real guard
+its recognition — `IF p_org IS NULL THEN RAISE ...; END IF;` before the
+assertion is a positive control. `RAISE NOTICE` is not an abort. The rule is
+strict-contract only, like the RETURN rule it extends.
+
+### F — body attribution (the same class, from the other side)
+
+```sql
+CREATE FUNCTION public.f_unreadable(p_org uuid) ... LANGUAGE internal
+  SECURITY DEFINER AS 'boolin';      -- no dollar-quoted body of its own
+CREATE FUNCTION public.f_guarded(p_org uuid) ... AS $guarded$ ... PERFORM guard ... $guarded$;
+```
+
+The body extractor searched **forward** for the first `AS $tag$`, so
+`f_unreadable` was scanned using `f_guarded`'s body and inherited its guard. A
+definition is now bounded by its own statement; a `SECURITY DEFINER` routine
+whose body the scanner cannot read is rejected, never lent someone else's. The
+SQL-standard `BEGIN ATOMIC` body is rejected the same way, at every migration
+age.
+
+### G — misleading REVOKE attribution
+
+| Fixture | Before | After |
+|---|---|---|
+| `REVOKE ... ON FUNCTION public.f_somewhere_else(uuid) FROM PUBLIC` | accepted | rejected |
+| `REVOKE ... ON FUNCTION public.f_c(text)` for a definition of `f_c(uuid)` | accepted | rejected |
+| REVOKE from PUBLIC, then `GRANT ... TO PUBLIC` | accepted | rejected |
+| REVOKE placed **before** the definition | accepted | rejected |
+| `REVOKE ... ON ALL FUNCTIONS IN SCHEMA public` | accepted | rejected (not attribution) |
+| close PUBLIC, grant `authenticated` (strict) | accepted | rejected |
+| close PUBLIC, grant `authenticated` (≤190) | accepted | **accepted** — see below |
+
+The exemption is now an ACL replay against the definition's own identity:
+PostgreSQL grants EXECUTE to PUBLIC on every new function, so the surface starts
+open, only a REVOKE that names this function closes it, and a later GRANT
+re-opens it.
+
+**Historical compatibility is explicit and bounded.** Requiring `anon` and
+`authenticated` to be closed as well — which is what the project contract has
+always said, "اسحب EXECUTE من PUBLIC **والعملاء**" — turns three immutable
+historical migrations red: `123_fix_user_profile_trigger_and_active_guards.sql`
+(`wardah_is_org_admin`), `175_rbac_consumer_migration_rpcs.sql`
+(`rpc_set_org_admin`) and `186_stock_moves_contract_repair.sql`
+(`rpc_complete_manufacturing_order`), each of which closes PUBLIC and grants
+`authenticated` while carrying its own reviewed authorization. So the full
+client closure is required **from the strict cutoff on**, and below it the
+historical PUBLIC-only test is preserved. The cutoff is a migration NUMBER; no
+function is exempted by name.
+
+A PUBLIC re-grant is rejected at every age — that one is not a historical
+practice, it is a defect.
+
+### H — `ALTER FUNCTION ... SECURITY DEFINER`
+
+| Fixture | Before | After |
+|---|---|---|
+| `ALTER FUNCTION public.f_legacy(uuid) SECURITY DEFINER;` alone | accepted (no CREATE to attribute to → skipped) | rejected |
+| the same, after a guarded function | accepted (borrowed that guard) | rejected |
+| the same, closed then `GRANT ... TO PUBLIC` | accepted | rejected |
+| `ALTER ... SECURITY INVOKER` (migration 120's shape) | accepted | **accepted** |
+| ALTER of a function this migration defines and guards | accepted | **accepted** |
+| ALTER plus a named full closure | accepted | **accepted** |
+
+An ALTER restates no body, so there is nothing to prove a guard from. It is
+accepted only when the same migration also defines that exact function — whose
+CREATE was checked on its own terms — or closes it to every client role. The
+repository contains no `ALTER FUNCTION ... SECURITY DEFINER` today, so this
+rule costs nothing now and closes the door before it is used.
+
+### I — quoted function identities
+
+`CREATE FUNCTION public."f_quoted"(...)` matched no definition at all: the name
+pattern read the MASKED text, where quoted-identifier content is blanked by
+design. Its `SECURITY DEFINER` was therefore attributed to an earlier function
+or dropped. Identities are now read from the unmasked source with case intact,
+which also settles `public."HAS_PERMISSION"` — a *different* function from
+`has_permission`, and no longer able to inherit its exemption. Another schema's
+same-named function is likewise no longer conflated with `public`'s.
+
+### J — overload guard impersonation
+
+| Fixture | Before | After |
+|---|---|---|
+| new overload `public.has_permission(uuid)` in a strict migration | accepted (exempt by name) | rejected |
+| the migration defines a no-op `wardah_assert_org_member(text)` and calls it | accepted | rejected |
+| `PERFORM public.wardah_assert_org_member()` — zero args | accepted | rejected |
+| `PERFORM public.wardah_assert_org_member(p_org, p_org)` | accepted | rejected |
+| `IF NOT wardah_is_org_member(p_org, p_org) THEN RAISE` | accepted | rejected |
+
+Three separate closures, because an overload is a different function in
+PostgreSQL: `KNOWN_EXEMPT` stops applying at the cutoff, a recognized guard call
+must match the helper's canonical arity, and a migration that redefines a
+recognized helper is a hard stop rather than a judgement call — the guard the
+scanner reads and the guard the database will run would be two different bodies.
+
+## 4. What did NOT change verdict
+
+`check_definer_guards.py` still reports **61 migrations clean** — the same set,
+with the same verdict, including Migration 191 and Migration 190.
+
+The full old-vs-new sweep over all 242 `sql/migrations/*.sql` and
+`sql/baseline/*.sql` files shows verdict changes only **outside** the scanned
+set, and every one is the same correction: the old window
+(`after.split("CREATE")[0]`) cut a file's REVOKE block off, so a function that
+its own migration genuinely closes was reported unguarded. `117` (one function)
+and the eleven `pg_dump` baselines — which emit every REVOKE at the end of the
+file, after every CREATE — are that false positive.
+
+Migration 191's own resolution, printed from the model:
+
+```
+public.wardah_apply_stock_incoming(...9 args...)   closed=True  guarded=False
+public.wardah_apply_stock_incoming(...10 args...)  closed=True  guarded=False
+public.wardah_apply_stock_outgoing(...8 args...)   closed=True  guarded=True
+public.wardah_apply_stock_outgoing(...9 args...)   closed=True  guarded=True
+public.rpc_cancel_stock_adjustment(uuid,text)      closed=False guarded=True
+public.rpc_manual_stock_movement_v2(jsonb)         closed=False guarded=True
+public.rpc_post_goods_receipt(jsonb)               closed=False guarded=True
+public.rpc_post_delivery_note(jsonb)               closed=False guarded=True
+public.rpc_submit_stock_adjustment(uuid)           closed=False guarded=True
+public.rpc_consume_reserved_materials_v2(...)      closed=False guarded=True
+public.rpc_create_mo_with_reservation(...)         closed=False guarded=True
+```
+
+`closed=True` here is the **strict** closure — PUBLIC *and* `anon` *and*
+`authenticated` — so 191 satisfies the hardest form of the contract on its own
+merits: nine guarded, two closed to every client, none exempted by name. That is
+asserted as a test, `test_migration_191_still_relies_on_no_exemption`, so it
+cannot quietly become an exemption later.
+
+## 5. Catalog contract and its selftest
+
+`acceptance_definer_guard_contract.sql` asserts five things the static scanner
+cannot:
+
+1. **Exception semantics, live.** P0001 is caught by its own code and by class
+   P0000; `unique_violation` does not catch it. If PostgreSQL ever changed
+   either, the scanner's rules would be wrong and this gate says so.
+2. **Guard identity.** Each recognized helper exists with exactly its reviewed
+   signature, has exactly one overload, is `SECURITY DEFINER` with a hardened
+   `search_path`, and — for the three raising helpers — actually contains a
+   `RAISE EXCEPTION`.
+3. **No mixed-case twins** anywhere in `public`.
+4. **Final security mode** of all thirteen Migration 191 objects, pinned
+   `prosecdef` by `prosecdef` — the catalog-side answer to a later `ALTER`.
+5. **Privilege ledger** for the five closure-exempt helpers, checked twice: via
+   `has_function_privilege` (which resolves the PUBLIC pseudo-role) and via
+   `aclexplode(...).grantee = 0`, plus a `proacl IS NULL` check because a
+   default ACL still carries PUBLIC's inherited EXECUTE.
+
+`selftest_definer_guard_contract.sh` drives four broken catalogs through the
+**real** contract file — a shadow guard overload, a quoted mixed-case name, an
+`ALTER ... SECURITY DEFINER`, and an EXECUTE grant to `authenticated` — requires
+each to be rejected **by its own error token** (so a mutant cannot pass the
+selftest by failing for an unrelated reason), then reverts every mutation and
+proves the contract green again.
+
+## 6. Verification run
+
+On a Fresh **PostgreSQL 17.11** database built exactly as the acceptance
+workflow does — shim → baseline `000_schema_baseline_20260905_184634.sql`
+(cutoff 189) → its reference-data pair → `190` → `191`:
+
+| Stage | Result |
+|---|---|
+| `check_definer_guards.py` | ✅ 61 migrations, 0 errors |
+| `test_check_definer_guards.py` | ✅ 44 tests |
+| `selftest_definer_guard_contract.sh` | ✅ `DEFINER_GUARD_CONTRACT_SELFTEST_PASS` (4 mutants, catalog restored) |
+| `acceptance_definer_guard_contract.sql` | ✅ `DEFINER_GUARD_CONTRACT_PASS` |
+| `acceptance_191_f2_stock_write_concurrency.sql` | ✅ `M191_ACCEPTANCE_CONTRACT_PASS` |
+| `12_acceptance_gate_selftest.sql` | ✅ `M191_GATE_SELFTEST_PASS` (positive=7 mutants=15) + `M191_GATE_SELFTEST_REMEDIATION_PASS` |
+| `12_acceptance_static_gates.sql` | ✅ `M191_ACCEPTANCE_STATIC_PASS` |
+| deterministic GREEN harness, 14 scripts | ✅ all `SLICE12_*_PASS` |
+| `acceptance_191_reconciliation.sql` | ✅ `M191_RECONCILIATION_PASS` |
+
+The behavioural harness and the reconciliation were rerun **after** the
+selftest's mutate/revert cycle, so they also evidence that the selftest leaves
+the catalog exactly as it found it.
+
+## 7. Known limits, stated rather than hidden
+
+- The rules remain **syntactic**. A guard called with a hard-coded organization
+  id rather than the one being written is still accepted; binding the assertion
+  to the operated tenant is a review question, not a scanner one.
+- Privileged work placed **before** an outer-level assertion is still accepted.
+  PL/pgSQL rolls the statement back when the assertion raises, so it is not a
+  persistence hole; it is a code-order preference, and rejecting it would be a
+  new contract rather than a closure of an accepted finding.
+- `REVOKE ... ON ALL FUNCTIONS IN SCHEMA` genuinely closes PUBLIC, but is
+  deliberately **not** credited as attribution: it names no function, and a
+  blanket statement is exactly the kind of thing a later `GRANT` undoes without
+  anyone noticing.
+- The strict reachability rules can reject a future function whose returns and
+  raises are all provably guarded. The remedy is to move the authorization
+  boundary earlier, never to weaken the gate.

--- a/docs/db/m191-evidence/M191_DEFINER_SCANNER_ACCEPTANCE_HARDENING.md
+++ b/docs/db/m191-evidence/M191_DEFINER_SCANNER_ACCEPTANCE_HARDENING.md
@@ -316,6 +316,108 @@ The behavioural harness and the reconciliation were rerun **after** the
 selftest's mutate/revert cycle, so they also evidence that the selftest leaves
 the catalog exactly as it found it.
 
+## 6a. Second pass — Codex findings K-O
+
+A Codex review of the first pass found five more, all in the same layer. They
+were reproduced through the real `check_file()` at `97eb585` before anything
+changed. **Two of the five are regressions the first pass introduced**, and are
+labelled as such below rather than presented as pre-existing gaps — the identity
+rewrite closed one door and opened another.
+
+The common root this time is narrower and worth naming: the first pass moved
+attribution onto identities, but kept reading three things off the **masked**
+text that masking is specifically designed to destroy — quoted grantees, quoted
+type names, and the offsets of literals inside an OR list — and it modelled the
+security mode as a property of the `CREATE` statement rather than as a **state**
+that a later `ALTER` changes.
+
+| # | Finding | Verdict at 97eb585 | Origin |
+|---|---|---|---|
+| K | `CREATE ... SECURITY INVOKER` then `ALTER ... SECURITY DEFINER` in the same file | accepted | **first-pass regression** |
+| L | SQLSTATE value read at another term's offset inside an OR list | accepted | pre-existing |
+| M | `GRANT ... TO "authenticated"` re-open invisible | accepted | pre-existing |
+| N | `"TypeA"` and `"TypeB"` overloads collapse to one signature | accepted | pre-existing |
+| O | `REVOKE` with the schema omitted credits another schema's function | accepted | pre-existing |
+
+### K — security mode is a state, not a declaration
+
+```sql
+CREATE OR REPLACE FUNCTION public.f_promoted(p_org uuid) ... SECURITY INVOKER ...;
+ALTER FUNCTION public.f_promoted(uuid) SECURITY DEFINER;   -- accepted, no error
+```
+
+The first pass skipped a promotion whose target is defined in the same file, on
+the reasoning that *"its CREATE was checked above"*. That reasoning holds only
+when the CREATE declared `SECURITY DEFINER`. When it declares `SECURITY INVOKER`
+— or omits the clause — the definition loop skips it as unprivileged and the
+ALTER loop skips it as already covered, so a privileged, unguarded,
+client-callable function passed with **no error at all**. It was the worst
+outcome of the five: not a weakened check, an absent one.
+
+`resolve_security_state()` now applies every ALTER to the definitions it names,
+in file order, before anything is judged. A definition is judged on its
+**final** mode. That fixes the mirror defect too: a function created
+`SECURITY DEFINER` and demoted in the same file ends the migration unprivileged
+and was being reported — a false red the same model removes. An ALTER that
+precedes its CREATE does not decide that CREATE's state; the later statement
+wins. The error message names the promotion so the author is not left wondering
+why an invoker function is being asked for a guard.
+
+### L — SQLSTATE offsets inside an OR list
+
+Masking blanks literal *content* and keeps the delimiters, so
+
+```sql
+WHEN SQLSTATE 'P0002' OR SQLSTATE 'P0001' THEN
+```
+
+masks to two terms that are **textually identical**. The term's offset was
+recovered with `str.index()`, which returns the first match, so the second
+term's value was read out of the first term's raw bytes: the handler catches
+P0001 and the scanner read `P0002`. `_split_top_level_or_spans()` carries real
+offsets instead. The false-red mirror (`'P0001' OR 'P0002'`) is covered too —
+that one happened to be rejected before, for the wrong reason.
+
+### M — quoted grantees
+
+`GRANT EXECUTE ON FUNCTION public.f_c(uuid) TO "authenticated";` named no
+grantee at all in masked text, so the re-open was invisible and the closure
+still looked intact. Grantees are read from the raw source now. A quoted name
+whose content matches the folded role is the same role; one that differs in case
+(`"Authenticated"`) is a different role and does not match — which is
+PostgreSQL's own rule, in both directions.
+
+### N — quoted type names
+
+`public."TypeA"` and `public."TypeB"` are different types, and masking blanks
+both to the same thing, so the two overloads normalized identically and a REVOKE
+naming one credited the other. Argument lists are now split on masked text (so a
+comma inside a literal still cannot split a parameter) but each parameter's text
+is taken from **raw** at the same offsets, and folded everywhere except inside
+quotes.
+
+### O — an omitted schema is not a wildcard
+
+`REVOKE EXECUTE ON FUNCTION f_s(uuid) FROM PUBLIC, anon, authenticated;` was
+credited to `other_schema.f_s`. PostgreSQL resolves an unqualified name through
+`search_path`, which for these migrations puts `public` first — it says nothing
+about a function in another schema. An omitted schema now matches only a
+definition in `public` (or one that also omits it).
+
+This was the one the review flagged as needing reproduction before judgement,
+and the reproduction settles it: it is a real exemption transfer, not a parser
+nit. The companion case — a REVOKE qualified to `public` against a definition in
+`other_schema` — was already rejected and is kept as a control.
+
+### What this pass did not change
+
+No new `KNOWN_EXEMPT` entries. Migration 191 was checked against every rule
+first and passes unchanged, and the scanner still reports 61 migrations clean.
+F3/F4/F5 from the earlier adversarial review (type aliases, argument-less
+REVOKE, malformed DDL skipped rather than failed closed) are deliberately still
+open — they were scoped out of this pass and none is reachable by a file that
+can pass the pglast syntax gate and apply to a Fresh DB.
+
 ## 7. Known limits, stated rather than hidden
 
 - The rules remain **syntactic**. A guard called with a hard-coded organization

--- a/docs/db/m191-evidence/README.md
+++ b/docs/db/m191-evidence/README.md
@@ -175,3 +175,18 @@ gap that let a `ORDER BY mr.id DESC` mutation of the real function stay GREEN, a
 missing UUID parser-parity matrix for Fix E. Their reproduction, fix, RED mutant proof and
 GREEN proof are in `M191_FINAL_REVIEW_REMEDIATION.md`. Migration 191's production body was
 not changed.
+
+## Scanner acceptance-layer hardening (later still)
+
+A subsequent review accepted six further findings, all of them in the SECURITY
+DEFINER scanner's own acceptance layer rather than in Migration 191: exception
+categories that catch an authorization failure, guards made unreachable by
+control flow, misleading REVOKE attribution, `ALTER FUNCTION ... SECURITY
+DEFINER`, quoted function identities, and overload guard impersonation. Each was
+reproduced through the real `check_file()` before any change, and the closure is
+one structural pass — attribution by identity rather than by position — plus a
+catalog-backed contract for the parts only PostgreSQL can answer.
+
+The reproduction, the layer split, the historical-compatibility boundary and the
+full verification run are in `M191_DEFINER_SCANNER_ACCEPTANCE_HARDENING.md`.
+Migration 191's production SQL is byte-unchanged.

--- a/scripts/ci/check_definer_guards.py
+++ b/scripts/ci/check_definer_guards.py
@@ -7,9 +7,15 @@ functions. Fails if any client-callable function lacks one of the reviewed
 server-boundary guards.
 
 A guard counts only when it appears as an executable function CALL
-(`guard(...)` or `public.guard(...)`) inside the masked function body. A
-textual occurrence of the name — a dollar-quote tag, a quoted identifier,
-a bare identifier, comment or literal text — never satisfies the gate.
+(`guard(...)` or `public.guard(...)`) with the helper's canonical arity, inside
+the masked function body. A textual occurrence of the name — a dollar-quote tag,
+a quoted identifier, a bare identifier, comment or literal text — never
+satisfies the gate, and neither does a call to a different overload of the name.
+
+It must also be able to RUN and to DENY: it cannot sit after a terminating
+RETURN or an outer-level aborting RAISE, and no enclosing EXCEPTION handler may
+be able to catch its P0001 — including through that code's class, P0000, which
+`WHEN plpgsql_error` and `WHEN SQLSTATE 'P0000'` both reach.
 
 Recognized guards:
   - wardah_assert_org_member / wardah_assert_org_admin: raise on denial, so a
@@ -24,9 +30,33 @@ Recognized guards:
     active-membership, role-org, role-active and expiry semantics.
 
 Exemptions:
-  - Functions with REVOKE EXECUTE/ALL FROM PUBLIC immediately after definition
+  - Functions this migration itself closes to every client role. The REVOKE must
+    NAME the function - same schema, name and argument types - and no later
+    GRANT in the file may put the privilege back. Below the strict cutoff this
+    keeps its historical meaning (close PUBLIC); from the cutoff on, closing
+    PUBLIC while granting `authenticated` is not a closure.
   - Functions listed in KNOWN_EXEMPT (intentionally open/delegating/superseded,
-    with a documented reason)
+    with a documented reason). That ledger is HISTORICAL: it is keyed by bare
+    name, so it stops applying at MIGRATION_STRICT_CUTOFF, where a new overload
+    of an exempt name would otherwise inherit an exemption written for a
+    different function.
+
+Statement model (what a rule is allowed to assume):
+  Attribution is by IDENTITY, not by position. Every CREATE/ALTER FUNCTION and
+  every GRANT/REVOKE is parsed once into a schema-qualified identity with its
+  argument type list, read from the UNMASKED source so that quoted identifiers
+  are visible and case-sensitive. A definition owns only its own statement, so
+  a routine with no dollar-quoted body cannot borrow the next one's guard, and
+  `ALTER FUNCTION ... SECURITY DEFINER` is a finding in its own right rather
+  than something blamed on the CREATE before it.
+
+Division of labour with the acceptance database:
+  This scanner proves STRUCTURE in one migration's bytes. It cannot see what the
+  whole chain finally produced, so the catalog-side facts - which functions are
+  really SECURITY DEFINER, who can really execute them, and whether a recognized
+  guard name still resolves to the reviewed single-signature helper - are
+  asserted by scripts/ci/fresh-db/acceptance_definer_guard_contract.sql, whose
+  own selftest drives four deliberately broken catalogs through it.
 """
 
 import pathlib
@@ -89,9 +119,6 @@ GUARD_CALL_PATTERN = (
     + r")\s*\("
 )
 GUARD_RE = re.compile(GUARD_CALL_PATTERN, re.IGNORECASE)
-
-# Kept for backwards compatibility with callers that only need the names.
-GUARD_PATTERNS = list(GUARD_NAMES)
 
 # ---------------------------------------------------------------------------
 # Boolean membership predicates
@@ -178,6 +205,12 @@ def _is_sole_negated_predicate(term: str) -> bool:
     m = NEGATED_PREDICATE_RE.match(term)
     if m is None:
         return False
+    # The predicate's own arity must match the reviewed helper's, for the same
+    # reason a raising guard's must: an overload is a different function.
+    if _call_arity(term, m.end() - 1) != GUARD_ARITY.get(
+        _predicate_name(term, m), object()
+    ):
+        return False
     # Consume the call's balanced argument list; anything after it disqualifies.
     depth = 0
     for i in range(m.end() - 1, len(term)):
@@ -188,6 +221,16 @@ def _is_sole_negated_predicate(term: str) -> bool:
             if depth == 0:
                 return not term[i + 1:].strip()
     return False
+
+
+_TRAILING_IDENT_RE = re.compile(r"([A-Za-z_][A-Za-z0-9_$]*)\s*$")
+
+
+def _predicate_name(term: str, match) -> str:
+    """The bare predicate name inside a matched `NOT [public.]pred(` prefix."""
+    head = term[match.start(): match.end() - 1]
+    m = _TRAILING_IDENT_RE.search(head)
+    return m.group(1).lower() if m else ""
 
 
 # ---------------------------------------------------------------------------
@@ -208,19 +251,93 @@ _NON_ABORTING_RAISE_RE = re.compile(
 )
 _RAISE_BEFORE_RE = re.compile(r"\bRAISE\s*$", re.IGNORECASE)
 
+# ---------------------------------------------------------------------------
+# Which EXCEPTION handlers can actually catch an authorization failure
+# ---------------------------------------------------------------------------
 # A PL/pgSQL `RAISE EXCEPTION` without an explicit SQLSTATE raises P0001
-# (raise_exception). Only a handler able to catch THAT can swallow an
-# authorization failure; an unrelated condition such as unique_violation cannot,
-# and must not produce a false red.
-_CATCHING_CONDITION_RE = re.compile(r"\b(OTHERS|raise_exception)\b", re.IGNORECASE)
+# (raise_exception), which is what all three recognized assertion helpers do.
+# A handler swallows the denial when any of its conditions matches that code.
+#
+# PostgreSQL matches a handler condition against the raised SQLSTATE in
+# exactly two ways (plpgsql exec.c, exception_matches_conditions):
+#
+#   exact     the condition's own code equals the raised code;
+#   CATEGORY  the condition's code is a category - its last three characters
+#             are '000' - and the raised code belongs to that class.
+#
+# So P0001 is caught by the exact code P0001 AND by its class code P0000. That
+# second door was open: `WHEN plpgsql_error` (P0000) and `WHEN SQLSTATE 'P0000'`
+# both catch a P0001 assertion and neither was recognized. Verified on a live
+# PostgreSQL, not inferred.
+#
+# Every condition NAME is resolved by PostgreSQL at compile time - an
+# unrecognized one is a hard error - so the only names that can reach P0001 are
+# the two below plus OTHERS. An unknown identifier therefore cannot be an
+# attacker's invention and is correctly treated as non-catching; that is what
+# keeps `WHEN unique_violation` from producing a false red.
+_P0001_CATCHING_CODES = frozenset({"P0001", "P0000"})
+_P0001_CATCHING_NAMES = frozenset({"others", "raise_exception", "plpgsql_error"})
 
+# Handler headers inside an EXCEPTION section, on MASKED text so that a WHEN in
+# a comment or a literal cannot invent one. Conditions are then split on OR.
+_HANDLER_WHEN_RE = re.compile(r"\bWHEN\b", re.IGNORECASE)
+_HANDLER_THEN_RE = re.compile(r"\bTHEN\b", re.IGNORECASE)
+_CONDITION_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 # The masker blanks literal CONTENT, so `WHEN SQLSTATE 'P0001'` reads as
-# `WHEN SQLSTATE '     '` in the masked body and a masked-text search can never
-# see it. Rather than unmasking literals globally - which would hand guard
-# detection back every string it was hardened against - this ONE condition is
-# recovered from the unmasked text, and only inside an EXCEPTION handler range.
-# Masking preserves offsets exactly, so the same slice indexes both texts.
-_SQLSTATE_CATCH_RE = re.compile(r"\bSQLSTATE\s+'P0001'", re.IGNORECASE)
+# `WHEN SQLSTATE '     '` in the masked body. Rather than unmasking literals
+# globally - which would hand guard detection back every string it was hardened
+# against - the SQLSTATE value alone is recovered from the unmasked text at the
+# same offsets, and only inside a handler condition. Locating the keyword and
+# the quotes on MASKED text is also what makes `WHEN SQLSTATE /* why */ 'P0001'`
+# resolve: the comment is whitespace by then, so no separator regex has to
+# anticipate it.
+_SQLSTATE_KEYWORD_RE = re.compile(r"\bSQLSTATE\b", re.IGNORECASE)
+
+
+def _handler_condition_spans(body: str, start: int, end: int):
+    """Absolute (start, end) spans of each `WHEN <conditions> THEN` list in
+    [start, end).
+
+    Deliberately permissive about which WHEN it finds: an extra span can only
+    add conditions to the catch test, which fails closed. A condition that is
+    not a recognized catching name still does not catch, so an ordinary
+    `CASE WHEN ... THEN` in a handler body cannot invent a false red.
+    """
+    spans = []
+    pos = start
+    while True:
+        w = _HANDLER_WHEN_RE.search(body, pos, end)
+        if w is None:
+            return spans
+        t = _HANDLER_THEN_RE.search(body, w.end(), end)
+        if t is None:
+            return spans
+        spans.append((w.end(), t.start()))
+        pos = t.end()
+
+
+def _condition_catches_p0001(body: str, raw_body: str | None, start: int, end: int) -> bool:
+    """True when one condition term in body[start:end] can catch a P0001."""
+    for term in _split_top_level_or(body[start:end]):
+        offset = start + body[start:end].index(term)
+        stripped = term.strip()
+        if _CONDITION_NAME_RE.match(stripped) and stripped.lower() in _P0001_CATCHING_NAMES:
+            return True
+        kw = _SQLSTATE_KEYWORD_RE.search(term)
+        if kw is None:
+            continue
+        # `SQLSTATE <literal>`: the delimiters survive masking, the value does
+        # not, so read the value from the unmasked source at the same offsets.
+        q1 = term.find("'", kw.end())
+        if q1 == -1:
+            continue
+        q2 = term.find("'", q1 + 1)
+        if q2 == -1 or raw_body is None:
+            continue
+        value = raw_body[offset + q1 + 1: offset + q2].strip()
+        if value.upper() in _P0001_CATCHING_CODES:
+            return True
+    return False
 
 
 class _Frame:
@@ -304,18 +421,17 @@ def _enclosing(frames, pos):
 def _handler_catches(body: str, frame, raw_body: str | None = None) -> bool:
     """True when the block's EXCEPTION handlers can catch a P0001 assertion.
 
-    `raw_body` is the SAME span of the unmasked source; it is consulted only for
-    the SQLSTATE literal, which masking necessarily hides.
+    Every `WHEN ... THEN` header in the handler section is resolved condition by
+    condition, so a catching condition anywhere in an OR-list counts and an
+    unrelated one (`unique_violation`) still does not. `raw_body` is the SAME
+    span of the unmasked source; it is consulted only for the SQLSTATE value,
+    which masking necessarily hides.
     """
     if frame.exc_pos is None:
         return False
-    handler = body[frame.exc_pos: frame.end]
-    if _CATCHING_CONDITION_RE.search(handler):
-        return True
-    if raw_body is not None and _SQLSTATE_CATCH_RE.search(
-        raw_body[frame.exc_pos: frame.end]
-    ):
-        return True
+    for start, end in _handler_condition_spans(body, frame.exc_pos, frame.end):
+        if _condition_catches_p0001(body, raw_body, start, end):
+            return True
     return False
 
 
@@ -381,6 +497,39 @@ def terminating_return_before(body: str, pos: int) -> bool:
     return m is not None
 
 
+# RETURN is not the only way the invocation can already be over. An aborting
+# RAISE at the function's OUTER statement level ends it just as surely, so an
+# assertion placed after one is dead code that no caller ever reaches:
+#
+#     RAISE EXCEPTION 'NOT_IMPLEMENTED';
+#     PERFORM public.wardah_assert_org_member(p_org);   -- never executes
+#
+# Only an OUTER-level raise counts. A raise inside an IF/LOOP/CASE or a nested
+# BEGIN is conditional, so a later assertion is still reachable and must not be
+# rejected. RAISE NOTICE/WARNING/INFO/LOG/DEBUG report without aborting and are
+# excluded; a bare re-`RAISE;` inside a handler is not outer level by
+# construction.
+_ABORTING_RAISE_RE = re.compile(
+    r"\bRAISE\b(?!\s+(?:NOTICE|WARNING|INFO|LOG|DEBUG)\b)", re.IGNORECASE
+)
+
+
+def unconditional_abort_before(body: str, frames, pos: int) -> bool:
+    """True when an outer-level aborting RAISE precedes `pos`."""
+    for m in _ABORTING_RAISE_RE.finditer(body, 0, pos):
+        if is_outer_statement_level(frames, m.start()):
+            return True
+    return False
+
+
+def is_unreachable_at(body: str, frames, pos: int) -> bool:
+    """True when the invocation can already have ended before `pos` - through a
+    terminating RETURN or an outer-level aborting RAISE."""
+    return terminating_return_before(body, pos) or unconditional_abort_before(
+        body, frames, pos
+    )
+
+
 # For migrations under the strict contract the assertion must be a STANDALONE
 # statement: `PERFORM [public.]guard(args);` and nothing else. PostgreSQL does
 # not execute the call in `PERFORM guard(x) WHERE false;` - the query returns no
@@ -437,7 +586,7 @@ def has_negated_raising_predicate(
             continue
         if strict and not is_outer_statement_level(frames, if_pos):
             continue
-        if strict and terminating_return_before(body, if_pos):
+        if strict and is_unreachable_at(body, frames, if_pos):
             continue
         condition = body[cond_start:cond_end]
         if any(_is_sole_negated_predicate(t) for t in _split_top_level_or(condition)):
@@ -454,6 +603,10 @@ def has_recognized_guard(
     the outer statement level, with no terminating RETURN before it."""
     frames = parse_blocks(body)
     for m in GUARD_RE.finditer(body):
+        # An overload is a different function in PostgreSQL, so a call that does
+        # not match the reviewed helper's arity is not the reviewed helper.
+        if not guard_call_has_canonical_arity(body, m):
+            continue
         if is_swallowed(body, frames, m.start(), raw_body):
             continue
         if strict:
@@ -461,7 +614,7 @@ def has_recognized_guard(
                 continue
             if not is_outer_statement_level(frames, m.start()):
                 continue
-            if terminating_return_before(body, m.start()):
+            if is_unreachable_at(body, frames, m.start()):
                 continue
         return True
     return has_negated_raising_predicate(body, strict=strict, raw_body=raw_body)
@@ -471,19 +624,6 @@ def migration_number(path: pathlib.Path):
     """Leading number of a migration filename, or None when it has none."""
     head = path.stem.split("_")[0]
     return int(head) if head.isdigit() else None
-
-
-DEFINER_FUNC_RE = re.compile(
-    r"CREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\s+(?:public\.)?(\w+)\s*\(",
-    re.IGNORECASE,
-)
-
-# Both REVOKE EXECUTE and REVOKE ALL remove the inherited PUBLIC EXECUTE grant.
-# REVOKE from authenticated alone is insufficient while PUBLIC still holds it.
-REVOKE_RE = re.compile(
-    r"REVOKE\s+(?:EXECUTE|ALL(?:\s+PRIVILEGES)?)\s+ON\s+FUNCTION\s+.*?\s+FROM\s+PUBLIC\b",
-    re.IGNORECASE | re.DOTALL,
-)
 
 
 class MaskError(Exception):
@@ -685,11 +825,6 @@ def mask_sql_checked(sql: str) -> tuple[str, list[str]]:
     return "".join(out), problems
 
 
-def mask_sql(sql: str) -> str:
-    """Backwards-compatible wrapper: masked text only."""
-    return mask_sql_checked(sql)[0]
-
-
 def get_cutoff() -> int:
     if BASELINE_FILE is None:
         return 0
@@ -697,34 +832,498 @@ def get_cutoff() -> int:
     return int(m.group(1)) if m else 0
 
 
-def extract_function_body_span(sql: str, func_start: int) -> tuple[int, int]:
-    """Span of the target function's text, so the masked and unmasked sources can
-    be sliced identically (masking preserves every offset)."""
-    delim_m = re.search(r"AS\s+(\$\w*\$)", sql[func_start:], re.IGNORECASE)
-    if delim_m:
-        delim = delim_m.group(1)
-        body_start = func_start + delim_m.end()
-        end = sql.find(delim, body_start)
-        if end != -1:
-            return func_start, end + len(delim)
-    return func_start, func_start + 4000
+# ---------------------------------------------------------------------------
+# Statement model: identities, definitions, ALTERs and the privilege ledger
+# ---------------------------------------------------------------------------
+# Attribution used to be positional: find `SECURITY DEFINER`, walk backwards to
+# the nearest `CREATE ... FUNCTION`, take 4000 characters as the body, and
+# accept any `REVOKE ... FROM PUBLIC` that happened to sit before the next
+# `CREATE`. Four different false greens came out of that one shortcut:
+#
+#   * a definition with no dollar-quoted body (`LANGUAGE internal AS 'boolin'`)
+#     borrowed the NEXT function's body, and therefore the next function's
+#     guard;
+#   * `ALTER FUNCTION ... SECURITY DEFINER` was blamed on whichever function was
+#     defined before it - or, with none before it, silently ignored;
+#   * a quoted identity (`CREATE FUNCTION public."f"(...)`) matched no CREATE at
+#     all, so the DEFINER occurrence was attributed to an earlier function or
+#     dropped;
+#   * a REVOKE naming a DIFFERENT function, or a different overload, exempted
+#     the unguarded one - and a later `GRANT ... TO PUBLIC` re-opened what the
+#     REVOKE had closed, invisibly.
+#
+# So statements are modelled once, by identity, and every later rule reads that
+# model instead of re-deriving position.
 
 
-def extract_function_body(sql: str, func_start: int) -> str:
-    """Return text from func_start to the closing dollar-quote block.
+class Identity:
+    """A schema-qualified function identity, with its argument TYPE list.
 
-    Detects the actual delimiter (e.g. $function$, $$) so that the guard
-    search is confined to the target function's body and cannot bleed into
-    a subsequent guarded function in the same migration file.
+    `args` is None when the statement carried no argument list at all. Quoted
+    identifiers keep their case (PostgreSQL folds only unquoted ones), so
+    `"HAS_PERMISSION"` is a different function from `has_permission` and cannot
+    inherit its exemption.
     """
-    delim_m = re.search(r"AS\s+(\$\w*\$)", sql[func_start:], re.IGNORECASE)
-    if delim_m:
-        delim = delim_m.group(1)
-        body_start = func_start + delim_m.end()
-        end = sql.find(delim, body_start)
-        if end != -1:
-            return sql[func_start: end + len(delim)]
-    return sql[func_start: func_start + 4000]
+
+    __slots__ = ("schema", "name", "quoted", "args")
+
+    def __init__(self, schema, name, quoted, args):
+        self.schema = schema
+        self.name = name
+        self.quoted = quoted
+        self.args = args
+
+    @property
+    def qualified(self) -> str:
+        base = f"{self.schema}.{self.name}" if self.schema else self.name
+        return base if self.args is None else f"{base}({','.join(self.args)})"
+
+    def same_function(self, other: "Identity") -> bool:
+        """Name match, plus argument-list match when BOTH sides carry one.
+
+        PostgreSQL identifies an overload by its argument types, so a REVOKE on
+        `f(text)` says nothing about `f(uuid)`. When either side omits the list
+        the name match is all that is available; an unparseable list is never
+        silently treated as equal.
+        """
+        if self.name != other.name:
+            return False
+        if self.schema and other.schema and self.schema != other.schema:
+            return False
+        if self.args is None or other.args is None:
+            return True
+        return self.args == other.args
+
+
+# The only built-in types whose FIRST word is part of the type rather than a
+# parameter name. Everything else that leads a two-token parameter is a name.
+_TYPE_LEAD_WORDS = frozenset(
+    {"character", "double", "bit", "national", "time", "timestamp", "interval"}
+)
+_ARG_MODES = frozenset({"in", "out", "inout", "variadic"})
+_PLAIN_IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_$]*$")
+_DEFAULT_SPLIT_RE = re.compile(r"\bDEFAULT\b|=", re.IGNORECASE)
+_UNQUOTED_IDENT_RE = re.compile(r"[A-Za-z_-￿][A-Za-z0-9_$-￿]*")
+
+
+def _normalize_arg_type(param: str) -> str | None:
+    """The declared TYPE of one parameter, normalized for comparison.
+
+    Accepts both the CREATE form (`p_org uuid`, `OUT v numeric`,
+    `p_x jsonb DEFAULT '{}'::jsonb`) and the privilege-statement form (`uuid`),
+    because PostgreSQL allows argument names in GRANT/REVOKE too. Returns None
+    when the parameter cannot be parsed, which callers treat as "not equal".
+    """
+    text = _DEFAULT_SPLIT_RE.split(param, 1)[0]
+    tokens = text.split()
+    if tokens and tokens[0].lower() in _ARG_MODES and len(tokens) > 1:
+        tokens = tokens[1:]
+    if (
+        len(tokens) > 1
+        and _PLAIN_IDENT_RE.match(tokens[0])
+        and tokens[0].lower() not in _TYPE_LEAD_WORDS
+    ):
+        tokens = tokens[1:]
+    if not tokens:
+        return None
+    normalized = " ".join(tokens).lower()
+    normalized = re.sub(r"\s*([(),\[\]])\s*", r"\1", normalized)
+    return re.sub(r"\s+", " ", normalized).strip() or None
+
+
+def _split_top_level_commas(text: str) -> list[str]:
+    parts, depth, start = [], 0, 0
+    for i, ch in enumerate(text):
+        if ch in "([":
+            depth += 1
+        elif ch in ")]":
+            depth -= 1
+        elif ch == "," and depth == 0:
+            parts.append(text[start:i])
+            start = i + 1
+    parts.append(text[start:])
+    return parts
+
+
+def _parse_arg_list(inner: str):
+    inner = inner.strip()
+    if not inner:
+        return ()
+    args = []
+    for part in _split_top_level_commas(inner):
+        if not part.strip():
+            continue
+        normalized = _normalize_arg_type(part)
+        if normalized is None:
+            return None
+        args.append(normalized)
+    return tuple(args)
+
+
+def _skip_ws(masked: str, i: int) -> int:
+    while i < len(masked) and masked[i].isspace():
+        i += 1
+    return i
+
+
+def _parse_identity(raw: str, masked: str, i: int):
+    """Parse a possibly quoted, possibly schema-qualified name at `i`.
+
+    Read from the UNMASKED text: the masker blanks quoted-identifier content by
+    design, so `public."f_quoted"` carries no name in the masked source. Offsets
+    are identical between the two, so the masked text still decides whitespace.
+    """
+    parts, quoted_any = [], False
+    n = len(raw)
+    while True:
+        i = _skip_ws(masked, i)
+        if i >= n:
+            return None, i
+        if raw[i] == '"':
+            j, buf = i + 1, []
+            closed = False
+            while j < n:
+                if raw[j] == '"':
+                    if raw.startswith('""', j):
+                        buf.append('"')
+                        j += 2
+                        continue
+                    j += 1
+                    closed = True
+                    break
+                buf.append(raw[j])
+                j += 1
+            if not closed:
+                return None, i
+            parts.append("".join(buf))
+            quoted_any = True
+            i = j
+        else:
+            m = _UNQUOTED_IDENT_RE.match(raw, i)
+            if m is None:
+                return None, i
+            parts.append(m.group(0).lower())
+            i = m.end()
+        nxt = _skip_ws(masked, i)
+        if nxt < n and raw[nxt] == ".":
+            i = nxt + 1
+            continue
+        return (parts, quoted_any), nxt
+
+
+def _balanced_parens(masked: str, i: int):
+    """(inner_text, index_after_close) for the parenthesis group opening at i."""
+    if i >= len(masked) or masked[i] != "(":
+        return None, i
+    depth = 0
+    for j in range(i, len(masked)):
+        if masked[j] == "(":
+            depth += 1
+        elif masked[j] == ")":
+            depth -= 1
+            if depth == 0:
+                return masked[i + 1: j], j + 1
+    return None, i
+
+
+def _identity_at(raw: str, masked: str, i: int):
+    """Identity plus the index just past its optional argument list."""
+    parsed, after = _parse_identity(raw, masked, i)
+    if parsed is None:
+        return None, after
+    parts, quoted = parsed
+    after = _skip_ws(masked, after)
+    args = None
+    if after < len(masked) and masked[after] == "(":
+        inner, after = _balanced_parens(masked, after)
+        if inner is None:
+            return None, after
+        args = _parse_arg_list(inner)
+    schema = parts[-2] if len(parts) > 1 else None
+    return Identity(schema, parts[-1], quoted, args), after
+
+
+def _scan_statement(masked: str, i: int):
+    """(end_of_statement, dollar_body_span) starting at `i`.
+
+    Walks the masked text honouring parentheses, single-quoted literals, quoted
+    identifiers and dollar-quoted bodies, and stops at the first `;` outside all
+    of them. The dollar-quoted body, when present, is reported separately so a
+    definition can never borrow the next one's.
+    """
+    n, depth, j = len(masked), 0, i
+    body = None
+    while j < n:
+        ch = masked[j]
+        if ch == "'":
+            k = masked.find("'", j + 1)
+            j = n if k == -1 else k + 1
+            continue
+        if ch == '"':
+            k = masked.find('"', j + 1)
+            j = n if k == -1 else k + 1
+            continue
+        if ch == "$":
+            tag = _dollar_tag_at(masked, j)
+            if tag is not None:
+                close = masked.find(tag, j + len(tag))
+                if close == -1:
+                    return n, body
+                if body is None:
+                    body = (j + len(tag), close)
+                j = close + len(tag)
+                continue
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth = max(0, depth - 1)
+        elif ch == ";" and depth == 0:
+            return j + 1, body
+        j += 1
+    return n, body
+
+
+_CREATE_ROUTINE_RE = re.compile(
+    r"\bCREATE\s+(?:OR\s+REPLACE\s+)?(?:FUNCTION|PROCEDURE)\s+", re.IGNORECASE
+)
+_ALTER_ROUTINE_RE = re.compile(r"\bALTER\s+(?:FUNCTION|PROCEDURE)\s+", re.IGNORECASE)
+_SECURITY_DEFINER_RE = re.compile(r"\bSECURITY\s+DEFINER\b", re.IGNORECASE)
+_REVOKE_HEAD_RE = re.compile(
+    r"\bREVOKE\s+(?:GRANT\s+OPTION\s+FOR\s+)?(?P<privs>[A-Za-z, ]*?)\s*\bON\s+",
+    re.IGNORECASE,
+)
+_GRANT_HEAD_RE = re.compile(
+    r"\bGRANT\s+(?P<privs>[A-Za-z, ]*?)\s*\bON\s+", re.IGNORECASE
+)
+_EXECUTE_PRIV_RE = re.compile(r"\b(EXECUTE|ALL)\b", re.IGNORECASE)
+_ON_ROUTINE_RE = re.compile(r"\A(?:FUNCTION|PROCEDURE|ROUTINE)\s+", re.IGNORECASE)
+_ON_ALL_ROUTINES_RE = re.compile(
+    r"\AALL\s+(?:FUNCTIONS|PROCEDURES|ROUTINES)\s+IN\s+SCHEMA\b", re.IGNORECASE
+)
+
+
+class Definition:
+    __slots__ = ("identity", "start", "end", "body_span", "is_definer")
+
+    def __init__(self, identity, start, end, body_span, is_definer):
+        self.identity = identity
+        self.start = start
+        self.end = end
+        self.body_span = body_span
+        self.is_definer = is_definer
+
+
+def parse_definitions(raw: str, masked: str) -> list[Definition]:
+    """Every CREATE [OR REPLACE] FUNCTION/PROCEDURE statement in the file."""
+    out = []
+    for m in _CREATE_ROUTINE_RE.finditer(masked):
+        identity, after = _identity_at(raw, masked, m.end())
+        if identity is None:
+            continue
+        end, body_span = _scan_statement(masked, after)
+        header = masked[m.start(): body_span[0]] if body_span else masked[m.start(): end]
+        trailer = masked[body_span[1]: end] if body_span else ""
+        definer = bool(
+            _SECURITY_DEFINER_RE.search(header) or _SECURITY_DEFINER_RE.search(trailer)
+        )
+        out.append(Definition(identity, m.start(), end, body_span, definer))
+    return out
+
+
+class AlterSecurity:
+    __slots__ = ("identity", "start", "end")
+
+    def __init__(self, identity, start, end):
+        self.identity = identity
+        self.start = start
+        self.end = end
+
+
+def parse_alter_security_definer(raw: str, masked: str) -> list[AlterSecurity]:
+    """Every `ALTER FUNCTION/PROCEDURE ... SECURITY DEFINER` statement.
+
+    These flip an EXISTING function to SECURITY DEFINER without restating its
+    body, so the scanner has nothing to read a guard from. They were invisible:
+    the positional scan blamed the occurrence on an earlier CREATE, or dropped
+    it when there was none.
+    """
+    out = []
+    for m in _ALTER_ROUTINE_RE.finditer(masked):
+        identity, after = _identity_at(raw, masked, m.end())
+        if identity is None:
+            continue
+        end, _ = _scan_statement(masked, after)
+        if _SECURITY_DEFINER_RE.search(masked[after:end]):
+            out.append(AlterSecurity(identity, m.start(), end))
+    return out
+
+
+# The client roles a SECURITY DEFINER function must not be reachable from when
+# it carries no guard. PUBLIC is implicit: PostgreSQL grants EXECUTE to PUBLIC
+# on every new function, and anon/authenticated inherit it from there.
+CLIENT_ROLES = ("public", "anon", "authenticated")
+_GRANTEE_NAME_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_$]*")
+
+
+class PrivilegeStatement:
+    __slots__ = ("start", "end", "is_revoke", "targets", "all_in_schema", "grantees")
+
+    def __init__(self, start, end, is_revoke, targets, all_in_schema, grantees):
+        self.start = start
+        self.end = end
+        self.is_revoke = is_revoke
+        self.targets = targets
+        self.all_in_schema = all_in_schema
+        self.grantees = grantees
+
+
+def parse_privilege_statements(raw: str, masked: str) -> list[PrivilegeStatement]:
+    """REVOKE/GRANT statements that carry EXECUTE (or ALL) on routines."""
+    out = []
+    for head_re, is_revoke in ((_REVOKE_HEAD_RE, True), (_GRANT_HEAD_RE, False)):
+        for m in head_re.finditer(masked):
+            if not _EXECUTE_PRIV_RE.search(m.group("privs") or ""):
+                continue
+            end, _ = _scan_statement(masked, m.end())
+            rest = masked[m.end(): end]
+            all_in_schema = bool(_ON_ALL_ROUTINES_RE.match(rest))
+            targets = []
+            if not all_in_schema:
+                on_routine = _ON_ROUTINE_RE.match(rest)
+                if on_routine is None:
+                    continue
+                pos = m.end() + on_routine.end()
+                while True:
+                    identity, after = _identity_at(raw, masked, pos)
+                    if identity is None:
+                        break
+                    targets.append(identity)
+                    nxt = _skip_ws(masked, after)
+                    if nxt < end and masked[nxt] == ",":
+                        pos = nxt + 1
+                        continue
+                    break
+                if not targets:
+                    continue
+            keyword = "FROM" if is_revoke else "TO"
+            km = re.compile(r"\b" + keyword + r"\b", re.IGNORECASE).search(
+                masked, m.end(), end
+            )
+            grantee_text = masked[km.end(): end] if km else ""
+            grantees = {
+                g.group(0).lower()
+                for g in _GRANTEE_NAME_RE.finditer(grantee_text)
+                if g.group(0).lower() not in ("group", "current_user", "session_user")
+            }
+            out.append(
+                PrivilegeStatement(
+                    m.start(), end, is_revoke, targets, all_in_schema, grantees
+                )
+            )
+    return out
+
+
+def revoke_closes_client_surface(
+    identity: Identity,
+    after: int,
+    privileges: list[PrivilegeStatement],
+    strict: bool = False,
+) -> bool:
+    """True when the migration leaves THIS function unreachable by every client.
+
+    The old test was a blanket `REVOKE ... FROM PUBLIC` regex anywhere before the
+    next CREATE. It neither checked that the statement named this function nor
+    that the closure survived - so a REVOKE on a different function, or on a
+    different overload, exempted an unguarded one, and a later
+    `GRANT ... TO PUBLIC` re-opened what it had closed.
+
+    The replacement replays the file's own privilege statements against this
+    identity and asks what the ACL looks like when the migration finishes.
+    PostgreSQL grants EXECUTE to PUBLIC on a new function, so the surface starts
+    open and only an explicit REVOKE closes it; anon and authenticated reach the
+    function through PUBLIC unless they hold an explicit grant of their own.
+    Under the STRICT contract, closing PUBLIC while granting `authenticated` is
+    not a closure at all - that is precisely the cross-tenant surface this
+    scanner exists to find, and the project contract has always read "revoke
+    EXECUTE from PUBLIC *and the clients*". Migrations at or below the cutoff
+    are immutable historical inputs, and three of them (123, 175, 186) do exactly
+    that while carrying their own reviewed authorization, so for them the
+    historical PUBLIC-only test is preserved. The cutoff is a migration NUMBER;
+    no function is exempted by name.
+    """
+    public_open = True
+    explicit = {role: False for role in CLIENT_ROLES if role != "public"}
+    for stmt in sorted(privileges, key=lambda s: s.start):
+        if stmt.start < after or stmt.all_in_schema:
+            continue
+        if not any(identity.same_function(t) for t in stmt.targets):
+            continue
+        for role in CLIENT_ROLES:
+            if role not in stmt.grantees:
+                continue
+            if role == "public":
+                public_open = not stmt.is_revoke
+            else:
+                explicit[role] = not stmt.is_revoke
+    if public_open:
+        return False
+    return not strict or not any(explicit.values())
+
+
+# ---------------------------------------------------------------------------
+# Recognized-guard integrity
+# ---------------------------------------------------------------------------
+# The canonical arity of every recognized helper. A call with a different
+# argument count cannot be the reviewed function, whatever it is named: an
+# overload is a DIFFERENT function in PostgreSQL, and a locally declared
+# `wardah_assert_org_member(text)` that does nothing would otherwise satisfy the
+# gate through the same call-shape match as the real one.
+GUARD_ARITY = {
+    "wardah_assert_org_member": 1,
+    "wardah_assert_org_admin": 1,
+    "wardah_178_assert_permission": 2,
+    "wardah_is_org_member": 1,
+}
+
+_GUARD_NAME_RE = re.compile(
+    r"(?:public\s*\.\s*)?(" + "|".join(GUARD_NAMES + BOOLEAN_PREDICATES) + r")\s*\(",
+    re.IGNORECASE,
+)
+
+
+def _call_arity(body: str, open_paren: int) -> int | None:
+    """Top-level argument count of the call whose `(` is at `open_paren`."""
+    inner, _ = _balanced_parens(body, open_paren)
+    if inner is None:
+        return None
+    if not inner.strip():
+        return 0
+    return len(_split_top_level_commas(inner))
+
+
+def guard_call_has_canonical_arity(body: str, match) -> bool:
+    """True when a matched guard call passes the helper's declared arity."""
+    name_m = _GUARD_NAME_RE.match(body, match.start())
+    if name_m is None:
+        return False
+    expected = GUARD_ARITY.get(name_m.group(1).lower())
+    if expected is None:
+        return False
+    return _call_arity(body, match.end() - 1) == expected
+
+
+def redefined_guard_names(definitions) -> list[str]:
+    """Recognized helper names this file itself defines or replaces.
+
+    A migration that redefines the very helper it leans on is not something a
+    per-file scanner can adjudicate: the guard it reads and the guard the
+    database will run are then two different bodies. Under the strict contract
+    that is a hard stop, not a judgement call.
+    """
+    recognized = {n.lower() for n in GUARD_NAMES + BOOLEAN_PREDICATES}
+    return sorted(
+        {d.identity.name.lower() for d in definitions if d.identity.name.lower() in recognized}
+    )
 
 
 def check_file(path: pathlib.Path) -> list[str]:
@@ -739,39 +1338,82 @@ def check_file(path: pathlib.Path) -> list[str]:
     # scanner exists to prevent.
     for problem in mask_problems:
         errors.append(
-            f"  \u274c {path.name}: cannot be scanned safely ({problem}); "
+            f"  ❌ {path.name}: cannot be scanned safely ({problem}); "
             f"fix the construct or split it out"
         )
     if mask_problems:
         return errors
 
-    for m in re.finditer(r"SECURITY\s+DEFINER", sql, re.IGNORECASE):
-        prefix = sql[: m.start()]
-        func_m = None
-        for fm in DEFINER_FUNC_RE.finditer(prefix):
-            func_m = fm
-        if func_m is None:
+    definitions = parse_definitions(raw_sql, sql)
+    privileges = parse_privilege_statements(raw_sql, sql)
+
+    if strict:
+        for name in redefined_guard_names(definitions):
+            errors.append(
+                f"  ❌ {path.name}: redefines the recognized authorization "
+                f"helper '{name}'; a migration may not both replace a guard and "
+                f"be validated by it"
+            )
+
+    for definition in definitions:
+        if not definition.is_definer:
             continue
 
-        func_name = func_m.group(1).lower()
-        if func_name in KNOWN_EXEMPT:
+        identity = definition.identity
+        # KNOWN_EXEMPT is a HISTORICAL ledger. It is keyed by bare name, so
+        # under the strict contract it would exempt a brand-new overload, and a
+        # quoted `"HAS_PERMISSION"` that folds to an exempt name is not that
+        # function at all. From the cutoff on, no name-based exemption applies.
+        if (
+            not strict
+            and not identity.quoted
+            and identity.schema in (None, "public")
+            and identity.name in KNOWN_EXEMPT
+        ):
             continue
 
-        body_start, body_end = extract_function_body_span(sql, func_m.start())
+        if revoke_closes_client_surface(
+            identity, definition.end, privileges, strict=strict
+        ):
+            continue
+
+        if definition.body_span is None:
+            errors.append(
+                f"  ❌ {path.name}: function '{identity.qualified}' is "
+                f"SECURITY DEFINER with no dollar-quoted body this scanner can "
+                f"read; revoke EXECUTE from PUBLIC in this migration or give it "
+                f"a readable body"
+            )
+            continue
+
+        body_start, body_end = definition.start, definition.body_span[1]
         body = sql[body_start:body_end]
         raw_body = raw_sql[body_start:body_end]
 
-        # Check for explicit REVOKE after definition and before the next CREATE.
-        after = sql[func_m.end():]
-        revoke_before_next_func = after.split("CREATE")[0] if "CREATE" in after else after
-        if REVOKE_RE.search(revoke_before_next_func):
-            continue
-
         if not has_recognized_guard(body, strict=strict, raw_body=raw_body):
             errors.append(
-                f"  ❌ {path.name}: function '{func_name}' is SECURITY DEFINER "
-                f"but has no recognized tenant/authorization assertion"
+                f"  ❌ {path.name}: function '{identity.qualified}' is "
+                f"SECURITY DEFINER but has no recognized tenant/authorization "
+                f"assertion"
             )
+
+    # `ALTER FUNCTION ... SECURITY DEFINER` restates no body, so there is
+    # nothing to prove a guard from. It is accepted only when the same migration
+    # also defines that exact function (its CREATE was checked above) or closes
+    # it to PUBLIC.
+    for alter in parse_alter_security_definer(raw_sql, sql):
+        if any(alter.identity.same_function(d.identity) for d in definitions):
+            continue
+        if revoke_closes_client_surface(
+            alter.identity, alter.end, privileges, strict=strict
+        ):
+            continue
+        errors.append(
+            f"  ❌ {path.name}: 'ALTER FUNCTION {alter.identity.qualified} "
+            f"SECURITY DEFINER' makes an existing function run as its owner "
+            f"without restating a guard; define it with its assertion in this "
+            f"migration or revoke EXECUTE from PUBLIC"
+        )
 
     return errors
 

--- a/scripts/ci/check_definer_guards.py
+++ b/scripts/ci/check_definer_guards.py
@@ -316,10 +316,36 @@ def _handler_condition_spans(body: str, start: int, end: int):
         pos = t.end()
 
 
+def _split_top_level_or_spans(condition: str, base: int) -> list[tuple[int, int]]:
+    """Absolute (start, end) span of each top-level OR term.
+
+    The string form cannot be used to locate a term: masking blanks literal
+    CONTENT but keeps the delimiters, so `SQLSTATE \'P0002\' OR SQLSTATE \'P0001\'`
+    masks to two textually IDENTICAL terms. Recovering a term\'s offset with
+    str.index() then returns the FIRST one, and the second term\'s SQLSTATE value
+    is read out of the first term\'s raw bytes - so a handler that really does
+    catch P0001 could be read as catching something else entirely.
+    """
+    spans, depth, start = [], 0, 0
+    for i, ch in enumerate(condition):
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth = max(0, depth - 1)
+        elif depth == 0:
+            m = _TOP_LEVEL_OR_RE.match(condition, i)
+            if m and (i == 0 or not (condition[i - 1].isalnum() or condition[i - 1] == "_")):
+                spans.append((base + start, base + i))
+                start = m.end()
+    spans.append((base + start, base + len(condition)))
+    return spans
+
+
 def _condition_catches_p0001(body: str, raw_body: str | None, start: int, end: int) -> bool:
     """True when one condition term in body[start:end] can catch a P0001."""
-    for term in _split_top_level_or(body[start:end]):
-        offset = start + body[start:end].index(term)
+    for term_start, term_end in _split_top_level_or_spans(body[start:end], start):
+        term = body[term_start:term_end]
+        offset = term_start
         stripped = term.strip()
         if _CONDITION_NAME_RE.match(stripped) and stripped.lower() in _P0001_CATCHING_NAMES:
             return True
@@ -888,8 +914,18 @@ class Identity:
         """
         if self.name != other.name:
             return False
-        if self.schema and other.schema and self.schema != other.schema:
-            return False
+        if self.schema and other.schema:
+            if self.schema != other.schema:
+                return False
+        elif self.schema or other.schema:
+            # One side omitted the schema. PostgreSQL resolves that through
+            # search_path - it is NOT a wildcard - and every migration here runs
+            # with `public` first. So an unqualified name resolves to `public`
+            # and says nothing about a function in another schema. Treating it as
+            # a match let a REVOKE with no schema exempt `other_schema.f`.
+            named = self.schema or other.schema
+            if named != "public":
+                return False
         if self.args is None or other.args is None:
             return True
         return self.args == other.args
@@ -904,6 +940,27 @@ _ARG_MODES = frozenset({"in", "out", "inout", "variadic"})
 _PLAIN_IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_$]*$")
 _DEFAULT_SPLIT_RE = re.compile(r"\bDEFAULT\b|=", re.IGNORECASE)
 _UNQUOTED_IDENT_RE = re.compile(r"[A-Za-z_-￿][A-Za-z0-9_$-￿]*")
+
+
+_QUOTED_SEGMENT_RE = re.compile(r'"(?:[^"]|"")*"')
+
+
+def _fold_type_text(text: str) -> str:
+    """Lower-case a type expression EXCEPT inside quoted identifiers.
+
+    PostgreSQL folds an unquoted type name and preserves a quoted one, so
+    `public."TypeA"` and `public."TypeB"` are different types. They are also the
+    two things masking destroys - it blanks quoted-identifier content - which is
+    why argument lists are normalized from the RAW source and folded here rather
+    than lower-cased wholesale.
+    """
+    out, last = [], 0
+    for m in _QUOTED_SEGMENT_RE.finditer(text):
+        out.append(text[last:m.start()].lower())
+        out.append(m.group(0))
+        last = m.end()
+    out.append(text[last:].lower())
+    return "".join(out)
 
 
 def _normalize_arg_type(param: str) -> str | None:
@@ -924,9 +981,13 @@ def _normalize_arg_type(param: str) -> str | None:
         and tokens[0].lower() not in _TYPE_LEAD_WORDS
     ):
         tokens = tokens[1:]
+    elif len(tokens) > 1 and tokens[0].startswith('"'):
+        # A quoted parameter NAME is still a name; a quoted TYPE never leads a
+        # multi-token parameter on its own, so dropping it here is safe.
+        tokens = tokens[1:]
     if not tokens:
         return None
-    normalized = " ".join(tokens).lower()
+    normalized = _fold_type_text(" ".join(tokens))
     normalized = re.sub(r"\s*([(),\[\]])\s*", r"\1", normalized)
     return re.sub(r"\s+", " ", normalized).strip() or None
 
@@ -945,15 +1006,21 @@ def _split_top_level_commas(text: str) -> list[str]:
     return parts
 
 
-def _parse_arg_list(inner: str):
-    inner = inner.strip()
-    if not inner:
+def _parse_arg_list(inner: str, raw_inner: str | None = None):
+    """Normalized argument types. `inner` is masked (used for structure only);
+    `raw_inner` is the same span unmasked and supplies each parameter's text."""
+    if raw_inner is None:
+        raw_inner = inner
+    if not inner.strip():
         return ()
     args = []
+    offset = 0
     for part in _split_top_level_commas(inner):
+        raw_part = raw_inner[offset: offset + len(part)]
+        offset += len(part) + 1
         if not part.strip():
             continue
-        normalized = _normalize_arg_type(part)
+        normalized = _normalize_arg_type(raw_part)
         if normalized is None:
             return None
         args.append(normalized)
@@ -1035,10 +1102,15 @@ def _identity_at(raw: str, masked: str, i: int):
     after = _skip_ws(masked, after)
     args = None
     if after < len(masked) and masked[after] == "(":
-        inner, after = _balanced_parens(masked, after)
+        open_paren = after
+        inner, after = _balanced_parens(masked, open_paren)
         if inner is None:
             return None, after
-        args = _parse_arg_list(inner)
+        # Structure is decided on MASKED text (so a comma inside a literal or a
+        # comment cannot split a parameter), but each parameter's TEXT is taken
+        # from RAW at the same offsets, because masking blanks quoted-identifier
+        # content and a quoted type name is part of the identity.
+        args = _parse_arg_list(inner, raw[open_paren + 1: after - 1])
     schema = parts[-2] if len(parts) > 1 else None
     return Identity(schema, parts[-1], quoted, args), after
 
@@ -1103,14 +1175,20 @@ _ON_ALL_ROUTINES_RE = re.compile(
 
 
 class Definition:
-    __slots__ = ("identity", "start", "end", "body_span", "is_definer")
+    __slots__ = ("identity", "start", "end", "body_span", "is_definer", "final_definer",
+                 "promoted_by")
 
     def __init__(self, identity, start, end, body_span, is_definer):
         self.identity = identity
         self.start = start
         self.end = end
         self.body_span = body_span
+        # The mode this statement DECLARES.
         self.is_definer = is_definer
+        # The mode the function ends the migration in, after every later ALTER
+        # in this file has been applied. resolve_security_state() sets it.
+        self.final_definer = is_definer
+        self.promoted_by = None
 
 
 def parse_definitions(raw: str, masked: str) -> list[Definition]:
@@ -1130,22 +1208,27 @@ def parse_definitions(raw: str, masked: str) -> list[Definition]:
     return out
 
 
-class AlterSecurity:
-    __slots__ = ("identity", "start", "end")
+_SECURITY_INVOKER_RE = re.compile(r"\bSECURITY\s+INVOKER\b", re.IGNORECASE)
 
-    def __init__(self, identity, start, end):
+
+class AlterSecurity:
+    __slots__ = ("identity", "start", "end", "sets_definer")
+
+    def __init__(self, identity, start, end, sets_definer):
         self.identity = identity
         self.start = start
         self.end = end
+        self.sets_definer = sets_definer
 
 
-def parse_alter_security_definer(raw: str, masked: str) -> list[AlterSecurity]:
-    """Every `ALTER FUNCTION/PROCEDURE ... SECURITY DEFINER` statement.
+def parse_alter_security(raw: str, masked: str) -> list[AlterSecurity]:
+    """Every `ALTER FUNCTION/PROCEDURE ... SECURITY {DEFINER|INVOKER}` statement.
 
-    These flip an EXISTING function to SECURITY DEFINER without restating its
-    body, so the scanner has nothing to read a guard from. They were invisible:
-    the positional scan blamed the occurrence on an earlier CREATE, or dropped
-    it when there was none.
+    Both directions are collected, because the security mode of a function is a
+    STATE, not a property of the statement that created it: PostgreSQL lets a
+    later ALTER change it without restating a line of the body. Reading only the
+    DEFINER direction gets the state wrong in both directions - it misses a
+    promotion and it keeps flagging a demotion.
     """
     out = []
     for m in _ALTER_ROUTINE_RE.finditer(masked):
@@ -1153,16 +1236,77 @@ def parse_alter_security_definer(raw: str, masked: str) -> list[AlterSecurity]:
         if identity is None:
             continue
         end, _ = _scan_statement(masked, after)
-        if _SECURITY_DEFINER_RE.search(masked[after:end]):
-            out.append(AlterSecurity(identity, m.start(), end))
+        clause = masked[after:end]
+        if _SECURITY_DEFINER_RE.search(clause):
+            out.append(AlterSecurity(identity, m.start(), end, True))
+        elif _SECURITY_INVOKER_RE.search(clause):
+            out.append(AlterSecurity(identity, m.start(), end, False))
     return out
+
+
+def parse_alter_security_definer(raw: str, masked: str) -> list[AlterSecurity]:
+    """Only the statements that make a function SECURITY DEFINER."""
+    return [a for a in parse_alter_security(raw, masked) if a.sets_definer]
+
+
+def resolve_security_state(definitions, alters):
+    """Apply every ALTER to the definitions it names, in file order.
+
+    Returns the ALTERs that matched no definition in this file - those promote a
+    function defined elsewhere, so this migration restates no body for them and
+    they have to be judged on their own.
+
+    A definition's FINAL mode is what matters. Judging the declared mode alone
+    was wrong twice over: a function created SECURITY INVOKER and promoted by a
+    later ALTER in the same file was never guard-checked at all (the CREATE was
+    skipped as unprivileged and the ALTER was skipped as "already covered by its
+    CREATE"), and a function created SECURITY DEFINER and demoted in the same
+    file was still reported.
+    """
+    external = []
+    for alter in sorted(alters, key=lambda a: a.start):
+        matched = [
+            d for d in definitions
+            if d.start < alter.start and alter.identity.same_function(d.identity)
+        ]
+        if not matched:
+            if alter.sets_definer:
+                external.append(alter)
+            continue
+        for definition in matched:
+            definition.final_definer = alter.sets_definer
+            definition.promoted_by = alter if alter.sets_definer else None
+    return external
 
 
 # The client roles a SECURITY DEFINER function must not be reachable from when
 # it carries no guard. PUBLIC is implicit: PostgreSQL grants EXECUTE to PUBLIC
 # on every new function, and anon/authenticated inherit it from there.
 CLIENT_ROLES = ("public", "anon", "authenticated")
-_GRANTEE_NAME_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_$]*")
+
+# Grantees are read from the RAW source. The masker blanks quoted-identifier
+# content, so `GRANT ... TO "authenticated"` had no grantee at all in the masked
+# text: the re-open was invisible and the closure still looked intact. A quoted
+# role name is the SAME role when its content matches - PostgreSQL folds the
+# unquoted form to lower case - so both spellings resolve here, and a quoted
+# form that differs in case (`"Authenticated"`) is a different role and does not.
+_GRANTEE_TOKEN_RE = re.compile(r'"(?:[^"]|"")*"|[A-Za-z_][A-Za-z0-9_$]*')
+_GRANTEE_NOISE = frozenset({"group", "current_user", "session_user", "current_role"})
+
+
+def _grantee_names(raw_region: str) -> set[str]:
+    """Role names named in a GRANT/REVOKE grantee list."""
+    names = set()
+    for m in _GRANTEE_TOKEN_RE.finditer(raw_region):
+        token = m.group(0)
+        if token.startswith('"'):
+            names.add(token[1:-1].replace('""', '"'))
+        else:
+            lowered = token.lower()
+            if lowered in _GRANTEE_NOISE:
+                continue
+            names.add(lowered)
+    return names
 
 
 class PrivilegeStatement:
@@ -1209,12 +1353,7 @@ def parse_privilege_statements(raw: str, masked: str) -> list[PrivilegeStatement
             km = re.compile(r"\b" + keyword + r"\b", re.IGNORECASE).search(
                 masked, m.end(), end
             )
-            grantee_text = masked[km.end(): end] if km else ""
-            grantees = {
-                g.group(0).lower()
-                for g in _GRANTEE_NAME_RE.finditer(grantee_text)
-                if g.group(0).lower() not in ("group", "current_user", "session_user")
-            }
+            grantees = _grantee_names(raw[km.end(): end]) if km else set()
             out.append(
                 PrivilegeStatement(
                     m.start(), end, is_revoke, targets, all_in_schema, grantees
@@ -1346,6 +1485,12 @@ def check_file(path: pathlib.Path) -> list[str]:
 
     definitions = parse_definitions(raw_sql, sql)
     privileges = parse_privilege_statements(raw_sql, sql)
+    # Security mode is a STATE. Resolve every CREATE against the ALTERs that
+    # follow it before judging anything, so a promotion cannot slip between the
+    # two statements and a demotion cannot be reported.
+    external_promotions = resolve_security_state(
+        definitions, parse_alter_security(raw_sql, sql)
+    )
 
     if strict:
         for name in redefined_guard_names(definitions):
@@ -1356,7 +1501,7 @@ def check_file(path: pathlib.Path) -> list[str]:
             )
 
     for definition in definitions:
-        if not definition.is_definer:
+        if not definition.final_definer:
             continue
 
         identity = definition.identity
@@ -1391,19 +1536,24 @@ def check_file(path: pathlib.Path) -> list[str]:
         raw_body = raw_sql[body_start:body_end]
 
         if not has_recognized_guard(body, strict=strict, raw_body=raw_body):
+            how = (
+                "is SECURITY DEFINER"
+                if definition.promoted_by is None
+                else "is made SECURITY DEFINER by a later ALTER in this migration"
+            )
             errors.append(
-                f"  ❌ {path.name}: function '{identity.qualified}' is "
-                f"SECURITY DEFINER but has no recognized tenant/authorization "
-                f"assertion"
+                f"  ❌ {path.name}: function '{identity.qualified}' {how} "
+                f"but has no recognized tenant/authorization assertion"
             )
 
-    # `ALTER FUNCTION ... SECURITY DEFINER` restates no body, so there is
-    # nothing to prove a guard from. It is accepted only when the same migration
-    # also defines that exact function (its CREATE was checked above) or closes
-    # it to PUBLIC.
-    for alter in parse_alter_security_definer(raw_sql, sql):
-        if any(alter.identity.same_function(d.identity) for d in definitions):
-            continue
+    # A promotion of a function this migration does NOT define restates no body,
+    # so there is nothing to prove a guard from. (A promotion of one it DOES
+    # define was folded into that definition's final state above and judged there
+    # against its real body - which is the case that used to be skipped on the
+    # false reasoning that "its CREATE was checked", when the CREATE had been an
+    # unprivileged INVOKER nobody checks.) It is accepted only when the migration
+    # closes it to every client role.
+    for alter in external_promotions:
         if revoke_closes_client_surface(
             alter.identity, alter.end, privileges, strict=strict
         ):

--- a/scripts/ci/check_definer_guards.py
+++ b/scripts/ci/check_definer_guards.py
@@ -1296,9 +1296,14 @@ _GRANTEE_NOISE = frozenset({"group", "current_user", "session_user", "current_ro
 
 def _grantee_names(raw_region: str) -> set[str]:
     """Role names named in a GRANT/REVOKE grantee list."""
+    # Locate tokens on masked structure so comments cannot invent grantees.
+    # Recover only those spans from raw SQL to preserve quoted role identities.
+    masked_region, problems = mask_sql_checked(raw_region)
+    if problems:
+        raise MaskError("; ".join(problems))
     names = set()
-    for m in _GRANTEE_TOKEN_RE.finditer(raw_region):
-        token = m.group(0)
+    for m in _GRANTEE_TOKEN_RE.finditer(masked_region):
+        token = raw_region[m.start():m.end()]
         if token.startswith('"'):
             names.add(token[1:-1].replace('""', '"'))
         else:

--- a/scripts/ci/fresh-db/acceptance_definer_guard_contract.sql
+++ b/scripts/ci/fresh-db/acceptance_definer_guard_contract.sql
@@ -1,0 +1,295 @@
+-- Catalog-backed acceptance for the SECURITY DEFINER guard contract.
+--
+-- Runs on a Fresh DB after the whole migration chain is applied. It is the
+-- companion to scripts/ci/check_definer_guards.py and deliberately NOT a copy
+-- of it: the static scanner proves STRUCTURE in one file's bytes, this file
+-- proves the SEMANTICS and the FINAL STATE that only PostgreSQL can answer.
+--
+-- The division of labour, stated once so neither side drifts into the other:
+--
+--   static scanner   one migration at a time; call shape, statement level,
+--                    reachability, identity, which REVOKE names which function.
+--                    It cannot see the database, so it cannot know what the
+--                    chain finally produced.
+--   this file        the catalog after every migration has run: which
+--                    functions actually ARE security definer, who can actually
+--                    execute them, whether the recognized guards are still the
+--                    reviewed functions, and whether the PL/pgSQL exception
+--                    semantics the scanner's rules rest on are still true.
+--
+-- Fail-closed: every assertion raises, and the psql exit code under
+-- ON_ERROR_STOP is the verdict. The closing notice is evidence, not the verdict.
+
+\set ON_ERROR_STOP on
+
+-- ---------------------------------------------------------------------------
+-- 1. The exception semantics the scanner's swallow analysis depends on
+-- ---------------------------------------------------------------------------
+-- The scanner treats a handler as swallowing an authorization failure when its
+-- condition resolves to P0001 (raise_exception) or to that code's CLASS, P0000
+-- (plpgsql_error) - because PostgreSQL matches a handler either exactly or by
+-- category. That category door is what `WHEN plpgsql_error` and
+-- `WHEN SQLSTATE 'P0000'` walk through, and it is asserted here against the
+-- running server rather than assumed from documentation. `unique_violation` is
+-- the negative control: if it ever started catching, the scanner's refusal to
+-- flag it would become a false green.
+DO $definer_exception_semantics$
+DECLARE
+  v_caught text[] := '{}'::text[];
+BEGIN
+  BEGIN
+    RAISE EXCEPTION 'AUTHZ_PROBE';
+  EXCEPTION WHEN plpgsql_error THEN
+    v_caught := array_append(v_caught, 'plpgsql_error');
+  END;
+
+  BEGIN
+    RAISE EXCEPTION 'AUTHZ_PROBE';
+  EXCEPTION WHEN SQLSTATE 'P0000' THEN
+    v_caught := array_append(v_caught, 'sqlstate_P0000');
+  END;
+
+  BEGIN
+    RAISE EXCEPTION 'AUTHZ_PROBE';
+  EXCEPTION WHEN raise_exception THEN
+    v_caught := array_append(v_caught, 'raise_exception');
+  END;
+
+  BEGIN
+    RAISE EXCEPTION 'AUTHZ_PROBE';
+  EXCEPTION WHEN SQLSTATE 'P0001' THEN
+    v_caught := array_append(v_caught, 'sqlstate_P0001');
+  END;
+
+  IF NOT (v_caught @> ARRAY['plpgsql_error', 'sqlstate_P0000',
+                            'raise_exception', 'sqlstate_P0001']) THEN
+    RAISE EXCEPTION
+      'DEFINER_CONTRACT_CATEGORY_SEMANTICS_CHANGED: caught only %', v_caught;
+  END IF;
+
+  -- Negative control: an unrelated condition must NOT catch a bare
+  -- RAISE EXCEPTION, or the scanner's "no false red" rule would be wrong.
+  BEGIN
+    BEGIN
+      RAISE EXCEPTION 'AUTHZ_PROBE';
+    EXCEPTION WHEN unique_violation THEN
+      RAISE EXCEPTION 'DEFINER_CONTRACT_UNRELATED_CONDITION_NOW_CATCHES_P0001';
+    END;
+  EXCEPTION WHEN SQLSTATE 'P0001' THEN
+    IF SQLERRM = 'DEFINER_CONTRACT_UNRELATED_CONDITION_NOW_CATCHES_P0001' THEN
+      RAISE;
+    END IF;
+  END;
+
+  RAISE NOTICE 'DEFINER_CONTRACT_EXCEPTION_SEMANTICS_OK: P0001 is caught by its own code and by class P0000; unrelated conditions do not catch it';
+END
+$definer_exception_semantics$;
+
+-- ---------------------------------------------------------------------------
+-- 2. The recognized guards are still the reviewed functions
+-- ---------------------------------------------------------------------------
+-- The static scanner accepts a call by NAME and arity. Overload resolution is
+-- the database's job, so only the database can prove that the name it accepted
+-- still resolves to the reviewed body: a second `wardah_assert_org_member(text)`
+-- that returns without raising would satisfy any per-file scan while
+-- authorizing nothing. Each recognized helper must therefore exist with exactly
+-- its reviewed signature, carry no extra overload, be SECURITY DEFINER, run
+-- with a hardened search_path, and - for the raising helpers - actually contain
+-- a RAISE.
+DO $definer_guard_identity$
+DECLARE
+  r record;
+  v_overloads int;
+  v_problems text[] := '{}'::text[];
+BEGIN
+  FOR r IN
+    SELECT *
+    FROM (VALUES
+      ('wardah_assert_org_member', 'public.wardah_assert_org_member(uuid)', true),
+      ('wardah_assert_org_admin', 'public.wardah_assert_org_admin(uuid)', true),
+      ('wardah_178_assert_permission',
+       'public.wardah_178_assert_permission(uuid,text)', true),
+      ('wardah_is_org_member', 'public.wardah_is_org_member(uuid)', false)
+    ) AS t(proname, sig, must_raise)
+  LOOP
+    IF to_regprocedure(r.sig) IS NULL THEN
+      v_problems := array_append(v_problems, r.sig || ' :missing');
+      CONTINUE;
+    END IF;
+
+    SELECT count(*) INTO v_overloads
+    FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = r.proname;
+
+    IF v_overloads <> 1 THEN
+      v_problems := array_append(
+        v_problems, r.sig || ' :' || v_overloads || '_overloads');
+    END IF;
+
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_proc p
+      WHERE p.oid = to_regprocedure(r.sig)::oid
+        AND p.prosecdef
+        AND p.proconfig IS NOT NULL
+        AND EXISTS (SELECT 1 FROM unnest(p.proconfig) c WHERE c LIKE 'search_path=%')
+    ) THEN
+      v_problems := array_append(v_problems, r.sig || ' :not_definer_or_unhardened');
+    END IF;
+
+    IF r.must_raise AND NOT EXISTS (
+      SELECT 1 FROM pg_proc p
+      WHERE p.oid = to_regprocedure(r.sig)::oid AND p.prosrc ~* '\mRAISE\s+EXCEPTION\M'
+    ) THEN
+      v_problems := array_append(v_problems, r.sig || ' :never_raises');
+    END IF;
+  END LOOP;
+
+  IF cardinality(v_problems) > 0 THEN
+    RAISE EXCEPTION 'DEFINER_CONTRACT_GUARD_IDENTITY_BROKEN: %', v_problems;
+  END IF;
+  RAISE NOTICE 'DEFINER_CONTRACT_GUARD_IDENTITY_OK: 4/4 recognized helpers, one signature each, definer + hardened, raising helpers raise';
+END
+$definer_guard_identity$;
+
+-- ---------------------------------------------------------------------------
+-- 3. No quoted mixed-case identity can impersonate an exempted name
+-- ---------------------------------------------------------------------------
+-- PostgreSQL folds an unquoted identifier to lower case and preserves a quoted
+-- one, so `CREATE FUNCTION public."HAS_PERMISSION"(...)` is a DIFFERENT function
+-- from `has_permission` while folding to the same string in any case-insensitive
+-- comparison - which is how a name-keyed exemption list gets impersonated. The
+-- scanner now compares identities case-sensitively; the catalog proves no such
+-- twin reached the database.
+DO $definer_case_twins$
+DECLARE
+  v_twins text[];
+BEGIN
+  SELECT coalesce(array_agg(DISTINCT p.oid::regprocedure::text ORDER BY p.oid::regprocedure::text), '{}')
+  INTO v_twins
+  FROM pg_proc p
+  JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public'
+    AND p.proname <> lower(p.proname);
+
+  IF cardinality(v_twins) > 0 THEN
+    RAISE EXCEPTION 'DEFINER_CONTRACT_MIXED_CASE_FUNCTION_NAME: %', v_twins;
+  END IF;
+  RAISE NOTICE 'DEFINER_CONTRACT_NO_CASE_TWINS_OK';
+END
+$definer_case_twins$;
+
+-- ---------------------------------------------------------------------------
+-- 4. Final security mode of the Migration 191 object set
+-- ---------------------------------------------------------------------------
+-- `ALTER FUNCTION ... SECURITY DEFINER` changes what a function runs as without
+-- restating a line of its body. A static scan of one migration cannot see an
+-- ALTER that a later migration issues, so the FINAL prosecdef is pinned here,
+-- object by object, for the whole thirteen-object set. The two SECURITY INVOKER
+-- entries are the ones the F2 design requires to stay invoker; the rest are the
+-- reviewed definer surface.
+DO $definer_mode_matrix$
+DECLARE
+  r record;
+  v_actual boolean;
+  v_drift text[] := '{}'::text[];
+BEGIN
+  FOR r IN
+    SELECT *
+    FROM (VALUES
+      ('public.wardah_apply_stock_incoming(uuid,uuid,uuid,numeric,numeric,text,uuid,text,date)', true),
+      ('public.wardah_apply_stock_incoming(uuid,uuid,uuid,numeric,numeric,text,uuid,text,date,uuid)', true),
+      ('public.wardah_apply_stock_outgoing(uuid,uuid,uuid,numeric,text,uuid,text,date)', true),
+      ('public.wardah_apply_stock_outgoing(uuid,uuid,uuid,numeric,text,uuid,text,date,uuid)', true),
+      ('public.rpc_cancel_stock_adjustment(uuid,text)', true),
+      ('public.rpc_manual_stock_movement_v2(jsonb)', true),
+      ('public.rpc_post_goods_receipt(jsonb)', true),
+      ('public.rpc_post_delivery_note(jsonb)', true),
+      ('public.rpc_submit_stock_adjustment(uuid)', true),
+      ('public.rpc_consume_reserved_materials_v2(uuid,uuid,jsonb)', true),
+      ('public.rpc_create_mo_with_reservation(jsonb,jsonb,uuid)', true),
+      ('public.release_expired_reservations(uuid)', false),
+      ('public.wardah_lock_products_for_stock_write(uuid,uuid[])', false)
+    ) AS t(sig, expect_definer)
+  LOOP
+    IF to_regprocedure(r.sig) IS NULL THEN
+      v_drift := array_append(v_drift, r.sig || ' :missing');
+      CONTINUE;
+    END IF;
+    SELECT prosecdef INTO v_actual FROM pg_proc WHERE oid = to_regprocedure(r.sig)::oid;
+    IF v_actual IS DISTINCT FROM r.expect_definer THEN
+      v_drift := array_append(
+        v_drift,
+        r.sig || ' :expected_definer=' || r.expect_definer || ' actual=' || coalesce(v_actual::text, 'null'));
+    END IF;
+  END LOOP;
+
+  IF cardinality(v_drift) > 0 THEN
+    RAISE EXCEPTION 'DEFINER_CONTRACT_SECURITY_MODE_DRIFT: %', v_drift;
+  END IF;
+  RAISE NOTICE 'DEFINER_CONTRACT_SECURITY_MODE_OK: 13/13 objects at their reviewed security mode';
+END
+$definer_mode_matrix$;
+
+-- ---------------------------------------------------------------------------
+-- 5. The privilege ledger the static REVOKE rule stands in for
+-- ---------------------------------------------------------------------------
+-- The scanner credits a REVOKE only when the statement NAMES the function and
+-- no later GRANT re-opens it - but the authority on "who can execute this" is
+-- the ACL itself, after every migration in the chain has had its turn. The four
+-- canonical stock helpers are the ones the scanner accepted on closure rather
+-- than on a guard, so their closure is exactly what must be true in the
+-- catalog. PUBLIC is checked twice on purpose: through has_function_privilege,
+-- which resolves the PUBLIC pseudo-role, and through aclexplode's grantee = 0,
+-- which reads the stored ACL directly. A default ACL (proacl IS NULL) means
+-- PUBLIC still holds the inherited EXECUTE grant and is a failure.
+DO $definer_privilege_ledger$
+DECLARE
+  r record;
+  v_open text[] := '{}'::text[];
+  v_role text;
+BEGIN
+  FOR r IN
+    SELECT sig
+    FROM unnest(ARRAY[
+      'public.wardah_apply_stock_incoming(uuid,uuid,uuid,numeric,numeric,text,uuid,text,date)',
+      'public.wardah_apply_stock_incoming(uuid,uuid,uuid,numeric,numeric,text,uuid,text,date,uuid)',
+      'public.wardah_apply_stock_outgoing(uuid,uuid,uuid,numeric,text,uuid,text,date)',
+      'public.wardah_apply_stock_outgoing(uuid,uuid,uuid,numeric,text,uuid,text,date,uuid)',
+      'public.wardah_lock_products_for_stock_write(uuid,uuid[])'
+    ]) AS t(sig)
+  LOOP
+    FOREACH v_role IN ARRAY ARRAY['public', 'anon', 'authenticated'] LOOP
+      IF has_function_privilege(v_role, r.sig, 'EXECUTE') THEN
+        v_open := array_append(v_open, r.sig || ' :' || v_role);
+      END IF;
+    END LOOP;
+
+    IF EXISTS (
+      SELECT 1 FROM pg_proc p, aclexplode(p.proacl) a
+      WHERE p.oid = to_regprocedure(r.sig)::oid
+        AND a.grantee = 0
+        AND a.privilege_type = 'EXECUTE'
+    ) THEN
+      v_open := array_append(v_open, r.sig || ' :acl_grantee_public');
+    END IF;
+
+    IF EXISTS (
+      SELECT 1 FROM pg_proc p
+      WHERE p.oid = to_regprocedure(r.sig)::oid AND p.proacl IS NULL
+    ) THEN
+      v_open := array_append(v_open, r.sig || ' :default_acl_public_execute');
+    END IF;
+  END LOOP;
+
+  IF cardinality(v_open) > 0 THEN
+    RAISE EXCEPTION 'DEFINER_CONTRACT_CLIENT_SURFACE_OPEN: %', v_open;
+  END IF;
+  RAISE NOTICE 'DEFINER_CONTRACT_PRIVILEGE_LEDGER_OK: 5/5 closure-exempt helpers hold no PUBLIC/anon/authenticated EXECUTE, by privilege test and by stored ACL';
+END
+$definer_privilege_ledger$;
+
+DO $definer_contract_pass$
+BEGIN
+  RAISE NOTICE 'DEFINER_GUARD_CONTRACT_PASS: exception_semantics=live guard_identity=4/4 case_twins=none security_mode=13/13 privilege_ledger=5/5';
+END
+$definer_contract_pass$;

--- a/scripts/ci/fresh-db/acceptance_definer_guard_contract.sql
+++ b/scripts/ci/fresh-db/acceptance_definer_guard_contract.sql
@@ -19,6 +19,19 @@
 --
 -- Fail-closed: every assertion raises, and the psql exit code under
 -- ON_ERROR_STOP is the verdict. The closing notice is evidence, not the verdict.
+--
+-- SCOPE, stated so a green run is not read as more than it is. Assertions 1-3
+-- (exception semantics, guard identity, mixed-case twins) are catalog-WIDE.
+-- Assertions 4 and 5 are FIXTURE-SCOPED: they pin thirteen named signatures and
+-- five respectively, against roughly 155 SECURITY DEFINER functions in public.
+-- A function outside those lists - unguarded, SECURITY DEFINER, granted to
+-- authenticated - leaves this file green; that was verified by creating exactly
+-- such a function and watching the PASS notice still print. The static scanner
+-- is what covers that case, and only for migrations newer than the baseline
+-- cutoff, so a definer surface opened by an older migration and never altered
+-- since is asserted by neither layer. Turning 4 and 5 into an enumeration with a
+-- pinned allowlist would require classifying all 155 - an audit, and a separate
+-- change from this one.
 
 \set ON_ERROR_STOP on
 

--- a/scripts/ci/fresh-db/selftest_definer_guard_contract.sh
+++ b/scripts/ci/fresh-db/selftest_definer_guard_contract.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Prove the catalog-backed DEFINER guard contract can actually fail.
+#
+# A gate that cannot fail is worth nothing, so each assertion in
+# acceptance_definer_guard_contract.sql is driven against a deliberately broken
+# catalog and must reject it with its OWN error token - not merely "some error".
+# The mutation is applied to the live acceptance database, the REAL contract file
+# is re-run against it (no duplicated predicate that could drift from the gate it
+# claims to test), and the mutation is then reverted and the contract proved
+# green again, so the database this script leaves behind is the one it found.
+#
+# The four mutants are the catalog-side shapes of the scanner findings:
+#   1. a shadow overload of a recognized guard      (overload impersonation)
+#   2. a quoted mixed-case function name            (identity impersonation)
+#   3. ALTER FUNCTION ... SECURITY DEFINER          (security-mode drift)
+#   4. an EXECUTE grant to a client role            (privilege re-opening)
+#
+# Usage: PGDATABASE=... bash scripts/ci/fresh-db/selftest_definer_guard_contract.sh
+
+set -Eeuo pipefail
+
+CONTRACT="${CONTRACT:-scripts/ci/fresh-db/acceptance_definer_guard_contract.sql}"
+PASS_TOKEN='DEFINER_GUARD_CONTRACT_PASS'
+OUT="${OUT:-/tmp/definer-contract-selftest}"
+mkdir -p "$OUT"
+
+INCOMING9='public.wardah_apply_stock_incoming(uuid,uuid,uuid,numeric,numeric,text,uuid,text,date)'
+HELPER='public.wardah_lock_products_for_stock_write(uuid, uuid[])'
+
+run_contract() {   # run_contract <logfile> ; returns psql's exit code
+  psql -v ON_ERROR_STOP=1 -f "$CONTRACT" >"$1" 2>&1
+}
+
+expect_pass() {    # expect_pass <label>
+  local log="$OUT/$1.pass.log"
+  if ! run_contract "$log"; then
+    echo "❌ $1: the contract failed on an unmutated catalog"
+    tail -20 "$log"
+    exit 1
+  fi
+  grep -q "$PASS_TOKEN" "$log" || {
+    echo "❌ $1: the contract exited 0 without $PASS_TOKEN"
+    tail -20 "$log"
+    exit 1
+  }
+  echo "   ✅ $1: contract green"
+}
+
+expect_fail() {    # expect_fail <label> <expected error token>
+  local log="$OUT/$1.fail.log"
+  if run_contract "$log"; then
+    echo "❌ $1: the contract PASSED against a catalog it must reject"
+    exit 1
+  fi
+  if ! grep -q "$2" "$log"; then
+    echo "❌ $1: rejected, but not by '$2' - the mutant may be failing for an"
+    echo "   unrelated reason, which would not prove this assertion at all"
+    tail -20 "$log"
+    exit 1
+  fi
+  if grep -q "$PASS_TOKEN" "$log"; then
+    echo "❌ $1: the contract printed its PASS notice while failing"
+    exit 1
+  fi
+  echo "   ✅ $1: rejected by $2"
+}
+
+mutate() { psql -v ON_ERROR_STOP=1 -q -c "$1"; }
+
+echo "🔍 DEFINER guard contract selftest — proving each assertion can fail"
+
+echo "0. baseline"
+expect_pass baseline
+
+echo "1. shadow overload of a recognized guard"
+mutate "CREATE FUNCTION public.wardah_assert_org_member(p_org text) RETURNS void
+        LANGUAGE plpgsql AS \$shadow\$ BEGIN NULL; END \$shadow\$;"
+expect_fail guard_identity DEFINER_CONTRACT_GUARD_IDENTITY_BROKEN
+mutate "DROP FUNCTION public.wardah_assert_org_member(text);"
+expect_pass guard_identity_reverted
+
+echo "2. quoted mixed-case function name"
+mutate "CREATE FUNCTION public.\"HAS_PERMISSION\"() RETURNS void
+        LANGUAGE sql AS \$twin\$ SELECT \$twin\$;"
+expect_fail case_twin DEFINER_CONTRACT_MIXED_CASE_FUNCTION_NAME
+mutate "DROP FUNCTION public.\"HAS_PERMISSION\"();"
+expect_pass case_twin_reverted
+
+echo "3. ALTER FUNCTION ... SECURITY DEFINER on an invoker helper"
+mutate "ALTER FUNCTION $HELPER SECURITY DEFINER;"
+expect_fail security_mode DEFINER_CONTRACT_SECURITY_MODE_DRIFT
+mutate "ALTER FUNCTION $HELPER SECURITY INVOKER;"
+expect_pass security_mode_reverted
+
+echo "4. EXECUTE granted back to a client role"
+mutate "GRANT EXECUTE ON FUNCTION $INCOMING9 TO authenticated;"
+expect_fail privilege_ledger DEFINER_CONTRACT_CLIENT_SURFACE_OPEN
+mutate "REVOKE EXECUTE ON FUNCTION $INCOMING9 FROM authenticated;"
+expect_pass privilege_ledger_reverted
+
+echo "✅ DEFINER_GUARD_CONTRACT_SELFTEST_PASS: 4 mutants rejected by their own assertion, catalog restored"

--- a/scripts/ci/test_check_definer_guards.py
+++ b/scripts/ci/test_check_definer_guards.py
@@ -1849,6 +1849,40 @@ class DefinerScannerTests(unittest.TestCase):
             with self.subTest(accept=name):
                 self.assertEqual(self.verdict(name, sql), [], name)
 
+    def test_comments_cannot_close_client_privileges(self) -> None:
+        """Commented role names must never exempt an unguarded definer."""
+        definition = """
+CREATE FUNCTION public.review_probe(p_org uuid) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN DELETE FROM public.bins WHERE org_id = p_org; END $$;
+"""
+        for comment in (
+            '/* PUBLIC, anon, authenticated */',
+            '-- PUBLIC, anon, authenticated\n',
+            '/* outer /* PUBLIC */ anon, "authenticated" */',
+            '/* unmatched quote " PUBLIC, anon, authenticated */',
+        ):
+            with self.subTest(comment=comment):
+                sql = definition + (
+                    'REVOKE EXECUTE ON FUNCTION public.review_probe(uuid) '
+                    f'FROM service_role {comment};'
+                )
+                self.assertTrue(self.verdict('commented_roles', sql))
+                # A real quoted client grant after closure still reopens it,
+                # even when a comment contains an unmatched double quote.
+                sql = definition + (
+                    'REVOKE EXECUTE ON FUNCTION public.review_probe(uuid) '
+                    'FROM PUBLIC, anon, authenticated; '
+                    'GRANT EXECUTE ON FUNCTION public.review_probe(uuid) '
+                    f'TO {comment} "authenticated";'
+                )
+                self.assertTrue(self.verdict('comment_before_grant', sql))
+                sql = definition + (
+                    'REVOKE EXECUTE ON FUNCTION public.review_probe(uuid) '
+                    f'FROM {comment} PUBLIC, "anon", "authenticated";'
+                )
+                self.assertEqual(self.verdict('real_commented_closure', sql), [])
+
     def test_grantee_name_resolution(self) -> None:
         """M: the grantee reader itself."""
         self.assertEqual(

--- a/scripts/ci/test_check_definer_guards.py
+++ b/scripts/ci/test_check_definer_guards.py
@@ -757,7 +757,8 @@ UNREACHABLE_ABORT_MUST_ACCEPT = {
 #    DEFINER routine the scanner cannot read a body from is rejected rather than
 #    given someone else's.
 GUARDED_NEXT = (
-    "CREATE OR REPLACE FUNCTION public.f_guarded(p_org uuid)\n"
+    # Scanner fixture only: written to a temporary file, never executed as SQL.
+    "CREATE OR REPLACE FUNCTION public.f_guarded(p_org uuid)\n"  # nosec B608
     "RETURNS void\nLANGUAGE plpgsql\nSECURITY DEFINER\n"
     "SET search_path TO 'public', 'pg_temp'\n"
     "AS $guarded$\nBEGIN\n"
@@ -773,7 +774,8 @@ BODY_ATTRIBUTION_MUST_REJECT = {
         + GUARDED_NEXT
     ),
     "sql_standard_body_is_not_readable": (
-        "CREATE OR REPLACE FUNCTION public.f_atomic(p_org uuid)\n"
+        # Scanner fixture only; concatenation tests body attribution, not DB execution.
+        "CREATE OR REPLACE FUNCTION public.f_atomic(p_org uuid)\n"  # nosec B608
         "RETURNS void\nLANGUAGE sql\nSECURITY DEFINER\n"
         "BEGIN ATOMIC\n"
         "  UPDATE public.bins SET actual_qty = 0 WHERE org_id = p_org;\n"
@@ -876,7 +878,8 @@ ALTER_DEFINER_MUST_ACCEPT = {
 #    exemption - and neither is another schema's same-named function.
 def quoted_definer(header: str) -> str:
     return (
-        f"{header}\n"
+        # Test-owned header: this SQL is input to check_file(), never a DB driver.
+        f"{header}\n"  # nosec B608
         "RETURNS void\nLANGUAGE plpgsql\nSECURITY DEFINER\n"
         "SET search_path TO 'public', 'pg_temp'\n"
         "AS $q$\nBEGIN\n"

--- a/scripts/ci/test_check_definer_guards.py
+++ b/scripts/ci/test_check_definer_guards.py
@@ -135,6 +135,10 @@ PostgreSQL actually does:
      NAME, so a new overload of an exempt name inherited an exemption written
      for a different function; and a guard call was matched by name, so a
      locally declared no-op overload of a recognized helper satisfied the gate.
+     The third rule - a migration may not redefine a helper it is validated by -
+     applies FROM THE CUTOFF ON and must: migrations 123 and 178 both replace a
+     recognized helper and both sit inside the scanned set, so a rule applied at
+     every age would turn two immutable historical migrations red.
 
 The catalog-side half of D, H, I and J - what the whole chain finally produced,
 which no per-file scan can see - is asserted by
@@ -634,7 +638,20 @@ MUST_FAIL_CLOSED = {
 # Astra findings D-I: acceptance-layer gaps in the scanner itself
 # ---------------------------------------------------------------------------
 # Every fixture below was run through the REAL check_file() at the reviewed head
-# before any change and returned [] - the false green, frozen.
+# before any change. Most returned [] - that is the false green, frozen. Six did
+# NOT, and they are marked as controls where they appear:
+#
+#   4 in EXCEPTION_CATEGORY_MUST_REJECT - OTHERS and raise_exception, which the
+#     old condition regex already matched by name, plus SQLSTATE 'P0001' alone
+#     and inside an OR list, which the old raw-text SQLSTATE search already found
+#     anywhere in the handler range;
+#   2 in REVOKE_ATTRIBUTION_MUST_REJECT - a REVOKE before the definition, which
+#     the old window (starting at the definition) never saw, and ON ALL FUNCTIONS
+#     IN SCHEMA, which the old pattern's required ON FUNCTION never matched.
+#
+# Each group therefore contributes 4 closures and its controls. They are kept
+# because the rewrite could easily have started accepting them; they are not
+# closed findings and must not be counted as any.
 
 
 def definer_outer_handler(handler: str, name: str = "f_probe") -> str:
@@ -679,10 +696,13 @@ EXCEPTION_CATEGORY_MUST_REJECT = {
     "handler_catches_as_later_or_term": definer_outer_handler(
         "unique_violation OR plpgsql_error"
     ),
+    # Controls that were already rejected at the reviewed head, kept so they
+    # cannot regress. The old SQLSTATE search scanned the whole handler range,
+    # so it matched inside an OR list too - which is why the OR form below is a
+    # control while its plpgsql_error twin above is a closure.
     "handler_catches_as_later_or_sqlstate": definer_outer_handler(
         "unique_violation OR SQLSTATE 'P0001'"
     ),
-    # Controls that were already rejected, kept so they cannot regress.
     "handler_catches_when_others": definer_outer_handler("OTHERS"),
     "handler_catches_raise_exception": definer_outer_handler("raise_exception"),
     "handler_catches_sqlstate_p0001": definer_outer_handler("SQLSTATE 'P0001'"),
@@ -781,6 +801,11 @@ REVOKE_ATTRIBUTION_MUST_REJECT = {
     "grant_to_public_reopens_the_revoke": definer("  PERFORM 1;", name="f_c")
     + closed()
     + "GRANT EXECUTE ON FUNCTION public.f_c(uuid) TO PUBLIC;\n",
+    # Controls, not closures: the old window started at the definition so an
+    # earlier REVOKE was never in it, and the old pattern required ON FUNCTION so
+    # ON ALL FUNCTIONS IN SCHEMA never matched. Both were already rejected; both
+    # are kept because the identity rewrite could easily have started crediting
+    # them, and neither should ever be credited.
     "revoke_precedes_the_definition": closed() + definer("  PERFORM 1;", name="f_c"),
     "all_functions_in_schema_is_not_attribution": definer("  PERFORM 1;", name="f_c")
     + "REVOKE EXECUTE ON ALL FUNCTIONS IN SCHEMA public FROM PUBLIC;\n",
@@ -857,6 +882,59 @@ def quoted_definer(header: str) -> str:
         "  UPDATE public.bins SET actual_qty = 0 WHERE org_id = p_org;\n"
         "END;\n$q$;\n"
     )
+
+
+# The security mode itself. parse_definitions() decides `is_definer` from the
+# statement's HEADER and its TRAILER while excluding the dollar-quoted body, so
+# that a `SECURITY DEFINER` written in the body's own text cannot make an INVOKER
+# function look like a definer, and an options clause placed AFTER the body is
+# still seen. Both directions are load-bearing and neither had a control: only
+# the fact that many other fixtures would fail protected them.
+SECURITY_MODE_MUST_REJECT = {
+    # Options may follow the AS clause, so a definer declared there is real.
+    "definer_declared_after_the_body": (
+        "CREATE OR REPLACE FUNCTION public.f_trailer(p_org uuid)\n"
+        "RETURNS void\nLANGUAGE plpgsql\n"
+        "AS $t$\nBEGIN\n"
+        "  UPDATE public.bins SET actual_qty = 0 WHERE org_id = p_org;\n"
+        "END;\n$t$\n"
+        "SECURITY DEFINER;\n"
+    ),
+}
+
+SECURITY_MODE_MUST_ACCEPT = {
+    # An unguarded SECURITY INVOKER function is not this scanner's business.
+    "invoker_function_is_not_scanned": (
+        "CREATE OR REPLACE FUNCTION public.f_invoker(p_org uuid)\n"
+        "RETURNS void\nLANGUAGE plpgsql\nSECURITY INVOKER\n"
+        "AS $i$\nBEGIN\n"
+        "  UPDATE public.bins SET actual_qty = 0 WHERE org_id = p_org;\n"
+        "END;\n$i$;\n"
+    ),
+    # Neither is one that simply omits the clause - INVOKER is the default.
+    "function_with_no_security_clause_is_not_scanned": (
+        "CREATE OR REPLACE FUNCTION public.f_default(p_org uuid)\n"
+        "RETURNS void\nLANGUAGE plpgsql\n"
+        "AS $d$\nBEGIN\n"
+        "  UPDATE public.bins SET actual_qty = 0 WHERE org_id = p_org;\n"
+        "END;\n$d$;\n"
+    ),
+    # A body that merely MENTIONS the phrase does not make the function a
+    # definer. Two layers hold this and the test does not claim otherwise: the
+    # masker blanks the literal's content first, and is_definer excludes the body
+    # span second. Verified: the phrase is already absent from the masked body,
+    # so this fixture evidences the combined behaviour, not the span exclusion on
+    # its own - that one is evidenced by definer_declared_after_the_body, which
+    # only passes because the TRAILER is read.
+    "the_phrase_inside_the_body_is_not_a_clause": (
+        "CREATE OR REPLACE FUNCTION public.f_mentions(p_org uuid)\n"
+        "RETURNS void\nLANGUAGE plpgsql\nSECURITY INVOKER\n"
+        "AS $m$\nBEGIN\n"
+        "  RAISE NOTICE 'this RPC is deliberately not SECURITY DEFINER';\n"
+        "  UPDATE public.bins SET actual_qty = 0 WHERE org_id = p_org;\n"
+        "END;\n$m$;\n"
+    ),
+}
 
 
 QUOTED_IDENTITY_MUST_REJECT = {
@@ -1380,6 +1458,34 @@ class DefinerScannerTests(unittest.TestCase):
         for name, sql in ALTER_DEFINER_MUST_ACCEPT.items():
             with self.subTest(accept=name):
                 self.assertEqual(self.verdict(name, sql), [], name)
+
+    def test_security_mode_is_read_from_header_and_trailer_only(self) -> None:
+        """The definer decision itself: options before AND after the body count,
+        the body's own text does not, and an INVOKER function is left alone."""
+        for name, sql in SECURITY_MODE_MUST_REJECT.items():
+            with self.subTest(reject=name):
+                self.assertTrue(self.verdict(name, sql), name)
+        for name, sql in SECURITY_MODE_MUST_ACCEPT.items():
+            with self.subTest(accept=name):
+                self.assertEqual(self.verdict(name, sql), [], name)
+
+    def test_is_definer_flag_matches_the_declared_mode(self) -> None:
+        """The flag itself, independent of check_file()."""
+        cases = {
+            "definer_declared_after_the_body": True,
+            "invoker_function_is_not_scanned": False,
+            "function_with_no_security_clause_is_not_scanned": False,
+            "the_phrase_inside_the_body_is_not_a_clause": False,
+        }
+        fixtures = {**SECURITY_MODE_MUST_REJECT, **SECURITY_MODE_MUST_ACCEPT}
+        for name, expected in cases.items():
+            raw = fixtures[name]
+            masked, problems = guards.mask_sql_checked(raw)
+            self.assertEqual(problems, [])
+            definitions = guards.parse_definitions(raw, masked)
+            self.assertEqual(len(definitions), 1, name)
+            with self.subTest(case=name):
+                self.assertIs(definitions[0].is_definer, expected, name)
 
     def test_quoted_identities_are_scanned(self) -> None:
         """I: a quoted identity used to match no CREATE at all."""

--- a/scripts/ci/test_check_definer_guards.py
+++ b/scripts/ci/test_check_definer_guards.py
@@ -362,6 +362,7 @@ def definer_named(number: int, body: str, name: str = "f_probe") -> tuple[str, s
 
 
 OUTER = "public.wardah_assert_org_member"
+WORK_LINE = "  UPDATE public.bins SET actual_qty = 0 WHERE org_id = p_org;"
 
 # Finding 5A/5B. Each names a real guard and calls it correctly; none of them
 # authorizes the privileged write that follows.
@@ -979,6 +980,225 @@ OVERLOAD_IMPERSONATION_MUST_REJECT = {
 }
 
 
+# ---------------------------------------------------------------------------
+# Codex findings K-O: the second hardening pass
+# ---------------------------------------------------------------------------
+# Every fixture below was run through the REAL check_file() at 97eb585 - after
+# the first hardening pass - and returned [] there, except where a row is marked
+# a control. Two of them were regressions the first pass itself introduced, and
+# they are called out as such rather than presented as pre-existing.
+
+
+def routine(name: str, mode: str, body: str = WORK_LINE, args: str = "p_org uuid") -> str:
+    """A function whose declared security mode is exactly `mode`."""
+    return (
+        f"CREATE OR REPLACE FUNCTION public.{name}({args})\n"
+        f"RETURNS void\nLANGUAGE plpgsql\n{mode}\n"
+        f"AS ${name}$\nBEGIN\n{body}\nEND;\n${name}$;\n"
+    )
+
+
+# K. Security mode is a STATE, not a property of the CREATE statement.
+#    PostgreSQL lets ALTER FUNCTION change it afterwards, and the first pass
+#    modelled only half of that: a promotion of a function defined in the SAME
+#    file was skipped with the comment "its CREATE was checked above" - but when
+#    that CREATE is SECURITY INVOKER, nothing checks it, because an invoker
+#    function is not this scanner's business. The result was a privileged,
+#    unguarded, client-callable function passing with no error at all. This is a
+#    regression the identity rewrite introduced, not a pre-existing gap.
+SECURITY_STATE_MUST_REJECT = {
+    "invoker_promoted_by_a_later_alter": (
+        routine("f_promoted", "SECURITY INVOKER")
+        + "ALTER FUNCTION public.f_promoted(uuid) SECURITY DEFINER;\n"
+    ),
+    "default_mode_promoted_by_a_later_alter": (
+        "CREATE OR REPLACE FUNCTION public.f_default(p_org uuid)\n"
+        "RETURNS void\nLANGUAGE plpgsql\nAS $d$\nBEGIN\n"
+        f"{WORK_LINE}\nEND;\n$d$;\n"
+        + "ALTER FUNCTION public.f_default(uuid) SECURITY DEFINER;\n"
+    ),
+    # The promotion still counts when the ALTER is the last statement and the
+    # closure names a DIFFERENT overload.
+    "promotion_with_a_closure_on_another_overload": (
+        routine("f_promoted", "SECURITY INVOKER")
+        + "REVOKE EXECUTE ON FUNCTION public.f_promoted(text) "
+          "FROM PUBLIC, anon, authenticated;\n"
+        + "ALTER FUNCTION public.f_promoted(uuid) SECURITY DEFINER;\n"
+    ),
+}
+
+SECURITY_STATE_MUST_ACCEPT = {
+    # The mirror regression: a definer DEMOTED in the same file ends the
+    # migration unprivileged, so there is nothing to guard. The first pass
+    # judged the declared mode and reported it.
+    "definer_demoted_by_a_later_alter": (
+        routine("f_demoted", "SECURITY DEFINER")
+        + "ALTER FUNCTION public.f_demoted(uuid) SECURITY INVOKER;\n"
+    ),
+    # A promotion followed by a real closure is still a closure.
+    "promotion_closed_to_every_client": (
+        routine("f_promoted", "SECURITY INVOKER")
+        + "ALTER FUNCTION public.f_promoted(uuid) SECURITY DEFINER;\n"
+        + "REVOKE EXECUTE ON FUNCTION public.f_promoted(uuid) "
+          "FROM PUBLIC, anon, authenticated;\n"
+    ),
+    # A promotion of a function that IS defined and guarded here.
+    "promotion_of_a_guarded_definition": (
+        routine(
+            "f_guarded",
+            "SECURITY DEFINER",
+            body=f"  PERFORM {OUTER}(p_org);\n{WORK_LINE}",
+        )
+        + "ALTER FUNCTION public.f_guarded(uuid) SECURITY DEFINER;\n"
+    ),
+    # An ALTER that precedes the CREATE does not decide the CREATE's state: the
+    # CREATE is the later statement and wins.
+    "alter_before_the_create_does_not_demote_it": (
+        "ALTER FUNCTION public.f_late(uuid) SECURITY INVOKER;\n"
+        + routine(
+            "f_late",
+            "SECURITY DEFINER",
+            body=f"  PERFORM {OUTER}(p_org);\n{WORK_LINE}",
+        )
+    ),
+}
+
+
+# L. SQLSTATE values were read at the wrong offset inside an OR list. Masking
+#    blanks literal CONTENT but keeps the delimiters, so two SQLSTATE terms in
+#    one condition mask to textually IDENTICAL text; the term's offset was then
+#    recovered with str.index(), which returns the FIRST match. The second term
+#    was therefore read out of the first term's raw bytes - so a handler that
+#    really catches P0001 could be read as catching something else.
+SQLSTATE_OFFSET_MUST_REJECT = {
+    "catching_sqlstate_is_the_second_or_term": definer_outer_handler(
+        "SQLSTATE 'P0002' OR SQLSTATE 'P0001'"
+    ),
+    "catching_sqlstate_is_the_third_or_term": definer_outer_handler(
+        "SQLSTATE 'P0002' OR SQLSTATE 'P0003' OR SQLSTATE 'P0000'"
+    ),
+    "catching_sqlstate_after_a_named_condition": definer_outer_handler(
+        "unique_violation OR SQLSTATE 'P0002' OR SQLSTATE 'P0001'"
+    ),
+}
+
+SQLSTATE_OFFSET_MUST_ACCEPT = {
+    # None of these codes can catch P0001; reading any of them at the wrong
+    # offset would have produced a false red instead.
+    "no_or_term_catches": definer_outer_handler(
+        "SQLSTATE 'P0002' OR SQLSTATE 'P0003'"
+    ),
+    "repeated_identical_non_catching_codes": definer_outer_handler(
+        "SQLSTATE '23505' OR SQLSTATE '23505'"
+    ),
+}
+
+
+# M. GRANT/REVOKE grantees were scanned on MASKED text, where a quoted
+#    identifier's content is blanked - so `GRANT ... TO "authenticated"` named no
+#    grantee at all and the re-open was invisible while the closure still looked
+#    intact. Grantees are read from RAW now, quoted and unquoted alike.
+QUOTED_GRANTEE_MUST_REJECT = {
+    "quoted_authenticated_regrant": (
+        routine("f_c", "SECURITY DEFINER")
+        + "REVOKE EXECUTE ON FUNCTION public.f_c(uuid) "
+          "FROM PUBLIC, anon, authenticated;\n"
+        + 'GRANT EXECUTE ON FUNCTION public.f_c(uuid) TO "authenticated";\n'
+    ),
+    "quoted_anon_regrant": (
+        routine("f_c", "SECURITY DEFINER")
+        + "REVOKE EXECUTE ON FUNCTION public.f_c(uuid) "
+          "FROM PUBLIC, anon, authenticated;\n"
+        + 'GRANT EXECUTE ON FUNCTION public.f_c(uuid) TO "anon";\n'
+    ),
+    "quoted_public_regrant": (
+        routine("f_c", "SECURITY DEFINER")
+        + "REVOKE EXECUTE ON FUNCTION public.f_c(uuid) "
+          "FROM PUBLIC, anon, authenticated;\n"
+        + 'GRANT EXECUTE ON FUNCTION public.f_c(uuid) TO "public";\n'
+    ),
+}
+
+QUOTED_GRANTEE_MUST_ACCEPT = {
+    # A quoted closure is a closure: the content matches the folded role name.
+    "quoted_grantees_in_the_revoke": (
+        routine("f_c", "SECURITY DEFINER")
+        + 'REVOKE EXECUTE ON FUNCTION public.f_c(uuid) '
+          'FROM PUBLIC, "anon", "authenticated";\n'
+    ),
+    # service_role is not a client role, quoted or not.
+    "quoted_service_role_is_not_a_client": (
+        routine("f_c", "SECURITY DEFINER")
+        + "REVOKE EXECUTE ON FUNCTION public.f_c(uuid) "
+          "FROM PUBLIC, anon, authenticated;\n"
+        + 'GRANT EXECUTE ON FUNCTION public.f_c(uuid) TO "service_role";\n'
+    ),
+}
+
+
+# N. A quoted TYPE name is part of the identity, and masking blanks it. Two
+#    overloads taking public."TypeA" and public."TypeB" normalized to the same
+#    signature, so a REVOKE naming one credited the other. Argument lists are
+#    read from RAW now and folded everywhere EXCEPT inside quotes.
+QUOTED_TYPE_MUST_REJECT = {
+    "quoted_type_overloads_must_not_collapse": (
+        routine("f_t", "SECURITY DEFINER", args='p_x public."TypeA"')
+        + routine("f_t", "SECURITY DEFINER", args='p_x public."TypeB"')
+        + 'REVOKE EXECUTE ON FUNCTION public.f_t(public."TypeA")\n'
+          "  FROM PUBLIC, anon, authenticated;\n"
+    ),
+    "quoted_type_is_not_its_unquoted_spelling": (
+        routine("f_t", "SECURITY DEFINER", args='p_x public."TypeA"')
+        + "REVOKE EXECUTE ON FUNCTION public.f_t(public.typea) "
+          "FROM PUBLIC, anon, authenticated;\n"
+    ),
+}
+
+QUOTED_TYPE_MUST_ACCEPT = {
+    "matching_quoted_type_closes_it": (
+        routine("f_t", "SECURITY DEFINER", args='p_x public."TypeA"')
+        + 'REVOKE EXECUTE ON FUNCTION public.f_t(public."TypeA") '
+          "FROM PUBLIC, anon, authenticated;\n"
+    ),
+}
+
+
+# O. An omitted schema is resolved by PostgreSQL through search_path; it is not
+#    a wildcard. Treating it as matching any schema let a REVOKE with no schema
+#    exempt a SECURITY DEFINER function in a DIFFERENT schema.
+OMITTED_SCHEMA_MUST_REJECT = {
+    "unqualified_revoke_does_not_reach_another_schema": (
+        "CREATE OR REPLACE FUNCTION other_schema.f_s(p_org uuid)\n"
+        "RETURNS void\nLANGUAGE plpgsql\nSECURITY DEFINER\nAS $s$\nBEGIN\n"
+        f"{WORK_LINE}\nEND;\n$s$;\n"
+        + "REVOKE EXECUTE ON FUNCTION f_s(uuid) FROM PUBLIC, anon, authenticated;\n"
+    ),
+    "qualified_revoke_does_not_reach_another_schema": (
+        "CREATE OR REPLACE FUNCTION other_schema.f_d(p_org uuid)\n"
+        "RETURNS void\nLANGUAGE plpgsql\nSECURITY DEFINER\nAS $a$\nBEGIN\n"
+        f"{WORK_LINE}\nEND;\n$a$;\n"
+        + routine("f_d", "SECURITY DEFINER")
+        + "REVOKE EXECUTE ON FUNCTION public.f_d(uuid) "
+          "FROM PUBLIC, anon, authenticated;\n"
+    ),
+}
+
+OMITTED_SCHEMA_MUST_ACCEPT = {
+    # Both sides resolve to public, so the closure is real.
+    "unqualified_revoke_closes_a_public_definition": (
+        routine("f_p", "SECURITY DEFINER")
+        + "REVOKE EXECUTE ON FUNCTION f_p(uuid) FROM PUBLIC, anon, authenticated;\n"
+    ),
+    "qualified_revoke_closes_an_unqualified_definition": (
+        "CREATE OR REPLACE FUNCTION f_u(p_org uuid)\n"
+        "RETURNS void\nLANGUAGE plpgsql\nSECURITY DEFINER\nAS $u$\nBEGIN\n"
+        f"{WORK_LINE}\nEND;\n$u$;\n"
+        + "REVOKE EXECUTE ON FUNCTION public.f_u(uuid) "
+          "FROM PUBLIC, anon, authenticated;\n"
+    ),
+}
+
+
 class DefinerScannerTests(unittest.TestCase):
     def setUp(self) -> None:
         self._dir = tempfile.TemporaryDirectory()
@@ -1557,6 +1777,119 @@ class DefinerScannerTests(unittest.TestCase):
             )
             self.assertNotIn(definition.identity.name, guards.KNOWN_EXEMPT)
         self.assertEqual(guards.redefined_guard_names(definitions), [])
+    # -- Codex findings K-O -------------------------------------------------
+
+    def test_security_mode_is_a_state_not_a_declaration(self) -> None:
+        """K: an ALTER after the CREATE decides the mode, in both directions."""
+        for name, sql in SECURITY_STATE_MUST_REJECT.items():
+            with self.subTest(reject=name):
+                self.assertTrue(self.verdict(name, sql), name)
+        for name, sql in SECURITY_STATE_MUST_ACCEPT.items():
+            with self.subTest(accept=name):
+                self.assertEqual(self.verdict(name, sql), [], name)
+
+    def test_promotion_is_named_in_the_error(self) -> None:
+        """K: the author must be told WHY an invoker function is being judged."""
+        errors = self.verdict(
+            "promoted", SECURITY_STATE_MUST_REJECT["invoker_promoted_by_a_later_alter"]
+        )
+        self.assertEqual(len(errors), 1, errors)
+        self.assertIn("made SECURITY DEFINER by a later ALTER", errors[0])
+
+    def test_resolve_security_state_transitions(self) -> None:
+        """K: the state machine itself, independent of check_file()."""
+        raw = (
+            SECURITY_STATE_MUST_REJECT["invoker_promoted_by_a_later_alter"]
+            + "ALTER FUNCTION public.f_promoted(uuid) SECURITY INVOKER;\n"
+            + "ALTER FUNCTION public.f_elsewhere(uuid) SECURITY DEFINER;\n"
+        )
+        masked, problems = guards.mask_sql_checked(raw)
+        self.assertEqual(problems, [])
+        definitions = guards.parse_definitions(raw, masked)
+        alters = guards.parse_alter_security(raw, masked)
+        self.assertEqual([a.sets_definer for a in alters], [True, False, True])
+        external = guards.resolve_security_state(definitions, alters)
+        # Last ALTER on the defined function wins: promoted, then demoted again.
+        self.assertFalse(definitions[0].final_definer)
+        self.assertTrue(definitions[0].is_definer is False)
+        # The ALTER naming a function this file never defines stays external.
+        self.assertEqual(len(external), 1)
+        self.assertEqual(external[0].identity.name, "f_elsewhere")
+
+    def test_sqlstate_values_are_read_at_their_own_offset(self) -> None:
+        """L: masking makes two SQLSTATE terms textually identical."""
+        for name, sql in SQLSTATE_OFFSET_MUST_REJECT.items():
+            with self.subTest(reject=name):
+                self.assertTrue(self.verdict(name, sql), name)
+        for name, sql in SQLSTATE_OFFSET_MUST_ACCEPT.items():
+            with self.subTest(accept=name):
+                self.assertEqual(self.verdict(name, sql), [], name)
+
+    def test_or_term_spans_are_distinct(self) -> None:
+        """L: the span splitter itself - identical masked terms, own offsets."""
+        raw = "SQLSTATE 'P0002' OR SQLSTATE 'P0001'"
+        masked, problems = guards.mask_sql_checked(raw)
+        self.assertEqual(problems, [])
+        spans = guards._split_top_level_or_spans(masked, 0)
+        self.assertEqual(len(spans), 2)
+        self.assertNotEqual(spans[0][0], spans[1][0], "both terms share an offset")
+        # The two terms are the SAME text after masking - that is the whole trap.
+        self.assertEqual(
+            masked[spans[0][0]:spans[0][1]].strip(),
+            masked[spans[1][0]:spans[1][1]].strip(),
+        )
+        self.assertTrue(guards._condition_catches_p0001(masked, raw, 0, len(masked)))
+
+    def test_quoted_grantees_are_seen(self) -> None:
+        """M: masking blanks a quoted grantee, so grantees are read from raw."""
+        for name, sql in QUOTED_GRANTEE_MUST_REJECT.items():
+            with self.subTest(reject=name):
+                self.assertTrue(self.verdict(name, sql), name)
+        for name, sql in QUOTED_GRANTEE_MUST_ACCEPT.items():
+            with self.subTest(accept=name):
+                self.assertEqual(self.verdict(name, sql), [], name)
+
+    def test_grantee_name_resolution(self) -> None:
+        """M: the grantee reader itself."""
+        self.assertEqual(
+            guards._grantee_names('PUBLIC, "anon", authenticated'),
+            {"public", "anon", "authenticated"},
+        )
+        self.assertEqual(guards._grantee_names("GROUP service_role"), {"service_role"})
+        # A quoted name that differs in CASE is a different role.
+        self.assertEqual(guards._grantee_names('"Authenticated"'), {"Authenticated"})
+
+    def test_quoted_type_names_keep_overloads_distinct(self) -> None:
+        """N: a quoted type is part of the identity and masking blanks it."""
+        for name, sql in QUOTED_TYPE_MUST_REJECT.items():
+            with self.subTest(reject=name):
+                self.assertTrue(self.verdict(name, sql), name)
+        for name, sql in QUOTED_TYPE_MUST_ACCEPT.items():
+            with self.subTest(accept=name):
+                self.assertEqual(self.verdict(name, sql), [], name)
+
+    def test_type_folding_preserves_quoted_segments(self) -> None:
+        """N: fold everything except what PostgreSQL would not fold."""
+        self.assertEqual(guards._normalize_arg_type('p_x public."TypeA"'), 'public."TypeA"')
+        self.assertEqual(guards._normalize_arg_type('public."TypeA"'), 'public."TypeA"')
+        self.assertNotEqual(
+            guards._normalize_arg_type('p_x public."TypeA"'),
+            guards._normalize_arg_type('p_x public."TypeB"'),
+        )
+        self.assertNotEqual(
+            guards._normalize_arg_type('p_x public."TypeA"'),
+            guards._normalize_arg_type("p_x public.typea"),
+        )
+        self.assertEqual(guards._normalize_arg_type("p_x PUBLIC.TypeA"), "public.typea")
+
+    def test_an_omitted_schema_is_not_a_wildcard(self) -> None:
+        """O: an unqualified name resolves through search_path, to public."""
+        for name, sql in OMITTED_SCHEMA_MUST_REJECT.items():
+            with self.subTest(reject=name):
+                self.assertTrue(self.verdict(name, sql), name)
+        for name, sql in OMITTED_SCHEMA_MUST_ACCEPT.items():
+            with self.subTest(accept=name):
+                self.assertEqual(self.verdict(name, sql), [], name)
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/scripts/ci/test_check_definer_guards.py
+++ b/scripts/ci/test_check_definer_guards.py
@@ -99,6 +99,47 @@ Final-review remediation (PR #241, Astra findings A/B/C):
      RETURN check ran only before the IF. A terminating RETURN between THEN and
      that RAISE now disqualifies the block, so the aborting RAISE must actually
      be reachable.
+
+Astra acceptance-layer findings D-J. Six classes that were all reproduced
+through the real check_file() at afc0272 before a line changed, and none of
+which more regex could close - they were consequences of the scanner attributing
+by POSITION rather than by IDENTITY, and of modelling only part of what
+PostgreSQL actually does:
+
+  D. Exception CATEGORIES. PostgreSQL matches an EXCEPTION handler on the exact
+     SQLSTATE or on its class - a code ending in '000'. A bare RAISE EXCEPTION
+     is P0001, whose class is P0000, so `WHEN plpgsql_error` and
+     `WHEN SQLSTATE 'P0000'` both swallow an authorization failure. Only the
+     exact code was recognized. The same rule was matched on RAW text, where a
+     block comment between `SQLSTATE` and its literal defeated it; conditions
+     are resolved on masked structure now, with only the VALUE recovered raw.
+  E. Reachability through an exit the model lacked: an outer-level aborting
+     RAISE ends the invocation exactly as a terminating RETURN does, so an
+     assertion after one is dead code.
+  F. Body attribution: a definition with no dollar-quoted body of its own
+     (`LANGUAGE internal AS 'boolin'`, an SQL-standard `BEGIN ATOMIC` body)
+     searched FORWARD and swallowed the next function's body, and with it the
+     next function's guard.
+  G. Privilege attribution: the exemption was a blanket `REVOKE ... FROM PUBLIC`
+     anywhere before the next CREATE. It never checked that the statement named
+     THIS function or THIS overload, and never noticed a later
+     `GRANT ... TO PUBLIC` putting the privilege back.
+  H. `ALTER FUNCTION ... SECURITY DEFINER` restates no body, so there was
+     nothing to read a guard from - and it was attributed to whatever CREATE
+     happened to precede it, or dropped entirely when none did.
+  I. Quoted identities. The CREATE pattern read the name off the MASKED text,
+     where a quoted identifier's content is blanked by design, so
+     `CREATE FUNCTION public."f"(...)` matched no definition at all. Case is
+     part of the identity too: a quoted "HAS_PERMISSION" is not `has_permission`.
+  J. Overload impersonation, from both directions: KNOWN_EXEMPT is keyed by bare
+     NAME, so a new overload of an exempt name inherited an exemption written
+     for a different function; and a guard call was matched by name, so a
+     locally declared no-op overload of a recognized helper satisfied the gate.
+
+The catalog-side half of D, H, I and J - what the whole chain finally produced,
+which no per-file scan can see - is asserted by
+scripts/ci/fresh-db/acceptance_definer_guard_contract.sql and proved falsifiable
+by scripts/ci/fresh-db/selftest_definer_guard_contract.sh.
 """
 
 from __future__ import annotations
@@ -589,6 +630,277 @@ MUST_FAIL_CLOSED = {
 }
 
 
+# ---------------------------------------------------------------------------
+# Astra findings D-I: acceptance-layer gaps in the scanner itself
+# ---------------------------------------------------------------------------
+# Every fixture below was run through the REAL check_file() at the reviewed head
+# before any change and returned [] - the false green, frozen.
+
+
+def definer_outer_handler(handler: str, name: str = "f_probe") -> str:
+    """A guard at the OUTER statement level whose own block handles `handler`.
+
+    The handler is on the FUNCTION's own BEGIN, so the fixture cannot pass or
+    fail for placement reasons: the only thing under test is whether that
+    handler can catch the assertion's P0001.
+    """
+    return (
+        f"CREATE OR REPLACE FUNCTION public.{name}(p_org uuid)\n"
+        "RETURNS void\n"
+        "LANGUAGE plpgsql\n"
+        "SECURITY DEFINER\n"
+        "SET search_path TO 'public', 'pg_temp'\n"
+        "AS $function$\n"
+        "BEGIN\n"
+        f"  PERFORM {OUTER}(p_org);\n"
+        "  UPDATE public.bins SET actual_qty = 0 WHERE org_id = p_org;\n"
+        f"EXCEPTION WHEN {handler} THEN\n"
+        "  UPDATE public.bins SET actual_qty = 0 WHERE org_id = p_org;\n"
+        "END;\n"
+        "$function$;\n"
+    )
+
+
+# D. PostgreSQL matches an EXCEPTION handler either on the exact SQLSTATE or on
+#    its CATEGORY - a condition whose code ends in '000'. A bare RAISE EXCEPTION
+#    is P0001, whose category is P0000, so `plpgsql_error` and
+#    `SQLSTATE 'P0000'` both catch an authorization failure. Only the exact code
+#    was recognized, so the category door stood open. The comment-separated form
+#    is the same defect from the other side: the condition was matched on RAW
+#    text, where a block comment between the keyword and the literal defeated the
+#    separator; it is resolved on masked structure now, with only the VALUE
+#    recovered from the raw source.
+EXCEPTION_CATEGORY_MUST_REJECT = {
+    "handler_catches_by_category_name": definer_outer_handler("plpgsql_error"),
+    "handler_catches_by_category_code": definer_outer_handler("SQLSTATE 'P0000'"),
+    "handler_catches_with_comment_separator": definer_outer_handler(
+        "SQLSTATE /* documented reason */ 'P0001'"
+    ),
+    "handler_catches_as_later_or_term": definer_outer_handler(
+        "unique_violation OR plpgsql_error"
+    ),
+    "handler_catches_as_later_or_sqlstate": definer_outer_handler(
+        "unique_violation OR SQLSTATE 'P0001'"
+    ),
+    # Controls that were already rejected, kept so they cannot regress.
+    "handler_catches_when_others": definer_outer_handler("OTHERS"),
+    "handler_catches_raise_exception": definer_outer_handler("raise_exception"),
+    "handler_catches_sqlstate_p0001": definer_outer_handler("SQLSTATE 'P0001'"),
+}
+
+# The other half of the same rule: a condition that CANNOT catch a P0001 must
+# not invalidate a real guard. PostgreSQL resolves every condition name at
+# compile time, so an unrecognized one is a hard error rather than an attacker's
+# invention - which is why treating an unknown name as non-catching is sound.
+EXCEPTION_CATEGORY_MUST_ACCEPT = {
+    "unique_violation_does_not_catch": definer_outer_handler("unique_violation"),
+    "fk_violation_does_not_catch": definer_outer_handler("foreign_key_violation"),
+    "unrelated_category_does_not_catch": definer_outer_handler("data_exception"),
+}
+
+
+# E. Reachability again, but through an exit the model did not have. A
+#    terminating RETURN was understood; an aborting RAISE at the OUTER statement
+#    level ends the invocation just as surely, so an assertion after one is dead
+#    code no caller ever reaches. A raise inside a conditional is NOT an exit,
+#    and must not cost a real guard its recognition.
+UNREACHABLE_ABORT_MUST_REJECT = {
+    "guard_after_outer_level_raise": definer(
+        f"  RAISE EXCEPTION 'NOT_IMPLEMENTED';\n  PERFORM {OUTER}(p_org);"
+    ),
+    "guard_after_outer_level_raise_using": definer(
+        "  RAISE EXCEPTION 'X' USING ERRCODE = '22023';\n"
+        f"  PERFORM {OUTER}(p_org);"
+    ),
+    "boolean_guard_after_outer_level_raise": definer(
+        "  RAISE EXCEPTION 'NOT_IMPLEMENTED';\n"
+        f"  IF NOT {QPRED}(p_org) THEN\n    RAISE EXCEPTION 'DENIED';\n  END IF;"
+    ),
+}
+
+UNREACHABLE_ABORT_MUST_ACCEPT = {
+    "conditional_raise_before_guard_is_not_an_exit": definer(
+        "  IF p_org IS NULL THEN\n    RAISE EXCEPTION 'ORG_REQUIRED';\n  END IF;\n"
+        f"  PERFORM {OUTER}(p_org);"
+    ),
+    "raise_notice_before_guard_is_not_an_exit": definer(
+        f"  RAISE NOTICE 'starting';\n  PERFORM {OUTER}(p_org);"
+    ),
+}
+
+
+# F. Body attribution. `extract_function_body_span` looked FORWARD from the
+#    CREATE for the first `AS $tag$`, so a definition with no dollar-quoted body
+#    of its own swallowed the NEXT function's - and with it the next function's
+#    guard. A definition is now bounded by its own statement, and a SECURITY
+#    DEFINER routine the scanner cannot read a body from is rejected rather than
+#    given someone else's.
+GUARDED_NEXT = (
+    "CREATE OR REPLACE FUNCTION public.f_guarded(p_org uuid)\n"
+    "RETURNS void\nLANGUAGE plpgsql\nSECURITY DEFINER\n"
+    "SET search_path TO 'public', 'pg_temp'\n"
+    "AS $guarded$\nBEGIN\n"
+    f"  PERFORM {OUTER}(p_org);\n"
+    "  UPDATE public.bins SET actual_qty = 0 WHERE org_id = p_org;\n"
+    "END;\n$guarded$;\n"
+)
+
+BODY_ATTRIBUTION_MUST_REJECT = {
+    "unreadable_body_borrows_the_next_guard": (
+        "CREATE OR REPLACE FUNCTION public.f_unreadable(p_org uuid)\n"
+        "RETURNS void\nLANGUAGE internal\nSECURITY DEFINER\nAS 'boolin';\n"
+        + GUARDED_NEXT
+    ),
+    "sql_standard_body_is_not_readable": (
+        "CREATE OR REPLACE FUNCTION public.f_atomic(p_org uuid)\n"
+        "RETURNS void\nLANGUAGE sql\nSECURITY DEFINER\n"
+        "BEGIN ATOMIC\n"
+        "  UPDATE public.bins SET actual_qty = 0 WHERE org_id = p_org;\n"
+        "END;\n"
+        + GUARDED_NEXT
+    ),
+}
+
+
+# G. Privilege attribution. The exemption was a blanket
+#    `REVOKE ... FROM PUBLIC` anywhere before the next CREATE: it never checked
+#    that the statement named THIS function, and never noticed a later GRANT
+#    putting the grant back. It is now an ACL replay against this identity.
+def closed(name: str = "f_c") -> str:
+    return (
+        f"REVOKE EXECUTE ON FUNCTION public.{name}(uuid) "
+        "FROM PUBLIC, anon, authenticated;\n"
+    )
+
+
+REVOKE_ATTRIBUTION_MUST_REJECT = {
+    "revoke_names_another_function": definer("  PERFORM 1;", name="f_c")
+    + closed("f_somewhere_else"),
+    "revoke_names_another_overload": definer("  PERFORM 1;", name="f_c")
+    + "REVOKE EXECUTE ON FUNCTION public.f_c(text) FROM PUBLIC, anon, authenticated;\n",
+    "grant_to_public_reopens_the_revoke": definer("  PERFORM 1;", name="f_c")
+    + closed()
+    + "GRANT EXECUTE ON FUNCTION public.f_c(uuid) TO PUBLIC;\n",
+    "revoke_precedes_the_definition": closed() + definer("  PERFORM 1;", name="f_c"),
+    "all_functions_in_schema_is_not_attribution": definer("  PERFORM 1;", name="f_c")
+    + "REVOKE EXECUTE ON ALL FUNCTIONS IN SCHEMA public FROM PUBLIC;\n",
+    "closing_public_while_granting_authenticated": definer("  PERFORM 1;", name="f_c")
+    + "REVOKE EXECUTE ON FUNCTION public.f_c(uuid) FROM PUBLIC, anon;\n"
+    + "GRANT EXECUTE ON FUNCTION public.f_c(uuid) TO authenticated;\n",
+}
+
+REVOKE_ATTRIBUTION_MUST_ACCEPT = {
+    "named_closure_of_this_identity": definer("  PERFORM 1;", name="f_c") + closed(),
+    "closure_split_over_lines": definer("  PERFORM 1;", name="f_c")
+    + "REVOKE EXECUTE\n  ON FUNCTION public.f_c(uuid)\n"
+      "  FROM PUBLIC, anon, authenticated;\n",
+    "closure_with_all_privileges": definer("  PERFORM 1;", name="f_c")
+    + "REVOKE ALL PRIVILEGES ON FUNCTION public.f_c(uuid) "
+      "FROM PUBLIC, anon, authenticated;\n",
+    "closure_naming_parameter_names": definer("  PERFORM 1;", name="f_c")
+    + "REVOKE EXECUTE ON FUNCTION public.f_c(p_org uuid) "
+      "FROM PUBLIC, anon, authenticated;\n",
+    "closure_listing_several_targets": definer("  PERFORM 1;", name="f_a")
+    + definer("  PERFORM 1;", name="f_b")
+    + "REVOKE EXECUTE ON FUNCTION public.f_a(uuid), public.f_b(uuid)\n"
+      "  FROM PUBLIC, anon, authenticated;\n",
+    "grant_to_service_role_is_not_a_reopen": definer("  PERFORM 1;", name="f_c")
+    + closed()
+    + "GRANT EXECUTE ON FUNCTION public.f_c(uuid) TO service_role;\n",
+}
+
+
+# H. `ALTER FUNCTION ... SECURITY DEFINER` makes an existing function run as its
+#    owner while restating nothing, so there is no body to read a guard from. The
+#    positional scan blamed the occurrence on whatever CREATE preceded it - or,
+#    with none before it, dropped it entirely.
+ALTER_DEFINER_MUST_REJECT = {
+    "alter_alone_in_the_migration": (
+        "ALTER FUNCTION public.f_legacy(uuid) SECURITY DEFINER;\n"
+    ),
+    "alter_borrows_an_earlier_guard": GUARDED_NEXT
+    + "ALTER FUNCTION public.f_legacy(uuid) SECURITY DEFINER;\n",
+    "alter_then_regrant_to_public": (
+        "ALTER FUNCTION public.f_legacy(uuid) SECURITY DEFINER;\n"
+        "REVOKE EXECUTE ON FUNCTION public.f_legacy(uuid) "
+        "FROM PUBLIC, anon, authenticated;\n"
+        "GRANT EXECUTE ON FUNCTION public.f_legacy(uuid) TO PUBLIC;\n"
+    ),
+}
+
+ALTER_DEFINER_MUST_ACCEPT = {
+    "alter_to_security_invoker_is_not_a_finding": GUARDED_NEXT
+    + "ALTER FUNCTION public.calculate_planned_load(uuid, date, date) "
+      "SECURITY INVOKER;\n",
+    "alter_of_a_function_defined_and_guarded_here": GUARDED_NEXT
+    + "ALTER FUNCTION public.f_guarded(uuid) SECURITY DEFINER;\n",
+    "alter_with_a_named_closure": (
+        "ALTER FUNCTION public.f_legacy(uuid) SECURITY DEFINER;\n"
+        "REVOKE EXECUTE ON FUNCTION public.f_legacy(uuid) "
+        "FROM PUBLIC, anon, authenticated;\n"
+    ),
+}
+
+
+# I. Identity. `DEFINER_FUNC_RE` read `(?:public\.)?(\w+)` off the MASKED text,
+#    where a quoted identifier's content is blanked by design. A quoted identity
+#    therefore matched no CREATE at all: its SECURITY DEFINER was attributed to
+#    an earlier function or dropped. Case is part of the identity too - a quoted
+#    "HAS_PERMISSION" is not `has_permission` and must not inherit its
+#    exemption - and neither is another schema's same-named function.
+def quoted_definer(header: str) -> str:
+    return (
+        f"{header}\n"
+        "RETURNS void\nLANGUAGE plpgsql\nSECURITY DEFINER\n"
+        "SET search_path TO 'public', 'pg_temp'\n"
+        "AS $q$\nBEGIN\n"
+        "  UPDATE public.bins SET actual_qty = 0 WHERE org_id = p_org;\n"
+        "END;\n$q$;\n"
+    )
+
+
+QUOTED_IDENTITY_MUST_REJECT = {
+    "quoted_function_name": quoted_definer(
+        'CREATE OR REPLACE FUNCTION public."f_quoted"(p_org uuid)'
+    ),
+    "quoted_schema_and_name": quoted_definer(
+        'CREATE OR REPLACE FUNCTION "public"."f_quoted"(p_org uuid)'
+    ),
+    "quoted_after_a_guarded_function": GUARDED_NEXT
+    + quoted_definer('CREATE OR REPLACE FUNCTION public."f_quoted"(p_org uuid)'),
+    "quoted_uppercase_impersonates_an_exempt_name": quoted_definer(
+        'CREATE OR REPLACE FUNCTION public."HAS_PERMISSION"(p_org uuid)'
+    ),
+    "another_schema_same_name": quoted_definer(
+        "CREATE OR REPLACE FUNCTION other_schema.f_elsewhere(p_org uuid)"
+    ),
+}
+
+
+# J. Overload impersonation. KNOWN_EXEMPT is keyed by bare NAME, so under the
+#    strict contract a brand-new overload of an exempt name would inherit an
+#    exemption written for a different function; and a recognized guard call is
+#    matched by name, so a locally declared no-op overload of that name would
+#    satisfy the gate through the same match as the real helper.
+OVERLOAD_IMPERSONATION_MUST_REJECT = {
+    "new_overload_of_an_exempt_name": quoted_definer(
+        "CREATE OR REPLACE FUNCTION public.has_permission(p_org uuid)"
+    ),
+    "migration_redefines_the_guard_it_leans_on": (
+        "CREATE OR REPLACE FUNCTION public.wardah_assert_org_member(p_org text)\n"
+        "RETURNS void\nLANGUAGE plpgsql\nAS $shadow$\nBEGIN\n  NULL;\nEND;\n$shadow$;\n"
+        + GUARDED_NEXT
+    ),
+    "guard_called_with_the_wrong_arity": definer(f"  PERFORM {OUTER}();"),
+    "guard_called_with_too_many_arguments": definer(
+        f"  PERFORM {OUTER}(p_org, p_org);"
+    ),
+    "boolean_predicate_called_with_the_wrong_arity": definer(
+        f"  IF NOT {QPRED}(p_org, p_org) THEN\n    RAISE EXCEPTION 'D';\n  END IF;"
+    ),
+}
+
+
 class DefinerScannerTests(unittest.TestCase):
     def setUp(self) -> None:
         self._dir = tempfile.TemporaryDirectory()
@@ -937,6 +1249,208 @@ class DefinerScannerTests(unittest.TestCase):
             _, problems = guards.mask_sql_checked(path.read_text(encoding="utf-8"))
             self.assertEqual(problems, [], f"{path.name}: {problems}")
 
+    # -- Astra findings D-I -------------------------------------------------
+
+    def test_exception_categories_that_catch_p0001_are_rejected(self) -> None:
+        """D: P0001 is caught by its own code AND by its class code P0000."""
+        for name, sql in EXCEPTION_CATEGORY_MUST_REJECT.items():
+            with self.subTest(case=name):
+                self.assertTrue(
+                    self.verdict(name, sql),
+                    f"{name}: the denial is swallowed by this handler",
+                )
+
+    def test_unrelated_exception_conditions_do_not_false_red(self) -> None:
+        """D: a condition that cannot catch P0001 must not cost a real guard."""
+        for name, sql in EXCEPTION_CATEGORY_MUST_ACCEPT.items():
+            with self.subTest(case=name):
+                self.assertEqual(self.verdict(name, sql), [], name)
+
+    def test_condition_resolver_discriminates(self) -> None:
+        """D: the resolver itself, independent of check_file()."""
+        def catches(condition: str) -> bool:
+            masked, problems = guards.mask_sql_checked(f"WHEN {condition} THEN")
+            self.assertEqual(problems, [])
+            raw = f"WHEN {condition} THEN"
+            spans = guards._handler_condition_spans(masked, 0, len(masked))
+            return any(
+                guards._condition_catches_p0001(masked, raw, s, e) for s, e in spans
+            )
+
+        for condition in (
+            "OTHERS",
+            "raise_exception",
+            "plpgsql_error",
+            "SQLSTATE 'P0001'",
+            "SQLSTATE 'P0000'",
+            "SQLSTATE /* why */ 'P0001'",
+            "unique_violation OR plpgsql_error",
+        ):
+            with self.subTest(catches=condition):
+                self.assertTrue(catches(condition), condition)
+        for condition in (
+            "unique_violation",
+            "foreign_key_violation",
+            "data_exception",
+            "SQLSTATE '23505'",
+            "no_data_found",
+        ):
+            with self.subTest(passes=condition):
+                self.assertFalse(catches(condition), condition)
+
+    def test_guard_after_an_outer_level_abort_is_rejected(self) -> None:
+        """E: an aborting RAISE at outer level ends the invocation."""
+        for name, sql in UNREACHABLE_ABORT_MUST_REJECT.items():
+            with self.subTest(case=name):
+                self.assertTrue(self.verdict(name, sql), name)
+        for name, sql in UNREACHABLE_ABORT_MUST_ACCEPT.items():
+            with self.subTest(accept=name):
+                self.assertEqual(self.verdict(name, sql), [], name)
+
+    def test_abort_rule_is_strict_contract_only(self) -> None:
+        """E: historical migrations keep their validated placement."""
+        sql = UNREACHABLE_ABORT_MUST_REJECT["guard_after_outer_level_raise"]
+        historical = self.root / "150_abort.sql"
+        historical.write_text(sql, encoding="utf-8")
+        self.assertEqual(guards.check_file(historical), [])
+        strict = self.root / f"{guards.MIGRATION_STRICT_CUTOFF}_abort.sql"
+        strict.write_text(sql, encoding="utf-8")
+        self.assertTrue(guards.check_file(strict))
+
+    def test_a_definition_cannot_borrow_the_next_functions_body(self) -> None:
+        """F: no dollar-quoted body of its own means no guard, at any age."""
+        for name, sql in BODY_ATTRIBUTION_MUST_REJECT.items():
+            for number in (150, guards.MIGRATION_STRICT_CUTOFF):
+                path = self.root / f"{number}_{name}.sql"
+                path.write_text(sql, encoding="utf-8")
+                with self.subTest(case=name, migration=number):
+                    self.assertTrue(guards.check_file(path), name)
+
+    def test_revoke_must_name_the_function_it_exempts(self) -> None:
+        """G: attribution by identity, and the closure must survive the file."""
+        for name, sql in REVOKE_ATTRIBUTION_MUST_REJECT.items():
+            with self.subTest(reject=name):
+                self.assertTrue(self.verdict(name, sql), name)
+        for name, sql in REVOKE_ATTRIBUTION_MUST_ACCEPT.items():
+            with self.subTest(accept=name):
+                self.assertEqual(self.verdict(name, sql), [], name)
+
+    def test_client_closure_rule_is_scoped_to_the_strict_contract(self) -> None:
+        """G: 123, 175 and 186 close PUBLIC and grant authenticated; they stay
+        green, and the same shape is rejected from the cutoff on."""
+        sql = REVOKE_ATTRIBUTION_MUST_REJECT["closing_public_while_granting_authenticated"]
+        historical = self.root / "150_closure.sql"
+        historical.write_text(sql, encoding="utf-8")
+        self.assertEqual(guards.check_file(historical), [])
+        strict = self.root / f"{guards.MIGRATION_STRICT_CUTOFF}_closure.sql"
+        strict.write_text(sql, encoding="utf-8")
+        self.assertTrue(guards.check_file(strict))
+        # A PUBLIC re-grant is never acceptable, at any age.
+        reopened = self.root / "150_reopened.sql"
+        reopened.write_text(
+            REVOKE_ATTRIBUTION_MUST_REJECT["grant_to_public_reopens_the_revoke"],
+            encoding="utf-8",
+        )
+        self.assertTrue(guards.check_file(reopened))
+
+    def test_argument_type_normalization(self) -> None:
+        """G: the overload comparison itself, independent of check_file()."""
+        cases = {
+            "p_org uuid": "uuid",
+            "uuid": "uuid",
+            "OUT p_total numeric": "numeric",
+            "VARIADIC p_ids uuid[]": "uuid[]",
+            "p_meta jsonb DEFAULT '{}'::jsonb": "jsonb",
+            "p_at timestamp with time zone": "timestamp with time zone",
+            "timestamp with time zone": "timestamp with time zone",
+            "p_name character varying": "character varying",
+            "character varying": "character varying",
+            "p_rate numeric(10,2)": "numeric(10,2)",
+            "p_x double precision": "double precision",
+        }
+        for param, expected in cases.items():
+            with self.subTest(param=param):
+                self.assertEqual(guards._normalize_arg_type(param), expected)
+
+    def test_alter_function_security_definer_is_a_finding(self) -> None:
+        """H: flipping an existing function to definer restates no guard."""
+        for name, sql in ALTER_DEFINER_MUST_REJECT.items():
+            with self.subTest(reject=name):
+                self.assertTrue(self.verdict(name, sql), name)
+        for name, sql in ALTER_DEFINER_MUST_ACCEPT.items():
+            with self.subTest(accept=name):
+                self.assertEqual(self.verdict(name, sql), [], name)
+
+    def test_quoted_identities_are_scanned(self) -> None:
+        """I: a quoted identity used to match no CREATE at all."""
+        for name, sql in QUOTED_IDENTITY_MUST_REJECT.items():
+            with self.subTest(case=name):
+                self.assertTrue(self.verdict(name, sql), name)
+
+    def test_overload_impersonation_is_rejected(self) -> None:
+        """J: neither the exemption list nor a guard name is a free pass."""
+        for name, sql in OVERLOAD_IMPERSONATION_MUST_REJECT.items():
+            with self.subTest(case=name):
+                self.assertTrue(self.verdict(name, sql), name)
+
+    def test_known_exempt_is_historical_only(self) -> None:
+        """J: the ledger still applies below the cutoff, never at or above it."""
+        sql = quoted_definer(
+            "CREATE OR REPLACE FUNCTION public.rpc_get_invitation_preview(p_org uuid)"
+        )
+        historical = self.root / "150_exempt.sql"
+        historical.write_text(sql, encoding="utf-8")
+        self.assertEqual(guards.check_file(historical), [])
+        strict = self.root / f"{guards.MIGRATION_STRICT_CUTOFF}_exempt.sql"
+        strict.write_text(sql, encoding="utf-8")
+        self.assertTrue(guards.check_file(strict))
+
+    def test_identity_comparison(self) -> None:
+        """The overload equality rule itself."""
+        raw = (
+            "CREATE FUNCTION public.f(p_org uuid) RETURNS void LANGUAGE sql AS $$"
+            "SELECT 1$$;\n"
+            "REVOKE EXECUTE ON FUNCTION public.f(text) FROM PUBLIC;\n"
+            "REVOKE EXECUTE ON FUNCTION public.f(uuid) FROM PUBLIC;\n"
+        )
+        masked, problems = guards.mask_sql_checked(raw)
+        self.assertEqual(problems, [])
+        definition = guards.parse_definitions(raw, masked)[0]
+        targets = [
+            t for stmt in guards.parse_privilege_statements(raw, masked)
+            for t in stmt.targets
+        ]
+        self.assertFalse(definition.identity.same_function(targets[0]))
+        self.assertTrue(definition.identity.same_function(targets[1]))
+
+    def test_migration_191_still_relies_on_no_exemption(self) -> None:
+        """191 must pass on guards and real closures, never on KNOWN_EXEMPT."""
+        path = pathlib.Path(
+            "sql/migrations/191_f2_stock_write_concurrency_closure.sql"
+        )
+        if not path.exists():
+            self.skipTest("migration 191 not present")
+        raw = path.read_text(encoding="utf-8")
+        masked, problems = guards.mask_sql_checked(raw)
+        self.assertEqual(problems, [])
+        definitions = guards.parse_definitions(raw, masked)
+        privileges = guards.parse_privilege_statements(raw, masked)
+        definers = [d for d in definitions if d.is_definer]
+        self.assertTrue(definers, "191 defines no SECURITY DEFINER function")
+        for definition in definers:
+            closed = guards.revoke_closes_client_surface(
+                definition.identity, definition.end, privileges, strict=True
+            )
+            body = masked[definition.start: definition.body_span[1]]
+            raw_body = raw[definition.start: definition.body_span[1]]
+            guarded = guards.has_recognized_guard(body, strict=True, raw_body=raw_body)
+            self.assertTrue(
+                closed or guarded,
+                f"{definition.identity.qualified} rests on neither a guard nor a "
+                f"closure",
+            )
+            self.assertNotIn(definition.identity.name, guards.KNOWN_EXEMPT)
+        self.assertEqual(guards.redefined_guard_names(definitions), [])
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Purpose

Targeted acceptance-proof hardening for PR #241 after the final Astra scanner review.

Base: `f2/m191-stock-concurrency-implementation` at `afc0272a09070e4a9c60c68c0eac4b8447e7ce14`
Head: `claude/dreamy-ptolemy-9ak1kv` at `430bc7d502d0577565971b1ddba47ea5f9843dd5`

This PR does **not** modify `sql/migrations/191_f2_stock_write_concurrency_closure.sql` or any production migration SQL. M191 SHA-256 remains:

`637a81caeaebea60693476222611b373dc1e738cd6b10c634bf4c236227f3f40`

## Scope

- Replace positional SECURITY DEFINER attribution with statement/function identity modeling.
- Harden exception-category handling, including P0000/plpgsql_error semantics.
- Bind REVOKE/GRANT effects to exact function identity and overload.
- Detect ALTER FUNCTION ... SECURITY DEFINER and quoted identities.
- Add canonical guard-signature/overload protection.
- Add Fresh PostgreSQL catalog-backed acceptance contract and mutation selftest.
- Wire the contract into CI and M191 acceptance.
- Correct evidence wording and scope disclosures from the adversarial self-review.
- Add regression coverage for SECURITY DEFINER header/trailer parsing.

## Verification

Exact verified head: `430bc7d502d0577565971b1ddba47ea5f9843dd5`.

- Codacy: success. The three B608 findings were scanner-only SQL fixtures, written to temporary files and passed to `check_file()`, never executed by a database driver. Three line-scoped `nosec B608` annotations document this; no analyzer or file-wide exclusion was added.
- [CI/CD Pipeline 34616127146](https://github.com/6thd/wardah-process-costing/actions/runs/34616127146): Test & Build success; Production deployment skipped.
- [M191 acceptance 34616127219](https://github.com/6thd/wardah-process-costing/actions/runs/34616127219): deterministic GREEN acceptance and rollback/forward recovery both successful.
- Local scanner tests: 57 pass. Explicit scan of all 61 migrations above 121: no errors.
- Additional M191 mutation probes: removing each of the seven client-facing RPC guards individually produces a scanner rejection in all seven cases.
- M191 production SQL SHA-256 remains unchanged: `637a81caeaebea60693476222611b373dc1e738cd6b10c634bf4c236227f3f40`.

The preceding grantee correction locates tokens on comment-masked structure and recovers only their original spans, retaining quoted roles without treating commented roles as real revocations. Its regression covers block/line/nested comments and quotes inside comments, plus real quoted grants and revocations. Both acceptance workflows now include this stacked PR's target branch.

This evidence concerns the current M191 scope and the listed scanner regressions; it is not a claim of complete PostgreSQL parsing or authorization verification for arbitrary future migrations. No merge or Production/Staging access was performed.

## Explicitly not included

Adversarial findings F3/F4/F5 from the self-review remain intentionally outside this pass because they are latent parser/fail-closed debts not exercised by current M191 or current repository migrations:

- textual type-alias normalization (`varchar` vs `character varying`, etc.);
- argument-less REVOKE overload ambiguity in static parsing;
- malformed CREATE/ALTER constructs already rejected by the preceding pglast gate.

These should not be silently treated as closed by this PR.

## Review constraints

- Review only; do not merge without explicit authorization.
- No Production or Staging access/write.
- Do not modify M191 production SQL.
- If approved, this PR is intended to be merged into the PR #241 branch first; PR #241 then receives a fresh exact-head CI run and new independent Codex + Astra closure reviews.